### PR TITLE
feat: add custom workflows and workflow selector

### DIFF
--- a/.claude/commands/speckit.commit.md
+++ b/.claude/commands/speckit.commit.md
@@ -1,0 +1,52 @@
+---
+description: Generate a commit for the current feature work
+---
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+## Instructions
+
+Create a well-structured commit for the current feature work.
+
+1. **Analyze changes**:
+   ```bash
+   git status
+   git diff --staged
+   git diff
+   ```
+
+2. **Determine commit scope**:
+   - If `$ARGUMENTS` specifies files/scope, use that
+   - Otherwise, stage all feature-related changes
+
+3. **Generate commit message** following conventional commits:
+   ```
+   <type>(<scope>): <description>
+
+   <body>
+
+   <footer>
+   ```
+
+   Types: `feat`, `fix`, `docs`, `style`, `refactor`, `test`, `chore`
+
+4. **Stage and commit**:
+   ```bash
+   git add <files>
+   git commit -m "<message>"
+   ```
+
+5. **Options** (from $ARGUMENTS):
+   - `--no-coauthor` - Skip Co-Authored-By line
+   - `--amend` - Amend previous commit
+   - `--wip` - Use "wip: " prefix for work-in-progress
+
+6. **Default behavior**:
+   - Include `Co-Authored-By: Claude <noreply@anthropic.com>` unless `--no-coauthor`
+   - Use feature branch name to determine scope
+
+Report the commit hash and message when complete.

--- a/.claude/commands/speckit.light-implement.md
+++ b/.claude/commands/speckit.light-implement.md
@@ -1,0 +1,35 @@
+---
+description: Lightweight implementation - direct coding without task breakdown
+---
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+## Instructions
+
+Implement the feature directly based on the spec and plan. This is a streamlined version without formal task management.
+
+1. **Read context**:
+   - `specs/{feature}/spec.md` - requirements
+   - `specs/{feature}/plan.md` - implementation approach
+
+2. **Implement directly**:
+   - Follow the plan's implementation steps
+   - Make changes to the files identified
+   - Write tests as you go
+
+3. **Skip**:
+   - Task file generation
+   - Phase-by-phase breakdown
+   - Progress tracking in tasks.md
+   - Formal task completion markers
+
+4. **When complete**, summarize:
+   - Files changed
+   - Tests added
+   - Any deviations from plan
+
+This lightweight implementation is for small features where formal task tracking adds overhead. Use `/speckit.implement` for larger features requiring structured progress tracking.

--- a/.claude/commands/speckit.light-plan.md
+++ b/.claude/commands/speckit.light-plan.md
@@ -1,0 +1,53 @@
+---
+description: Lightweight planning - quick implementation outline
+---
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+## Instructions
+
+Create a lightweight implementation plan. This is a streamlined version for rapid development.
+
+1. **Read the spec** from the current feature's `spec.md`
+
+2. **Create minimal plan** at `specs/{feature}/plan.md`:
+
+```markdown
+# Implementation Plan
+
+## Approach
+
+[2-3 paragraphs describing the high-level approach]
+
+## Files to Change
+
+| File | Change |
+|------|--------|
+| path/to/file | Description of change |
+
+## Implementation Steps
+
+1. [Step 1]
+2. [Step 2]
+3. [Step 3]
+
+## Testing
+
+- [ ] [Test case 1]
+- [ ] [Test case 2]
+```
+
+3. **Skip**:
+   - Research phase
+   - Data model design
+   - Quickstart guide
+   - Constitution checks
+   - Detailed architecture
+
+4. Report completion with plan path.
+
+This lightweight plan is meant for small features or when you already know the approach. Use `/speckit.plan` for comprehensive planning.

--- a/.claude/commands/speckit.light-specify.md
+++ b/.claude/commands/speckit.light-specify.md
@@ -1,0 +1,53 @@
+---
+description: Lightweight spec generation - minimal structure, fast iteration
+---
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+## Instructions
+
+Create a lightweight feature specification for rapid prototyping. This is a streamlined version focused on speed over completeness.
+
+1. **Generate branch name** using pattern `NNN-short-name` (check existing branches/specs for next number)
+
+2. **Create minimal spec** at `specs/{branch-name}/spec.md`:
+
+```markdown
+# Feature: [Feature Name]
+
+**Branch**: {branch-name}
+**Created**: {date}
+
+## Summary
+
+[2-3 sentences describing what the feature does and why]
+
+## User Stories
+
+- As a [user], I want to [action] so that [benefit]
+
+## Acceptance Criteria
+
+- [ ] [Criterion 1]
+- [ ] [Criterion 2]
+- [ ] [Criterion 3]
+
+## Notes
+
+[Any important context or constraints]
+```
+
+3. **Skip**:
+   - Detailed scenarios
+   - Edge cases analysis
+   - Formal requirements (FR-XXX)
+   - Quality checklists
+   - Clarification rounds
+
+4. Report completion with branch name and spec path.
+
+This lightweight spec is meant for small features, spikes, or rapid iteration. Use `/speckit.specify` for full specifications.

--- a/.claude/commands/speckit.pr.md
+++ b/.claude/commands/speckit.pr.md
@@ -1,0 +1,61 @@
+---
+description: Create a pull request for the current feature
+---
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+## Instructions
+
+Create a pull request for the current feature branch.
+
+1. **Gather context**:
+   - Current branch name
+   - Read `specs/{feature}/spec.md` for feature description
+   - Read `specs/{feature}/plan.md` for implementation approach
+   - Get commit history: `git log main..HEAD --oneline`
+
+2. **Ensure branch is pushed**:
+   ```bash
+   git push -u origin HEAD
+   ```
+
+3. **Generate PR content**:
+
+   **Title**: `feat(<scope>): <description>` (from branch/spec)
+
+   **Body**:
+   ```markdown
+   ## Summary
+
+   [Brief description from spec]
+
+   ## Changes
+
+   - [Key change 1]
+   - [Key change 2]
+
+   ## Testing
+
+   - [ ] [Test performed]
+
+   ## Related
+
+   - Spec: `specs/{feature}/spec.md`
+   - Plan: `specs/{feature}/plan.md`
+   ```
+
+4. **Create PR**:
+   ```bash
+   gh pr create --title "<title>" --body "<body>" --base main
+   ```
+
+5. **Options** (from $ARGUMENTS):
+   - `--draft` - Create as draft PR
+   - `--reviewer <user>` - Add reviewer
+   - `--label <label>` - Add label
+
+Report the PR URL when complete.

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,6 +9,32 @@
     "chat.tools.terminal.autoApprove": {
         ".specify/scripts/bash/": true,
         ".specify/scripts/powershell/": true
-    }
+    },
+    "speckit.customCommands": [
+        {
+            "name": "commit",
+            "title": "Commit",
+            "command": "/speckit.commit",
+            "step": "tasks",
+            "tooltip": "Generate a commit for completed work"
+        },
+        {
+            "name": "pr",
+            "title": "Create PR",
+            "command": "/speckit.pr",
+            "step": "tasks",
+            "tooltip": "Create a pull request for the feature"
+        }
+    ],
+    "speckit.customWorkflows": [
+        {
+            "name": "light",
+            "displayName": "Light Workflow",
+            "description": "Streamlined workflow for small features",
+            "step-specify": "/speckit.light-specify",
+            "step-plan": "/speckit.light-plan",
+            "step-implement": "/speckit.light-implement"
+        }
+    ]
 }
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,6 +106,7 @@ User data stored in workspace `.claude/` directory:
 - TypeScript 5.3+ (ES2022 target, strict mode) + VS Code Extension API (`@types/vscode ^1.84.0`), Webpack 5 (011-spec-viewer-polish)
 - N/A (file-based in `.claude/specs/` directory) (011-spec-viewer-polish)
 - File-based in `.codex/` directory structure (012-codex-cli-provider)
+- File-based in `.claude/` directory structure for feature context persistence (001-custom-workflows)
 
 ## Recent Changes
 - 011-spec-viewer-polish: Added TypeScript 5.3+ (ES2022 target, strict mode) + VS Code Extension API (`@types/vscode ^1.84.0`), Webpack 5

--- a/README.md
+++ b/README.md
@@ -210,20 +210,60 @@ Access these commands via the Command Palette (`Cmd+Shift+P` / `Ctrl+Shift+P`):
 
 ### Custom Commands
 
-You can add custom SpecKit slash commands in VS Code settings and run them with **SpecKit: Run Custom Command**.
+Add custom SpecKit slash commands in VS Code settings. Run them with **SpecKit: Run Custom Command** or see them in the workflow editor based on `step`.
 
 ```json
 {
   "speckit.customCommands": [
     "review",
     {
-      "title": "Risk Review",
-      "command": "/speckit.risk-review ${specDir}",
-      "autoExecute": false
+      "name": "commit",
+      "title": "Commit Changes",
+      "command": "/speckit.commit",
+      "step": "tasks",
+      "tooltip": "Generate a commit for completed work",
+      "requiresSpecDir": false
+    },
+    {
+      "name": "pr",
+      "title": "Create PR",
+      "command": "/speckit.pr",
+      "step": "tasks",
+      "tooltip": "Create a pull request for the feature"
     }
   ]
 }
 ```
+
+**Properties:**
+- `name` - Command identifier
+- `title` - Display name in picker
+- `command` - Slash command to execute
+- `step` - Phase to show in: `spec`, `plan`, `tasks`, or `all` (default)
+- `tooltip` - Description shown on hover
+- `autoExecute` - Auto-run in terminal (default: true)
+- `requiresSpecDir` - Inject spec directory (default: true)
+
+### Custom Workflows
+
+Define alternative workflows with different commands for each step:
+
+```json
+{
+  "speckit.customWorkflows": [
+    {
+      "name": "light",
+      "displayName": "Light Workflow",
+      "description": "Streamlined workflow for small features",
+      "step-specify": "/speckit.light-specify",
+      "step-plan": "/speckit.light-plan",
+      "step-implement": "/speckit.light-implement"
+    }
+  ]
+}
+```
+
+When multiple workflows exist, you'll be prompted to choose when starting a new spec.
 
 ## Configuration
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "speckit-companion",
-  "version": "0.3.0",
+  "version": "0.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "speckit-companion",
-      "version": "0.3.0",
+      "version": "0.3.3",
       "license": "MIT",
       "dependencies": {
         "js-yaml": "^4.1.0"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "speckit-companion",
   "displayName": "SpecKit Companion",
   "description": "VS Code companion for GitHub SpecKit - spec-driven development with AI assistants",
-  "version": "0.3.0",
+  "version": "0.3.3",
   "license": "MIT",
   "publisher": "alfredoperez",
   "icon": "icon.png",
@@ -576,7 +576,7 @@
           "default": [],
           "scope": "window",
           "order": 6,
-          "description": "Custom SpecKit slash commands available in 'Run Custom Command'. Each entry can be a string (command name) or an object with name, title, command, requiresSpecDir, and autoExecute.",
+          "description": "Custom SpecKit slash commands available in 'Run Custom Command'. Each entry can be a string (command name) or an object with name, title, command, step, tooltip, requiresSpecDir, and autoExecute.",
           "items": {
             "anyOf": [
               {
@@ -606,6 +606,21 @@
                   "autoExecute": {
                     "type": "boolean",
                     "description": "Auto-run the command in the terminal (default: true)"
+                  },
+                  "step": {
+                    "type": "string",
+                    "enum": [
+                      "spec",
+                      "plan",
+                      "tasks",
+                      "all"
+                    ],
+                    "default": "all",
+                    "description": "Which phase to show this command in (spec, plan, tasks, or all)"
+                  },
+                  "tooltip": {
+                    "type": "string",
+                    "description": "Tooltip text shown on hover"
                   }
                 },
                 "additionalProperties": false
@@ -660,6 +675,47 @@
           "default": false,
           "scope": "window",
           "description": "Show Settings view"
+        },
+        "speckit.customWorkflows": {
+          "type": "array",
+          "default": [],
+          "scope": "window",
+          "order": 7,
+          "description": "Custom workflow definitions for spec-driven development",
+          "items": {
+            "type": "object",
+            "required": [
+              "name"
+            ],
+            "properties": {
+              "name": {
+                "type": "string",
+                "pattern": "^[a-z][a-z0-9-]*$",
+                "description": "Unique workflow identifier (lowercase, hyphenated)"
+              },
+              "displayName": {
+                "type": "string",
+                "description": "Display name shown in workflow picker"
+              },
+              "description": {
+                "type": "string",
+                "description": "Description shown in workflow picker"
+              },
+              "step-specify": {
+                "type": "string",
+                "description": "Custom command for specify step"
+              },
+              "step-plan": {
+                "type": "string",
+                "description": "Custom command for plan step"
+              },
+              "step-implement": {
+                "type": "string",
+                "description": "Custom command for implement step"
+              }
+            },
+            "additionalProperties": false
+          }
         }
       }
     }

