### PR TITLE
feat: add Codex CLI provider with prompt template support

### DIFF
--- a/.codex/prompts/speckit.analyze.md
+++ b/.codex/prompts/speckit.analyze.md
@@ -1,0 +1,184 @@
+---
+description: Perform a non-destructive cross-artifact consistency and quality analysis across spec.md, plan.md, and tasks.md after task generation.
+---
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Goal
+
+Identify inconsistencies, duplications, ambiguities, and underspecified items across the three core artifacts (`spec.md`, `plan.md`, `tasks.md`) before implementation. This command MUST run only after `/speckit.tasks` has successfully produced a complete `tasks.md`.
+
+## Operating Constraints
+
+**STRICTLY READ-ONLY**: Do **not** modify any files. Output a structured analysis report. Offer an optional remediation plan (user must explicitly approve before any follow-up editing commands would be invoked manually).
+
+**Constitution Authority**: The project constitution (`.specify/memory/constitution.md`) is **non-negotiable** within this analysis scope. Constitution conflicts are automatically CRITICAL and require adjustment of the spec, plan, or tasks—not dilution, reinterpretation, or silent ignoring of the principle. If a principle itself needs to change, that must occur in a separate, explicit constitution update outside `/speckit.analyze`.
+
+## Execution Steps
+
+### 1. Initialize Analysis Context
+
+Run `.specify/scripts/bash/check-prerequisites.sh --json --require-tasks --include-tasks` once from repo root and parse JSON for FEATURE_DIR and AVAILABLE_DOCS. Derive absolute paths:
+
+- SPEC = FEATURE_DIR/spec.md
+- PLAN = FEATURE_DIR/plan.md
+- TASKS = FEATURE_DIR/tasks.md
+
+Abort with an error message if any required file is missing (instruct the user to run missing prerequisite command).
+For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot").
+
+### 2. Load Artifacts (Progressive Disclosure)
+
+Load only the minimal necessary context from each artifact:
+
+**From spec.md:**
+
+- Overview/Context
+- Functional Requirements
+- Non-Functional Requirements
+- User Stories
+- Edge Cases (if present)
+
+**From plan.md:**
+
+- Architecture/stack choices
+- Data Model references
+- Phases
+- Technical constraints
+
+**From tasks.md:**
+
+- Task IDs
+- Descriptions
+- Phase grouping
+- Parallel markers [P]
+- Referenced file paths
+
+**From constitution:**
+
+- Load `.specify/memory/constitution.md` for principle validation
+
+### 3. Build Semantic Models
+
+Create internal representations (do not include raw artifacts in output):
+
+- **Requirements inventory**: Each functional + non-functional requirement with a stable key (derive slug based on imperative phrase; e.g., "User can upload file" → `user-can-upload-file`)
+- **User story/action inventory**: Discrete user actions with acceptance criteria
+- **Task coverage mapping**: Map each task to one or more requirements or stories (inference by keyword / explicit reference patterns like IDs or key phrases)
+- **Constitution rule set**: Extract principle names and MUST/SHOULD normative statements
+
+### 4. Detection Passes (Token-Efficient Analysis)
+
+Focus on high-signal findings. Limit to 50 findings total; aggregate remainder in overflow summary.
+
+#### A. Duplication Detection
+
+- Identify near-duplicate requirements
+- Mark lower-quality phrasing for consolidation
+
+#### B. Ambiguity Detection
+
+- Flag vague adjectives (fast, scalable, secure, intuitive, robust) lacking measurable criteria
+- Flag unresolved placeholders (TODO, TKTK, ???, `<placeholder>`, etc.)
+
+#### C. Underspecification
+
+- Requirements with verbs but missing object or measurable outcome
+- User stories missing acceptance criteria alignment
+- Tasks referencing files or components not defined in spec/plan
+
+#### D. Constitution Alignment
+
+- Any requirement or plan element conflicting with a MUST principle
+- Missing mandated sections or quality gates from constitution
+
+#### E. Coverage Gaps
+
+- Requirements with zero associated tasks
+- Tasks with no mapped requirement/story
+- Non-functional requirements not reflected in tasks (e.g., performance, security)
+
+#### F. Inconsistency
+
+- Terminology drift (same concept named differently across files)
+- Data entities referenced in plan but absent in spec (or vice versa)
+- Task ordering contradictions (e.g., integration tasks before foundational setup tasks without dependency note)
+- Conflicting requirements (e.g., one requires Next.js while other specifies Vue)
+
+### 5. Severity Assignment
+
+Use this heuristic to prioritize findings:
+
+- **CRITICAL**: Violates constitution MUST, missing core spec artifact, or requirement with zero coverage that blocks baseline functionality
+- **HIGH**: Duplicate or conflicting requirement, ambiguous security/performance attribute, untestable acceptance criterion
+- **MEDIUM**: Terminology drift, missing non-functional task coverage, underspecified edge case
+- **LOW**: Style/wording improvements, minor redundancy not affecting execution order
+
+### 6. Produce Compact Analysis Report
+
+Output a Markdown report (no file writes) with the following structure:
+
+## Specification Analysis Report
+
+| ID | Category | Severity | Location(s) | Summary | Recommendation |
+|----|----------|----------|-------------|---------|----------------|
+| A1 | Duplication | HIGH | spec.md:L120-134 | Two similar requirements ... | Merge phrasing; keep clearer version |
+
+(Add one row per finding; generate stable IDs prefixed by category initial.)
+
+**Coverage Summary Table:**
+
+| Requirement Key | Has Task? | Task IDs | Notes |
+|-----------------|-----------|----------|-------|
+
+**Constitution Alignment Issues:** (if any)
+
+**Unmapped Tasks:** (if any)
+
+**Metrics:**
+
+- Total Requirements
+- Total Tasks
+- Coverage % (requirements with >=1 task)
+- Ambiguity Count
+- Duplication Count
+- Critical Issues Count
+
+### 7. Provide Next Actions
+
+At end of report, output a concise Next Actions block:
+
+- If CRITICAL issues exist: Recommend resolving before `/speckit.implement`
+- If only LOW/MEDIUM: User may proceed, but provide improvement suggestions
+- Provide explicit command suggestions: e.g., "Run /speckit.specify with refinement", "Run /speckit.plan to adjust architecture", "Manually edit tasks.md to add coverage for 'performance-metrics'"
+
+### 8. Offer Remediation
+
+Ask the user: "Would you like me to suggest concrete remediation edits for the top N issues?" (Do NOT apply them automatically.)
+
+## Operating Principles
+
+### Context Efficiency
+
+- **Minimal high-signal tokens**: Focus on actionable findings, not exhaustive documentation
+- **Progressive disclosure**: Load artifacts incrementally; don't dump all content into analysis
+- **Token-efficient output**: Limit findings table to 50 rows; summarize overflow
+- **Deterministic results**: Rerunning without changes should produce consistent IDs and counts
+
+### Analysis Guidelines
+
+- **NEVER modify files** (this is read-only analysis)
+- **NEVER hallucinate missing sections** (if absent, report them accurately)
+- **Prioritize constitution violations** (these are always CRITICAL)
+- **Use examples over exhaustive rules** (cite specific instances, not generic patterns)
+- **Report zero issues gracefully** (emit success report with coverage statistics)
+
+## Context
+
+$ARGUMENTS

--- a/.codex/prompts/speckit.checklist.md
+++ b/.codex/prompts/speckit.checklist.md
@@ -1,0 +1,294 @@
+---
+description: Generate a custom checklist for the current feature based on user requirements.
+---
+
+## Checklist Purpose: "Unit Tests for English"
+
+**CRITICAL CONCEPT**: Checklists are **UNIT TESTS FOR REQUIREMENTS WRITING** - they validate the quality, clarity, and completeness of requirements in a given domain.
+
+**NOT for verification/testing**:
+
+- ❌ NOT "Verify the button clicks correctly"
+- ❌ NOT "Test error handling works"
+- ❌ NOT "Confirm the API returns 200"
+- ❌ NOT checking if code/implementation matches the spec
+
+**FOR requirements quality validation**:
+
+- ✅ "Are visual hierarchy requirements defined for all card types?" (completeness)
+- ✅ "Is 'prominent display' quantified with specific sizing/positioning?" (clarity)
+- ✅ "Are hover state requirements consistent across all interactive elements?" (consistency)
+- ✅ "Are accessibility requirements defined for keyboard navigation?" (coverage)
+- ✅ "Does the spec define what happens when logo image fails to load?" (edge cases)
+
+**Metaphor**: If your spec is code written in English, the checklist is its unit test suite. You're testing whether the requirements are well-written, complete, unambiguous, and ready for implementation - NOT whether the implementation works.
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Execution Steps
+
+1. **Setup**: Run `.specify/scripts/bash/check-prerequisites.sh --json` from repo root and parse JSON for FEATURE_DIR and AVAILABLE_DOCS list.
+   - All file paths must be absolute.
+   - For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot").
+
+2. **Clarify intent (dynamic)**: Derive up to THREE initial contextual clarifying questions (no pre-baked catalog). They MUST:
+   - Be generated from the user's phrasing + extracted signals from spec/plan/tasks
+   - Only ask about information that materially changes checklist content
+   - Be skipped individually if already unambiguous in `$ARGUMENTS`
+   - Prefer precision over breadth
+
+   Generation algorithm:
+   1. Extract signals: feature domain keywords (e.g., auth, latency, UX, API), risk indicators ("critical", "must", "compliance"), stakeholder hints ("QA", "review", "security team"), and explicit deliverables ("a11y", "rollback", "contracts").
+   2. Cluster signals into candidate focus areas (max 4) ranked by relevance.
+   3. Identify probable audience & timing (author, reviewer, QA, release) if not explicit.
+   4. Detect missing dimensions: scope breadth, depth/rigor, risk emphasis, exclusion boundaries, measurable acceptance criteria.
+   5. Formulate questions chosen from these archetypes:
+      - Scope refinement (e.g., "Should this include integration touchpoints with X and Y or stay limited to local module correctness?")
+      - Risk prioritization (e.g., "Which of these potential risk areas should receive mandatory gating checks?")
+      - Depth calibration (e.g., "Is this a lightweight pre-commit sanity list or a formal release gate?")
+      - Audience framing (e.g., "Will this be used by the author only or peers during PR review?")
+      - Boundary exclusion (e.g., "Should we explicitly exclude performance tuning items this round?")
+      - Scenario class gap (e.g., "No recovery flows detected—are rollback / partial failure paths in scope?")
+
+   Question formatting rules:
+   - If presenting options, generate a compact table with columns: Option | Candidate | Why It Matters
+   - Limit to A–E options maximum; omit table if a free-form answer is clearer
+   - Never ask the user to restate what they already said
+   - Avoid speculative categories (no hallucination). If uncertain, ask explicitly: "Confirm whether X belongs in scope."
+
+   Defaults when interaction impossible:
+   - Depth: Standard
+   - Audience: Reviewer (PR) if code-related; Author otherwise
+   - Focus: Top 2 relevance clusters
+
+   Output the questions (label Q1/Q2/Q3). After answers: if ≥2 scenario classes (Alternate / Exception / Recovery / Non-Functional domain) remain unclear, you MAY ask up to TWO more targeted follow‑ups (Q4/Q5) with a one-line justification each (e.g., "Unresolved recovery path risk"). Do not exceed five total questions. Skip escalation if user explicitly declines more.
+
+3. **Understand user request**: Combine `$ARGUMENTS` + clarifying answers:
+   - Derive checklist theme (e.g., security, review, deploy, ux)
+   - Consolidate explicit must-have items mentioned by user
+   - Map focus selections to category scaffolding
+   - Infer any missing context from spec/plan/tasks (do NOT hallucinate)
+
+4. **Load feature context**: Read from FEATURE_DIR:
+   - spec.md: Feature requirements and scope
+   - plan.md (if exists): Technical details, dependencies
+   - tasks.md (if exists): Implementation tasks
+
+   **Context Loading Strategy**:
+   - Load only necessary portions relevant to active focus areas (avoid full-file dumping)
+   - Prefer summarizing long sections into concise scenario/requirement bullets
+   - Use progressive disclosure: add follow-on retrieval only if gaps detected
+   - If source docs are large, generate interim summary items instead of embedding raw text
+
+5. **Generate checklist** - Create "Unit Tests for Requirements":
+   - Create `FEATURE_DIR/checklists/` directory if it doesn't exist
+   - Generate unique checklist filename:
+     - Use short, descriptive name based on domain (e.g., `ux.md`, `api.md`, `security.md`)
+     - Format: `[domain].md`
+     - If file exists, append to existing file
+   - Number items sequentially starting from CHK001
+   - Each `/speckit.checklist` run creates a NEW file (never overwrites existing checklists)
+
+   **CORE PRINCIPLE - Test the Requirements, Not the Implementation**:
+   Every checklist item MUST evaluate the REQUIREMENTS THEMSELVES for:
+   - **Completeness**: Are all necessary requirements present?
+   - **Clarity**: Are requirements unambiguous and specific?
+   - **Consistency**: Do requirements align with each other?
+   - **Measurability**: Can requirements be objectively verified?
+   - **Coverage**: Are all scenarios/edge cases addressed?
+
+   **Category Structure** - Group items by requirement quality dimensions:
+   - **Requirement Completeness** (Are all necessary requirements documented?)
+   - **Requirement Clarity** (Are requirements specific and unambiguous?)
+   - **Requirement Consistency** (Do requirements align without conflicts?)
+   - **Acceptance Criteria Quality** (Are success criteria measurable?)
+   - **Scenario Coverage** (Are all flows/cases addressed?)
+   - **Edge Case Coverage** (Are boundary conditions defined?)
+   - **Non-Functional Requirements** (Performance, Security, Accessibility, etc. - are they specified?)
+   - **Dependencies & Assumptions** (Are they documented and validated?)
+   - **Ambiguities & Conflicts** (What needs clarification?)
+
+   **HOW TO WRITE CHECKLIST ITEMS - "Unit Tests for English"**:
+
+   ❌ **WRONG** (Testing implementation):
+   - "Verify landing page displays 3 episode cards"
+   - "Test hover states work on desktop"
+   - "Confirm logo click navigates home"
+
+   ✅ **CORRECT** (Testing requirements quality):
+   - "Are the exact number and layout of featured episodes specified?" [Completeness]
+   - "Is 'prominent display' quantified with specific sizing/positioning?" [Clarity]
+   - "Are hover state requirements consistent across all interactive elements?" [Consistency]
+   - "Are keyboard navigation requirements defined for all interactive UI?" [Coverage]
+   - "Is the fallback behavior specified when logo image fails to load?" [Edge Cases]
+   - "Are loading states defined for asynchronous episode data?" [Completeness]
+   - "Does the spec define visual hierarchy for competing UI elements?" [Clarity]
+
+   **ITEM STRUCTURE**:
+   Each item should follow this pattern:
+   - Question format asking about requirement quality
+   - Focus on what's WRITTEN (or not written) in the spec/plan
+   - Include quality dimension in brackets [Completeness/Clarity/Consistency/etc.]
+   - Reference spec section `[Spec §X.Y]` when checking existing requirements
+   - Use `[Gap]` marker when checking for missing requirements
+
+   **EXAMPLES BY QUALITY DIMENSION**:
+
+   Completeness:
+   - "Are error handling requirements defined for all API failure modes? [Gap]"
+   - "Are accessibility requirements specified for all interactive elements? [Completeness]"
+   - "Are mobile breakpoint requirements defined for responsive layouts? [Gap]"
+
+   Clarity:
+   - "Is 'fast loading' quantified with specific timing thresholds? [Clarity, Spec §NFR-2]"
+   - "Are 'related episodes' selection criteria explicitly defined? [Clarity, Spec §FR-5]"
+   - "Is 'prominent' defined with measurable visual properties? [Ambiguity, Spec §FR-4]"
+
+   Consistency:
+   - "Do navigation requirements align across all pages? [Consistency, Spec §FR-10]"
+   - "Are card component requirements consistent between landing and detail pages? [Consistency]"
+
+   Coverage:
+   - "Are requirements defined for zero-state scenarios (no episodes)? [Coverage, Edge Case]"
+   - "Are concurrent user interaction scenarios addressed? [Coverage, Gap]"
+   - "Are requirements specified for partial data loading failures? [Coverage, Exception Flow]"
+
+   Measurability:
+   - "Are visual hierarchy requirements measurable/testable? [Acceptance Criteria, Spec §FR-1]"
+   - "Can 'balanced visual weight' be objectively verified? [Measurability, Spec §FR-2]"
+
+   **Scenario Classification & Coverage** (Requirements Quality Focus):
+   - Check if requirements exist for: Primary, Alternate, Exception/Error, Recovery, Non-Functional scenarios
+   - For each scenario class, ask: "Are [scenario type] requirements complete, clear, and consistent?"
+   - If scenario class missing: "Are [scenario type] requirements intentionally excluded or missing? [Gap]"
+   - Include resilience/rollback when state mutation occurs: "Are rollback requirements defined for migration failures? [Gap]"
+
+   **Traceability Requirements**:
+   - MINIMUM: ≥80% of items MUST include at least one traceability reference
+   - Each item should reference: spec section `[Spec §X.Y]`, or use markers: `[Gap]`, `[Ambiguity]`, `[Conflict]`, `[Assumption]`
+   - If no ID system exists: "Is a requirement & acceptance criteria ID scheme established? [Traceability]"
+
+   **Surface & Resolve Issues** (Requirements Quality Problems):
+   Ask questions about the requirements themselves:
+   - Ambiguities: "Is the term 'fast' quantified with specific metrics? [Ambiguity, Spec §NFR-1]"
+   - Conflicts: "Do navigation requirements conflict between §FR-10 and §FR-10a? [Conflict]"
+   - Assumptions: "Is the assumption of 'always available podcast API' validated? [Assumption]"
+   - Dependencies: "Are external podcast API requirements documented? [Dependency, Gap]"
+   - Missing definitions: "Is 'visual hierarchy' defined with measurable criteria? [Gap]"
+
+   **Content Consolidation**:
+   - Soft cap: If raw candidate items > 40, prioritize by risk/impact
+   - Merge near-duplicates checking the same requirement aspect
+   - If >5 low-impact edge cases, create one item: "Are edge cases X, Y, Z addressed in requirements? [Coverage]"
+
+   **🚫 ABSOLUTELY PROHIBITED** - These make it an implementation test, not a requirements test:
+   - ❌ Any item starting with "Verify", "Test", "Confirm", "Check" + implementation behavior
+   - ❌ References to code execution, user actions, system behavior
+   - ❌ "Displays correctly", "works properly", "functions as expected"
+   - ❌ "Click", "navigate", "render", "load", "execute"
+   - ❌ Test cases, test plans, QA procedures
+   - ❌ Implementation details (frameworks, APIs, algorithms)
+
+   **✅ REQUIRED PATTERNS** - These test requirements quality:
+   - ✅ "Are [requirement type] defined/specified/documented for [scenario]?"
+   - ✅ "Is [vague term] quantified/clarified with specific criteria?"
+   - ✅ "Are requirements consistent between [section A] and [section B]?"
+   - ✅ "Can [requirement] be objectively measured/verified?"
+   - ✅ "Are [edge cases/scenarios] addressed in requirements?"
+   - ✅ "Does the spec define [missing aspect]?"
+
+6. **Structure Reference**: Generate the checklist following the canonical template in `.specify/templates/checklist-template.md` for title, meta section, category headings, and ID formatting. If template is unavailable, use: H1 title, purpose/created meta lines, `##` category sections containing `- [ ] CHK### <requirement item>` lines with globally incrementing IDs starting at CHK001.
+
+7. **Report**: Output full path to created checklist, item count, and remind user that each run creates a new file. Summarize:
+   - Focus areas selected
+   - Depth level
+   - Actor/timing
+   - Any explicit user-specified must-have items incorporated
+
+**Important**: Each `/speckit.checklist` command invocation creates a checklist file using short, descriptive names unless file already exists. This allows:
+
+- Multiple checklists of different types (e.g., `ux.md`, `test.md`, `security.md`)
+- Simple, memorable filenames that indicate checklist purpose
+- Easy identification and navigation in the `checklists/` folder
+
+To avoid clutter, use descriptive types and clean up obsolete checklists when done.
+
+## Example Checklist Types & Sample Items
+
+**UX Requirements Quality:** `ux.md`
+
+Sample items (testing the requirements, NOT the implementation):
+
+- "Are visual hierarchy requirements defined with measurable criteria? [Clarity, Spec §FR-1]"
+- "Is the number and positioning of UI elements explicitly specified? [Completeness, Spec §FR-1]"
+- "Are interaction state requirements (hover, focus, active) consistently defined? [Consistency]"
+- "Are accessibility requirements specified for all interactive elements? [Coverage, Gap]"
+- "Is fallback behavior defined when images fail to load? [Edge Case, Gap]"
+- "Can 'prominent display' be objectively measured? [Measurability, Spec §FR-4]"
+
+**API Requirements Quality:** `api.md`
+
+Sample items:
+
+- "Are error response formats specified for all failure scenarios? [Completeness]"
+- "Are rate limiting requirements quantified with specific thresholds? [Clarity]"
+- "Are authentication requirements consistent across all endpoints? [Consistency]"
+- "Are retry/timeout requirements defined for external dependencies? [Coverage, Gap]"
+- "Is versioning strategy documented in requirements? [Gap]"
+
+**Performance Requirements Quality:** `performance.md`
+
+Sample items:
+
+- "Are performance requirements quantified with specific metrics? [Clarity]"
+- "Are performance targets defined for all critical user journeys? [Coverage]"
+- "Are performance requirements under different load conditions specified? [Completeness]"
+- "Can performance requirements be objectively measured? [Measurability]"
+- "Are degradation requirements defined for high-load scenarios? [Edge Case, Gap]"
+
+**Security Requirements Quality:** `security.md`
+
+Sample items:
+
+- "Are authentication requirements specified for all protected resources? [Coverage]"
+- "Are data protection requirements defined for sensitive information? [Completeness]"
+- "Is the threat model documented and requirements aligned to it? [Traceability]"
+- "Are security requirements consistent with compliance obligations? [Consistency]"
+- "Are security failure/breach response requirements defined? [Gap, Exception Flow]"
+
+## Anti-Examples: What NOT To Do
+
+**❌ WRONG - These test implementation, not requirements:**
+
+```markdown
+- [ ] CHK001 - Verify landing page displays 3 episode cards [Spec §FR-001]
+- [ ] CHK002 - Test hover states work correctly on desktop [Spec §FR-003]
+- [ ] CHK003 - Confirm logo click navigates to home page [Spec §FR-010]
+- [ ] CHK004 - Check that related episodes section shows 3-5 items [Spec §FR-005]
+```
+
+**✅ CORRECT - These test requirements quality:**
+
+```markdown
+- [ ] CHK001 - Are the number and layout of featured episodes explicitly specified? [Completeness, Spec §FR-001]
+- [ ] CHK002 - Are hover state requirements consistently defined for all interactive elements? [Consistency, Spec §FR-003]
+- [ ] CHK003 - Are navigation requirements clear for all clickable brand elements? [Clarity, Spec §FR-010]
+- [ ] CHK004 - Is the selection criteria for related episodes documented? [Gap, Spec §FR-005]
+- [ ] CHK005 - Are loading state requirements defined for asynchronous episode data? [Gap]
+- [ ] CHK006 - Can "visual hierarchy" requirements be objectively measured? [Measurability, Spec §FR-001]
+```
+
+**Key Differences:**
+
+- Wrong: Tests if the system works correctly
+- Correct: Tests if the requirements are written correctly
+- Wrong: Verification of behavior
+- Correct: Validation of requirement quality
+- Wrong: "Does it do X?"
+- Correct: "Is X clearly specified?"

