### PR TITLE
feat: add setting to control Claude permission mode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "speckit-companion",
-  "version": "0.2.85",
+  "version": "0.2.86",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "speckit-companion",
-      "version": "0.2.85",
+      "version": "0.2.86",
       "license": "MIT",
       "dependencies": {
         "js-yaml": "^4.1.0"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "speckit-companion",
   "displayName": "SpecKit Companion",
   "description": "VS Code companion for GitHub SpecKit - spec-driven development with AI assistants",
-  "version": "0.2.85",
+  "version": "0.2.86",
   "license": "MIT",
   "publisher": "alfredoperez",
   "icon": "icon.png",
@@ -532,6 +532,21 @@
           "scope": "machine",
           "order": 2,
           "description": "AI assistant to use for spec generation"
+        },
+        "speckit.claudePermissionMode": {
+          "type": "string",
+          "default": "bypassPermissions",
+          "enum": [
+            "bypassPermissions",
+            "default"
+          ],
+          "enumDescriptions": [
+            "Skip all permission prompts (YOLO mode)",
+            "Use default interactive permission prompts"
+          ],
+          "scope": "machine",
+          "order": 3,
+          "description": "Controls how Claude CLI handles permission prompts"
         },
         "speckit.geminiPath": {
           "type": "string",

--- a/src/ai-providers/claudeCodeProvider.ts
+++ b/src/ai-providers/claudeCodeProvider.ts
@@ -44,6 +44,25 @@ export class ClaudeCodeProvider implements IAIProvider {
     }
 
     /**
+     * Get permission flag based on user setting
+     * Returns the --permission-mode flag or empty string for default mode
+     */
+    private getPermissionFlag(): string {
+        const config = vscode.workspace.getConfiguration('speckit');
+        const mode = config.get<string>('claudePermissionMode', 'bypassPermissions');
+        return mode === 'bypassPermissions' ? '--permission-mode bypassPermissions ' : '';
+    }
+
+    /**
+     * Static version of getPermissionFlag for use in static methods
+     */
+    private static getPermissionFlagStatic(): string {
+        const config = vscode.workspace.getConfiguration('speckit');
+        const mode = config.get<string>('claudePermissionMode', 'bypassPermissions');
+        return mode === 'bypassPermissions' ? '--permission-mode bypassPermissions ' : '';
+    }
+
+    /**
      * Create a temporary file with content
      */
     private async createTempFile(content: string, prefix: string = 'prompt'): Promise<string> {
@@ -93,7 +112,8 @@ export class ClaudeCodeProvider implements IAIProvider {
             await this.ensurePermissions();
 
             const promptFilePath = await this.createTempFile(prompt, 'prompt');
-            const command = `claude --permission-mode bypassPermissions "$(cat "${promptFilePath}")"`;
+            const permissionFlag = this.getPermissionFlag();
+            const command = `claude ${permissionFlag}"$(cat "${promptFilePath}")"`;
 
             const terminal = vscode.window.createTerminal({
                 name: title,
@@ -144,7 +164,8 @@ export class ClaudeCodeProvider implements IAIProvider {
         const cwd = workspaceFolder?.uri.fsPath;
 
         const promptFilePath = await this.createTempFile(prompt, 'background-prompt');
-        const commandLine = `claude --permission-mode bypassPermissions "$(cat "${promptFilePath}")"`;
+        const permissionFlag = this.getPermissionFlag();
+        const commandLine = `claude ${permissionFlag}"$(cat "${promptFilePath}")"`;
 
         const terminal = vscode.window.createTerminal({
             name: 'Claude Code Background',
@@ -219,7 +240,8 @@ export class ClaudeCodeProvider implements IAIProvider {
 
             // Ensure command starts with /
             const slashCommand = command.startsWith('/') ? command : `/${command}`;
-            const fullCommand = `claude --permission-mode bypassPermissions "${slashCommand}"`;
+            const permissionFlag = this.getPermissionFlag();
+            const fullCommand = `claude ${permissionFlag}"${slashCommand}"`;
 
             const terminal = vscode.window.createTerminal({
                 name: title,
@@ -279,8 +301,9 @@ export class ClaudeCodeProvider implements IAIProvider {
         });
 
         terminal.show();
+        const permissionFlag = ClaudeCodeProvider.getPermissionFlagStatic();
         terminal.sendText(
-            'claude --permission-mode bypassPermissions',
+            `claude ${permissionFlag}`.trim(),
             true
         );
 

--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -53,6 +53,7 @@ export const ConfigKeys = {
     workflowEditorEnabled: 'speckit.workflowEditor.enabled',
     claudePath: 'speckit.claudePath',
     aiProvider: 'speckit.aiProvider',
+    claudePermissionMode: 'speckit.claudePermissionMode',
     geminiInitDelay: 'speckit.geminiInitDelay',
     customCommands: 'speckit.customCommands',
     views: {

--- a/src/features/steering/steeringManager.ts
+++ b/src/features/steering/steeringManager.ts
@@ -178,8 +178,11 @@ Analyze the document and:
         terminal.show();
 
         const delay = this.configManager.getTerminalDelay();
+        const config = vscode.workspace.getConfiguration('speckit');
+        const mode = config.get<string>('claudePermissionMode', 'bypassPermissions');
+        const permissionFlag = mode === 'bypassPermissions' ? '--permission-mode bypassPermissions ' : '';
         setTimeout(() => {
-            terminal.sendText('claude --permission-mode bypassPermissions "/init"');
+            terminal.sendText(`claude ${permissionFlag}"/init"`);
         }, delay);
     }
 


### PR DESCRIPTION
## Summary
- Adds `speckit.claudePermissionMode` setting with two options:
  - `bypassPermissions` - Skip all permission prompts (YOLO mode, default)
  - `default` - Use interactive permission prompts
- Updates all Claude CLI command executions to respect the new setting

Closes #7

## Test plan
- [ ] Set `speckit.claudePermissionMode` to `"default"` in VS Code settings
- [ ] Run any SpecKit command (e.g., execute a skill)
- [ ] Verify Claude runs interactively, prompting for permissions
- [ ] Set back to `"bypassPermissions"` and verify YOLO mode works