--- a/specs/001-custom-workflows/checklists/requirements.md
+++ b/specs/001-custom-workflows/checklists/requirements.md
@@ -1,0 +1,37 @@
+# Specification Quality Checklist: Custom Workflows
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-01-26
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All checklist items pass validation
+- Specification is ready for `/speckit.clarify` or `/speckit.plan`
+- Edge cases have been identified with reasonable default behaviors documented
+- Assumptions section clearly outlines user responsibilities for custom command templates

--- a/specs/001-custom-workflows/contracts/workflow-api.ts
+++ b/specs/001-custom-workflows/contracts/workflow-api.ts
@@ -1,0 +1,297 @@
+/**
+ * Custom Workflows API Contract
+ *
+ * This file defines the public API surface for the custom workflows feature.
+ * Implementation should adhere to these contracts.
+ *
+ * Feature: 001-custom-workflows
+ * Date: 2026-01-26
+ */
+
+import * as vscode from 'vscode';
+
+// ============================================================================
+// Configuration Types (from VS Code settings)
+// ============================================================================
+
+/**
+ * Checkpoint type identifiers
+ */
+export type CheckpointId = 'commit' | 'pr';
+
+/**
+ * Checkpoint trigger points
+ */
+export type CheckpointTrigger = 'after-implement' | 'after-commit';
+
+/**
+ * Checkpoint status values
+ */
+export type CheckpointStatus = 'pending' | 'completed' | 'skipped';
+
+/**
+ * Checkpoint configuration
+ */
+export interface CheckpointConfig {
+  id: CheckpointId;
+  trigger: CheckpointTrigger;
+  requiresApproval?: boolean;
+  excludeCoAuthor?: boolean;
+  prTitleTemplate?: string;
+}
+
+/**
+ * Workflow configuration from VS Code settings
+ */
+export interface WorkflowConfig {
+  name: string;
+  displayName?: string;
+  description?: string;
+  'step-specify'?: string;
+  'step-plan'?: string;
+  'step-implement'?: string;
+  checkpoints?: CheckpointConfig[];
+}
+
+/**
+ * Feature workflow context persisted in .speckit.json
+ */
+export interface FeatureWorkflowContext {
+  workflow: string;
+  selectedAt: string;
+  checkpointStatus?: Record<CheckpointId, CheckpointStatus>;
+}
+
+// ============================================================================
+// Workflow Manager API
+// ============================================================================
+
+/**
+ * Workflow manager interface for loading and managing workflows
+ */
+export interface IWorkflowManager {
+  /**
+   * Get all configured workflows including the default workflow
+   * @returns Array of workflow configurations
+   */
+  getWorkflows(): WorkflowConfig[];
+
+  /**
+   * Get a specific workflow by name
+   * @param name Workflow name
+   * @returns Workflow configuration or undefined if not found
+   */
+  getWorkflow(name: string): WorkflowConfig | undefined;
+
+  /**
+   * Validate a workflow configuration
+   * @param config Workflow configuration to validate
+   * @returns Validation result with errors if invalid
+   */
+  validateWorkflow(config: WorkflowConfig): ValidationResult;
+
+  /**
+   * Get the selected workflow for a feature
+   * @param featureDir Path to feature directory
+   * @returns Workflow context or undefined if not selected
+   */
+  getFeatureWorkflow(featureDir: string): Promise<FeatureWorkflowContext | undefined>;
+
+  /**
+   * Save workflow selection for a feature
+   * @param featureDir Path to feature directory
+   * @param workflowName Name of selected workflow
+   */
+  saveFeatureWorkflow(featureDir: string, workflowName: string): Promise<void>;
+
+  /**
+   * Resolve the command for a workflow step
+   * @param workflow Workflow configuration
+   * @param step Step name (specify, plan, implement)
+   * @returns Resolved command name
+   */
+  resolveStepCommand(workflow: WorkflowConfig, step: WorkflowStep): string;
+}
+
+/**
+ * Validation result for workflow configurations
+ */
+export interface ValidationResult {
+  valid: boolean;
+  errors: string[];
+  warnings: string[];
+}
+
+/**
+ * Workflow step identifiers
+ */
+export type WorkflowStep = 'specify' | 'plan' | 'implement';
+
+// ============================================================================
+// Workflow Selector API
+// ============================================================================
+
+/**
+ * Workflow selector interface for UI interactions
+ */
+export interface IWorkflowSelector {
+  /**
+   * Show workflow selection picker
+   * @param featureDir Path to feature directory (for context)
+   * @returns Selected workflow or undefined if cancelled
+   */
+  selectWorkflow(featureDir: string): Promise<WorkflowConfig | undefined>;
+
+  /**
+   * Check if workflow selection is needed
+   * @returns True if multiple workflows are configured
+   */
+  needsSelection(): boolean;
+}
+
+// ============================================================================
+// Checkpoint Handler API
+// ============================================================================
+
+/**
+ * Checkpoint execution result
+ */
+export interface CheckpointResult {
+  status: CheckpointStatus;
+  error?: string;
+  output?: string;
+}
+
+/**
+ * Checkpoint handler interface for commit/PR operations
+ */
+export interface ICheckpointHandler {
+  /**
+   * Execute a checkpoint
+   * @param checkpoint Checkpoint configuration
+   * @param featureDir Path to feature directory
+   * @param context Additional context for the checkpoint
+   * @returns Execution result
+   */
+  executeCheckpoint(
+    checkpoint: CheckpointConfig,
+    featureDir: string,
+    context: CheckpointContext
+  ): Promise<CheckpointResult>;
+
+  /**
+   * Prompt user for checkpoint approval
+   * @param checkpoint Checkpoint configuration
+   * @param featureDir Path to feature directory
+   * @returns True if approved, false if declined
+   */
+  promptForApproval(
+    checkpoint: CheckpointConfig,
+    featureDir: string
+  ): Promise<boolean>;
+
+  /**
+   * Get checkpoints triggered after a specific event
+   * @param workflow Workflow configuration
+   * @param trigger Trigger event
+   * @returns Array of checkpoints to execute
+   */
+  getTriggeredCheckpoints(
+    workflow: WorkflowConfig,
+    trigger: CheckpointTrigger
+  ): CheckpointConfig[];
+}
+
+/**
+ * Context passed to checkpoint execution
+ */
+export interface CheckpointContext {
+  featureName: string;
+  branchName: string;
+  commitMessage?: string;
+}
+
+// ============================================================================
+// VS Code Command Handlers
+// ============================================================================
+
+/**
+ * Command handler signatures for workflow-related commands
+ */
+export interface WorkflowCommandHandlers {
+  /**
+   * Execute the specify step with workflow selection
+   * @param specDir Optional spec directory
+   * @param refinementContext Optional refinement context
+   */
+  'speckit.specify': (specDir?: string, refinementContext?: string) => Promise<void>;
+
+  /**
+   * Execute the plan step with workflow selection
+   * @param specDir Optional spec directory
+   * @param refinementContext Optional refinement context
+   */
+  'speckit.plan': (specDir?: string, refinementContext?: string) => Promise<void>;
+
+  /**
+   * Execute the implement step with workflow selection and checkpoints
+   * @param specDir Optional spec directory
+   * @param refinementContext Optional refinement context
+   */
+  'speckit.implement': (specDir?: string, refinementContext?: string) => Promise<void>;
+}
+
+// ============================================================================
+// Events
+// ============================================================================
+
+/**
+ * Event emitted when workflow selection changes
+ */
+export interface WorkflowChangedEvent {
+  featureDir: string;
+  workflowName: string;
+  previousWorkflow?: string;
+}
+
+/**
+ * Event emitted when a checkpoint completes
+ */
+export interface CheckpointCompletedEvent {
+  featureDir: string;
+  checkpointId: CheckpointId;
+  status: CheckpointStatus;
+  error?: string;
+}
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+/**
+ * Default workflow configuration
+ */
+export const DEFAULT_WORKFLOW: WorkflowConfig = {
+  name: 'default',
+  displayName: 'Default',
+  description: 'Standard SpecKit workflow',
+  'step-specify': 'speckit.specify',
+  'step-plan': 'speckit.plan',
+  'step-implement': 'speckit.implement',
+  checkpoints: [],
+};
+
+/**
+ * Configuration key for custom workflows
+ */
+export const CONFIG_KEY_CUSTOM_WORKFLOWS = 'speckit.customWorkflows';
+
+/**
+ * File name for feature workflow context
+ */
+export const FEATURE_CONTEXT_FILE = '.speckit.json';
+
+/**
+ * Workflow name validation pattern
+ */
+export const WORKFLOW_NAME_PATTERN = /^[a-z][a-z0-9-]*$/;