--- a/.codex/prompts/speckit.clarify.md
+++ b/.codex/prompts/speckit.clarify.md
@@ -1,0 +1,181 @@
+---
+description: Identify underspecified areas in the current feature spec by asking up to 5 highly targeted clarification questions and encoding answers back into the spec.
+handoffs: 
+  - label: Build Technical Plan
+    agent: speckit.plan
+    prompt: Create a plan for the spec. I am building with...
+---
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Outline
+
+Goal: Detect and reduce ambiguity or missing decision points in the active feature specification and record the clarifications directly in the spec file.
+
+Note: This clarification workflow is expected to run (and be completed) BEFORE invoking `/speckit.plan`. If the user explicitly states they are skipping clarification (e.g., exploratory spike), you may proceed, but must warn that downstream rework risk increases.
+
+Execution steps:
+
+1. Run `.specify/scripts/bash/check-prerequisites.sh --json --paths-only` from repo root **once** (combined `--json --paths-only` mode / `-Json -PathsOnly`). Parse minimal JSON payload fields:
+   - `FEATURE_DIR`
+   - `FEATURE_SPEC`
+   - (Optionally capture `IMPL_PLAN`, `TASKS` for future chained flows.)
+   - If JSON parsing fails, abort and instruct user to re-run `/speckit.specify` or verify feature branch environment.
+   - For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot").
+
+2. Load the current spec file. Perform a structured ambiguity & coverage scan using this taxonomy. For each category, mark status: Clear / Partial / Missing. Produce an internal coverage map used for prioritization (do not output raw map unless no questions will be asked).
+
+   Functional Scope & Behavior:
+   - Core user goals & success criteria
+   - Explicit out-of-scope declarations
+   - User roles / personas differentiation
+
+   Domain & Data Model:
+   - Entities, attributes, relationships
+   - Identity & uniqueness rules
+   - Lifecycle/state transitions
+   - Data volume / scale assumptions
+
+   Interaction & UX Flow:
+   - Critical user journeys / sequences
+   - Error/empty/loading states
+   - Accessibility or localization notes
+
+   Non-Functional Quality Attributes:
+   - Performance (latency, throughput targets)
+   - Scalability (horizontal/vertical, limits)
+   - Reliability & availability (uptime, recovery expectations)
+   - Observability (logging, metrics, tracing signals)
+   - Security & privacy (authN/Z, data protection, threat assumptions)
+   - Compliance / regulatory constraints (if any)
+
+   Integration & External Dependencies:
+   - External services/APIs and failure modes
+   - Data import/export formats
+   - Protocol/versioning assumptions
+
+   Edge Cases & Failure Handling:
+   - Negative scenarios
+   - Rate limiting / throttling
+   - Conflict resolution (e.g., concurrent edits)
+
+   Constraints & Tradeoffs:
+   - Technical constraints (language, storage, hosting)
+   - Explicit tradeoffs or rejected alternatives
+
+   Terminology & Consistency:
+   - Canonical glossary terms
+   - Avoided synonyms / deprecated terms
+
+   Completion Signals:
+   - Acceptance criteria testability
+   - Measurable Definition of Done style indicators
+
+   Misc / Placeholders:
+   - TODO markers / unresolved decisions
+   - Ambiguous adjectives ("robust", "intuitive") lacking quantification
+
+   For each category with Partial or Missing status, add a candidate question opportunity unless:
+   - Clarification would not materially change implementation or validation strategy
+   - Information is better deferred to planning phase (note internally)
+
+3. Generate (internally) a prioritized queue of candidate clarification questions (maximum 5). Do NOT output them all at once. Apply these constraints:
+    - Maximum of 10 total questions across the whole session.
+    - Each question must be answerable with EITHER:
+       - A short multiple‑choice selection (2–5 distinct, mutually exclusive options), OR
+       - A one-word / short‑phrase answer (explicitly constrain: "Answer in <=5 words").
+    - Only include questions whose answers materially impact architecture, data modeling, task decomposition, test design, UX behavior, operational readiness, or compliance validation.
+    - Ensure category coverage balance: attempt to cover the highest impact unresolved categories first; avoid asking two low-impact questions when a single high-impact area (e.g., security posture) is unresolved.
+    - Exclude questions already answered, trivial stylistic preferences, or plan-level execution details (unless blocking correctness).
+    - Favor clarifications that reduce downstream rework risk or prevent misaligned acceptance tests.
+    - If more than 5 categories remain unresolved, select the top 5 by (Impact * Uncertainty) heuristic.
+
+4. Sequential questioning loop (interactive):
+    - Present EXACTLY ONE question at a time.
+    - For multiple‑choice questions:
+       - **Analyze all options** and determine the **most suitable option** based on:
+          - Best practices for the project type
+          - Common patterns in similar implementations
+          - Risk reduction (security, performance, maintainability)
+          - Alignment with any explicit project goals or constraints visible in the spec
+       - Present your **recommended option prominently** at the top with clear reasoning (1-2 sentences explaining why this is the best choice).
+       - Format as: `**Recommended:** Option [X] - <reasoning>`
+       - Then render all options as a Markdown table:
+
+       | Option | Description |
+       |--------|-------------|
+       | A | <Option A description> |
+       | B | <Option B description> |
+       | C | <Option C description> (add D/E as needed up to 5) |
+       | Short | Provide a different short answer (<=5 words) (Include only if free-form alternative is appropriate) |
+
+       - After the table, add: `You can reply with the option letter (e.g., "A"), accept the recommendation by saying "yes" or "recommended", or provide your own short answer.`
+    - For short‑answer style (no meaningful discrete options):
+       - Provide your **suggested answer** based on best practices and context.
+       - Format as: `**Suggested:** <your proposed answer> - <brief reasoning>`
+       - Then output: `Format: Short answer (<=5 words). You can accept the suggestion by saying "yes" or "suggested", or provide your own answer.`
+    - After the user answers:
+       - If the user replies with "yes", "recommended", or "suggested", use your previously stated recommendation/suggestion as the answer.
+       - Otherwise, validate the answer maps to one option or fits the <=5 word constraint.
+       - If ambiguous, ask for a quick disambiguation (count still belongs to same question; do not advance).
+       - Once satisfactory, record it in working memory (do not yet write to disk) and move to the next queued question.
+    - Stop asking further questions when:
+       - All critical ambiguities resolved early (remaining queued items become unnecessary), OR
+       - User signals completion ("done", "good", "no more"), OR
+       - You reach 5 asked questions.
+    - Never reveal future queued questions in advance.
+    - If no valid questions exist at start, immediately report no critical ambiguities.
+
+5. Integration after EACH accepted answer (incremental update approach):
+    - Maintain in-memory representation of the spec (loaded once at start) plus the raw file contents.
+    - For the first integrated answer in this session:
+       - Ensure a `## Clarifications` section exists (create it just after the highest-level contextual/overview section per the spec template if missing).
+       - Under it, create (if not present) a `### Session YYYY-MM-DD` subheading for today.
+    - Append a bullet line immediately after acceptance: `- Q: <question> → A: <final answer>`.
+    - Then immediately apply the clarification to the most appropriate section(s):
+       - Functional ambiguity → Update or add a bullet in Functional Requirements.
+       - User interaction / actor distinction → Update User Stories or Actors subsection (if present) with clarified role, constraint, or scenario.
+       - Data shape / entities → Update Data Model (add fields, types, relationships) preserving ordering; note added constraints succinctly.
+       - Non-functional constraint → Add/modify measurable criteria in Non-Functional / Quality Attributes section (convert vague adjective to metric or explicit target).
+       - Edge case / negative flow → Add a new bullet under Edge Cases / Error Handling (or create such subsection if template provides placeholder for it).
+       - Terminology conflict → Normalize term across spec; retain original only if necessary by adding `(formerly referred to as "X")` once.
+    - If the clarification invalidates an earlier ambiguous statement, replace that statement instead of duplicating; leave no obsolete contradictory text.
+    - Save the spec file AFTER each integration to minimize risk of context loss (atomic overwrite).
+    - Preserve formatting: do not reorder unrelated sections; keep heading hierarchy intact.
+    - Keep each inserted clarification minimal and testable (avoid narrative drift).
+
+6. Validation (performed after EACH write plus final pass):
+   - Clarifications session contains exactly one bullet per accepted answer (no duplicates).
+   - Total asked (accepted) questions ≤ 5.
+   - Updated sections contain no lingering vague placeholders the new answer was meant to resolve.
+   - No contradictory earlier statement remains (scan for now-invalid alternative choices removed).
+   - Markdown structure valid; only allowed new headings: `## Clarifications`, `### Session YYYY-MM-DD`.
+   - Terminology consistency: same canonical term used across all updated sections.
+
+7. Write the updated spec back to `FEATURE_SPEC`.
+
+8. Report completion (after questioning loop ends or early termination):
+   - Number of questions asked & answered.
+   - Path to updated spec.
+   - Sections touched (list names).
+   - Coverage summary table listing each taxonomy category with Status: Resolved (was Partial/Missing and addressed), Deferred (exceeds question quota or better suited for planning), Clear (already sufficient), Outstanding (still Partial/Missing but low impact).
+   - If any Outstanding or Deferred remain, recommend whether to proceed to `/speckit.plan` or run `/speckit.clarify` again later post-plan.
+   - Suggested next command.
+
+Behavior rules:
+
+- If no meaningful ambiguities found (or all potential questions would be low-impact), respond: "No critical ambiguities detected worth formal clarification." and suggest proceeding.
+- If spec file missing, instruct user to run `/speckit.specify` first (do not create a new spec here).
+- Never exceed 5 total asked questions (clarification retries for a single question do not count as new questions).
+- Avoid speculative tech stack questions unless the absence blocks functional clarity.
+- Respect user early termination signals ("stop", "done", "proceed").
+- If no questions asked due to full coverage, output a compact coverage summary (all categories Clear) then suggest advancing.
+- If quota reached with unresolved high-impact categories remaining, explicitly flag them under Deferred with rationale.
+
+Context for prioritization: $ARGUMENTS