--- a/specs/001-custom-workflows/data-model.md
+++ b/specs/001-custom-workflows/data-model.md
@@ -1,0 +1,324 @@
+# Data Model: Custom Workflows
+
+**Feature**: 001-custom-workflows
+**Date**: 2026-01-26
+
+## Entity Definitions
+
+### WorkflowConfig
+
+The primary configuration entity for a custom workflow.
+
+```typescript
+/**
+ * Custom workflow configuration stored in VS Code settings
+ */
+interface WorkflowConfig {
+  /** Unique identifier for the workflow (required, must be non-empty) */
+  name: string;
+
+  /** Optional display name (defaults to name if not provided) */
+  displayName?: string;
+
+  /** Optional description shown in workflow picker */
+  description?: string;
+
+  /** Custom command for the specify step (defaults to 'speckit.specify') */
+  'step-specify'?: string;
+
+  /** Custom command for the plan step (defaults to 'speckit.plan') */
+  'step-plan'?: string;
+
+  /** Custom command for the implement step (defaults to 'speckit.implement') */
+  'step-implement'?: string;
+
+  /** Optional checkpoint definitions */
+  checkpoints?: CheckpointConfig[];
+}
+```
+
+**Validation Rules**:
+- `name` is required and must be unique across all workflows
+- `name` cannot be "default" (reserved for built-in workflow)
+- `name` must match pattern `^[a-z][a-z0-9-]*$` (lowercase, hyphenated)
+- Step commands, if provided, must be non-empty strings
+- Workflow with missing step commands inherits from default
+
+### CheckpointConfig
+
+Configuration for workflow checkpoints (pause points with user prompts).
+
+```typescript
+/**
+ * Checkpoint configuration for commit/PR generation
+ */
+interface CheckpointConfig {
+  /** Checkpoint identifier */
+  id: 'commit' | 'pr';
+
+  /** When to trigger the checkpoint */
+  trigger: 'after-implement' | 'after-commit';
+
+  /** Whether to prompt user before executing (default: true) */
+  requiresApproval?: boolean;
+
+  /** For commit checkpoint: exclude co-author attribution */
+  excludeCoAuthor?: boolean;
+
+  /** For PR checkpoint: custom PR title template */
+  prTitleTemplate?: string;
+}
+```
+
+**Validation Rules**:
+- `id` must be one of the defined checkpoint types
+- `trigger: 'after-commit'` is only valid for `id: 'pr'`
+- `excludeCoAuthor` is only applicable when `id: 'commit'`
+- `prTitleTemplate` is only applicable when `id: 'pr'`
+
+### FeatureWorkflowContext
+
+Persisted context linking a feature to its selected workflow.
+
+```typescript
+/**
+ * Feature-workflow context stored in .speckit.json
+ */
+interface FeatureWorkflowContext {
+  /** Name of the selected workflow */
+  workflow: string;
+
+  /** Timestamp when workflow was selected */
+  selectedAt: string; // ISO 8601
+
+  /** Checkpoint progress tracking */
+  checkpointStatus?: {
+    commit?: 'pending' | 'completed' | 'skipped';
+    pr?: 'pending' | 'completed' | 'skipped';
+  };
+}
+```
+
+**File Location**: `specs/{feature-name}/.speckit.json`
+
+### DefaultWorkflow
+
+The built-in default workflow (always available).
+
+```typescript
+const DEFAULT_WORKFLOW: WorkflowConfig = {
+  name: 'default',
+  displayName: 'Default',
+  description: 'Standard SpecKit workflow',
+  'step-specify': 'speckit.specify',
+  'step-plan': 'speckit.plan',
+  'step-implement': 'speckit.implement',
+  checkpoints: []
+};
+```
+
+## Relationships
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                    VS Code Settings                          │
+│  speckit.customWorkflows: WorkflowConfig[]                  │
+└────────────────────────┬────────────────────────────────────┘
+                         │ 1:N
+                         ▼
+┌─────────────────────────────────────────────────────────────┐
+│                    WorkflowConfig                            │
+│  name, step-specify, step-plan, step-implement              │
+└────────────────────────┬────────────────────────────────────┘
+                         │ 1:N (optional)
+                         ▼
+┌─────────────────────────────────────────────────────────────┐
+│                   CheckpointConfig                           │
+│  id, trigger, requiresApproval, excludeCoAuthor             │
+└─────────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────────┐
+│              Feature Directory (specs/{name}/)               │
+│  spec.md, plan.md, tasks.md                                 │
+└────────────────────────┬────────────────────────────────────┘
+                         │ 1:1
+                         ▼
+┌─────────────────────────────────────────────────────────────┐
+│             .speckit.json (FeatureWorkflowContext)          │
+│  workflow, selectedAt, checkpointStatus                     │
+└─────────────────────────────────────────────────────────────┘
+```
+
+## State Transitions
+
+### Workflow Selection State
+
+```
+[No Selection] ──(user runs specify)──▶ [Selection Prompt]
+                                              │
+                    ┌─────────────────────────┴─────────────────────────┐
+                    │                                                   │
+                    ▼                                                   ▼
+            [Only Default]                                    [Multiple Available]
+            (auto-select)                                     (show QuickPick)
+                    │                                                   │
+                    └─────────────────────────┬─────────────────────────┘
+                                              ▼
+                                    [Workflow Selected]
+                                              │
+                                              ▼
+                               [Persist to .speckit.json]
+```
+
+### Checkpoint Execution State
+
+```
+[Workflow Step Complete] ──(has checkpoint)──▶ [Checkpoint Triggered]
+                                                        │
+                    ┌───────────────────────────────────┴───────────────────────────┐
+                    │                                   │                           │
+                    ▼                                   ▼                           ▼
+        [requiresApproval: true]           [requiresApproval: false]          [No Checkpoint]
+        (show approval prompt)             (auto-execute)                     (continue)
+                    │                                   │
+        ┌───────────┴───────────┐                      │
+        ▼                       ▼                      │
+    [Approved]              [Declined]                 │
+        │                       │                      │
+        ▼                       ▼                      │
+    [Execute]               [Skip]                     │
+        │                       │                      │
+        └───────────┬───────────┴──────────────────────┘
+                    ▼
+            [Update Status]
+                    │
+                    ▼
+        [Next Checkpoint or Complete]
+```
+
+## Configuration Schema (package.json)
+
+```json
+{
+  "speckit.customWorkflows": {
+    "type": "array",
+    "default": [],
+    "scope": "window",
+    "description": "Custom workflow definitions for spec-driven development",
+    "items": {
+      "type": "object",
+      "required": ["name"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "pattern": "^[a-z][a-z0-9-]*$",
+          "description": "Unique workflow identifier (lowercase, hyphenated)"
+        },
+        "displayName": {
+          "type": "string",
+          "description": "Display name shown in workflow picker"
+        },
+        "description": {
+          "type": "string",
+          "description": "Description shown in workflow picker"
+        },
+        "step-specify": {
+          "type": "string",
+          "description": "Custom command for specify step"
+        },
+        "step-plan": {
+          "type": "string",
+          "description": "Custom command for plan step"
+        },
+        "step-implement": {
+          "type": "string",
+          "description": "Custom command for implement step"
+        },
+        "checkpoints": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["id", "trigger"],
+            "properties": {
+              "id": {
+                "type": "string",
+                "enum": ["commit", "pr"],
+                "description": "Checkpoint type"
+              },
+              "trigger": {
+                "type": "string",
+                "enum": ["after-implement", "after-commit"],
+                "description": "When to trigger checkpoint"
+              },
+              "requiresApproval": {
+                "type": "boolean",
+                "default": true,
+                "description": "Prompt user before executing"
+              },
+              "excludeCoAuthor": {
+                "type": "boolean",
+                "default": false,
+                "description": "Exclude co-author attribution from commit"
+              },
+              "prTitleTemplate": {
+                "type": "string",
+                "description": "Template for PR title (supports ${featureName})"
+              }
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}
+```
+
+## Example Configurations
+
+### Lightweight Workflow
+
+```json
+{
+  "speckit.customWorkflows": [
+    {
+      "name": "light",
+      "displayName": "Lightweight",
+      "description": "Quick workflow with auto-commit and PR",
+      "step-specify": "speckit.light-specify",
+      "step-plan": "speckit.light-plan",
+      "step-implement": "speckit.light-implement",
+      "checkpoints": [
+        {
+          "id": "commit",
+          "trigger": "after-implement",
+          "requiresApproval": true,
+          "excludeCoAuthor": true
+        },
+        {
+          "id": "pr",
+          "trigger": "after-commit",
+          "requiresApproval": true
+        }
+      ]
+    }
+  ]
+}
+```
+
+### Team-Specific Workflow
+
+```json
+{
+  "speckit.customWorkflows": [
+    {
+      "name": "frontend",
+      "displayName": "Frontend Team",
+      "description": "Workflow for UI components",
+      "step-specify": "speckit.frontend-specify",
+      "step-plan": "speckit.plan",
+      "step-implement": "speckit.frontend-implement"
+    }
+  ]
+}
+```

--- a/specs/001-custom-workflows/plan.md
+++ b/specs/001-custom-workflows/plan.md
@@ -1,0 +1,106 @@
+# Implementation Plan: Custom Workflows
+
+**Branch**: `001-custom-workflows` | **Date**: 2026-01-26 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/001-custom-workflows/spec.md`
+
+## Summary
+
+Enable users to define custom workflows with configurable step mappings (specify, plan, implement) via VS Code settings. The feature includes workflow selection when multiple workflows are available, step-to-command mapping, and optional checkpoint definitions for lightweight workflow variants that automate commit and PR generation.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.3+ (ES2022 target, strict mode)
+**Primary Dependencies**: VS Code Extension API (`@types/vscode ^1.84.0`), Webpack 5
+**Storage**: File-based in `.claude/` directory structure for feature context persistence
+**Testing**: Jest 29.7.0 with ts-jest
+**Target Platform**: VS Code ^1.84.0 (cross-platform: macOS, Windows, Linux)
+**Project Type**: Single (VS Code extension with Node.js backend + webview UI)
+**Performance Goals**: Workflow selection adds no more than 5 seconds to spec generation
+**Constraints**: Must integrate with existing AI provider architecture, maintain backwards compatibility with default workflow
+**Scale/Scope**: Single VS Code extension, workspace-scoped configurations
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| **I. Extensibility and Configuration** | ✅ PASS | Workflows are configurable via settings; design allows for future workflow types |
+| **II. Spec-Driven Workflow** | ✅ PASS | Feature enhances the Spec → Plan → Tasks workflow by allowing custom command mappings |
+| **III. Visual and Interactive** | ✅ PASS | Workflow selection uses VS Code QuickPick; checkpoints provide interactive prompts |
+| **IV. Modular Architecture** | ✅ PASS | Implementation follows manager/provider pattern; workflow logic isolated in dedicated module |
+
+**Pre-Design Gate**: PASSED - All principles satisfied
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/001-custom-workflows/
+├── plan.md              # This file (/speckit.plan command output)
+├── research.md          # Phase 0 output (/speckit.plan command)
+├── data-model.md        # Phase 1 output (/speckit.plan command)
+├── quickstart.md        # Phase 1 output (/speckit.plan command)
+├── contracts/           # Phase 1 output (/speckit.plan command)
+└── tasks.md             # Phase 2 output (/speckit.tasks command - NOT created by /speckit.plan)
+```
+
+### Source Code (repository root)
+
+```text
+src/
+├── core/
+│   ├── types/
+│   │   └── config.ts           # Add WorkflowConfig, CheckpointConfig interfaces
+│   └── constants.ts            # Add workflow-related constants
+├── features/
+│   └── workflows/              # NEW: Custom workflows feature module
+│       ├── index.ts            # Module exports
+│       ├── workflowManager.ts  # Workflow CRUD, validation, persistence
+│       ├── workflowSelector.ts # QuickPick workflow selection UI
+│       ├── checkpointHandler.ts # Checkpoint prompt and git operations
+│       └── types.ts            # Workflow-specific type definitions
+├── features/specs/
+│   └── specCommands.ts         # Modify to integrate workflow selection
+└── extension.ts                # Register workflow-related commands
+
+tests/
+└── features/
+    └── workflows/
+        ├── workflowManager.test.ts
+        ├── workflowSelector.test.ts
+        └── checkpointHandler.test.ts
+```
+
+**Structure Decision**: VS Code extension single-project structure. New `workflows` feature module follows the established Manager pattern. Integration points in existing `specs` feature and `extension.ts`.
+
+## Complexity Tracking
+
+> **Fill ONLY if Constitution Check has violations that must be justified**
+
+No violations - all constitution principles satisfied.
+
+## Post-Design Constitution Re-Check
+
+| Principle | Status | Post-Design Notes |
+|-----------|--------|-------------------|
+| **I. Extensibility and Configuration** | ✅ PASS | `speckit.customWorkflows` setting is extensible; new checkpoint types can be added |
+| **II. Spec-Driven Workflow** | ✅ PASS | Design maintains Spec → Plan → Tasks flow; custom commands are variants, not replacements |
+| **III. Visual and Interactive** | ✅ PASS | QuickPick for workflow selection; confirmation dialogs for checkpoints |
+| **IV. Modular Architecture** | ✅ PASS | `workflows/` module with separate manager, selector, and handler files |
+
+**Post-Design Gate**: PASSED
+
+## Generated Artifacts
+
+| Artifact | Path | Status |
+|----------|------|--------|
+| Research | `specs/001-custom-workflows/research.md` | ✅ Complete |
+| Data Model | `specs/001-custom-workflows/data-model.md` | ✅ Complete |
+| API Contract | `specs/001-custom-workflows/contracts/workflow-api.ts` | ✅ Complete |
+| Quickstart | `specs/001-custom-workflows/quickstart.md` | ✅ Complete |
+
+## Next Steps
+
+Run `/speckit.tasks` to generate implementation tasks based on this plan.

--- a/specs/001-custom-workflows/quickstart.md
+++ b/specs/001-custom-workflows/quickstart.md
@@ -1,0 +1,166 @@
+# Quickstart: Custom Workflows Implementation
+
+**Feature**: 001-custom-workflows
+**Date**: 2026-01-26
+
+## Prerequisites
+
+- Node.js 18+
+- VS Code 1.84.0+
+- Extension development environment configured (`npm install` completed)
+
+## Implementation Order
+
+### Phase 1: Foundation (Types and Configuration)
+
+1. **Add workflow types** (`src/features/workflows/types.ts`)
+   ```typescript
+   // Copy interfaces from contracts/workflow-api.ts
+   export interface WorkflowConfig { ... }
+   export interface CheckpointConfig { ... }
+   export interface FeatureWorkflowContext { ... }
+   ```
+
+2. **Update package.json** - Add configuration schema for `speckit.customWorkflows`
+
+3. **Update constants** (`src/core/constants.ts`)
+   ```typescript
+   export const ConfigKeys = {
+     // existing...
+     customWorkflows: 'speckit.customWorkflows',
+   };
+   ```
+
+### Phase 2: Workflow Manager
+
+4. **Create WorkflowManager** (`src/features/workflows/workflowManager.ts`)
+   - `getWorkflows()` - Load from settings + add default
+   - `validateWorkflow()` - Check name, step commands
+   - `getFeatureWorkflow()` - Read from `.speckit.json`
+   - `saveFeatureWorkflow()` - Write to `.speckit.json`
+   - `resolveStepCommand()` - Get command for step
+
+### Phase 3: Workflow Selection UI
+
+5. **Create WorkflowSelector** (`src/features/workflows/workflowSelector.ts`)
+   - `needsSelection()` - Check if multiple workflows exist
+   - `selectWorkflow()` - Show QuickPick, return selection
+
+### Phase 4: Integration
+
+6. **Modify specCommands.ts** (`src/features/specs/specCommands.ts`)
+   - Import workflow manager and selector
+   - Add workflow selection before phase commands
+   - Resolve step command from selected workflow
+
+### Phase 5: Checkpoints (User Story 3)
+
+7. **Create CheckpointHandler** (`src/features/workflows/checkpointHandler.ts`)
+   - `promptForApproval()` - Show confirmation dialog
+   - `executeCommit()` - Create commit via Git API
+   - `executePR()` - Create PR via `gh` CLI
+
+8. **Integrate checkpoints** into implement command
+
+## Key Files to Modify
+
+| File | Changes |
+|------|---------|
+| `package.json` | Add `speckit.customWorkflows` configuration schema |
+| `src/core/constants.ts` | Add `ConfigKeys.customWorkflows` |
+| `src/core/types/config.ts` | Add workflow interfaces |
+| `src/features/specs/specCommands.ts` | Integrate workflow selection |
+
+## Key Files to Create
+
+| File | Purpose |
+|------|---------|
+| `src/features/workflows/index.ts` | Module exports |
+| `src/features/workflows/types.ts` | Type definitions |
+| `src/features/workflows/workflowManager.ts` | Workflow CRUD and validation |
+| `src/features/workflows/workflowSelector.ts` | QuickPick UI |
+| `src/features/workflows/checkpointHandler.ts` | Commit/PR automation |
+
+## Testing Strategy
+
+### Unit Tests
+
+```typescript
+// tests/features/workflows/workflowManager.test.ts
+describe('WorkflowManager', () => {
+  it('should return default workflow when no custom workflows configured');
+  it('should merge custom workflows with default');
+  it('should validate workflow names');
+  it('should reject duplicate workflow names');
+  it('should resolve step commands with fallback to default');
+});
+
+// tests/features/workflows/workflowSelector.test.ts
+describe('WorkflowSelector', () => {
+  it('should not prompt when only default workflow exists');
+  it('should show QuickPick with all available workflows');
+  it('should return undefined when user cancels');
+});
+```
+
+### Integration Tests
+
+1. Configure custom workflow in settings.json
+2. Run specify command
+3. Verify workflow picker appears
+4. Select custom workflow
+5. Verify correct command is executed
+6. Verify `.speckit.json` is created
+
+## Example Usage
+
+### User Configuration
+
+```json
+// .vscode/settings.json
+{
+  "speckit.customWorkflows": [
+    {
+      "name": "light",
+      "displayName": "Lightweight",
+      "description": "Quick workflow without detailed planning",
+      "step-specify": "speckit.light-specify",
+      "step-plan": "speckit.light-plan",
+      "step-implement": "speckit.light-implement",
+      "checkpoints": [
+        {
+          "id": "commit",
+          "trigger": "after-implement",
+          "excludeCoAuthor": true
+        },
+        {
+          "id": "pr",
+          "trigger": "after-commit"
+        }
+      ]
+    }
+  ]
+}
+```
+
+### Expected Behavior
+
+1. User runs "SpecKit: Create" command
+2. QuickPick shows: "Default", "Lightweight"
+3. User selects "Lightweight"
+4. Extension runs `/speckit.light-specify {spec-dir}`
+5. After implementation, user sees: "Generate Commit?" [Yes] [No]
+6. On approval, commit is created without co-author
+7. User sees: "Create PR?" [Yes] [No]
+8. On approval, PR is created via `gh pr create`
+
+## Validation Checklist
+
+- [ ] Workflow configuration validates on extension load
+- [ ] Invalid workflows show warning, are skipped
+- [ ] Default workflow always available
+- [ ] Workflow selection appears only when multiple workflows exist
+- [ ] Selected workflow persists in `.speckit.json`
+- [ ] Checkpoints prompt before execution
+- [ ] Git operations handle errors gracefully
+- [ ] Missing custom commands fall back to default with warning

--- a/specs/001-custom-workflows/research.md
+++ b/specs/001-custom-workflows/research.md
@@ -1,0 +1,133 @@
+# Research: Custom Workflows
+
+**Feature**: 001-custom-workflows
+**Date**: 2026-01-26
+
+## Research Questions
+
+### 1. VS Code Configuration Array Schema Best Practices
+
+**Question**: What is the best approach for defining complex configuration arrays in VS Code extensions?
+
+**Research Findings**:
+- VS Code supports `anyOf` schema for mixed array types (string or object)
+- The existing `speckit.customCommands` setting already demonstrates this pattern
+- Schema should include `additionalProperties: false` for strict validation
+- VS Code validates configuration on load and provides IntelliSense support
+
+**Decision**: Use `speckit.customWorkflows` configuration array with JSON schema validation
+**Rationale**: Follows established pattern from `customCommands`, provides IDE support, validates at load time
+**Alternatives Considered**:
+- Separate settings file: Rejected - adds complexity, no IDE integration
+- JSON file in workspace: Rejected - not portable, no schema support
+
+### 2. Workflow Selection UI Pattern
+
+**Question**: How should the workflow selection be presented when multiple workflows exist?
+
+**Research Findings**:
+- VS Code QuickPick is standard for selection UI in extensions
+- Current phase commands (specify, plan, etc.) do not prompt for workflow
+- QuickPick supports description text and detail for each option
+- Can be skipped when only default workflow exists (FR-006)
+
+**Decision**: Use VS Code QuickPick with workflow name as label, description showing step mappings
+**Rationale**: Consistent with VS Code patterns, non-blocking, informative
+**Alternatives Considered**:
+- TreeView selection: Rejected - too heavy for simple selection
+- Command palette nested menu: Rejected - more clicks, less informative
+
+### 3. Feature Context Persistence
+
+**Question**: How should the selected workflow be persisted with a feature?
+
+**Research Findings**:
+- Features are stored in `specs/{feature-name}/` directories
+- Current approach uses individual markdown files (spec.md, plan.md, tasks.md)
+- Other extensions use hidden metadata files (e.g., `.vscode/settings.json`)
+- The `speckit-settings.json` file exists in constants but is not yet used
+
+**Decision**: Store workflow selection in `specs/{feature-name}/.speckit.json` metadata file
+**Rationale**: Keeps workflow context with feature, doesn't pollute markdown, easy to parse
+**Alternatives Considered**:
+- Frontmatter in spec.md: Rejected - modifies user content, parsing complexity
+- Global workspace state: Rejected - not tied to specific feature
+
+### 4. Checkpoint Git Operations
+
+**Question**: How should checkpoints handle commit and PR generation?
+
+**Research Findings**:
+- VS Code has built-in Git extension with programmatic API
+- `vscode.commands.executeCommand` can invoke Git commands
+- Current extension uses terminal for AI commands
+- Git operations need error handling for uncommitted changes, conflicts, etc.
+
+**Decision**: Use VS Code Git extension API (`vscode.git`) for commit, `gh` CLI via terminal for PR
+**Rationale**: Git API is reliable and integrated; `gh` CLI is standard for GitHub PR creation
+**Alternatives Considered**:
+- All terminal-based: Rejected - less reliable, harder error handling
+- All API-based: Rejected - no native PR API, would need GitHub API token management
+
+### 5. Custom Command/Template Resolution
+
+**Question**: How should custom step commands be resolved and validated?
+
+**Research Findings**:
+- Current slash commands follow `/speckit.{name}` pattern
+- Commands are defined in `.claude/skills/` or `.specify/templates/commands/`
+- Missing commands should gracefully fallback to default with warning (edge case in spec)
+- Validation can happen at load time or execution time
+
+**Decision**: Validate command existence at execution time, warn on missing, offer to use default
+**Rationale**: Templates may be added after workflow configuration, execution-time check is more flexible
+**Alternatives Considered**:
+- Load-time validation only: Rejected - fails if templates added later
+- Silent fallback: Rejected - user should be aware of missing templates
+
+### 6. Commit Attribution Handling
+
+**Question**: How should the "no co-author" checkpoint behavior be implemented?
+
+**Research Findings**:
+- Current commits include `Co-Authored-By: Claude` trailer
+- Git commits support arbitrary message formats
+- VS Code Git API allows specifying commit message programmatically
+
+**Decision**: Checkpoint config includes `excludeCoAuthor: boolean`, default false
+**Rationale**: Explicit opt-in per checkpoint, maintains backwards compatibility
+**Alternatives Considered**:
+- Global setting: Rejected - should be per-workflow/checkpoint specific
+- Always exclude: Rejected - some users want attribution
+
+## Integration Points Analysis
+
+### Existing Code to Modify
+
+1. **`src/features/specs/specCommands.ts`**
+   - `registerPhaseCommands()`: Add workflow selection before command execution
+   - Inject selected workflow's step mapping into command resolution
+
+2. **`src/core/types/config.ts`**
+   - Add `WorkflowConfig` and `CheckpointConfig` interfaces
+
+3. **`src/core/constants.ts`**
+   - Add `ConfigKeys.customWorkflows` constant
+   - Add workflow-related file names
+
+4. **`package.json`**
+   - Add `speckit.customWorkflows` configuration schema
+   - Add checkpoint-related settings (optional)
+
+### New Files to Create
+
+1. **`src/features/workflows/`** - New feature module
+   - `workflowManager.ts` - Load, validate, and manage workflows
+   - `workflowSelector.ts` - QuickPick UI for workflow selection
+   - `checkpointHandler.ts` - Handle checkpoint prompts and git operations
+   - `types.ts` - Workflow-specific type definitions
+   - `index.ts` - Module exports
+
+## Unresolved Items
+
+None - all research questions have been addressed with clear decisions.

--- a/specs/001-custom-workflows/spec.md
+++ b/specs/001-custom-workflows/spec.md
@@ -1,0 +1,127 @@
+# Feature Specification: Custom Workflows
+
+**Feature Branch**: `001-custom-workflows`
+**Created**: 2026-01-26
+**Status**: Draft
+**Input**: User description: "Add capability to create custom workflows with configurable steps instead of using default specify/plan/implement commands. Users can define workflow variants (e.g., 'light') with custom command mappings. Include lightweight workflow variants with commit and PR generation checkpoints."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Configure Custom Workflow in Settings (Priority: P1)
+
+As a developer, I want to define custom workflows in VS Code settings so that I can use alternative command sequences tailored to my project's needs.
+
+**Why this priority**: This is the foundational capability that enables all other features. Without workflow configuration, users cannot access custom workflows.
+
+**Independent Test**: Can be fully tested by adding a workflow configuration to settings.json and verifying it is recognized by the extension. Delivers value by allowing personalized workflow definitions.
+
+**Acceptance Scenarios**:
+
+1. **Given** VS Code is open with the extension installed, **When** I add a `speckit.customWorkflows` array to my settings.json with a valid workflow definition, **Then** the workflow is recognized and available for selection
+2. **Given** I have configured a custom workflow named "light", **When** I view available workflows, **Then** "light" appears alongside the "default" workflow option
+3. **Given** I have configured a custom workflow with invalid structure (missing required fields), **When** the extension loads, **Then** a warning is displayed and the invalid workflow is skipped
+
+---
+
+### User Story 2 - Select Workflow When Generating Specs (Priority: P1)
+
+As a developer, I want to choose between default and custom workflows when starting a new feature so that I can use the appropriate workflow for each situation.
+
+**Why this priority**: This enables users to actually use their configured custom workflows, making the configuration meaningful.
+
+**Independent Test**: Can be fully tested by triggering spec generation and verifying a workflow selection prompt appears with all configured options.
+
+**Acceptance Scenarios**:
+
+1. **Given** I have both default and custom workflows configured, **When** I run the specify command, **Then** I am presented with a choice between "default" and my custom workflow(s)
+2. **Given** I have only the default workflow (no custom workflows configured), **When** I run the specify command, **Then** the default workflow is used automatically without prompting
+3. **Given** I select the "light" custom workflow, **When** the workflow proceeds, **Then** the steps defined in my "light" workflow configuration are used
+
+---
+
+### User Story 3 - Use Lightweight Workflow with Checkpoints (Priority: P2)
+
+As a developer using a lightweight workflow, I want automatic checkpoints for committing and creating PRs so that I can streamline my development process without manual git operations.
+
+**Why this priority**: This provides the key differentiator for lightweight workflows - reducing friction in the development process through integrated git operations.
+
+**Independent Test**: Can be fully tested by running the implement step of a lightweight workflow and verifying commit/PR checkpoint prompts appear at the appropriate stages.
+
+**Acceptance Scenarios**:
+
+1. **Given** I am using the "light" workflow and reach the implementation phase, **When** implementation is complete, **Then** I am prompted with "Generate Commit" checkpoint
+2. **Given** I am at the commit checkpoint, **When** I approve, **Then** a commit is generated without co-author attribution
+3. **Given** I have approved the commit, **When** the commit succeeds, **Then** I am prompted with "Generate PR" checkpoint
+4. **Given** I am at the PR checkpoint, **When** I approve, **Then** a pull request is created based on the feature branch
+
+---
+
+### User Story 4 - Custom Workflow Step Mapping (Priority: P2)
+
+As a developer, I want to map each workflow step to custom command names so that I can organize my prompt templates according to my team's conventions.
+
+**Why this priority**: Enables teams to use their own naming conventions and prompt organization while still leveraging the workflow structure.
+
+**Independent Test**: Can be fully tested by configuring step mappings and verifying the correct commands are invoked at each workflow stage.
+
+**Acceptance Scenarios**:
+
+1. **Given** I have configured `"step-specify": "light-specify"` in my workflow, **When** the specify step runs, **Then** the "light-specify" command/template is used instead of the default
+2. **Given** I have configured `"step-plan": "light-plan"` in my workflow, **When** the plan step runs, **Then** the "light-plan" command/template is used instead of the default
+3. **Given** I have configured `"step-implement": "light-implement"` in my workflow, **When** the implement step runs, **Then** the "light-implement" command/template is used instead of the default
+
+---
+
+### Edge Cases
+
+- What happens when a configured custom command/template does not exist? (Display error message and allow user to fix or skip step)
+- How does the system handle workflows with partial step definitions? (Use default commands for undefined steps)
+- What happens if the user cancels at a checkpoint? (Workflow pauses, user can resume or abort)
+- How does the system behave when git operations fail at checkpoints? (Display error, allow retry or skip)
+- What happens when a workflow is deleted from settings while a feature is using it? (Fall back to default workflow with warning)
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST support a `speckit.customWorkflows` configuration array in VS Code settings
+- **FR-002**: Each workflow definition MUST have a unique `name` property
+- **FR-003**: Workflow definitions MUST support `step-specify`, `step-plan`, and `step-implement` properties for custom command mapping
+- **FR-004**: System MUST always include a "default" workflow option that uses the standard speckit commands
+- **FR-005**: System MUST present a workflow selection prompt when multiple workflows are available
+- **FR-006**: System MUST skip workflow selection when only the default workflow exists
+- **FR-007**: Workflow steps MUST be able to reference custom command/template names
+- **FR-008**: System MUST validate workflow configurations on load and warn about invalid entries
+- **FR-009**: Lightweight workflow variants MUST support checkpoint definitions for commit and PR generation
+- **FR-010**: Commit generation at checkpoints MUST exclude co-author attribution when specified
+- **FR-011**: PR generation at checkpoints MUST use the current feature branch
+- **FR-012**: Checkpoints MUST prompt user for approval before executing git operations
+- **FR-013**: System MUST store the selected workflow choice with the feature for subsequent steps
+- **FR-014**: System MUST handle missing or invalid custom commands gracefully with appropriate error messages
+
+### Key Entities
+
+- **Workflow**: A named configuration defining the command mappings for each workflow step (specify, plan, implement) and optional checkpoint definitions
+- **Checkpoint**: A pause point in the workflow that prompts for user approval before executing an action (commit, PR)
+- **Step Mapping**: The association between a workflow step (specify, plan, implement) and a custom command name
+- **Feature Context**: The persisted state of a feature including which workflow was selected
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Users can create and configure custom workflows in under 2 minutes using settings.json
+- **SC-002**: Workflow selection adds no more than 5 seconds to the spec generation process
+- **SC-003**: 100% of configured valid workflows appear in the selection prompt
+- **SC-004**: Checkpoint prompts allow users to approve or modify actions before execution
+- **SC-005**: Commits generated via checkpoints complete successfully with correct commit message format
+- **SC-006**: PRs created via checkpoints are properly linked to the feature branch
+- **SC-007**: Invalid workflow configurations are identified and reported to users at load time
+
+## Assumptions
+
+- Users are responsible for creating the custom command templates that their workflows reference
+- The naming convention for custom commands follows the existing speckit patterns (e.g., `light-specify`, `light-plan`)
+- Checkpoint behavior (commit without attribution, PR creation) applies only to workflows that explicitly configure these features
+- The "default" workflow cannot be modified or removed
+- Workflow configuration is workspace-scoped (each project can have different workflows)

--- a/specs/001-custom-workflows/tasks.md
+++ b/specs/001-custom-workflows/tasks.md
@@ -1,0 +1,231 @@
+# Tasks: Custom Workflows
+
+**Input**: Design documents from `/specs/001-custom-workflows/`
+**Prerequisites**: plan.md (required), spec.md (required), research.md, data-model.md, contracts/workflow-api.ts
+
+**Tests**: Not requested in the feature specification - test tasks omitted.
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3, US4)
+- Include exact file paths in descriptions
+
+## Path Conventions
+
+- **Project type**: VS Code extension (single project)
+- **Source**: `src/` at repository root
+- **Feature module**: `src/features/workflows/`
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Project initialization and type definitions for custom workflows
+
+- [x] T001 [P] Create workflow type definitions from contracts in src/features/workflows/types.ts
+- [x] T002 [P] Add ConfigKeys.customWorkflows constant in src/core/constants.ts
+- [x] T003 Add speckit.customWorkflows configuration schema to package.json contributes.configuration
+- [x] T004 Create module exports barrel file in src/features/workflows/index.ts
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Core workflow infrastructure that MUST be complete before ANY user story can be implemented
+
+**CRITICAL**: No user story work can begin until this phase is complete
+
+- [x] T005 Implement DEFAULT_WORKFLOW constant in src/features/workflows/workflowManager.ts
+- [x] T006 Implement validateWorkflow() function with name pattern and structure validation in src/features/workflows/workflowManager.ts
+- [x] T007 Implement getWorkflows() to load from VS Code settings and merge with default in src/features/workflows/workflowManager.ts
+- [x] T008 Add extension activation validation to warn about invalid workflow configurations in src/extension.ts
+
+**Checkpoint**: Foundation ready - user story implementation can now begin
+
+---
+
+## Phase 3: User Story 1 - Configure Custom Workflow in Settings (Priority: P1)
+
+**Goal**: Enable developers to define custom workflows in VS Code settings with validation
+
+**Independent Test**: Add a workflow configuration to settings.json and verify it is recognized by the extension. Invalid workflows should show warnings and be skipped.
+
+### Implementation for User Story 1
+
+- [x] T009 [US1] Implement getWorkflow(name) to retrieve specific workflow by name in src/features/workflows/workflowManager.ts
+- [x] T010 [US1] Add validation error collection and warning display via vscode.window.showWarningMessage in src/features/workflows/workflowManager.ts
+- [x] T011 [US1] Implement onDidChangeConfiguration listener to re-validate workflows on settings change in src/features/workflows/workflowManager.ts
+- [x] T012 [US1] Register configuration change handler in extension activation in src/extension.ts
+
+**Checkpoint**: At this point, User Story 1 should be fully functional - workflows can be configured and validated
+
+---
+
+## Phase 4: User Story 2 - Select Workflow When Generating Specs (Priority: P1)
+
+**Goal**: Present workflow selection when multiple workflows exist; auto-select default when only one exists
+
+**Independent Test**: Trigger spec generation and verify workflow selection prompt appears with all configured options. Verify auto-selection when only default exists.
+
+### Implementation for User Story 2
+
+- [x] T013 [US2] Implement needsSelection() to check if multiple workflows exist in src/features/workflows/workflowSelector.ts
+- [x] T014 [US2] Implement selectWorkflow() with VS Code QuickPick UI in src/features/workflows/workflowSelector.ts
+- [x] T015 [US2] Implement getFeatureWorkflow() to read workflow context from .speckit.json in src/features/workflows/workflowManager.ts
+- [x] T016 [US2] Implement saveFeatureWorkflow() to persist workflow selection to .speckit.json in src/features/workflows/workflowManager.ts
+- [x] T017 [US2] Integrate workflow selection into specify command flow in src/features/specs/specCommands.ts
+- [x] T018 [US2] Add workflow context persistence after selection in specify command in src/features/specs/specCommands.ts
+
+**Checkpoint**: At this point, User Stories 1 AND 2 should both work - workflows can be configured and selected
+
+---
+
+## Phase 5: User Story 3 - Use Lightweight Workflow with Checkpoints (Priority: P2)
+
+**Goal**: Automatic checkpoints for committing and creating PRs after implementation with user approval prompts
+
+**Independent Test**: Run the implement step of a workflow with checkpoints defined and verify commit/PR prompts appear at appropriate stages.
+
+### Implementation for User Story 3
+
+- [x] T019 [US3] Implement getTriggeredCheckpoints() to find checkpoints for a trigger event in src/features/workflows/checkpointHandler.ts
+- [x] T020 [US3] Implement promptForApproval() to show confirmation dialog for checkpoints in src/features/workflows/checkpointHandler.ts
+- [x] T021 [US3] Implement executeCommit() using VS Code Git API with excludeCoAuthor option in src/features/workflows/checkpointHandler.ts
+- [x] T022 [US3] Implement executePR() using gh CLI via terminal in src/features/workflows/checkpointHandler.ts
+- [x] T023 [US3] Implement executeCheckpoint() to orchestrate approval and execution in src/features/workflows/checkpointHandler.ts
+- [x] T024 [US3] Implement checkpoint status tracking and update in .speckit.json in src/features/workflows/checkpointHandler.ts
+- [x] T025 [US3] Integrate checkpoint execution into implement command flow in src/features/specs/specCommands.ts
+- [x] T026 [US3] Add error handling for git operation failures with retry/skip options in src/features/workflows/checkpointHandler.ts
+
+**Checkpoint**: At this point, User Stories 1, 2, AND 3 should all work - full lightweight workflow with checkpoints
+
+---
+
+## Phase 6: User Story 4 - Custom Workflow Step Mapping (Priority: P2)
+
+**Goal**: Map each workflow step to custom command names for team-specific conventions
+
+**Independent Test**: Configure step mappings and verify the correct commands are invoked at each workflow stage.
+
+### Implementation for User Story 4
+
+- [x] T027 [US4] Implement resolveStepCommand() to get command for a workflow step with fallback in src/features/workflows/workflowManager.ts
+- [x] T028 [US4] Add command existence validation at execution time in src/features/workflows/workflowManager.ts
+- [x] T029 [US4] Integrate step command resolution into specify command in src/features/specs/specCommands.ts
+- [x] T030 [US4] Integrate step command resolution into plan command in src/features/specs/specCommands.ts
+- [x] T031 [US4] Integrate step command resolution into implement command in src/features/specs/specCommands.ts
+- [x] T032 [US4] Add warning message when custom command not found with fallback to default in src/features/workflows/workflowManager.ts
+
+**Checkpoint**: All user stories should now be independently functional
+
+---
+
+## Phase 7: Polish & Cross-Cutting Concerns
+
+**Purpose**: Improvements that affect multiple user stories
+
+- [x] T033 [P] Add JSDoc documentation to all exported functions and interfaces in src/features/workflows/
+- [x] T034 [P] Verify edge case handling: missing commands fall back to default with warning
+- [x] T035 [P] Verify edge case handling: workflow deleted while feature uses it
+- [x] T036 [P] Verify edge case handling: user cancels at checkpoint (workflow pauses)
+- [x] T037 Run quickstart.md validation scenarios
+- [x] T038 Code cleanup: ensure consistent error handling across workflow module
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies - can start immediately
+- **Foundational (Phase 2)**: Depends on Setup completion - BLOCKS all user stories
+- **User Story 1 (Phase 3)**: Depends on Foundational phase completion
+- **User Story 2 (Phase 4)**: Depends on Foundational phase completion (can run in parallel with US1)
+- **User Story 3 (Phase 5)**: Depends on Foundational phase completion (can run in parallel with US1, US2)
+- **User Story 4 (Phase 6)**: Depends on Foundational phase completion (can run in parallel with US1, US2, US3)
+- **Polish (Phase 7)**: Depends on all user stories being complete
+
+### User Story Dependencies
+
+- **User Story 1 (P1)**: Can start after Foundational - No dependencies on other stories
+- **User Story 2 (P1)**: Can start after Foundational - Independent of US1 for core functionality, integrates during specCommands.ts modifications
+- **User Story 3 (P2)**: Can start after Foundational - Independent of US1/US2 for core checkpoint logic
+- **User Story 4 (P2)**: Can start after Foundational - Independent of other stories for core mapping logic
+
+### Within Each User Story
+
+- Core module functions before integration points
+- Manager/handler functions before specCommands.ts integration
+- Validation before execution logic
+
+### Parallel Opportunities
+
+- T001, T002 can run in parallel (different files, Setup phase)
+- T033-T036 can run in parallel (verification/documentation tasks)
+- User stories can be worked on in parallel by different developers after Foundational phase
+
+---
+
+## Parallel Example: Setup Phase
+
+```bash
+# Launch all parallel Setup tasks together:
+Task: "Create workflow type definitions from contracts in src/features/workflows/types.ts"
+Task: "Add ConfigKeys.customWorkflows constant in src/core/constants.ts"
+```
+
+## Parallel Example: User Stories After Foundation
+
+```bash
+# After Phase 2 completes, these can start in parallel:
+Developer A: User Story 1 (T009-T012) - Configure workflows
+Developer B: User Story 2 (T013-T018) - Workflow selection
+Developer C: User Story 3 (T019-T026) - Checkpoints
+Developer D: User Story 4 (T027-T032) - Step mapping
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Stories 1 + 2 Only)
+
+1. Complete Phase 1: Setup
+2. Complete Phase 2: Foundational (CRITICAL - blocks all stories)
+3. Complete Phase 3: User Story 1 (Configure workflows)
+4. Complete Phase 4: User Story 2 (Select workflows)
+5. **STOP and VALIDATE**: Test workflow configuration and selection independently
+6. Deploy/demo if ready - users can now define and select custom workflows
+
+### Incremental Delivery
+
+1. Complete Setup + Foundational -> Foundation ready
+2. Add User Story 1 + 2 -> Test independently -> Deploy/Demo (MVP: custom workflow selection!)
+3. Add User Story 3 -> Test independently -> Deploy/Demo (adds checkpoints)
+4. Add User Story 4 -> Test independently -> Deploy/Demo (adds step mapping)
+5. Each story adds value without breaking previous stories
+
+### Parallel Team Strategy
+
+With multiple developers:
+
+1. Team completes Setup + Foundational together
+2. Once Foundational is done:
+   - Developer A: User Story 1 + User Story 2 (closely related - workflow configuration and selection)
+   - Developer B: User Story 3 (independent checkpoint logic)
+   - Developer C: User Story 4 (independent step mapping logic)
+3. Stories complete and integrate via specCommands.ts modifications
+
+---
+
+## Notes
+
+- [P] tasks = different files, no dependencies
+- [Story] label maps task to specific user story for traceability
+- Each user story is independently completable and testable
+- Commit after each task or logical group
+- Stop at any checkpoint to validate story independently
+- Key integration point: src/features/specs/specCommands.ts - coordinate changes across stories

--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -56,6 +56,7 @@ export const ConfigKeys = {
     claudePermissionMode: 'speckit.claudePermissionMode',
     geminiInitDelay: 'speckit.geminiInitDelay',
     customCommands: 'speckit.customCommands',
+    customWorkflows: 'speckit.customWorkflows',
     views: {
         specsVisible: 'speckit.views.specs.visible',
         agentsVisible: 'speckit.views.agents.visible',

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -15,6 +15,7 @@ import { PermissionManager } from './features/permission';
 import { WorkflowEditorProvider, registerWorkflowEditorCommands } from './features/workflow-editor';
 import { registerSpecEditorCommands } from './features/spec-editor';
 import { registerSpecViewerCommands, isSpecDocument } from './features/spec-viewer';
+import { validateWorkflowsOnActivation, registerWorkflowConfigChangeListener } from './features/workflows';
 
 // SpecKit CLI integration
 import { SpecKitDetector, UpdateChecker, registerCliCommands, registerUtilityCommands } from './speckit';
@@ -142,6 +143,11 @@ export async function activate(context: vscode.ExtensionContext) {
 
     // Set up tasks watcher for phase completion notifications
     setupTasksWatcher(context, outputChannel);
+
+    // Validate custom workflows on activation and register change listener
+    validateWorkflowsOnActivation();
+    context.subscriptions.push(registerWorkflowConfigChangeListener(context));
+    outputChannel.appendLine('Custom workflows validated');
 
     // Check for updates on startup
     updateChecker.checkForUpdates();

--- a/src/features/spec-editor/types.ts
+++ b/src/features/spec-editor/types.ts
@@ -138,16 +138,39 @@ export interface TempFileManifest {
 }
 
 // ============================================
+// Workflow Types
+// ============================================
+
+/**
+ * A workflow definition for spec-driven development
+ */
+export interface WorkflowDefinition {
+    /** Unique workflow identifier */
+    name: string;
+    /** Display name shown in picker */
+    displayName: string;
+    /** Description shown in picker */
+    description?: string;
+    /** Command for specify step */
+    stepSpecify: string;
+    /** Command for plan step */
+    stepPlan?: string;
+    /** Command for implement step */
+    stepImplement?: string;
+}
+
+// ============================================
 // Message Types: Webview → Extension
 // ============================================
 
 export type SpecEditorToExtensionMessage =
-    | { type: 'submit'; content: string; images: string[] }
+    | { type: 'submit'; content: string; images: string[]; workflow: string }
     | { type: 'preview' }
     | { type: 'attachImage'; name: string; size: number; dataUri: string }
     | { type: 'removeImage'; imageId: string }
     | { type: 'loadTemplate'; specPath: string }
     | { type: 'requestTemplateDialog' }
+    | { type: 'ready' }
     | { type: 'cancel' };
 
 // ============================================
@@ -155,6 +178,7 @@ export type SpecEditorToExtensionMessage =
 // ============================================
 
 export type ExtensionToSpecEditorMessage =
+    | { type: 'init'; workflows: WorkflowDefinition[] }
     | { type: 'imageSaved'; imageId: string; thumbnailUri: string; originalName: string }
     | { type: 'imageRemoved'; imageId: string }
     | { type: 'templateLoaded'; content: string }

--- a/src/features/workflows/checkpointHandler.ts
+++ b/src/features/workflows/checkpointHandler.ts
@@ -1,0 +1,290 @@
+/**
+ * Checkpoint Handler
+ *
+ * Handles checkpoint execution for commit and PR generation.
+ * Provides prompts for user approval and executes git operations.
+ */
+
+import * as vscode from 'vscode';
+import * as path from 'path';
+import * as fs from 'fs';
+import {
+    WorkflowConfig,
+    CheckpointConfig,
+    CheckpointTrigger,
+    CheckpointResult,
+    CheckpointContext,
+    CheckpointId,
+    FeatureWorkflowContext,
+    FEATURE_CONTEXT_FILE,
+} from './types';
+
+/**
+ * Get checkpoints triggered after a specific event
+ * @param workflow Workflow configuration
+ * @param trigger Trigger event
+ * @returns Array of checkpoints to execute
+ */
+export function getTriggeredCheckpoints(
+    workflow: WorkflowConfig,
+    trigger: CheckpointTrigger
+): CheckpointConfig[] {
+    if (!workflow.checkpoints || workflow.checkpoints.length === 0) {
+        return [];
+    }
+
+    return workflow.checkpoints.filter(cp => cp.trigger === trigger);
+}
+
+/**
+ * Prompt user for checkpoint approval
+ * @param checkpoint Checkpoint configuration
+ * @param featureDir Path to feature directory
+ * @returns True if approved, false if declined
+ */
+export async function promptForApproval(
+    checkpoint: CheckpointConfig,
+    featureDir: string
+): Promise<boolean> {
+    const featureName = path.basename(featureDir);
+    const checkpointDescription =
+        checkpoint.id === 'commit'
+            ? `Create a commit for "${featureName}"?`
+            : `Create a pull request for "${featureName}"?`;
+
+    const result = await vscode.window.showInformationMessage(
+        checkpointDescription,
+        { modal: false },
+        'Yes',
+        'No'
+    );
+
+    return result === 'Yes';
+}
+
+/**
+ * Execute a commit checkpoint
+ * @param checkpoint Checkpoint configuration
+ * @param featureDir Path to feature directory
+ * @param context Checkpoint context
+ * @returns Execution result
+ */
+export async function executeCommit(
+    checkpoint: CheckpointConfig,
+    featureDir: string,
+    context: CheckpointContext
+): Promise<CheckpointResult> {
+    try {
+        // Get the workspace folder
+        const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
+        if (!workspaceFolder) {
+            return {
+                status: 'skipped',
+                error: 'No workspace folder found',
+            };
+        }
+
+        // Build commit message
+        let commitMessage = context.commitMessage || `feat(${context.featureName}): implement feature`;
+
+        // Add co-author unless excluded
+        if (!checkpoint.excludeCoAuthor) {
+            commitMessage += '\n\nCo-Authored-By: Claude <noreply@anthropic.com>';
+        }
+
+        // Create terminal and execute git commands
+        const terminal = vscode.window.createTerminal({
+            name: 'SpecKit - Commit',
+            cwd: workspaceFolder.uri.fsPath,
+        });
+
+        terminal.show();
+        terminal.sendText(`git add -A && git commit -m "${commitMessage.replace(/"/g, '\\"')}"`);
+
+        // Update checkpoint status
+        await updateCheckpointStatus(featureDir, 'commit', 'completed');
+
+        return {
+            status: 'completed',
+            output: 'Commit created successfully',
+        };
+    } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+        return {
+            status: 'skipped',
+            error: `Failed to create commit: ${errorMessage}`,
+        };
+    }
+}
+
+/**
+ * Execute a PR checkpoint
+ * @param checkpoint Checkpoint configuration
+ * @param featureDir Path to feature directory
+ * @param context Checkpoint context
+ * @returns Execution result
+ */
+export async function executePR(
+    checkpoint: CheckpointConfig,
+    featureDir: string,
+    context: CheckpointContext
+): Promise<CheckpointResult> {
+    try {
+        // Get the workspace folder
+        const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
+        if (!workspaceFolder) {
+            return {
+                status: 'skipped',
+                error: 'No workspace folder found',
+            };
+        }
+
+        // Build PR title
+        let prTitle = checkpoint.prTitleTemplate || `feat: ${context.featureName}`;
+        prTitle = prTitle.replace(/\$\{featureName\}/g, context.featureName);
+
+        // Create terminal and execute gh CLI
+        const terminal = vscode.window.createTerminal({
+            name: 'SpecKit - PR',
+            cwd: workspaceFolder.uri.fsPath,
+        });
+
+        terminal.show();
+        terminal.sendText(`gh pr create --title "${prTitle.replace(/"/g, '\\"')}" --fill`);
+
+        // Update checkpoint status
+        await updateCheckpointStatus(featureDir, 'pr', 'completed');
+
+        return {
+            status: 'completed',
+            output: 'PR creation initiated',
+        };
+    } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+        return {
+            status: 'skipped',
+            error: `Failed to create PR: ${errorMessage}`,
+        };
+    }
+}
+
+/**
+ * Execute a checkpoint (orchestrates approval and execution)
+ * @param checkpoint Checkpoint configuration
+ * @param featureDir Path to feature directory
+ * @param context Checkpoint context
+ * @returns Execution result
+ */
+export async function executeCheckpoint(
+    checkpoint: CheckpointConfig,
+    featureDir: string,
+    context: CheckpointContext
+): Promise<CheckpointResult> {
+    // Check if approval is required
+    const requiresApproval = checkpoint.requiresApproval !== false;
+
+    if (requiresApproval) {
+        const approved = await promptForApproval(checkpoint, featureDir);
+        if (!approved) {
+            await updateCheckpointStatus(featureDir, checkpoint.id, 'skipped');
+            return {
+                status: 'skipped',
+                output: 'User declined checkpoint',
+            };
+        }
+    }
+
+    // Execute based on checkpoint type
+    if (checkpoint.id === 'commit') {
+        return executeCommit(checkpoint, featureDir, context);
+    } else if (checkpoint.id === 'pr') {
+        return executePR(checkpoint, featureDir, context);
+    }
+
+    return {
+        status: 'skipped',
+        error: `Unknown checkpoint type: ${checkpoint.id}`,
+    };
+}
+
+/**
+ * Update checkpoint status in .speckit.json
+ * @param featureDir Path to feature directory
+ * @param checkpointId Checkpoint identifier
+ * @param status New status
+ */
+async function updateCheckpointStatus(
+    featureDir: string,
+    checkpointId: CheckpointId,
+    status: 'pending' | 'completed' | 'skipped'
+): Promise<void> {
+    const contextPath = path.join(featureDir, FEATURE_CONTEXT_FILE);
+
+    try {
+        let context: FeatureWorkflowContext;
+
+        try {
+            const content = await fs.promises.readFile(contextPath, 'utf-8');
+            context = JSON.parse(content);
+        } catch {
+            // File doesn't exist, create minimal context
+            context = {
+                workflow: 'default',
+                selectedAt: new Date().toISOString(),
+            };
+        }
+
+        // Update checkpoint status
+        if (!context.checkpointStatus) {
+            context.checkpointStatus = {} as Record<CheckpointId, 'pending' | 'completed' | 'skipped'>;
+        }
+        context.checkpointStatus[checkpointId] = status;
+
+        await fs.promises.writeFile(contextPath, JSON.stringify(context, null, 2), 'utf-8');
+    } catch (error) {
+        console.error('Failed to update checkpoint status:', error);
+    }
+}
+
+/**
+ * Execute all checkpoints for a given trigger
+ * @param workflow Workflow configuration
+ * @param trigger Trigger event
+ * @param featureDir Path to feature directory
+ * @param context Checkpoint context
+ * @returns Array of execution results
+ */
+export async function executeCheckpointsForTrigger(
+    workflow: WorkflowConfig,
+    trigger: CheckpointTrigger,
+    featureDir: string,
+    context: CheckpointContext
+): Promise<CheckpointResult[]> {
+    const checkpoints = getTriggeredCheckpoints(workflow, trigger);
+    const results: CheckpointResult[] = [];
+
+    for (const checkpoint of checkpoints) {
+        const result = await executeCheckpoint(checkpoint, featureDir, context);
+        results.push(result);
+
+        // Stop execution if checkpoint failed (unless it was skipped by user)
+        if (result.status === 'skipped' && result.error) {
+            const retry = await vscode.window.showErrorMessage(
+                `Checkpoint "${checkpoint.id}" failed: ${result.error}`,
+                'Retry',
+                'Skip',
+                'Cancel'
+            );
+
+            if (retry === 'Retry') {
+                const retryResult = await executeCheckpoint(checkpoint, featureDir, context);
+                results[results.length - 1] = retryResult;
+            } else if (retry === 'Cancel') {
+                break;
+            }
+            // 'Skip' continues to next checkpoint
+        }
+    }
+
+    return results;
+}

--- a/src/features/workflows/index.ts
+++ b/src/features/workflows/index.ts
@@ -1,0 +1,46 @@
+/**
+ * Custom Workflows Module
+ *
+ * Provides workflow configuration, selection, and checkpoint handling
+ * for spec-driven development workflows.
+ */
+
+// Types
+export type {
+    CheckpointId,
+    CheckpointTrigger,
+    CheckpointStatus,
+    CheckpointConfig,
+    WorkflowConfig,
+    FeatureWorkflowContext,
+    WorkflowStep,
+    ValidationResult,
+    CheckpointResult,
+    CheckpointContext,
+} from './types';
+
+export { WORKFLOW_NAME_PATTERN, FEATURE_CONTEXT_FILE } from './types';
+
+// Workflow Manager
+export {
+    DEFAULT_WORKFLOW,
+    getWorkflows,
+    getWorkflow,
+    validateWorkflow,
+    getFeatureWorkflow,
+    saveFeatureWorkflow,
+    resolveStepCommand,
+    validateWorkflowsOnActivation,
+    registerWorkflowConfigChangeListener,
+} from './workflowManager';
+
+// Workflow Selector
+export { needsSelection, selectWorkflow, getOrSelectWorkflow } from './workflowSelector';
+
+// Checkpoint Handler
+export {
+    getTriggeredCheckpoints,
+    promptForApproval,
+    executeCheckpoint,
+    executeCheckpointsForTrigger,
+} from './checkpointHandler';

--- a/src/features/workflows/types.ts
+++ b/src/features/workflows/types.ts
@@ -1,0 +1,96 @@
+/**
+ * Custom Workflows Type Definitions
+ *
+ * Type definitions for the custom workflows feature.
+ * Based on contracts from specs/001-custom-workflows/contracts/workflow-api.ts
+ */
+
+/**
+ * Checkpoint type identifiers
+ */
+export type CheckpointId = 'commit' | 'pr';
+
+/**
+ * Checkpoint trigger points
+ */
+export type CheckpointTrigger = 'after-implement' | 'after-commit';
+
+/**
+ * Checkpoint status values
+ */
+export type CheckpointStatus = 'pending' | 'completed' | 'skipped';
+
+/**
+ * Checkpoint configuration
+ */
+export interface CheckpointConfig {
+    id: CheckpointId;
+    trigger: CheckpointTrigger;
+    requiresApproval?: boolean;
+    excludeCoAuthor?: boolean;
+    prTitleTemplate?: string;
+}
+
+/**
+ * Workflow configuration from VS Code settings
+ */
+export interface WorkflowConfig {
+    name: string;
+    displayName?: string;
+    description?: string;
+    'step-specify'?: string;
+    'step-plan'?: string;
+    'step-implement'?: string;
+    checkpoints?: CheckpointConfig[];
+}
+
+/**
+ * Feature workflow context persisted in .speckit.json
+ */
+export interface FeatureWorkflowContext {
+    workflow: string;
+    selectedAt: string;
+    checkpointStatus?: Record<CheckpointId, CheckpointStatus>;
+}
+
+/**
+ * Workflow step identifiers
+ */
+export type WorkflowStep = 'specify' | 'plan' | 'implement';
+
+/**
+ * Validation result for workflow configurations
+ */
+export interface ValidationResult {
+    valid: boolean;
+    errors: string[];
+    warnings: string[];
+}
+
+/**
+ * Checkpoint execution result
+ */
+export interface CheckpointResult {
+    status: CheckpointStatus;
+    error?: string;
+    output?: string;
+}
+
+/**
+ * Context passed to checkpoint execution
+ */
+export interface CheckpointContext {
+    featureName: string;
+    branchName: string;
+    commitMessage?: string;
+}
+
+/**
+ * Workflow name validation pattern
+ */
+export const WORKFLOW_NAME_PATTERN = /^[a-z][a-z0-9-]*$/;
+
+/**
+ * File name for feature workflow context
+ */
+export const FEATURE_CONTEXT_FILE = '.speckit.json';

--- a/src/features/workflows/workflowManager.ts
+++ b/src/features/workflows/workflowManager.ts
@@ -1,0 +1,289 @@
+/**
+ * Workflow Manager
+ *
+ * Handles workflow loading, validation, and persistence.
+ * Manages the mapping between features and their selected workflows.
+ */
+
+import * as vscode from 'vscode';
+import * as path from 'path';
+import * as fs from 'fs';
+import {
+    WorkflowConfig,
+    WorkflowStep,
+    ValidationResult,
+    FeatureWorkflowContext,
+    WORKFLOW_NAME_PATTERN,
+    FEATURE_CONTEXT_FILE,
+} from './types';
+import { ConfigKeys } from '../../core/constants';
+
+/**
+ * Default workflow configuration (always available)
+ */
+export const DEFAULT_WORKFLOW: WorkflowConfig = {
+    name: 'default',
+    displayName: 'Default',
+    description: 'Standard SpecKit workflow',
+    'step-specify': 'speckit.specify',
+    'step-plan': 'speckit.plan',
+    'step-implement': 'speckit.implement',
+    checkpoints: [],
+};
+
+/**
+ * Validate a workflow configuration
+ * @param config Workflow configuration to validate
+ * @returns Validation result with errors and warnings
+ */
+export function validateWorkflow(config: WorkflowConfig): ValidationResult {
+    const errors: string[] = [];
+    const warnings: string[] = [];
+
+    // Check required name field
+    if (!config.name) {
+        errors.push('Workflow name is required');
+        return { valid: false, errors, warnings };
+    }
+
+    // Check reserved name
+    if (config.name === 'default') {
+        errors.push('Workflow name "default" is reserved');
+        return { valid: false, errors, warnings };
+    }
+
+    // Validate name pattern
+    if (!WORKFLOW_NAME_PATTERN.test(config.name)) {
+        errors.push(
+            `Invalid workflow name "${config.name}". Must start with lowercase letter, followed by lowercase letters, numbers, or hyphens.`
+        );
+    }
+
+    // Validate step commands if provided
+    const steps = ['step-specify', 'step-plan', 'step-implement'] as const;
+    for (const step of steps) {
+        const value = config[step];
+        if (value !== undefined && typeof value !== 'string') {
+            errors.push(`Invalid ${step} value: must be a string`);
+        } else if (value !== undefined && value.trim() === '') {
+            warnings.push(`Empty ${step} value will use default command`);
+        }
+    }
+
+    // Validate checkpoints
+    if (config.checkpoints) {
+        if (!Array.isArray(config.checkpoints)) {
+            errors.push('Checkpoints must be an array');
+        } else {
+            for (let i = 0; i < config.checkpoints.length; i++) {
+                const cp = config.checkpoints[i];
+                if (!cp.id || !['commit', 'pr'].includes(cp.id)) {
+                    errors.push(`Checkpoint ${i + 1}: Invalid id. Must be "commit" or "pr"`);
+                }
+                if (!cp.trigger || !['after-implement', 'after-commit'].includes(cp.trigger)) {
+                    errors.push(`Checkpoint ${i + 1}: Invalid trigger. Must be "after-implement" or "after-commit"`);
+                }
+                // Validate trigger/id combinations
+                if (cp.trigger === 'after-commit' && cp.id !== 'pr') {
+                    warnings.push(`Checkpoint ${i + 1}: trigger "after-commit" is typically used with id "pr"`);
+                }
+            }
+        }
+    }
+
+    return {
+        valid: errors.length === 0,
+        errors,
+        warnings,
+    };
+}
+
+/**
+ * Get all configured workflows including the default
+ * @returns Array of workflow configurations
+ */
+export function getWorkflows(): WorkflowConfig[] {
+    const config = vscode.workspace.getConfiguration(ConfigKeys.namespace);
+    const customWorkflows = config.get<WorkflowConfig[]>('customWorkflows', []);
+
+    const validWorkflows: WorkflowConfig[] = [DEFAULT_WORKFLOW];
+    const seenNames = new Set<string>(['default']);
+
+    for (const workflow of customWorkflows) {
+        const result = validateWorkflow(workflow);
+        if (result.valid) {
+            // Check for duplicates
+            if (seenNames.has(workflow.name)) {
+                vscode.window.showWarningMessage(
+                    `Duplicate workflow name "${workflow.name}" - skipping duplicate`
+                );
+                continue;
+            }
+            seenNames.add(workflow.name);
+            validWorkflows.push(workflow);
+        } else {
+            // Log validation errors
+            const errorMsg = result.errors.join('; ');
+            vscode.window.showWarningMessage(
+                `Invalid workflow "${workflow.name || 'unnamed'}": ${errorMsg}`
+            );
+        }
+    }
+
+    return validWorkflows;
+}
+
+/**
+ * Get a specific workflow by name
+ * @param name Workflow name
+ * @returns Workflow configuration or undefined if not found
+ */
+export function getWorkflow(name: string): WorkflowConfig | undefined {
+    const workflows = getWorkflows();
+    return workflows.find(w => w.name === name);
+}
+
+/**
+ * Get the selected workflow for a feature from .speckit.json
+ * @param featureDir Path to feature directory
+ * @returns Workflow context or undefined if not selected
+ */
+export async function getFeatureWorkflow(
+    featureDir: string
+): Promise<FeatureWorkflowContext | undefined> {
+    const contextPath = path.join(featureDir, FEATURE_CONTEXT_FILE);
+
+    try {
+        const content = await fs.promises.readFile(contextPath, 'utf-8');
+        const context = JSON.parse(content) as FeatureWorkflowContext;
+
+        // Validate the workflow still exists
+        const workflow = getWorkflow(context.workflow);
+        if (!workflow) {
+            vscode.window.showWarningMessage(
+                `Workflow "${context.workflow}" no longer exists. Please select a new workflow.`
+            );
+            return undefined;
+        }
+
+        return context;
+    } catch {
+        // File doesn't exist or is invalid
+        return undefined;
+    }
+}
+
+/**
+ * Save workflow selection for a feature to .speckit.json
+ * @param featureDir Path to feature directory
+ * @param workflowName Name of selected workflow
+ */
+export async function saveFeatureWorkflow(
+    featureDir: string,
+    workflowName: string
+): Promise<void> {
+    const contextPath = path.join(featureDir, FEATURE_CONTEXT_FILE);
+
+    // Read existing context or create new
+    let context: FeatureWorkflowContext;
+    try {
+        const content = await fs.promises.readFile(contextPath, 'utf-8');
+        const existing = JSON.parse(content);
+        context = {
+            ...existing,
+            workflow: workflowName,
+            selectedAt: new Date().toISOString(),
+        };
+    } catch {
+        context = {
+            workflow: workflowName,
+            selectedAt: new Date().toISOString(),
+        };
+    }
+
+    await fs.promises.writeFile(contextPath, JSON.stringify(context, null, 2), 'utf-8');
+}
+
+/**
+ * Resolve the command for a workflow step
+ * @param workflow Workflow configuration
+ * @param step Step name (specify, plan, implement)
+ * @returns Resolved command name
+ */
+export function resolveStepCommand(workflow: WorkflowConfig, step: WorkflowStep): string {
+    const stepKey = `step-${step}` as keyof WorkflowConfig;
+    const customCommand = workflow[stepKey] as string | undefined;
+
+    if (customCommand && customCommand.trim()) {
+        return customCommand;
+    }
+
+    // Fall back to default workflow commands
+    const defaultCommand = DEFAULT_WORKFLOW[stepKey] as string;
+    return defaultCommand;
+}
+
+/**
+ * Register configuration change listener for workflow validation
+ * @param context Extension context for subscription management
+ * @returns Disposable for the configuration listener
+ */
+export function registerWorkflowConfigChangeListener(
+    context: vscode.ExtensionContext
+): vscode.Disposable {
+    return vscode.workspace.onDidChangeConfiguration(e => {
+        if (e.affectsConfiguration(ConfigKeys.customWorkflows)) {
+            validateWorkflowsOnActivation();
+        }
+    });
+}
+
+/**
+ * Validate all workflows and display warnings for any issues
+ * Called during extension activation
+ */
+export function validateWorkflowsOnActivation(): void {
+    const config = vscode.workspace.getConfiguration(ConfigKeys.namespace);
+    const customWorkflows = config.get<WorkflowConfig[]>('customWorkflows', []);
+
+    if (customWorkflows.length === 0) {
+        return;
+    }
+
+    let hasErrors = false;
+    const seenNames = new Set<string>();
+
+    for (const workflow of customWorkflows) {
+        const result = validateWorkflow(workflow);
+
+        // Check for duplicate names
+        if (workflow.name && seenNames.has(workflow.name)) {
+            vscode.window.showWarningMessage(
+                `Duplicate workflow name "${workflow.name}" found in settings`
+            );
+            hasErrors = true;
+        }
+        if (workflow.name) {
+            seenNames.add(workflow.name);
+        }
+
+        // Show validation warnings
+        for (const warning of result.warnings) {
+            vscode.window.showWarningMessage(`Workflow "${workflow.name}": ${warning}`);
+        }
+
+        // Show validation errors
+        if (!result.valid) {
+            hasErrors = true;
+            for (const error of result.errors) {
+                vscode.window.showWarningMessage(`Workflow "${workflow.name || 'unnamed'}": ${error}`);
+            }
+        }
+    }
+
+    if (hasErrors) {
+        vscode.window.showWarningMessage(
+            'Some workflows have configuration errors and will be skipped. Check the settings.'
+        );
+    }
+}

--- a/src/features/workflows/workflowSelector.ts
+++ b/src/features/workflows/workflowSelector.ts
@@ -1,0 +1,155 @@
+/**
+ * Workflow Selector
+ *
+ * Provides UI for selecting a workflow when multiple workflows are available.
+ * Uses VS Code QuickPick for workflow selection.
+ */
+
+import * as vscode from 'vscode';
+import { WorkflowConfig } from './types';
+import { getWorkflows, getFeatureWorkflow, saveFeatureWorkflow, getWorkflow } from './workflowManager';
+
+/**
+ * Check if workflow selection is needed
+ * @returns True if multiple workflows are configured
+ */
+export function needsSelection(): boolean {
+    const workflows = getWorkflows();
+    return workflows.length > 1;
+}
+
+/**
+ * Show workflow selection picker
+ * @param featureDir Path to feature directory (for context)
+ * @returns Selected workflow or undefined if cancelled
+ */
+export async function selectWorkflow(featureDir: string): Promise<WorkflowConfig | undefined> {
+    const workflows = getWorkflows();
+
+    // If only default workflow, auto-select it
+    if (workflows.length === 1) {
+        return workflows[0];
+    }
+
+    // Check if feature already has a workflow selected
+    const existingContext = await getFeatureWorkflow(featureDir);
+    if (existingContext) {
+        const existingWorkflow = getWorkflow(existingContext.workflow);
+        if (existingWorkflow) {
+            // Ask if user wants to keep existing or select new
+            const action = await vscode.window.showQuickPick(
+                [
+                    {
+                        label: `$(check) Continue with "${existingWorkflow.displayName || existingWorkflow.name}"`,
+                        description: 'Use the previously selected workflow',
+                        action: 'keep' as const,
+                    },
+                    {
+                        label: '$(list-selection) Select a different workflow',
+                        description: 'Choose a new workflow for this feature',
+                        action: 'select' as const,
+                    },
+                ],
+                {
+                    title: 'Workflow Selection',
+                    placeHolder: `This feature is using the "${existingWorkflow.displayName || existingWorkflow.name}" workflow`,
+                }
+            );
+
+            if (!action) {
+                return undefined; // User cancelled
+            }
+
+            if (action.action === 'keep') {
+                return existingWorkflow;
+            }
+            // Fall through to show picker
+        }
+    }
+
+    // Build quick pick items
+    const items = workflows.map(workflow => ({
+        label: workflow.displayName || workflow.name,
+        description: workflow.name === 'default' ? '(built-in)' : '',
+        detail: buildWorkflowDetail(workflow),
+        workflow,
+    }));
+
+    const selection = await vscode.window.showQuickPick(items, {
+        title: 'Select Workflow',
+        placeHolder: 'Choose a workflow for this feature',
+        matchOnDescription: true,
+        matchOnDetail: true,
+    });
+
+    if (!selection) {
+        return undefined; // User cancelled
+    }
+
+    // Save selection to feature context
+    await saveFeatureWorkflow(featureDir, selection.workflow.name);
+
+    return selection.workflow;
+}
+
+/**
+ * Build detail string for workflow quick pick item
+ */
+function buildWorkflowDetail(workflow: WorkflowConfig): string {
+    const parts: string[] = [];
+
+    if (workflow.description) {
+        parts.push(workflow.description);
+    }
+
+    // Show step mappings if custom
+    const customSteps: string[] = [];
+    if (workflow['step-specify'] && workflow['step-specify'] !== 'speckit.specify') {
+        customSteps.push(`specify: ${workflow['step-specify']}`);
+    }
+    if (workflow['step-plan'] && workflow['step-plan'] !== 'speckit.plan') {
+        customSteps.push(`plan: ${workflow['step-plan']}`);
+    }
+    if (workflow['step-implement'] && workflow['step-implement'] !== 'speckit.implement') {
+        customSteps.push(`implement: ${workflow['step-implement']}`);
+    }
+
+    if (customSteps.length > 0) {
+        parts.push(`Steps: ${customSteps.join(', ')}`);
+    }
+
+    // Show checkpoint info
+    if (workflow.checkpoints && workflow.checkpoints.length > 0) {
+        const checkpointTypes = workflow.checkpoints.map(cp => cp.id).join(', ');
+        parts.push(`Checkpoints: ${checkpointTypes}`);
+    }
+
+    return parts.join(' | ') || 'Standard SpecKit workflow';
+}
+
+/**
+ * Get the workflow for a feature, prompting for selection if needed
+ * @param featureDir Path to feature directory
+ * @returns Selected workflow or undefined if cancelled
+ */
+export async function getOrSelectWorkflow(featureDir: string): Promise<WorkflowConfig | undefined> {
+    // Check if feature has existing workflow
+    const existingContext = await getFeatureWorkflow(featureDir);
+    if (existingContext) {
+        const workflow = getWorkflow(existingContext.workflow);
+        if (workflow) {
+            return workflow;
+        }
+        // Workflow no longer exists, need to select new one
+    }
+
+    // Check if selection is needed
+    if (!needsSelection()) {
+        // Auto-select default workflow
+        const workflows = getWorkflows();
+        return workflows[0];
+    }
+
+    // Show selection picker
+    return selectWorkflow(featureDir);
+}

--- a/webview/src/spec-editor/types.ts
+++ b/webview/src/spec-editor/types.ts
@@ -17,19 +17,27 @@ export interface VSCodeApi {
 // ============================================
 
 export type SpecEditorToExtensionMessage =
-    | { type: 'submit'; content: string; images: string[] }
+    | { type: 'submit'; content: string; images: string[]; workflow: string }
     | { type: 'preview' }
     | { type: 'attachImage'; name: string; size: number; dataUri: string }
     | { type: 'removeImage'; imageId: string }
     | { type: 'loadTemplate'; specPath: string }
     | { type: 'requestTemplateDialog' }
+    | { type: 'ready' }
     | { type: 'cancel' };
 
 // ============================================
 // Message Types: Extension → Webview
 // ============================================
 
+export interface WorkflowDefinition {
+    name: string;
+    displayName: string;
+    description?: string;
+}
+
 export type ExtensionToSpecEditorMessage =
+    | { type: 'init'; workflows: WorkflowDefinition[] }
     | { type: 'imageSaved'; imageId: string; thumbnailUri: string; originalName: string }
     | { type: 'imageRemoved'; imageId: string }
     | { type: 'templateLoaded'; content: string }

--- a/webview/styles/spec-editor.css
+++ b/webview/styles/spec-editor.css
@@ -257,6 +257,47 @@
 }
 
 /* ============================================
+   Workflow Row
+   ============================================ */
+
+.workflow-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 12px;
+}
+
+.workflow-row .template-loader {
+    margin-bottom: 0;
+}
+
+.workflow-selector {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.workflow-selector label {
+    font-size: 0.85em;
+    color: var(--vscode-descriptionForeground);
+}
+
+.workflow-selector select {
+    padding: 4px 8px;
+    border: 1px solid var(--vscode-input-border, var(--vscode-widget-border));
+    border-radius: 4px;
+    background-color: var(--vscode-input-background);
+    color: var(--vscode-input-foreground);
+    font-size: 0.85em;
+    cursor: pointer;
+}
+
+.workflow-selector select:focus {
+    outline: none;
+    border-color: var(--vscode-focusBorder);
+}
+
+/* ============================================
    Action Buttons
    ============================================ */
 


### PR DESCRIPTION
## Summary

- Add workflow selector dropdown to spec editor UI for choosing between default and custom workflows
- Support custom workflows via `speckit.customWorkflows` setting
- Add `step` and `tooltip` properties to `customCommands` schema for phase-specific command display
- Add light workflow commands (`light-specify`, `light-plan`, `light-implement`)
- Add `commit` and `pr` commands for workflow automation

## Changes

- **Spec Editor**: Workflow dropdown appears when custom workflows are configured
- **Settings Schema**: Updated `customCommands` with `step` and `tooltip`, simplified `customWorkflows`
- **New Commands**: Added 5 new slash commands for light workflows and git operations
- **Documentation**: Updated README with configuration examples

## Configuration Example

```json
{
  "speckit.customCommands": [
    {
      "name": "commit",
      "title": "Commit",
      "command": "/speckit.commit",
      "step": "tasks",
      "tooltip": "Generate a commit"
    }
  ],
  "speckit.customWorkflows": [
    {
      "name": "light",
      "displayName": "Light Workflow",
      "step-specify": "/speckit.light-specify",
      "step-plan": "/speckit.light-plan",
      "step-implement": "/speckit.light-implement"
    }
  ]
}
```

## Test Plan

- [ ] Open spec editor with no custom workflows configured - dropdown should be hidden
- [ ] Add custom workflow to settings - dropdown should appear with Default + custom option
- [ ] Select custom workflow and submit - should use custom command
- [ ] Verify custom commands appear in correct workflow phase