--- a/.codex/prompts/speckit.constitution.md
+++ b/.codex/prompts/speckit.constitution.md
@@ -1,0 +1,82 @@
+---
+description: Create or update the project constitution from interactive or provided principle inputs, ensuring all dependent templates stay in sync.
+handoffs: 
+  - label: Build Specification
+    agent: speckit.specify
+    prompt: Implement the feature specification based on the updated constitution. I want to build...
+---
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Outline
+
+You are updating the project constitution at `.specify/memory/constitution.md`. This file is a TEMPLATE containing placeholder tokens in square brackets (e.g. `[PROJECT_NAME]`, `[PRINCIPLE_1_NAME]`). Your job is to (a) collect/derive concrete values, (b) fill the template precisely, and (c) propagate any amendments across dependent artifacts.
+
+Follow this execution flow:
+
+1. Load the existing constitution template at `.specify/memory/constitution.md`.
+   - Identify every placeholder token of the form `[ALL_CAPS_IDENTIFIER]`.
+   **IMPORTANT**: The user might require less or more principles than the ones used in the template. If a number is specified, respect that - follow the general template. You will update the doc accordingly.
+
+2. Collect/derive values for placeholders:
+   - If user input (conversation) supplies a value, use it.
+   - Otherwise infer from existing repo context (README, docs, prior constitution versions if embedded).
+   - For governance dates: `RATIFICATION_DATE` is the original adoption date (if unknown ask or mark TODO), `LAST_AMENDED_DATE` is today if changes are made, otherwise keep previous.
+   - `CONSTITUTION_VERSION` must increment according to semantic versioning rules:
+     - MAJOR: Backward incompatible governance/principle removals or redefinitions.
+     - MINOR: New principle/section added or materially expanded guidance.
+     - PATCH: Clarifications, wording, typo fixes, non-semantic refinements.
+   - If version bump type ambiguous, propose reasoning before finalizing.
+
+3. Draft the updated constitution content:
+   - Replace every placeholder with concrete text (no bracketed tokens left except intentionally retained template slots that the project has chosen not to define yet—explicitly justify any left).
+   - Preserve heading hierarchy and comments can be removed once replaced unless they still add clarifying guidance.
+   - Ensure each Principle section: succinct name line, paragraph (or bullet list) capturing non‑negotiable rules, explicit rationale if not obvious.
+   - Ensure Governance section lists amendment procedure, versioning policy, and compliance review expectations.
+
+4. Consistency propagation checklist (convert prior checklist into active validations):
+   - Read `.specify/templates/plan-template.md` and ensure any "Constitution Check" or rules align with updated principles.
+   - Read `.specify/templates/spec-template.md` for scope/requirements alignment—update if constitution adds/removes mandatory sections or constraints.
+   - Read `.specify/templates/tasks-template.md` and ensure task categorization reflects new or removed principle-driven task types (e.g., observability, versioning, testing discipline).
+   - Read each command file in `.specify/templates/commands/*.md` (including this one) to verify no outdated references (agent-specific names like CLAUDE only) remain when generic guidance is required.
+   - Read any runtime guidance docs (e.g., `README.md`, `docs/quickstart.md`, or agent-specific guidance files if present). Update references to principles changed.
+
+5. Produce a Sync Impact Report (prepend as an HTML comment at top of the constitution file after update):
+   - Version change: old → new
+   - List of modified principles (old title → new title if renamed)
+   - Added sections
+   - Removed sections
+   - Templates requiring updates (✅ updated / ⚠ pending) with file paths
+   - Follow-up TODOs if any placeholders intentionally deferred.
+
+6. Validation before final output:
+   - No remaining unexplained bracket tokens.
+   - Version line matches report.
+   - Dates ISO format YYYY-MM-DD.
+   - Principles are declarative, testable, and free of vague language ("should" → replace with MUST/SHOULD rationale where appropriate).
+
+7. Write the completed constitution back to `.specify/memory/constitution.md` (overwrite).
+
+8. Output a final summary to the user with:
+   - New version and bump rationale.
+   - Any files flagged for manual follow-up.
+   - Suggested commit message (e.g., `docs: amend constitution to vX.Y.Z (principle additions + governance update)`).
+
+Formatting & Style Requirements:
+
+- Use Markdown headings exactly as in the template (do not demote/promote levels).
+- Wrap long rationale lines to keep readability (<100 chars ideally) but do not hard enforce with awkward breaks.
+- Keep a single blank line between sections.
+- Avoid trailing whitespace.
+
+If the user supplies partial updates (e.g., only one principle revision), still perform validation and version decision steps.
+
+If critical info missing (e.g., ratification date truly unknown), insert `TODO(<FIELD_NAME>): explanation` and include in the Sync Impact Report under deferred items.
+
+Do not create a new template; always operate on the existing `.specify/memory/constitution.md` file.

--- a/.codex/prompts/speckit.implement.md
+++ b/.codex/prompts/speckit.implement.md
@@ -1,0 +1,135 @@
+---
+description: Execute the implementation plan by processing and executing all tasks defined in tasks.md
+---
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Outline
+
+1. Run `.specify/scripts/bash/check-prerequisites.sh --json --require-tasks --include-tasks` from repo root and parse FEATURE_DIR and AVAILABLE_DOCS list. All paths must be absolute. For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot").
+
+2. **Check checklists status** (if FEATURE_DIR/checklists/ exists):
+   - Scan all checklist files in the checklists/ directory
+   - For each checklist, count:
+     - Total items: All lines matching `- [ ]` or `- [X]` or `- [x]`
+     - Completed items: Lines matching `- [X]` or `- [x]`
+     - Incomplete items: Lines matching `- [ ]`
+   - Create a status table:
+
+     ```text
+     | Checklist | Total | Completed | Incomplete | Status |
+     |-----------|-------|-----------|------------|--------|
+     | ux.md     | 12    | 12        | 0          | ✓ PASS |
+     | test.md   | 8     | 5         | 3          | ✗ FAIL |
+     | security.md | 6   | 6         | 0          | ✓ PASS |
+     ```
+
+   - Calculate overall status:
+     - **PASS**: All checklists have 0 incomplete items
+     - **FAIL**: One or more checklists have incomplete items
+
+   - **If any checklist is incomplete**:
+     - Display the table with incomplete item counts
+     - **STOP** and ask: "Some checklists are incomplete. Do you want to proceed with implementation anyway? (yes/no)"
+     - Wait for user response before continuing
+     - If user says "no" or "wait" or "stop", halt execution
+     - If user says "yes" or "proceed" or "continue", proceed to step 3
+
+   - **If all checklists are complete**:
+     - Display the table showing all checklists passed
+     - Automatically proceed to step 3
+
+3. Load and analyze the implementation context:
+   - **REQUIRED**: Read tasks.md for the complete task list and execution plan
+   - **REQUIRED**: Read plan.md for tech stack, architecture, and file structure
+   - **IF EXISTS**: Read data-model.md for entities and relationships
+   - **IF EXISTS**: Read contracts/ for API specifications and test requirements
+   - **IF EXISTS**: Read research.md for technical decisions and constraints
+   - **IF EXISTS**: Read quickstart.md for integration scenarios
+
+4. **Project Setup Verification**:
+   - **REQUIRED**: Create/verify ignore files based on actual project setup:
+
+   **Detection & Creation Logic**:
+   - Check if the following command succeeds to determine if the repository is a git repo (create/verify .gitignore if so):
+
+     ```sh
+     git rev-parse --git-dir 2>/dev/null
+     ```
+
+   - Check if Dockerfile* exists or Docker in plan.md → create/verify .dockerignore
+   - Check if .eslintrc* exists → create/verify .eslintignore
+   - Check if eslint.config.* exists → ensure the config's `ignores` entries cover required patterns
+   - Check if .prettierrc* exists → create/verify .prettierignore
+   - Check if .npmrc or package.json exists → create/verify .npmignore (if publishing)
+   - Check if terraform files (*.tf) exist → create/verify .terraformignore
+   - Check if .helmignore needed (helm charts present) → create/verify .helmignore
+
+   **If ignore file already exists**: Verify it contains essential patterns, append missing critical patterns only
+   **If ignore file missing**: Create with full pattern set for detected technology
+
+   **Common Patterns by Technology** (from plan.md tech stack):
+   - **Node.js/JavaScript/TypeScript**: `node_modules/`, `dist/`, `build/`, `*.log`, `.env*`
+   - **Python**: `__pycache__/`, `*.pyc`, `.venv/`, `venv/`, `dist/`, `*.egg-info/`
+   - **Java**: `target/`, `*.class`, `*.jar`, `.gradle/`, `build/`
+   - **C#/.NET**: `bin/`, `obj/`, `*.user`, `*.suo`, `packages/`
+   - **Go**: `*.exe`, `*.test`, `vendor/`, `*.out`
+   - **Ruby**: `.bundle/`, `log/`, `tmp/`, `*.gem`, `vendor/bundle/`
+   - **PHP**: `vendor/`, `*.log`, `*.cache`, `*.env`
+   - **Rust**: `target/`, `debug/`, `release/`, `*.rs.bk`, `*.rlib`, `*.prof*`, `.idea/`, `*.log`, `.env*`
+   - **Kotlin**: `build/`, `out/`, `.gradle/`, `.idea/`, `*.class`, `*.jar`, `*.iml`, `*.log`, `.env*`
+   - **C++**: `build/`, `bin/`, `obj/`, `out/`, `*.o`, `*.so`, `*.a`, `*.exe`, `*.dll`, `.idea/`, `*.log`, `.env*`
+   - **C**: `build/`, `bin/`, `obj/`, `out/`, `*.o`, `*.a`, `*.so`, `*.exe`, `Makefile`, `config.log`, `.idea/`, `*.log`, `.env*`
+   - **Swift**: `.build/`, `DerivedData/`, `*.swiftpm/`, `Packages/`
+   - **R**: `.Rproj.user/`, `.Rhistory`, `.RData`, `.Ruserdata`, `*.Rproj`, `packrat/`, `renv/`
+   - **Universal**: `.DS_Store`, `Thumbs.db`, `*.tmp`, `*.swp`, `.vscode/`, `.idea/`
+
+   **Tool-Specific Patterns**:
+   - **Docker**: `node_modules/`, `.git/`, `Dockerfile*`, `.dockerignore`, `*.log*`, `.env*`, `coverage/`
+   - **ESLint**: `node_modules/`, `dist/`, `build/`, `coverage/`, `*.min.js`
+   - **Prettier**: `node_modules/`, `dist/`, `build/`, `coverage/`, `package-lock.json`, `yarn.lock`, `pnpm-lock.yaml`
+   - **Terraform**: `.terraform/`, `*.tfstate*`, `*.tfvars`, `.terraform.lock.hcl`
+   - **Kubernetes/k8s**: `*.secret.yaml`, `secrets/`, `.kube/`, `kubeconfig*`, `*.key`, `*.crt`
+
+5. Parse tasks.md structure and extract:
+   - **Task phases**: Setup, Tests, Core, Integration, Polish
+   - **Task dependencies**: Sequential vs parallel execution rules
+   - **Task details**: ID, description, file paths, parallel markers [P]
+   - **Execution flow**: Order and dependency requirements
+
+6. Execute implementation following the task plan:
+   - **Phase-by-phase execution**: Complete each phase before moving to the next
+   - **Respect dependencies**: Run sequential tasks in order, parallel tasks [P] can run together  
+   - **Follow TDD approach**: Execute test tasks before their corresponding implementation tasks
+   - **File-based coordination**: Tasks affecting the same files must run sequentially
+   - **Validation checkpoints**: Verify each phase completion before proceeding
+
+7. Implementation execution rules:
+   - **Setup first**: Initialize project structure, dependencies, configuration
+   - **Tests before code**: If you need to write tests for contracts, entities, and integration scenarios
+   - **Core development**: Implement models, services, CLI commands, endpoints
+   - **Integration work**: Database connections, middleware, logging, external services
+   - **Polish and validation**: Unit tests, performance optimization, documentation
+
+8. Progress tracking and error handling:
+   - Report progress after each completed task
+   - Halt execution if any non-parallel task fails
+   - For parallel tasks [P], continue with successful tasks, report failed ones
+   - Provide clear error messages with context for debugging
+   - Suggest next steps if implementation cannot proceed
+   - **IMPORTANT** For completed tasks, make sure to mark the task off as [X] in the tasks file.
+
+9. Completion validation:
+   - Verify all required tasks are completed
+   - Check that implemented features match the original specification
+   - Validate that tests pass and coverage meets requirements
+   - Confirm the implementation follows the technical plan
+   - Report final status with summary of completed work
+
+Note: This command assumes a complete task breakdown exists in tasks.md. If tasks are incomplete or missing, suggest running `/speckit.tasks` first to regenerate the task list.

--- a/.codex/prompts/speckit.plan.md
+++ b/.codex/prompts/speckit.plan.md
@@ -1,0 +1,89 @@
+---
+description: Execute the implementation planning workflow using the plan template to generate design artifacts.
+handoffs: 
+  - label: Create Tasks
+    agent: speckit.tasks
+    prompt: Break the plan into tasks
+    send: true
+  - label: Create Checklist
+    agent: speckit.checklist
+    prompt: Create a checklist for the following domain...
+---
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Outline
+
+1. **Setup**: Run `.specify/scripts/bash/setup-plan.sh --json` from repo root and parse JSON for FEATURE_SPEC, IMPL_PLAN, SPECS_DIR, BRANCH. For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot").
+
+2. **Load context**: Read FEATURE_SPEC and `.specify/memory/constitution.md`. Load IMPL_PLAN template (already copied).
+
+3. **Execute plan workflow**: Follow the structure in IMPL_PLAN template to:
+   - Fill Technical Context (mark unknowns as "NEEDS CLARIFICATION")
+   - Fill Constitution Check section from constitution
+   - Evaluate gates (ERROR if violations unjustified)
+   - Phase 0: Generate research.md (resolve all NEEDS CLARIFICATION)
+   - Phase 1: Generate data-model.md, contracts/, quickstart.md
+   - Phase 1: Update agent context by running the agent script
+   - Re-evaluate Constitution Check post-design
+
+4. **Stop and report**: Command ends after Phase 2 planning. Report branch, IMPL_PLAN path, and generated artifacts.
+
+## Phases
+
+### Phase 0: Outline & Research
+
+1. **Extract unknowns from Technical Context** above:
+   - For each NEEDS CLARIFICATION → research task
+   - For each dependency → best practices task
+   - For each integration → patterns task
+
+2. **Generate and dispatch research agents**:
+
+   ```text
+   For each unknown in Technical Context:
+     Task: "Research {unknown} for {feature context}"
+   For each technology choice:
+     Task: "Find best practices for {tech} in {domain}"
+   ```
+
+3. **Consolidate findings** in `research.md` using format:
+   - Decision: [what was chosen]
+   - Rationale: [why chosen]
+   - Alternatives considered: [what else evaluated]
+
+**Output**: research.md with all NEEDS CLARIFICATION resolved
+
+### Phase 1: Design & Contracts
+
+**Prerequisites:** `research.md` complete
+
+1. **Extract entities from feature spec** → `data-model.md`:
+   - Entity name, fields, relationships
+   - Validation rules from requirements
+   - State transitions if applicable
+
+2. **Generate API contracts** from functional requirements:
+   - For each user action → endpoint
+   - Use standard REST/GraphQL patterns
+   - Output OpenAPI/GraphQL schema to `/contracts/`
+
+3. **Agent context update**:
+   - Run `.specify/scripts/bash/update-agent-context.sh codex`
+   - These scripts detect which AI agent is in use
+   - Update the appropriate agent-specific context file
+   - Add only new technology from current plan
+   - Preserve manual additions between markers
+
+**Output**: data-model.md, /contracts/*, quickstart.md, agent-specific file
+
+## Key rules
+
+- Use absolute paths
+- ERROR on gate failures or unresolved clarifications

--- a/.codex/prompts/speckit.specify.md
+++ b/.codex/prompts/speckit.specify.md
@@ -1,0 +1,258 @@
+---
+description: Create or update the feature specification from a natural language feature description.
+handoffs: 
+  - label: Build Technical Plan
+    agent: speckit.plan
+    prompt: Create a plan for the spec. I am building with...
+  - label: Clarify Spec Requirements
+    agent: speckit.clarify
+    prompt: Clarify specification requirements
+    send: true
+---
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Outline
+
+The text the user typed after `/speckit.specify` in the triggering message **is** the feature description. Assume you always have it available in this conversation even if `$ARGUMENTS` appears literally below. Do not ask the user to repeat it unless they provided an empty command.
+
+Given that feature description, do this:
+
+1. **Generate a concise short name** (2-4 words) for the branch:
+   - Analyze the feature description and extract the most meaningful keywords
+   - Create a 2-4 word short name that captures the essence of the feature
+   - Use action-noun format when possible (e.g., "add-user-auth", "fix-payment-bug")
+   - Preserve technical terms and acronyms (OAuth2, API, JWT, etc.)
+   - Keep it concise but descriptive enough to understand the feature at a glance
+   - Examples:
+     - "I want to add user authentication" → "user-auth"
+     - "Implement OAuth2 integration for the API" → "oauth2-api-integration"
+     - "Create a dashboard for analytics" → "analytics-dashboard"
+     - "Fix payment processing timeout bug" → "fix-payment-timeout"
+
+2. **Check for existing branches before creating new one**:
+
+   a. First, fetch all remote branches to ensure we have the latest information:
+
+      ```bash
+      git fetch --all --prune
+      ```
+
+   b. Find the highest feature number across all sources for the short-name:
+      - Remote branches: `git ls-remote --heads origin | grep -E 'refs/heads/[0-9]+-<short-name>$'`
+      - Local branches: `git branch | grep -E '^[* ]*[0-9]+-<short-name>$'`
+      - Specs directories: Check for directories matching `specs/[0-9]+-<short-name>`
+
+   c. Determine the next available number:
+      - Extract all numbers from all three sources
+      - Find the highest number N
+      - Use N+1 for the new branch number
+
+   d. Run the script `.specify/scripts/bash/create-new-feature.sh --json "$ARGUMENTS"` with the calculated number and short-name:
+      - Pass `--number N+1` and `--short-name "your-short-name"` along with the feature description
+      - Bash example: `.specify/scripts/bash/create-new-feature.sh --json "$ARGUMENTS" --json --number 5 --short-name "user-auth" "Add user authentication"`
+      - PowerShell example: `.specify/scripts/bash/create-new-feature.sh --json "$ARGUMENTS" -Json -Number 5 -ShortName "user-auth" "Add user authentication"`
+
+   **IMPORTANT**:
+   - Check all three sources (remote branches, local branches, specs directories) to find the highest number
+   - Only match branches/directories with the exact short-name pattern
+   - If no existing branches/directories found with this short-name, start with number 1
+   - You must only ever run this script once per feature
+   - The JSON is provided in the terminal as output - always refer to it to get the actual content you're looking for
+   - The JSON output will contain BRANCH_NAME and SPEC_FILE paths
+   - For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot")
+
+3. Load `.specify/templates/spec-template.md` to understand required sections.
+
+4. Follow this execution flow:
+
+    1. Parse user description from Input
+       If empty: ERROR "No feature description provided"
+    2. Extract key concepts from description
+       Identify: actors, actions, data, constraints
+    3. For unclear aspects:
+       - Make informed guesses based on context and industry standards
+       - Only mark with [NEEDS CLARIFICATION: specific question] if:
+         - The choice significantly impacts feature scope or user experience
+         - Multiple reasonable interpretations exist with different implications
+         - No reasonable default exists
+       - **LIMIT: Maximum 3 [NEEDS CLARIFICATION] markers total**
+       - Prioritize clarifications by impact: scope > security/privacy > user experience > technical details
+    4. Fill User Scenarios & Testing section
+       If no clear user flow: ERROR "Cannot determine user scenarios"
+    5. Generate Functional Requirements
+       Each requirement must be testable
+       Use reasonable defaults for unspecified details (document assumptions in Assumptions section)
+    6. Define Success Criteria
+       Create measurable, technology-agnostic outcomes
+       Include both quantitative metrics (time, performance, volume) and qualitative measures (user satisfaction, task completion)
+       Each criterion must be verifiable without implementation details
+    7. Identify Key Entities (if data involved)
+    8. Return: SUCCESS (spec ready for planning)
+
+5. Write the specification to SPEC_FILE using the template structure, replacing placeholders with concrete details derived from the feature description (arguments) while preserving section order and headings.
+
+6. **Specification Quality Validation**: After writing the initial spec, validate it against quality criteria:
+
+   a. **Create Spec Quality Checklist**: Generate a checklist file at `FEATURE_DIR/checklists/requirements.md` using the checklist template structure with these validation items:
+
+      ```markdown
+      # Specification Quality Checklist: [FEATURE NAME]
+      
+      **Purpose**: Validate specification completeness and quality before proceeding to planning
+      **Created**: [DATE]
+      **Feature**: [Link to spec.md]
+      
+      ## Content Quality
+      
+      - [ ] No implementation details (languages, frameworks, APIs)
+      - [ ] Focused on user value and business needs
+      - [ ] Written for non-technical stakeholders
+      - [ ] All mandatory sections completed
+      
+      ## Requirement Completeness
+      
+      - [ ] No [NEEDS CLARIFICATION] markers remain
+      - [ ] Requirements are testable and unambiguous
+      - [ ] Success criteria are measurable
+      - [ ] Success criteria are technology-agnostic (no implementation details)
+      - [ ] All acceptance scenarios are defined
+      - [ ] Edge cases are identified
+      - [ ] Scope is clearly bounded
+      - [ ] Dependencies and assumptions identified
+      
+      ## Feature Readiness
+      
+      - [ ] All functional requirements have clear acceptance criteria
+      - [ ] User scenarios cover primary flows
+      - [ ] Feature meets measurable outcomes defined in Success Criteria
+      - [ ] No implementation details leak into specification
+      
+      ## Notes
+      
+      - Items marked incomplete require spec updates before `/speckit.clarify` or `/speckit.plan`
+      ```
+
+   b. **Run Validation Check**: Review the spec against each checklist item:
+      - For each item, determine if it passes or fails
+      - Document specific issues found (quote relevant spec sections)
+
+   c. **Handle Validation Results**:
+
+      - **If all items pass**: Mark checklist complete and proceed to step 6
+
+      - **If items fail (excluding [NEEDS CLARIFICATION])**:
+        1. List the failing items and specific issues
+        2. Update the spec to address each issue
+        3. Re-run validation until all items pass (max 3 iterations)
+        4. If still failing after 3 iterations, document remaining issues in checklist notes and warn user
+
+      - **If [NEEDS CLARIFICATION] markers remain**:
+        1. Extract all [NEEDS CLARIFICATION: ...] markers from the spec
+        2. **LIMIT CHECK**: If more than 3 markers exist, keep only the 3 most critical (by scope/security/UX impact) and make informed guesses for the rest
+        3. For each clarification needed (max 3), present options to user in this format:
+
+           ```markdown
+           ## Question [N]: [Topic]
+           
+           **Context**: [Quote relevant spec section]
+           
+           **What we need to know**: [Specific question from NEEDS CLARIFICATION marker]
+           
+           **Suggested Answers**:
+           
+           | Option | Answer | Implications |
+           |--------|--------|--------------|
+           | A      | [First suggested answer] | [What this means for the feature] |
+           | B      | [Second suggested answer] | [What this means for the feature] |
+           | C      | [Third suggested answer] | [What this means for the feature] |
+           | Custom | Provide your own answer | [Explain how to provide custom input] |
+           
+           **Your choice**: _[Wait for user response]_
+           ```
+
+        4. **CRITICAL - Table Formatting**: Ensure markdown tables are properly formatted:
+           - Use consistent spacing with pipes aligned
+           - Each cell should have spaces around content: `| Content |` not `|Content|`
+           - Header separator must have at least 3 dashes: `|--------|`
+           - Test that the table renders correctly in markdown preview
+        5. Number questions sequentially (Q1, Q2, Q3 - max 3 total)
+        6. Present all questions together before waiting for responses
+        7. Wait for user to respond with their choices for all questions (e.g., "Q1: A, Q2: Custom - [details], Q3: B")
+        8. Update the spec by replacing each [NEEDS CLARIFICATION] marker with the user's selected or provided answer
+        9. Re-run validation after all clarifications are resolved
+
+   d. **Update Checklist**: After each validation iteration, update the checklist file with current pass/fail status
+
+7. Report completion with branch name, spec file path, checklist results, and readiness for the next phase (`/speckit.clarify` or `/speckit.plan`).
+
+**NOTE:** The script creates and checks out the new branch and initializes the spec file before writing.
+
+## General Guidelines
+
+## Quick Guidelines
+
+- Focus on **WHAT** users need and **WHY**.
+- Avoid HOW to implement (no tech stack, APIs, code structure).
+- Written for business stakeholders, not developers.
+- DO NOT create any checklists that are embedded in the spec. That will be a separate command.
+
+### Section Requirements
+
+- **Mandatory sections**: Must be completed for every feature
+- **Optional sections**: Include only when relevant to the feature
+- When a section doesn't apply, remove it entirely (don't leave as "N/A")
+
+### For AI Generation
+
+When creating this spec from a user prompt:
+
+1. **Make informed guesses**: Use context, industry standards, and common patterns to fill gaps
+2. **Document assumptions**: Record reasonable defaults in the Assumptions section
+3. **Limit clarifications**: Maximum 3 [NEEDS CLARIFICATION] markers - use only for critical decisions that:
+   - Significantly impact feature scope or user experience
+   - Have multiple reasonable interpretations with different implications
+   - Lack any reasonable default
+4. **Prioritize clarifications**: scope > security/privacy > user experience > technical details
+5. **Think like a tester**: Every vague requirement should fail the "testable and unambiguous" checklist item
+6. **Common areas needing clarification** (only if no reasonable default exists):
+   - Feature scope and boundaries (include/exclude specific use cases)
+   - User types and permissions (if multiple conflicting interpretations possible)
+   - Security/compliance requirements (when legally/financially significant)
+
+**Examples of reasonable defaults** (don't ask about these):
+
+- Data retention: Industry-standard practices for the domain
+- Performance targets: Standard web/mobile app expectations unless specified
+- Error handling: User-friendly messages with appropriate fallbacks
+- Authentication method: Standard session-based or OAuth2 for web apps
+- Integration patterns: RESTful APIs unless specified otherwise
+
+### Success Criteria Guidelines
+
+Success criteria must be:
+
+1. **Measurable**: Include specific metrics (time, percentage, count, rate)
+2. **Technology-agnostic**: No mention of frameworks, languages, databases, or tools
+3. **User-focused**: Describe outcomes from user/business perspective, not system internals
+4. **Verifiable**: Can be tested/validated without knowing implementation details
+
+**Good examples**:
+
+- "Users can complete checkout in under 3 minutes"
+- "System supports 10,000 concurrent users"
+- "95% of searches return results in under 1 second"
+- "Task completion rate improves by 40%"
+
+**Bad examples** (implementation-focused):
+
+- "API response time is under 200ms" (too technical, use "Users see results instantly")
+- "Database can handle 1000 TPS" (implementation detail, use user-facing metric)
+- "React components render efficiently" (framework-specific)
+- "Redis cache hit rate above 80%" (technology-specific)

--- a/.codex/prompts/speckit.tasks.md
+++ b/.codex/prompts/speckit.tasks.md
@@ -1,0 +1,137 @@
+---
+description: Generate an actionable, dependency-ordered tasks.md for the feature based on available design artifacts.
+handoffs: 
+  - label: Analyze For Consistency
+    agent: speckit.analyze
+    prompt: Run a project analysis for consistency
+    send: true
+  - label: Implement Project
+    agent: speckit.implement
+    prompt: Start the implementation in phases
+    send: true
+---
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Outline
+
+1. **Setup**: Run `.specify/scripts/bash/check-prerequisites.sh --json` from repo root and parse FEATURE_DIR and AVAILABLE_DOCS list. All paths must be absolute. For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot").
+
+2. **Load design documents**: Read from FEATURE_DIR:
+   - **Required**: plan.md (tech stack, libraries, structure), spec.md (user stories with priorities)
+   - **Optional**: data-model.md (entities), contracts/ (API endpoints), research.md (decisions), quickstart.md (test scenarios)
+   - Note: Not all projects have all documents. Generate tasks based on what's available.
+
+3. **Execute task generation workflow**:
+   - Load plan.md and extract tech stack, libraries, project structure
+   - Load spec.md and extract user stories with their priorities (P1, P2, P3, etc.)
+   - If data-model.md exists: Extract entities and map to user stories
+   - If contracts/ exists: Map endpoints to user stories
+   - If research.md exists: Extract decisions for setup tasks
+   - Generate tasks organized by user story (see Task Generation Rules below)
+   - Generate dependency graph showing user story completion order
+   - Create parallel execution examples per user story
+   - Validate task completeness (each user story has all needed tasks, independently testable)
+
+4. **Generate tasks.md**: Use `.specify/templates/tasks-template.md` as structure, fill with:
+   - Correct feature name from plan.md
+   - Phase 1: Setup tasks (project initialization)
+   - Phase 2: Foundational tasks (blocking prerequisites for all user stories)
+   - Phase 3+: One phase per user story (in priority order from spec.md)
+   - Each phase includes: story goal, independent test criteria, tests (if requested), implementation tasks
+   - Final Phase: Polish & cross-cutting concerns
+   - All tasks must follow the strict checklist format (see Task Generation Rules below)
+   - Clear file paths for each task
+   - Dependencies section showing story completion order
+   - Parallel execution examples per story
+   - Implementation strategy section (MVP first, incremental delivery)
+
+5. **Report**: Output path to generated tasks.md and summary:
+   - Total task count
+   - Task count per user story
+   - Parallel opportunities identified
+   - Independent test criteria for each story
+   - Suggested MVP scope (typically just User Story 1)
+   - Format validation: Confirm ALL tasks follow the checklist format (checkbox, ID, labels, file paths)
+
+Context for task generation: $ARGUMENTS
+
+The tasks.md should be immediately executable - each task must be specific enough that an LLM can complete it without additional context.
+
+## Task Generation Rules
+
+**CRITICAL**: Tasks MUST be organized by user story to enable independent implementation and testing.
+
+**Tests are OPTIONAL**: Only generate test tasks if explicitly requested in the feature specification or if user requests TDD approach.
+
+### Checklist Format (REQUIRED)
+
+Every task MUST strictly follow this format:
+
+```text
+- [ ] [TaskID] [P?] [Story?] Description with file path
+```
+
+**Format Components**:
+
+1. **Checkbox**: ALWAYS start with `- [ ]` (markdown checkbox)
+2. **Task ID**: Sequential number (T001, T002, T003...) in execution order
+3. **[P] marker**: Include ONLY if task is parallelizable (different files, no dependencies on incomplete tasks)
+4. **[Story] label**: REQUIRED for user story phase tasks only
+   - Format: [US1], [US2], [US3], etc. (maps to user stories from spec.md)
+   - Setup phase: NO story label
+   - Foundational phase: NO story label  
+   - User Story phases: MUST have story label
+   - Polish phase: NO story label
+5. **Description**: Clear action with exact file path
+
+**Examples**:
+
+- ✅ CORRECT: `- [ ] T001 Create project structure per implementation plan`
+- ✅ CORRECT: `- [ ] T005 [P] Implement authentication middleware in src/middleware/auth.py`
+- ✅ CORRECT: `- [ ] T012 [P] [US1] Create User model in src/models/user.py`
+- ✅ CORRECT: `- [ ] T014 [US1] Implement UserService in src/services/user_service.py`
+- ❌ WRONG: `- [ ] Create User model` (missing ID and Story label)
+- ❌ WRONG: `T001 [US1] Create model` (missing checkbox)
+- ❌ WRONG: `- [ ] [US1] Create User model` (missing Task ID)
+- ❌ WRONG: `- [ ] T001 [US1] Create model` (missing file path)
+
+### Task Organization
+
+1. **From User Stories (spec.md)** - PRIMARY ORGANIZATION:
+   - Each user story (P1, P2, P3...) gets its own phase
+   - Map all related components to their story:
+     - Models needed for that story
+     - Services needed for that story
+     - Endpoints/UI needed for that story
+     - If tests requested: Tests specific to that story
+   - Mark story dependencies (most stories should be independent)
+
+2. **From Contracts**:
+   - Map each contract/endpoint → to the user story it serves
+   - If tests requested: Each contract → contract test task [P] before implementation in that story's phase
+
+3. **From Data Model**:
+   - Map each entity to the user story(ies) that need it
+   - If entity serves multiple stories: Put in earliest story or Setup phase
+   - Relationships → service layer tasks in appropriate story phase
+
+4. **From Setup/Infrastructure**:
+   - Shared infrastructure → Setup phase (Phase 1)
+   - Foundational/blocking tasks → Foundational phase (Phase 2)
+   - Story-specific setup → within that story's phase
+
+### Phase Structure
+
+- **Phase 1**: Setup (project initialization)
+- **Phase 2**: Foundational (blocking prerequisites - MUST complete before user stories)
+- **Phase 3+**: User Stories in priority order (P1, P2, P3...)
+  - Within each story: Tests (if requested) → Models → Services → Endpoints → Integration
+  - Each phase should be a complete, independently testable increment
+- **Final Phase**: Polish & Cross-Cutting Concerns

--- a/.codex/prompts/speckit.taskstoissues.md
+++ b/.codex/prompts/speckit.taskstoissues.md
@@ -1,0 +1,30 @@
+---
+description: Convert existing tasks into actionable, dependency-ordered GitHub issues for the feature based on available design artifacts.
+tools: ['github/github-mcp-server/issue_write']
+---
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Outline
+
+1. Run `.specify/scripts/bash/check-prerequisites.sh --json --require-tasks --include-tasks` from repo root and parse FEATURE_DIR and AVAILABLE_DOCS list. All paths must be absolute. For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot").
+1. From the executed script, extract the path to **tasks**.
+1. Get the Git remote by running:
+
+```bash
+git config --get remote.origin.url
+```
+
+> [!CAUTION]
+> ONLY PROCEED TO NEXT STEPS IF THE REMOTE IS A GITHUB URL
+
+1. For each task in the list, use the GitHub MCP server to create a new issue in the repository that is representative of the Git remote.
+
+> [!CAUTION]
+> UNDER NO CIRCUMSTANCES EVER CREATE ISSUES IN REPOSITORIES THAT DO NOT MATCH THE REMOTE URL

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,3 +101,11 @@ User data stored in workspace `.claude/` directory:
 - VS Code Extension API (`@types/vscode ^1.84.0`)
 - Webpack 5 for bundling
 - highlight.js (CDN) for syntax highlighting in webviews
+
+## Active Technologies
+- TypeScript 5.3+ (ES2022 target, strict mode) + VS Code Extension API (`@types/vscode ^1.84.0`), Webpack 5 (011-spec-viewer-polish)
+- N/A (file-based in `.claude/specs/` directory) (011-spec-viewer-polish)
+- File-based in `.codex/` directory structure (012-codex-cli-provider)
+
+## Recent Changes
+- 011-spec-viewer-polish: Added TypeScript 5.3+ (ES2022 target, strict mode) + VS Code Extension API (`@types/vscode ^1.84.0`), Webpack 5

--- a/README.md
+++ b/README.md
@@ -205,6 +205,24 @@ Access these commands via the Command Palette (`Cmd+Shift+P` / `Ctrl+Shift+P`):
 | `SpecKit: Upgrade Project Files` | Update project's SpecKit configuration |
 | `SpecKit: Upgrade All (CLI + Project)` | Upgrade both CLI and project files |
 | `SpecKit: Check for Updates` | Check for new extension versions |
+| `SpecKit: Run Custom Command` | Run a configured custom SpecKit slash command |
+
+### Custom Commands
+
+You can add custom SpecKit slash commands in VS Code settings and run them with **SpecKit: Run Custom Command**.
+
+```json
+{
+  "speckit.customCommands": [
+    "review",
+    {
+      "title": "Risk Review",
+      "command": "/speckit.risk-review ${specDir}",
+      "autoExecute": false
+    }
+  ]
+}
+```
 
 ## Configuration
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "speckit-companion",
-  "version": "0.2.80",
+  "version": "0.2.85",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "speckit-companion",
-      "version": "0.2.80",
+      "version": "0.2.85",
       "license": "MIT",
       "dependencies": {
         "js-yaml": "^4.1.0"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "speckit-companion",
   "displayName": "SpecKit Companion",
   "description": "VS Code companion for GitHub SpecKit - spec-driven development with AI assistants",
-  "version": "0.2.80",
+  "version": "0.2.85",
   "license": "MIT",
   "publisher": "alfredoperez",
   "icon": "icon.png",
@@ -84,7 +84,7 @@
         {
           "id": "speckit.views.skills",
           "name": "Skills",
-          "when": "!(workbenchState == empty || workspaceFolderCount == 0) && config.speckit.aiProvider == 'claude' && config.speckit.views.skills.visible"
+          "when": "!(workbenchState == empty || workspaceFolderCount == 0) && (config.speckit.aiProvider == 'claude' || config.speckit.aiProvider == 'codex') && config.speckit.views.skills.visible"
         },
         {
           "id": "speckit.views.mcp",
@@ -201,6 +201,12 @@
         "title": "Checklist",
         "category": "SpecKit",
         "icon": "$(tasklist)"
+      },
+      {
+        "command": "speckit.customCommand",
+        "title": "Run Custom Command",
+        "category": "SpecKit",
+        "icon": "$(terminal)"
       },
       {
         "command": "speckit.constitution",
@@ -514,12 +520,14 @@
           "enum": [
             "claude",
             "gemini",
-            "copilot"
+            "copilot",
+            "codex"
           ],
           "enumDescriptions": [
             "Claude Code - Full feature support (steering, agents, hooks, MCP)",
             "Gemini CLI - Steering and MCP support",
-            "GitHub Copilot CLI - Steering, agents, and MCP support"
+            "GitHub Copilot CLI - Steering, agents, and MCP support",
+            "Codex CLI - Steering, skills, and MCP support"
           ],
           "scope": "machine",
           "order": 2,
@@ -547,6 +555,48 @@
           "scope": "machine",
           "order": 5,
           "description": "Delay in milliseconds before sending prompt to Gemini CLI (allows time for initialization)"
+        },
+        "speckit.customCommands": {
+          "type": "array",
+          "default": [],
+          "scope": "window",
+          "order": 6,
+          "description": "Custom SpecKit slash commands available in 'Run Custom Command'. Each entry can be a string (command name) or an object with name, title, command, requiresSpecDir, and autoExecute.",
+          "items": {
+            "anyOf": [
+              {
+                "type": "string",
+                "description": "Command name (e.g., \"review\" becomes /speckit.review)"
+              },
+              {
+                "type": "object",
+                "required": [],
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "Command name (e.g., \"review\" becomes /speckit.review)"
+                  },
+                  "title": {
+                    "type": "string",
+                    "description": "Display title in the picker"
+                  },
+                  "command": {
+                    "type": "string",
+                    "description": "Full slash command (e.g., \"/speckit.review\"). If omitted, name is used."
+                  },
+                  "requiresSpecDir": {
+                    "type": "boolean",
+                    "description": "Append or inject the spec directory (default: true)"
+                  },
+                  "autoExecute": {
+                    "type": "boolean",
+                    "description": "Auto-run the command in the terminal (default: true)"
+                  }
+                },
+                "additionalProperties": false
+              }
+            ]
+          }
         },
         "speckit.notifications.phaseCompletion": {
           "type": "boolean",

--- a/specs/012-codex-cli-provider/checklists/requirements.md
+++ b/specs/012-codex-cli-provider/checklists/requirements.md
@@ -1,0 +1,37 @@
+# Specification Quality Checklist: Codex CLI Provider
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-01-25
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass validation
+- Specification is ready for `/speckit.clarify` or `/speckit.plan`
+- The spec makes reasonable assumptions about Codex CLI behavior based on documentation
+- Out of scope items clearly define boundaries to prevent scope creep

--- a/specs/012-codex-cli-provider/data-model.md
+++ b/specs/012-codex-cli-provider/data-model.md
@@ -1,0 +1,123 @@
+# Data Model: Codex CLI Provider
+
+**Feature**: 012-codex-cli-provider
+**Date**: 2026-01-25
+
+## Type Changes
+
+### AIProviderType Union
+
+```typescript
+// Before
+export type AIProviderType = 'claude' | 'gemini' | 'copilot';
+
+// After
+export type AIProviderType = 'claude' | 'gemini' | 'copilot' | 'codex';
+```
+
+### PROVIDER_PATHS Extension
+
+```typescript
+export const PROVIDER_PATHS: Record<AIProviderType, ProviderPaths> = {
+    // ... existing providers ...
+
+    codex: {
+        steeringFile: 'AGENTS.md',
+        steeringDir: '.codex',
+        steeringPattern: 'AGENTS.md',
+        agentsDir: '',  // Codex uses AGENTS.md hierarchy, not separate agents
+        agentsPattern: '',
+        skillsDir: '.codex/skills',
+        skillsPattern: '*/SKILL.md',
+        mcpConfigPath: '~/.codex/config.toml',  // Note: home directory, TOML format
+        supportsHooks: false,
+    },
+};
+```
+
+## Provider Paths Comparison
+
+| Path Property | Claude | Gemini | Copilot | Codex |
+|---------------|--------|--------|---------|-------|
+| steeringFile | `CLAUDE.md` | `GEMINI.md` | `.github/copilot-instructions.md` | `AGENTS.md` |
+| steeringDir | `.claude/steering` | (empty) | `.github/instructions` | `.codex` |
+| steeringPattern | `*.md` | `GEMINI.md` | `*.instructions.md` | `AGENTS.md` |
+| agentsDir | `.claude/agents` | (empty) | `.github/agents` | (empty) |
+| agentsPattern | `*.md` | (empty) | `*.agent.md` | (empty) |
+| skillsDir | `.claude/skills` | (empty) | (empty) | `.codex/skills` |
+| skillsPattern | `*/SKILL.md` | (empty) | (empty) | `*/SKILL.md` |
+| mcpConfigPath | `.claude/settings.json` | `.gemini/settings.json` | `.copilot/mcp-config.json` | `~/.codex/config.toml` |
+| supportsHooks | `true` | `false` | `false` | `false` |
+
+## CodexCliProvider Class
+
+```typescript
+export class CodexCliProvider implements IAIProvider {
+    public readonly name = 'Codex CLI';
+
+    private context: vscode.ExtensionContext;
+    private outputChannel: vscode.OutputChannel;
+    private configManager: ConfigManager;
+
+    constructor(context: vscode.ExtensionContext, outputChannel: vscode.OutputChannel);
+
+    // IAIProvider interface
+    async isInstalled(): Promise<boolean>;
+    async executeInTerminal(prompt: string, title?: string): Promise<vscode.Terminal>;
+    async executeHeadless(prompt: string): Promise<AIExecutionResult>;
+    async executeSlashCommand(command: string, title?: string, autoExecute?: boolean): Promise<vscode.Terminal>;
+
+    // Private helpers
+    private async createTempFile(content: string, prefix?: string): Promise<string>;
+    private convertPathIfWSL(filePath: string): string;
+}
+```
+
+## Configuration Schema (package.json)
+
+```json
+{
+    "speckit.aiProvider": {
+        "type": "string",
+        "default": "claude",
+        "enum": ["claude", "gemini", "copilot", "codex"],
+        "enumDescriptions": [
+            "Claude Code - Full feature support (steering, agents, hooks, MCP)",
+            "Gemini CLI - Steering and MCP support",
+            "GitHub Copilot CLI - Steering, agents, and MCP (no hooks)",
+            "Codex CLI - Steering, skills, and MCP support"
+        ]
+    }
+}
+```
+
+## Command Mapping
+
+| Operation | Command |
+|-----------|---------|
+| Version check | `codex --version` |
+| Terminal prompt | `codex exec --yolo "$(cat "{promptFilePath}")"` |
+| Headless prompt | `codex exec --yolo "$(cat "{promptFilePath}")"` |
+| Slash command | `codex exec --yolo "Run the following command: {command}"` |
+
+## Feature Support Matrix
+
+| Feature | Claude | Gemini | Copilot | Codex |
+|---------|--------|--------|---------|-------|
+| Prompt execution | ✅ | ✅ | ✅ | ✅ |
+| Headless mode | ✅ | ✅ | ✅ | ✅ |
+| Slash commands | ✅ (native) | ✅ (wrapped) | ✅ (wrapped) | ✅ (wrapped) |
+| Steering files | ✅ | ✅ | ✅ | ✅ |
+| Agents | ✅ | ❌ | ✅ | ❌ |
+| Skills | ✅ | ❌ | ❌ | ✅ |
+| Hooks | ✅ | ❌ | ❌ | ❌ |
+| MCP | ✅ | ✅ | ✅ | ✅ |
+| Permissions | ✅ (managed) | ❌ | ❌ | ❌ |
+
+## Validation Rules
+
+1. Provider type must be one of: `'claude' | 'gemini' | 'copilot' | 'codex'`
+2. Installation check must verify `codex` command exists
+3. Prompt files must be cleaned up after execution (30s delay)
+4. WSL path conversion applies on Windows platform
+5. Terminal delay uses configured value (default 800ms)

--- a/specs/012-codex-cli-provider/plan.md
+++ b/specs/012-codex-cli-provider/plan.md
@@ -1,0 +1,93 @@
+# Implementation Plan: Codex CLI Provider
+
+**Branch**: `012-codex-cli-provider` | **Date**: 2026-01-25 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/012-codex-cli-provider/spec.md`
+
+## Summary
+
+Add OpenAI Codex CLI as a new AI provider option in SpecKit Companion, implementing the `IAIProvider` interface to enable prompt execution, slash commands, and provider-specific file management. The implementation follows the existing provider pattern used by Claude Code, Gemini CLI, and Copilot CLI providers.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.3+ (ES2022 target, strict mode)
+**Primary Dependencies**: VS Code Extension API (`@types/vscode ^1.84.0`)
+**Storage**: File-based in `.codex/` directory structure
+**Testing**: Manual testing via VS Code Extension Development Host (F5)
+**Target Platform**: VS Code Extension (macOS, Linux; Windows/WSL experimental)
+**Project Type**: VS Code Extension (single project)
+**Performance Goals**: Terminal command execution within 800ms delay
+**Constraints**: Must integrate with existing provider factory pattern
+**Scale/Scope**: Single new provider implementation (~250 lines of code)
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Evidence |
+|-----------|--------|----------|
+| I. Extensibility and Configuration | ✅ PASS | Adds new provider via existing factory pattern; provider-specific logic in dedicated class; follows IAIProvider interface |
+| II. Spec-Driven Workflow | ✅ PASS | Enables Spec→Plan→Tasks workflow through Codex CLI; all existing SpecKit commands work with new provider |
+| III. Visual and Interactive | ✅ PASS | Integrates with existing VS Code UI (provider selection QuickPick, terminal views, tree views for agents/steering) |
+| IV. Modular Architecture | ✅ PASS | Single provider file following established pattern; no webview complexity; provider-specific paths in central config |
+
+**Gate Result**: ✅ PASS - No violations. Implementation follows established patterns.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/012-codex-cli-provider/
+├── plan.md              # This file
+├── research.md          # Phase 0: Codex CLI research
+├── data-model.md        # Phase 1: Provider paths and types
+├── quickstart.md        # Phase 1: Integration steps
+└── tasks.md             # Phase 2 output (/speckit.tasks command)
+```
+
+### Source Code (repository root)
+
+```text
+src/
+├── ai-providers/
+│   ├── aiProvider.ts           # [MODIFY] Add 'codex' to AIProviderType, add PROVIDER_PATHS entry
+│   ├── aiProviderFactory.ts    # [MODIFY] Add case for 'codex' provider instantiation
+│   ├── codexCliProvider.ts     # [NEW] Codex CLI provider implementation
+│   └── index.ts                # [MODIFY] Export new provider
+└── extension.ts                # No changes needed (uses factory pattern)
+
+package.json                    # [MODIFY] Add 'codex' to aiProvider enum
+```
+
+**Structure Decision**: Follows existing VS Code extension structure. Single new provider file added to `src/ai-providers/` directory, with minimal modifications to existing files for registration.
+
+## Complexity Tracking
+
+> **Fill ONLY if Constitution Check has violations that must be justified**
+
+*No violations - all constitution principles satisfied.*
+
+## Post-Design Constitution Re-Check
+
+*Re-evaluated after Phase 1 design completion.*
+
+| Principle | Status | Design Verification |
+|-----------|--------|---------------------|
+| I. Extensibility and Configuration | ✅ PASS | `CodexCliProvider` class follows `IAIProvider` interface; paths configurable via `PROVIDER_PATHS`; provider-specific logic isolated |
+| II. Spec-Driven Workflow | ✅ PASS | All SpecKit commands (`/speckit.specify`, `/speckit.plan`, `/speckit.tasks`) work via `executeSlashCommand()` |
+| III. Visual and Interactive | ✅ PASS | Terminal execution in ViewColumn.Two; steering/skills visible in tree views; QuickPick for selection |
+| IV. Modular Architecture | ✅ PASS | Single 250-line provider file; no need for submodules at this complexity level |
+
+**Post-Design Gate Result**: ✅ PASS - Design adheres to all constitution principles.
+
+## Generated Artifacts
+
+| Artifact | Path | Description |
+|----------|------|-------------|
+| Research | [research.md](./research.md) | Codex CLI command structure, flags, configuration |
+| Data Model | [data-model.md](./data-model.md) | Type definitions, paths configuration, class structure |
+| Quickstart | [quickstart.md](./quickstart.md) | Step-by-step implementation guide |
+
+## Next Steps
+
+Run `/speckit.tasks` to generate the implementation task list from this plan.

--- a/specs/012-codex-cli-provider/quickstart.md
+++ b/specs/012-codex-cli-provider/quickstart.md
@@ -1,0 +1,114 @@
+# Quickstart: Codex CLI Provider
+
+**Feature**: 012-codex-cli-provider
+**Date**: 2026-01-25
+
+## Implementation Steps
+
+### Step 1: Update AIProviderType and PROVIDER_PATHS
+
+**File**: `src/ai-providers/aiProvider.ts`
+
+1. Add `'codex'` to the `AIProviderType` union (line 53)
+2. Add codex entry to `PROVIDER_PATHS` record (after copilot entry)
+3. Add codex option to `promptForProviderSelection()` QuickPick items
+
+### Step 2: Create CodexCliProvider Class
+
+**File**: `src/ai-providers/codexCliProvider.ts` (new file)
+
+Create provider class implementing `IAIProvider` interface:
+
+```typescript
+import * as vscode from "vscode";
+import * as fs from "fs";
+import * as path from "path";
+import { exec } from "child_process";
+import { promisify } from "util";
+import { ConfigManager } from "../core/utils/configManager";
+import { ConfigKeys, Timing } from "../core/constants";
+import { IAIProvider, AIExecutionResult } from "./aiProvider";
+
+const execAsync = promisify(exec);
+
+export class CodexCliProvider implements IAIProvider {
+  public readonly name = "Codex CLI";
+  // ... implementation following ClaudeCodeProvider pattern
+}
+```
+
+Key differences from Claude Code:
+
+- No permission management (Codex handles auth separately)
+- Use `codex exec --yolo` instead of `claude --permission-mode bypassPermissions`
+- Wrap slash commands as prompts
+
+### Step 3: Update AIProviderFactory
+
+**File**: `src/ai-providers/aiProviderFactory.ts`
+
+1. Import `CodexCliProvider`
+2. Add case for `'codex'` in switch statement
+3. Add entry to `getSupportedProviders()` array
+
+### Step 4: Update Module Exports
+
+**File**: `src/ai-providers/index.ts`
+
+Add export for new provider:
+
+```typescript
+export { CodexCliProvider } from "./codexCliProvider";
+```
+
+### Step 5: Update package.json Configuration
+
+**File**: `package.json`
+
+Add `'codex'` to the aiProvider enum and description:
+
+```json
+"speckit.aiProvider": {
+    "enum": ["claude", "gemini", "copilot", "codex"],
+    "enumDescriptions": [
+        "Claude Code - Full feature support (steering, agents, hooks, MCP)",
+        "Gemini CLI - Steering and MCP support",
+        "GitHub Copilot CLI - Steering, agents, and MCP (no hooks)",
+        "Codex CLI - Steering, skills, and MCP support"
+    ]
+}
+```
+
+## Testing Checklist
+
+- [ ] Run `npm run compile` - verify no TypeScript errors
+- [ ] Press F5 to launch Extension Development Host
+- [ ] Clear existing provider setting (if any)
+- [ ] Verify Codex CLI appears in provider selection QuickPick
+- [ ] Select Codex CLI and verify setting persists
+- [ ] Trigger a prompt action and verify terminal opens with correct command
+- [ ] Verify steering tree view shows AGENTS.md file
+- [ ] Verify skills tree view shows `.codex/skills` directory
+- [ ] Test with Codex CLI not installed - verify helpful error message
+
+## Files Modified Summary
+
+| File                                    | Change Type | Description                       |
+| --------------------------------------- | ----------- | --------------------------------- |
+| `src/ai-providers/aiProvider.ts`        | Modify      | Add type, paths, QuickPick option |
+| `src/ai-providers/codexCliProvider.ts`  | New         | Provider implementation           |
+| `src/ai-providers/aiProviderFactory.ts` | Modify      | Add factory case                  |
+| `src/ai-providers/index.ts`             | Modify      | Add export                        |
+| `package.json`                          | Modify      | Add enum value                    |
+
+## Rollback Plan
+
+If issues arise:
+
+1. Remove `'codex'` from `AIProviderType` union
+2. Remove codex entry from `PROVIDER_PATHS`
+3. Delete `codexCliProvider.ts`
+4. Remove factory case and export
+5. Remove enum value from `package.json`
+
+All changes are additive and do not affect existing providers.

--- a/specs/012-codex-cli-provider/research.md
+++ b/specs/012-codex-cli-provider/research.md
@@ -1,0 +1,134 @@
+# Research: Codex CLI Provider
+
+**Feature**: 012-codex-cli-provider
+**Date**: 2026-01-25
+
+## Research Questions
+
+### RQ-1: Codex CLI Command Structure
+
+**Decision**: Use `codex exec` subcommand for non-interactive execution with `--yolo` flag for bypassing approvals.
+
+**Rationale**:
+- `codex` (no subcommand) launches interactive TUI - unsuitable for extension automation
+- `codex exec` (alias: `codex e`) runs non-interactively, designed for automation
+- `--dangerously-bypass-approvals-and-sandbox` (or `--yolo`) provides equivalent to Claude's `--permission-mode bypassPermissions`
+- Prompts can be passed directly as positional argument or via stdin with `-`
+
+**Alternatives Considered**:
+- `--full-auto` flag: Lower friction but still may prompt for some approvals
+- Interactive mode with prompt injection: More complex, less reliable
+
+**Command Patterns**:
+```bash
+# Terminal execution (visible, with approval bypass)
+codex exec --yolo "PROMPT"
+
+# Alternative: pipe from file
+codex exec --yolo - < prompt.md
+
+# Alternative: cat command substitution (matches Claude pattern)
+codex exec --yolo "$(cat /path/to/prompt.md)"
+```
+
+### RQ-2: Installation Detection
+
+**Decision**: Check for `codex --version` command.
+
+**Rationale**: Standard CLI pattern used by all existing providers. Codex CLI follows npm installation via `npm i -g @openai/codex`.
+
+**Command**: `codex --version`
+
+### RQ-3: Headless/Background Execution
+
+**Decision**: Use `codex exec` with `--json` flag for structured output in headless mode.
+
+**Rationale**:
+- `codex exec --json` prints newline-delimited JSON events
+- `--output-last-message path` can write final response to file
+- Better exit code tracking than raw terminal execution
+
+**Headless Pattern**:
+```bash
+codex exec --yolo --json "PROMPT"
+```
+
+### RQ-4: Slash Command Execution
+
+**Decision**: Convert slash commands to prompts with instruction to run the command.
+
+**Rationale**:
+- Codex CLI doesn't have native slash command support like Claude Code
+- Skills are invoked with `$skill-name` syntax, not `/command`
+- Best approach: wrap command in instruction prompt
+
+**Pattern**:
+```bash
+codex exec --yolo "Run the following SpecKit command: /speckit.plan"
+```
+
+### RQ-5: Provider-Specific File Paths
+
+**Decision**: Map Codex file conventions to ProviderPaths interface.
+
+**Findings**:
+| File Type | Codex Path | Notes |
+|-----------|------------|-------|
+| Steering File | `AGENTS.md` | Equivalent to CLAUDE.md |
+| Steering Directory | `.codex/` | Additional AGENTS.md files |
+| Agents Directory | N/A | Codex uses AGENTS.md hierarchy |
+| Skills Directory | `.codex/skills` | Skill folders with SKILL.md |
+| MCP Config | `~/.codex/config.toml` | TOML format (not JSON) |
+| Hooks | Not supported | No hook system in Codex |
+
+**Rationale**: AGENTS.md serves same purpose as CLAUDE.md (project instructions). Skills are in `.codex/skills/*/SKILL.md` format similar to Claude's skill structure.
+
+### RQ-6: Windows/WSL Support
+
+**Decision**: Apply same WSL path conversion as Claude Code provider.
+
+**Rationale**:
+- Codex CLI documentation notes "Windows support is experimental"
+- Recommends using WSL for best experience
+- Existing `convertPathIfWSL` helper already handles path translation
+
+### RQ-7: Permission/Authentication
+
+**Decision**: Do not manage authentication; let Codex CLI handle it.
+
+**Rationale**:
+- Codex CLI has its own `codex auth` command for setup
+- Uses ChatGPT OAuth, device auth, or API key
+- Extension should detect and guide user, not manage auth directly
+- Matches spec assumption: "Users will authenticate Codex CLI independently"
+
+### RQ-8: MCP Configuration Location
+
+**Decision**: Use `~/.codex/config.toml` as MCP config path (home directory).
+
+**Rationale**:
+- Codex MCP servers configured in main config file
+- `[mcp]` section in config.toml
+- Can also use `codex mcp add/remove` CLI commands
+- Different from Claude's per-project `.claude/settings.json`
+
+## Technology Mapping
+
+| Claude Code | Codex CLI | Notes |
+|-------------|-----------|-------|
+| `claude` | `codex exec` | Non-interactive execution |
+| `--permission-mode bypassPermissions` | `--yolo` / `--dangerously-bypass-approvals-and-sandbox` | Bypass approvals |
+| `CLAUDE.md` | `AGENTS.md` | Steering file |
+| `.claude/steering/` | `.codex/` hierarchy | Additional steering |
+| `.claude/agents/` | N/A (uses AGENTS.md) | Agent definitions |
+| `.claude/skills/` | `.codex/skills/` | Skill definitions |
+| `.claude/settings.json` | `~/.codex/config.toml` | Config location |
+| Hooks | Not supported | N/A |
+
+## Sources
+
+- [Codex CLI Reference](https://developers.openai.com/codex/cli/reference/)
+- [Codex CLI Features](https://developers.openai.com/codex/cli/features/)
+- [AGENTS.md Guide](https://developers.openai.com/codex/guides/agents-md)
+- [Codex Skills](https://developers.openai.com/codex/skills/)
+- [@openai/codex npm package](https://www.npmjs.com/package/@openai/codex)

--- a/specs/012-codex-cli-provider/spec.md
+++ b/specs/012-codex-cli-provider/spec.md
@@ -1,0 +1,129 @@
+# Feature Specification: Codex CLI Provider
+
+**Feature Branch**: `012-codex-cli-provider`
+**Created**: 2026-01-25
+**Status**: Draft
+**Input**: User description: "Add support for Codex CLI as a new AI Provider"
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Select Codex CLI as AI Provider (Priority: P1)
+
+Users who prefer OpenAI's Codex CLI over other AI assistants want to configure SpecKit Companion to use Codex as their primary AI provider for all spec-driven development workflows.
+
+**Why this priority**: This is the foundational capability that enables all other Codex CLI features. Without provider selection, users cannot use any Codex-specific functionality.
+
+**Independent Test**: Can be fully tested by opening VS Code, triggering the AI provider selection prompt, choosing "Codex CLI", and verifying the selection is persisted in settings.
+
+**Acceptance Scenarios**:
+
+1. **Given** SpecKit Companion is installed and no AI provider is configured, **When** the user opens a workspace, **Then** they see "Codex CLI" as an option in the AI provider selection prompt alongside existing providers.
+2. **Given** the user selects "Codex CLI" from the provider prompt, **When** the selection is confirmed, **Then** the choice is saved to VS Code settings and persists across sessions.
+3. **Given** a user has previously configured a different provider, **When** they change the setting to "Codex CLI" via VS Code settings, **Then** all subsequent SpecKit operations use Codex CLI.
+
+---
+
+### User Story 2 - Execute Prompts via Codex CLI (Priority: P1)
+
+Users want to execute AI prompts through Codex CLI from within VS Code, whether through visible terminals for interactive sessions or headless execution for background tasks.
+
+**Why this priority**: Core functionality that enables the extension's value proposition. Users need to be able to send prompts to Codex CLI for spec generation, planning, and task execution.
+
+**Independent Test**: Can be fully tested by selecting a spec file, clicking "Refine with AI", and verifying the prompt is sent to Codex CLI in a terminal window.
+
+**Acceptance Scenarios**:
+
+1. **Given** Codex CLI is selected as the AI provider and is installed on the system, **When** the user triggers a prompt-based action, **Then** a terminal opens and executes the prompt using the `codex` command.
+2. **Given** the user triggers a background operation, **When** the operation requires AI processing, **Then** Codex CLI executes in headless mode without visible terminal interruption.
+3. **Given** Codex CLI is not installed on the system, **When** the user attempts to use Codex-dependent features, **Then** a helpful error message appears explaining that Codex CLI needs to be installed via `npm i -g @openai/codex`.
+
+---
+
+### User Story 3 - Execute Slash Commands (Priority: P2)
+
+Users want to run SpecKit slash commands (like `/speckit.specify`, `/speckit.plan`) through Codex CLI in the terminal.
+
+**Why this priority**: Enables the full SpecKit workflow integration with Codex CLI, but depends on basic prompt execution working first.
+
+**Independent Test**: Can be fully tested by right-clicking a spec and selecting "Execute Plan" action, verifying the `/speckit.plan` command runs in Codex CLI terminal.
+
+**Acceptance Scenarios**:
+
+1. **Given** Codex CLI is the active provider, **When** the user triggers a slash command action, **Then** a terminal opens with the command prefilled and ready to execute.
+2. **Given** the user wants to add additional context before executing, **When** they trigger a slash command with auto-execute disabled, **Then** the command appears in terminal but waits for user to press Enter.
+
+---
+
+### User Story 4 - Codex-Specific File Management (Priority: P2)
+
+Users want the extension to recognize and manage Codex CLI's configuration files (like `AGENTS.md` for custom agents or configuration files) alongside their specs.
+
+**Why this priority**: Provides parity with existing providers that manage steering files and enhances the user experience for Codex users.
+
+**Independent Test**: Can be fully tested by creating a Codex agents file and verifying it appears in the SpecKit tree view.
+
+**Acceptance Scenarios**:
+
+1. **Given** the user has Codex CLI configured, **When** they view the SpecKit sidebar, **Then** they see Codex-specific configuration file locations (agents directory, rules, MCP config).
+2. **Given** the user creates a new steering/agents file for Codex, **When** they save the file, **Then** it appears in the appropriate tree view section.
+
+---
+
+### Edge Cases
+
+- What happens when the user switches from Codex CLI to another provider mid-session?
+  - The extension updates all subsequent operations to use the newly selected provider without requiring a restart.
+- How does the system handle when Codex CLI is selected but authentication is not configured?
+  - Display a clear message that authentication is required and guide users to run `codex` to complete setup.
+- What happens when running on Windows without WSL?
+  - Codex CLI has experimental Windows/WSL support. The extension should detect the platform and provide appropriate guidance.
+- How does the system handle network connectivity issues during Codex CLI execution?
+  - Let Codex CLI handle its own error messages and display them in the terminal for user visibility.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST include "Codex CLI" as a selectable option in the AI provider configuration
+- **FR-002**: System MUST detect whether Codex CLI is installed by checking if the `codex` command is available
+- **FR-003**: System MUST execute prompts in a visible terminal using the `codex` command with appropriate flags
+- **FR-004**: System MUST support headless/background execution for non-interactive AI operations
+- **FR-005**: System MUST support slash command execution through Codex CLI
+- **FR-006**: System MUST display a user-friendly error when Codex CLI is not installed, including installation instructions
+- **FR-007**: System MUST handle WSL path conversion for Windows users (consistent with existing providers)
+- **FR-008**: System MUST persist Codex CLI as the selected provider across VS Code sessions
+- **FR-009**: System MUST define Codex-specific file paths for steering files, agents, and MCP configuration
+- **FR-010**: System MUST integrate with the existing provider factory pattern to instantiate Codex CLI provider
+
+### Key Entities
+
+- **Codex CLI Provider**: Implementation of the IAIProvider interface for OpenAI's Codex CLI tool
+- **Provider Paths Configuration**: Codex-specific paths for agents directory, rules, and MCP configuration files
+- **Provider Type**: New 'codex' type added to the AIProviderType union
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Users can select Codex CLI as their AI provider and complete a full spec workflow (specify → plan → tasks) without errors
+- **SC-002**: All existing SpecKit commands work identically whether using Claude Code, Gemini CLI, Copilot CLI, or Codex CLI
+- **SC-003**: Users receive clear feedback within 3 seconds when Codex CLI is not installed
+- **SC-004**: The provider selection UI clearly displays Codex CLI capabilities and limitations compared to other providers
+- **SC-005**: No regression in functionality for existing Claude Code, Gemini CLI, or Copilot CLI users
+
+## Assumptions
+
+- Codex CLI follows a similar invocation pattern to Claude Code (command-line tool that accepts prompts)
+- Codex CLI uses `codex` as the command name (based on npm package @openai/codex)
+- Users will authenticate Codex CLI independently before using it with SpecKit Companion
+- Codex CLI supports MCP (Model Context Protocol) for third-party tool integration, similar to Claude Code
+- The extension does not need to handle Codex Cloud tasks - only local CLI execution
+- Codex CLI's approval modes and safety features are handled by the CLI itself, not the extension
+
+## Out of Scope
+
+- Codex Cloud integration (remote/cloud-based task execution)
+- Model selection within Codex CLI (users can use `/model` command directly in terminal)
+- Image input handling specific to Codex (standard file operations apply)
+- Codex-specific features like web search or code review agents (users access these directly via CLI)
+- Authentication/API key management for Codex (handled by the CLI on first run)

--- a/specs/012-codex-cli-provider/tasks.md
+++ b/specs/012-codex-cli-provider/tasks.md
@@ -1,0 +1,206 @@
+# Tasks: Codex CLI Provider
+
+**Input**: Design documents from `/specs/012-codex-cli-provider/`
+**Prerequisites**: plan.md ✅, spec.md ✅, research.md ✅, data-model.md ✅, quickstart.md ✅
+
+**Tests**: Not requested in feature specification - implementation tasks only.
+
+**Organization**: Tasks grouped by user story to enable independent implementation and testing.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+## Path Conventions
+
+- **Single project**: VS Code extension with `src/` at repository root
+- Paths follow existing structure in `src/ai-providers/`
+
+---
+
+## Phase 1: Setup (Type System Updates)
+
+**Purpose**: Update type definitions and configuration to recognize Codex as a valid provider
+
+- [x] T001 Add 'codex' to AIProviderType union in src/ai-providers/aiProvider.ts
+- [x] T002 Add codex entry to PROVIDER_PATHS record in src/ai-providers/aiProvider.ts
+- [x] T003 Add 'codex' enum value and description to package.json aiProvider configuration
+
+---
+
+## Phase 2: Foundational (Provider Infrastructure)
+
+**Purpose**: Create the core provider class that MUST be complete before any user story features work
+
+**⚠️ CRITICAL**: Provider class must exist before prompt execution, slash commands, or file management can be implemented
+
+- [x] T004 Create codexCliProvider.ts with class skeleton implementing IAIProvider in src/ai-providers/codexCliProvider.ts
+- [x] T005 Add constructor with context, outputChannel, and configManager initialization in src/ai-providers/codexCliProvider.ts
+- [x] T006 Add createTempFile private helper method in src/ai-providers/codexCliProvider.ts
+- [x] T007 Add convertPathIfWSL private helper method in src/ai-providers/codexCliProvider.ts
+- [x] T008 Import CodexCliProvider in src/ai-providers/aiProviderFactory.ts
+- [x] T009 Add 'codex' case to getProviderByType switch statement in src/ai-providers/aiProviderFactory.ts
+- [x] T010 Add codex entry to getSupportedProviders array in src/ai-providers/aiProviderFactory.ts
+- [x] T011 Export CodexCliProvider from src/ai-providers/index.ts
+
+**Checkpoint**: Foundation ready - provider class exists and is registered in factory
+
+---
+
+## Phase 3: User Story 1 - Select Codex CLI as AI Provider (Priority: P1) 🎯 MVP
+
+**Goal**: Users can select Codex CLI as their AI provider and the selection persists
+
+**Independent Test**: Open VS Code, trigger provider selection prompt, choose "Codex CLI", verify setting persists in VS Code settings
+
+### Implementation for User Story 1
+
+- [x] T012 [US1] Implement isInstalled() method checking for 'codex --version' in src/ai-providers/codexCliProvider.ts
+- [x] T013 [US1] Add Codex CLI option to promptForProviderSelection QuickPick in src/ai-providers/aiProvider.ts
+
+**Checkpoint**: User Story 1 complete - users can select and persist Codex CLI as their provider
+
+---
+
+## Phase 4: User Story 2 - Execute Prompts via Codex CLI (Priority: P1)
+
+**Goal**: Users can execute AI prompts through Codex CLI in visible terminals or headless mode
+
+**Independent Test**: Select a spec file, click "Refine with AI", verify prompt executes in Codex CLI terminal with `codex exec --yolo` command
+
+### Implementation for User Story 2
+
+- [x] T014 [US2] Implement executeInTerminal() method using 'codex exec --yolo' command in src/ai-providers/codexCliProvider.ts
+- [x] T015 [US2] Implement executeHeadless() method for background execution in src/ai-providers/codexCliProvider.ts
+- [x] T016 [US2] Add installation check error handling with npm install guidance in src/ai-providers/codexCliProvider.ts
+
+**Checkpoint**: User Story 2 complete - prompts execute via Codex CLI in terminal and headless modes
+
+---
+
+## Phase 5: User Story 3 - Execute Slash Commands (Priority: P2)
+
+**Goal**: Users can run SpecKit slash commands through Codex CLI
+
+**Independent Test**: Right-click a spec, select "Execute Plan" action, verify `/speckit.plan` runs in Codex CLI terminal
+
+### Implementation for User Story 3
+
+- [x] T017 [US3] Implement executeSlashCommand() method wrapping commands as prompts in src/ai-providers/codexCliProvider.ts
+
+**Checkpoint**: User Story 3 complete - slash commands execute through Codex CLI
+
+---
+
+## Phase 6: User Story 4 - Codex-Specific File Management (Priority: P2)
+
+**Goal**: Extension recognizes Codex CLI configuration files (AGENTS.md, .codex/ directory, skills)
+
+**Independent Test**: Create AGENTS.md file in workspace, verify it appears in SpecKit steering tree view
+
+### Implementation for User Story 4
+
+- [x] T018 [US4] Verify PROVIDER_PATHS codex entry has correct steeringFile, steeringDir, skillsDir values in src/ai-providers/aiProvider.ts
+- [x] T019 [US4] Verify skills tree view condition includes codex provider in package.json
+
+**Checkpoint**: User Story 4 complete - Codex configuration files appear in tree views
+
+---
+
+## Phase 7: Polish & Cross-Cutting Concerns
+
+**Purpose**: Final validation and cleanup
+
+- [x] T020 Run npm run compile to verify no TypeScript errors
+- [ ] T021 Test provider switching from other providers to Codex and back
+- [ ] T022 Verify no regression in Claude Code, Gemini CLI, or Copilot CLI functionality
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies - can start immediately
+- **Foundational (Phase 2)**: Depends on Phase 1 completion - BLOCKS all user stories
+- **User Stories (Phase 3-6)**: All depend on Foundational phase completion
+  - US1 and US2 are both P1 priority but US2 depends on US1 (provider must be selectable first)
+  - US3 depends on US2 (slash commands use prompt execution infrastructure)
+  - US4 can proceed independently after Foundational
+- **Polish (Phase 7)**: Depends on all user stories being complete
+
+### User Story Dependencies
+
+- **User Story 1 (P1)**: Can start after Foundational (Phase 2) - No dependencies on other stories
+- **User Story 2 (P1)**: Depends on US1 (provider must be registered and selectable)
+- **User Story 3 (P2)**: Depends on US2 (uses executeInTerminal infrastructure)
+- **User Story 4 (P2)**: Can start after Foundational (Phase 2) - Only needs PROVIDER_PATHS entry
+
+### Parallel Opportunities
+
+- T001, T002, T003 are all in different files and can run in parallel
+- T008, T009, T010, T011 can run in parallel (different files, after T004)
+- T018, T019 can run in parallel with US3 implementation
+
+---
+
+## Parallel Example: Setup Phase
+
+```bash
+# Launch all Setup tasks together (different files):
+Task: "Add 'codex' to AIProviderType union in src/ai-providers/aiProvider.ts"
+Task: "Add codex entry to PROVIDER_PATHS record in src/ai-providers/aiProvider.ts"
+Task: "Add 'codex' enum value and description to package.json aiProvider configuration"
+```
+
+## Parallel Example: Foundational Phase (after T004)
+
+```bash
+# Launch factory updates together (different files):
+Task: "Import CodexCliProvider in src/ai-providers/aiProviderFactory.ts"
+Task: "Export CodexCliProvider from src/ai-providers/index.ts"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Stories 1 + 2)
+
+1. Complete Phase 1: Setup (type definitions)
+2. Complete Phase 2: Foundational (provider class skeleton)
+3. Complete Phase 3: User Story 1 (provider selection)
+4. Complete Phase 4: User Story 2 (prompt execution)
+5. **STOP and VALIDATE**: Test selecting Codex and running a prompt
+
+### Incremental Delivery
+
+1. Setup + Foundational → Provider registered in factory
+2. Add User Story 1 → Provider selectable → Deploy/Demo (provider works!)
+3. Add User Story 2 → Prompts execute → Deploy/Demo (MVP complete!)
+4. Add User Story 3 → Slash commands work → Deploy/Demo
+5. Add User Story 4 → File management → Deploy/Demo (feature complete)
+
+### Files Modified Summary
+
+| File | Phase | Change |
+|------|-------|--------|
+| src/ai-providers/aiProvider.ts | 1, 3 | Add type, paths, QuickPick option |
+| src/ai-providers/codexCliProvider.ts | 2, 3, 4, 5 | New provider implementation |
+| src/ai-providers/aiProviderFactory.ts | 2 | Add factory case |
+| src/ai-providers/index.ts | 2 | Add export |
+| package.json | 1, 6 | Add enum value, skills condition |
+
+---
+
+## Notes
+
+- [P] tasks = different files, no dependencies
+- [Story] label maps task to specific user story for traceability
+- Each user story should be independently completable and testable
+- Commit after each phase or logical task group
+- Stop at any checkpoint to validate story independently
+- Codex CLI uses `codex exec --yolo` instead of Claude's `claude --permission-mode bypassPermissions`
+- No permission management needed (Codex handles auth separately via `codex auth`)

--- a/src/ai-providers/aiProvider.ts
+++ b/src/ai-providers/aiProvider.ts
@@ -50,7 +50,7 @@ export interface IAIProvider {
 /**
  * Supported AI provider types
  */
-export type AIProviderType = 'claude' | 'gemini' | 'copilot';
+export type AIProviderType = 'claude' | 'gemini' | 'copilot' | 'codex';
 
 /**
  * Provider configuration paths and patterns
@@ -113,6 +113,17 @@ export const PROVIDER_PATHS: Record<AIProviderType, ProviderPaths> = {
         mcpConfigPath: '.copilot/mcp-config.json',
         supportsHooks: false,
     },
+    codex: {
+        steeringFile: 'AGENTS.md',
+        steeringDir: '.codex',
+        steeringPattern: 'AGENTS.md',
+        agentsDir: '', // Codex uses AGENTS.md hierarchy, not separate agents
+        agentsPattern: '',
+        skillsDir: '.codex/skills',
+        skillsPattern: '*/SKILL.md',
+        mcpConfigPath: '~/.codex/config.toml', // Note: home directory, TOML format
+        supportsHooks: false,
+    },
 };
 
 /**
@@ -166,6 +177,11 @@ export async function promptForProviderSelection(): Promise<AIProviderType | und
                 label: '$(sparkle) Gemini CLI',
                 description: 'Steering and MCP support (no agents or hooks)',
                 value: 'gemini' as AIProviderType
+            },
+            {
+                label: '$(terminal) Codex CLI',
+                description: 'Steering, skills, and MCP support',
+                value: 'codex' as AIProviderType
             }
         ],
         {

--- a/src/ai-providers/aiProviderFactory.ts
+++ b/src/ai-providers/aiProviderFactory.ts
@@ -3,6 +3,7 @@ import { IAIProvider, AIProviderType, getConfiguredProviderType } from './aiProv
 import { ClaudeCodeProvider } from './claudeCodeProvider';
 import { GeminiCliProvider } from './geminiCliProvider';
 import { CopilotCliProvider } from './copilotCliProvider';
+import { CodexCliProvider } from './codexCliProvider';
 
 /**
  * Factory for creating AI provider instances based on configuration
@@ -48,6 +49,9 @@ export class AIProviderFactory {
             case 'copilot':
                 provider = new CopilotCliProvider(context, outputChannel);
                 break;
+            case 'codex':
+                provider = new CodexCliProvider(context, outputChannel);
+                break;
             default:
                 outputChannel.appendLine(`[AIProviderFactory] Unknown provider type: ${type}, falling back to Claude Code`);
                 provider = new ClaudeCodeProvider(context, outputChannel);
@@ -71,7 +75,8 @@ export class AIProviderFactory {
         return [
             { type: 'claude', name: 'Claude Code', available: true },
             { type: 'gemini', name: 'Gemini CLI', available: true },
-            { type: 'copilot', name: 'GitHub Copilot CLI', available: true }
+            { type: 'copilot', name: 'GitHub Copilot CLI', available: true },
+            { type: 'codex', name: 'Codex CLI', available: true }
         ];
     }
 }

--- a/src/ai-providers/codexCliProvider.ts
+++ b/src/ai-providers/codexCliProvider.ts
@@ -1,0 +1,333 @@
+import * as vscode from 'vscode';
+import * as fs from 'fs';
+import * as path from 'path';
+import { exec } from 'child_process';
+import { promisify } from 'util';
+import { ConfigManager } from '../core/utils/configManager';
+import { ConfigKeys, Timing } from '../core/constants';
+import { IAIProvider, AIExecutionResult } from './aiProvider';
+
+const execAsync = promisify(exec);
+
+export class CodexCliProvider implements IAIProvider {
+    public readonly name = 'Codex CLI';
+
+    private context: vscode.ExtensionContext;
+    private outputChannel: vscode.OutputChannel;
+    private configManager: ConfigManager;
+
+    constructor(context: vscode.ExtensionContext, outputChannel: vscode.OutputChannel) {
+        this.context = context;
+        this.outputChannel = outputChannel;
+
+        this.configManager = ConfigManager.getInstance();
+        this.configManager.loadSettings();
+        // Listen for configuration changes
+        vscode.workspace.onDidChangeConfiguration(e => {
+            if (e.affectsConfiguration(ConfigKeys.namespace)) {
+                this.configManager.loadSettings();
+            }
+        });
+    }
+
+    /**
+     * Check if Codex CLI is installed
+     */
+    async isInstalled(): Promise<boolean> {
+        try {
+            await execAsync('codex --version');
+            return true;
+        } catch {
+            return false;
+        }
+    }
+
+    /**
+     * Create a temporary file with content
+     */
+    private async createTempFile(content: string, prefix: string = 'prompt'): Promise<string> {
+        const tempDir = this.context.globalStorageUri.fsPath;
+        await vscode.workspace.fs.createDirectory(this.context.globalStorageUri);
+
+        const tempFile = path.join(tempDir, `${prefix}-${Date.now()}.md`);
+        await fs.promises.writeFile(tempFile, content);
+
+        return this.convertPathIfWSL(tempFile);
+    }
+
+    /**
+     * Convert Windows path to WSL path if needed
+     */
+    private convertPathIfWSL(filePath: string): string {
+        if (process.platform === 'win32' && filePath.match(/^[A-Za-z]:\\/)) {
+            let wslPath = filePath.replace(/\\/g, '/');
+            wslPath = wslPath.replace(/^([A-Za-z]):/, (_match, drive) => `/mnt/${drive.toLowerCase()}`);
+            return wslPath;
+        }
+        return filePath;
+    }
+
+    /**
+     * Parse a slash command into skill name and arguments
+     * Only parses the first line - refinement context may follow on subsequent lines
+     */
+    private parseSlashCommand(prompt: string): { skillName: string; args: string } | null {
+        // Only look at the first line of the prompt
+        const firstLine = prompt.split('\n')[0].trim();
+        const match = firstLine.match(/^\/(speckit\.\w+)\s*(.*)$/);
+        if (!match) return null;
+        return { skillName: match[1], args: match[2]?.trim() || '' };
+    }
+
+    /**
+     * Escape a string for safe use in sed substitution
+     */
+    private escapeForSed(str: string): string {
+        return str
+            .replace(/\\/g, '\\\\')
+            .replace(/\//g, '\\/')
+            .replace(/&/g, '\\&')
+            .replace(/'/g, "'\\''");
+    }
+
+    /**
+     * Get the relative path to a prompt file if it exists
+     */
+    private getPromptFilePath(skillName: string): string | null {
+        const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
+        if (!workspaceFolder) return null;
+        const promptPath = path.join(workspaceFolder.uri.fsPath, '.codex', 'prompts', `${skillName}.md`);
+        return fs.existsSync(promptPath) ? `.codex/prompts/${skillName}.md` : null;
+    }
+
+    /**
+     * Check if Codex CLI is installed and show helpful error if not
+     */
+    private async ensureInstalled(): Promise<void> {
+        const installed = await this.isInstalled();
+        if (!installed) {
+            const action = await vscode.window.showErrorMessage(
+                'Codex CLI is not installed. Install it with: npm install -g @openai/codex',
+                'Copy Install Command'
+            );
+            if (action === 'Copy Install Command') {
+                await vscode.env.clipboard.writeText('npm install -g @openai/codex');
+                vscode.window.showInformationMessage('Install command copied to clipboard');
+            }
+            throw new Error('Codex CLI is not installed');
+        }
+    }
+
+    /**
+     * Execute a prompt in a visible terminal (split view)
+     * Uses sed + pipe for known SpecKit skills, falls back to temp file for custom prompts
+     */
+    async executeInTerminal(prompt: string, title: string = 'SpecKit - Codex CLI'): Promise<vscode.Terminal> {
+        try {
+            await this.ensureInstalled();
+
+            let command: string;
+            let tempFilePath: string | null = null;
+
+            const parsed = this.parseSlashCommand(prompt.trim());
+            const promptFile = parsed ? this.getPromptFilePath(parsed.skillName) : null;
+
+            this.outputChannel.appendLine(`[Codex] Prompt: "${prompt.substring(0, 100)}..."`);
+            this.outputChannel.appendLine(`[Codex] Parsed: ${JSON.stringify(parsed)}`);
+            this.outputChannel.appendLine(`[Codex] Prompt file: ${promptFile}`);
+
+            if (parsed && promptFile) {
+                // Use sed + pipe for known SpecKit skills
+                const escapedArgs = this.escapeForSed(parsed.args);
+                command = `sed "s/\\$ARGUMENTS/${escapedArgs}/" "${promptFile}" | codex exec - `;
+            } else {
+                // Fallback: write temp file for custom prompts
+                tempFilePath = await this.createTempFile(prompt, 'prompt');
+                command = `codex exec - < "${tempFilePath}" `;
+            }
+
+            const terminal = vscode.window.createTerminal({
+                name: title,
+                cwd: vscode.workspace.workspaceFolders?.[0]?.uri.fsPath,
+                location: {
+                    viewColumn: vscode.ViewColumn.Two
+                }
+            });
+
+            terminal.show();
+
+            const delay = this.configManager.getTerminalDelay();
+            setTimeout(() => {
+                terminal.sendText(command, true);
+            }, delay);
+
+            // Clean up temp file after delay (only if we created one)
+            if (tempFilePath) {
+                const fileToClean = tempFilePath;
+                setTimeout(async () => {
+                    try {
+                        await fs.promises.unlink(fileToClean);
+                        this.outputChannel.appendLine(`[Codex] Cleaned up prompt file: ${fileToClean}`);
+                    } catch (e) {
+                        this.outputChannel.appendLine(`[Codex] Failed to cleanup temp file: ${e}`);
+                    }
+                }, Timing.tempFileCleanupDelay);
+            }
+
+            return terminal;
+
+        } catch (error) {
+            this.outputChannel.appendLine(`[Codex] ERROR: Failed to send to Codex CLI: ${error}`);
+            vscode.window.showErrorMessage(`Failed to run Codex CLI: ${error}`);
+            throw error;
+        }
+    }
+
+    /**
+     * Execute a prompt in headless/background mode
+     * Uses sed + pipe for known SpecKit skills, falls back to temp file for custom prompts
+     */
+    async executeHeadless(prompt: string): Promise<AIExecutionResult> {
+        await this.ensureInstalled();
+
+        this.outputChannel.appendLine(`[CodexCliProvider] Invoking Codex CLI in headless mode`);
+        this.outputChannel.appendLine(`========================================`);
+        this.outputChannel.appendLine(prompt);
+        this.outputChannel.appendLine(`========================================`);
+
+        const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
+        const cwd = workspaceFolder?.uri.fsPath;
+
+        let commandLine: string;
+        let tempFilePath: string | null = null;
+
+        const parsed = this.parseSlashCommand(prompt);
+        const promptFile = parsed ? this.getPromptFilePath(parsed.skillName) : null;
+
+        if (parsed && promptFile) {
+            // Use sed + pipe for known SpecKit skills
+            const escapedArgs = this.escapeForSed(parsed.args);
+            commandLine = `sed "s/\\$ARGUMENTS/${escapedArgs}/" "${promptFile}" | codex exec - `;
+        } else {
+            // Fallback: write temp file for custom prompts
+            tempFilePath = await this.createTempFile(prompt, 'background-prompt');
+            commandLine = `codex exec - < "${tempFilePath}" `;
+        }
+
+        const terminal = vscode.window.createTerminal({
+            name: 'Codex CLI Background',
+            cwd,
+            hideFromUser: true
+        });
+
+        return new Promise((resolve) => {
+            let shellIntegrationChecks = 0;
+
+            const checkShellIntegration = setInterval(() => {
+                shellIntegrationChecks++;
+
+                if (terminal.shellIntegration) {
+                    clearInterval(checkShellIntegration);
+
+                    const execution = terminal.shellIntegration.executeCommand(commandLine);
+
+                    const disposable = vscode.window.onDidEndTerminalShellExecution(event => {
+                        if (event.terminal === terminal && event.execution === execution) {
+                            disposable.dispose();
+
+                            if (event.exitCode !== 0) {
+                                this.outputChannel.appendLine(`[Codex] Command failed with exit code: ${event.exitCode}`);
+                                this.outputChannel.appendLine(`[Codex] Command was: ${commandLine}`);
+                            }
+
+                            resolve({
+                                exitCode: event.exitCode,
+                                output: undefined
+                            });
+
+                            setTimeout(async () => {
+                                terminal.dispose();
+                                if (tempFilePath) {
+                                    try {
+                                        await fs.promises.unlink(tempFilePath);
+                                        this.outputChannel.appendLine(`[Codex] Cleaned up temp file: ${tempFilePath}`);
+                                    } catch (e) {
+                                        this.outputChannel.appendLine(`[Codex] Failed to cleanup temp file: ${e}`);
+                                    }
+                                }
+                            }, Timing.terminalDisposeDelay);
+                        }
+                    });
+                } else if (shellIntegrationChecks > Timing.shellIntegrationMaxChecks) {
+                    clearInterval(checkShellIntegration);
+                    this.outputChannel.appendLine(`[Codex] Shell integration not available, using fallback mode`);
+                    terminal.sendText(commandLine);
+
+                    setTimeout(async () => {
+                        resolve({ exitCode: undefined });
+                        terminal.dispose();
+                        if (tempFilePath) {
+                            try {
+                                await fs.promises.unlink(tempFilePath);
+                            } catch (e) {
+                                // Ignore cleanup errors
+                            }
+                        }
+                    }, Timing.shellIntegrationFallbackTimeout);
+                }
+            }, Timing.shellIntegrationCheckInterval);
+        });
+    }
+
+    /**
+     * Execute a slash command in terminal
+     * Uses sed + pipe for known SpecKit skills, falls back to echo wrapper for other commands
+     * @param command - The slash command to execute (e.g., "/speckit.specify specs/012-feature")
+     * @param title - Terminal title
+     * @param autoExecute - If false, shows command but waits for user to press Enter (default: true)
+     */
+    async executeSlashCommand(command: string, title: string = 'SpecKit - Codex CLI', autoExecute: boolean = true): Promise<vscode.Terminal> {
+        try {
+            await this.ensureInstalled();
+
+            // Ensure command starts with /
+            const slashCommand = command.startsWith('/') ? command : `/${command}`;
+
+            let terminalCommand: string;
+            const parsed = this.parseSlashCommand(slashCommand);
+            const promptFile = parsed ? this.getPromptFilePath(parsed.skillName) : null;
+
+            if (parsed && promptFile) {
+                // Use sed + pipe for known SpecKit skills
+                const escapedArgs = this.escapeForSed(parsed.args);
+                terminalCommand = `sed "s/\\$ARGUMENTS/${escapedArgs}/" "${promptFile}" | codex exec - `;
+            } else {
+                // Fallback: wrap as instruction prompt for unknown commands
+                terminalCommand = `echo "Run the following SpecKit command: ${slashCommand}" | codex exec - `;
+            }
+
+            const terminal = vscode.window.createTerminal({
+                name: title,
+                cwd: vscode.workspace.workspaceFolders?.[0]?.uri.fsPath,
+                location: {
+                    viewColumn: vscode.ViewColumn.Two
+                }
+            });
+
+            terminal.show();
+
+            const delay = this.configManager.getTerminalDelay();
+            setTimeout(() => {
+                // autoExecute=false: show command but don't press Enter (user can add more input)
+                terminal.sendText(terminalCommand, autoExecute);
+            }, delay);
+
+            return terminal;
+
+        } catch (error) {
+            this.outputChannel.appendLine(`[Codex] ERROR: Failed to execute slash command: ${error}`);
+            vscode.window.showErrorMessage(`Failed to run Codex CLI: ${error}`);
+            throw error;
+        }
+    }
+}

--- a/src/ai-providers/index.ts
+++ b/src/ai-providers/index.ts
@@ -3,3 +3,4 @@ export * from './aiProviderFactory';
 export * from './claudeCodeProvider';
 export * from './geminiCliProvider';
 export * from './copilotCliProvider';
+export * from './codexCliProvider';

--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -10,6 +10,7 @@ export const Commands = {
     clarify: 'speckit.clarify',
     analyze: 'speckit.analyze',
     checklist: 'speckit.checklist',
+    customCommand: 'speckit.customCommand',
     constitution: 'speckit.constitution',
     refresh: 'speckit.refresh',
     delete: 'speckit.delete',
@@ -53,6 +54,7 @@ export const ConfigKeys = {
     claudePath: 'speckit.claudePath',
     aiProvider: 'speckit.aiProvider',
     geminiInitDelay: 'speckit.geminiInitDelay',
+    customCommands: 'speckit.customCommands',
     views: {
         specsVisible: 'speckit.views.specs.visible',
         agentsVisible: 'speckit.views.agents.visible',

--- a/src/core/types/config.ts
+++ b/src/core/types/config.ts
@@ -69,3 +69,17 @@ export interface SpecTreeItem {
     label: string;
     specPath?: string;
 }
+
+// Custom slash command configuration (settings)
+export interface CustomCommandConfig {
+    /** Optional friendly name (used for labels) */
+    name?: string;
+    /** Optional display title shown in quick pick */
+    title?: string;
+    /** Full slash command (e.g., "/speckit.review") */
+    command?: string;
+    /** Whether to append or inject the spec directory */
+    requiresSpecDir?: boolean;
+    /** Whether to auto-execute in terminal (default: true) */
+    autoExecute?: boolean;
+}


### PR DESCRIPTION
## Summary
- Add CodexCliProvider for OpenAI Codex CLI integration as a new AI provider option
- Parse slash commands (`/speckit.specify`, `/speckit.plan`, etc.) and substitute `$ARGUMENTS` in `.codex/prompts/` templates
- Use sed piping for known SpecKit skills, with temp file fallback for custom prompts
- Include `.codex/prompts/` templates for all SpecKit skills

## Test plan
- [ ] Select "Codex CLI" as AI provider in settings
- [ ] Trigger a SpecKit command (e.g., `/speckit.specify`)
- [ ] Verify terminal shows `sed ... | codex exec -` command pattern
- [ ] Verify Codex receives the prompt with substituted arguments

Fixes #8

