### PR TITLE
feat: add Qwen Code CLI provider (issue #18)

### DIFF
--- a/docs/providers/qwen-setup.md
+++ b/docs/providers/qwen-setup.md
@@ -1,0 +1,130 @@
+# Qwen Code CLI — Setup Guide
+
+This guide explains how to install and configure **Qwen Code CLI** (`qwen`) for use with
+SpecKit Companion.
+
+---
+
+## Prerequisites
+
+- Node.js 18+ (for npm installation)
+- A Qwen / Alibaba Cloud account for authentication
+
+---
+
+## Installation
+
+### npm (recommended)
+
+```bash
+npm install -g @qwen-code/qwen-code@latest
+```
+
+Verify the installation:
+
+```bash
+qwen --version
+```
+
+---
+
+## Authentication
+
+Qwen Code supports two authentication methods:
+
+### Option 1 — OAuth (browser-based)
+
+Run the interactive CLI once to trigger the OAuth flow:
+
+```bash
+qwen
+```
+
+Follow the prompts to log in with your Alibaba Cloud / Qwen account.
+
+### Option 2 — API Key
+
+Set the `QWEN_API_KEY` environment variable (or `DASHSCOPE_API_KEY` for DashScope):
+
+```bash
+export QWEN_API_KEY="your-api-key-here"
+```
+
+Add this to your shell profile (`~/.zshrc`, `~/.bashrc`, etc.) to persist it across sessions.
+
+---
+
+## Configuring SpecKit Companion
+
+### 1. Select Qwen Code as the AI provider
+
+Open VS Code Settings (`Cmd/Ctrl + ,`) and search for **SpecKit AI Provider**, then choose
+`qwen`. Alternatively, set it directly in `settings.json`:
+
+```json
+"speckit.aiProvider": "qwen"
+```
+
+### 2. Available settings
+
+| Setting | Default | Description |
+|---|---|---|
+| `speckit.qwenPath` | `"qwen"` | Path to the Qwen Code CLI executable. Change this if `qwen` is not on your `PATH`. |
+| `speckit.qwenYoloMode` | `false` | Enable `--yolo` mode to auto-approve all Qwen actions without prompts. |
+
+Example `settings.json`:
+
+```json
+{
+  "speckit.aiProvider": "qwen",
+  "speckit.qwenPath": "qwen",
+  "speckit.qwenYoloMode": false
+}
+```
+
+---
+
+## Verifying it works
+
+1. Open a workspace that contains a `.claude/specs/` directory (or run **SpecKit: Create Spec**).
+2. Open the Command Palette (`Cmd/Ctrl + Shift + P`) and run **SpecKit: Specify**.
+3. A split-view terminal should open and run:
+   ```
+   qwen -p "$(cat /path/to/prompt.md)"
+   ```
+4. If `qwen` is not installed, SpecKit will show an error with a **Copy Install Command** button.
+
+---
+
+## Steering files
+
+Qwen Code uses `QWEN.md` as its steering file, similar to how Claude uses `CLAUDE.md`.
+
+| File | Purpose |
+|---|---|
+| `~/.qwen/QWEN.md` | Global user-level instructions |
+| `QWEN.md` (project root) | Project-level instructions |
+| `.qwen/steering/*.md` | Additional steering documents |
+
+The **Steering** panel in SpecKit will show the global and project `QWEN.md` files.
+
+---
+
+## Troubleshooting
+
+### `qwen: command not found`
+
+- Make sure the npm global bin directory is on your `PATH`.
+- Run `npm bin -g` to find the directory and add it to your shell profile.
+- Or set `speckit.qwenPath` to the absolute path of the `qwen` binary.
+
+### Authentication errors
+
+- Re-run `qwen` interactively to refresh your OAuth token.
+- Check that `QWEN_API_KEY` (or `DASHSCOPE_API_KEY`) is set correctly.
+
+### Prompt never executes
+
+- Increase `speckit.terminalDelay` if the terminal needs more time to initialise.
+- Ensure your shell has the `qwen` binary available in non-interactive sessions (check `PATH` in
+  `.zshenv` or `.bashrc`, not just `.zshrc`).

--- a/package.json
+++ b/package.json
@@ -521,13 +521,15 @@
             "claude",
             "gemini",
             "copilot",
-            "codex"
+            "codex",
+            "qwen"
           ],
           "enumDescriptions": [
             "Claude Code - Full feature support (steering, agents, hooks, MCP)",
             "Gemini CLI - Steering and MCP support",
             "GitHub Copilot CLI - Steering, agents, and MCP support",
-            "Codex CLI - Steering, skills, and MCP support"
+            "Codex CLI - Steering, skills, and MCP support",
+            "Qwen Code - Steering and MCP support"
           ],
           "scope": "machine",
           "order": 2,
@@ -570,6 +572,20 @@
           "scope": "machine",
           "order": 5,
           "description": "Delay in milliseconds before sending prompt to Gemini CLI (allows time for initialization)"
+        },
+        "speckit.qwenPath": {
+          "type": "string",
+          "default": "qwen",
+          "scope": "machine",
+          "order": 6,
+          "description": "Path to Qwen Code CLI executable"
+        },
+        "speckit.qwenYoloMode": {
+          "type": "boolean",
+          "default": false,
+          "scope": "machine",
+          "order": 7,
+          "description": "Enable YOLO mode (--yolo) to auto-approve all Qwen actions"
         },
         "speckit.customCommands": {
           "type": "array",

--- a/src/ai-providers/aiProvider.ts
+++ b/src/ai-providers/aiProvider.ts
@@ -50,7 +50,7 @@ export interface IAIProvider {
 /**
  * Supported AI provider types
  */
-export type AIProviderType = 'claude' | 'gemini' | 'copilot' | 'codex';
+export type AIProviderType = 'claude' | 'gemini' | 'copilot' | 'codex' | 'qwen';
 
 /**
  * Provider configuration paths and patterns
@@ -124,6 +124,17 @@ export const PROVIDER_PATHS: Record<AIProviderType, ProviderPaths> = {
         mcpConfigPath: '~/.codex/config.toml', // Note: home directory, TOML format
         supportsHooks: false,
     },
+    qwen: {
+        steeringFile: 'QWEN.md',
+        steeringDir: '.qwen/steering',
+        steeringPattern: '*.md',
+        agentsDir: '',
+        agentsPattern: '',
+        skillsDir: '',
+        skillsPattern: '',
+        mcpConfigPath: '.qwen/settings.json',
+        supportsHooks: false,
+    },
 };
 
 /**
@@ -182,6 +193,11 @@ export async function promptForProviderSelection(): Promise<AIProviderType | und
                 label: '$(terminal) Codex CLI',
                 description: 'Steering, skills, and MCP support',
                 value: 'codex' as AIProviderType
+            },
+            {
+                label: '$(hubot) Qwen Code',
+                description: 'Steering and MCP support (no agents or hooks)',
+                value: 'qwen' as AIProviderType
             }
         ],
         {

--- a/src/ai-providers/aiProviderFactory.ts
+++ b/src/ai-providers/aiProviderFactory.ts
@@ -4,6 +4,7 @@ import { ClaudeCodeProvider } from './claudeCodeProvider';
 import { GeminiCliProvider } from './geminiCliProvider';
 import { CopilotCliProvider } from './copilotCliProvider';
 import { CodexCliProvider } from './codexCliProvider';
+import { QwenCliProvider } from './qwenCliProvider';
 
 /**
  * Factory for creating AI provider instances based on configuration
@@ -52,6 +53,9 @@ export class AIProviderFactory {
             case 'codex':
                 provider = new CodexCliProvider(context, outputChannel);
                 break;
+            case 'qwen':
+                provider = new QwenCliProvider(context, outputChannel);
+                break;
             default:
                 outputChannel.appendLine(`[AIProviderFactory] Unknown provider type: ${type}, falling back to Claude Code`);
                 provider = new ClaudeCodeProvider(context, outputChannel);
@@ -76,7 +80,8 @@ export class AIProviderFactory {
             { type: 'claude', name: 'Claude Code', available: true },
             { type: 'gemini', name: 'Gemini CLI', available: true },
             { type: 'copilot', name: 'GitHub Copilot CLI', available: true },
-            { type: 'codex', name: 'Codex CLI', available: true }
+            { type: 'codex', name: 'Codex CLI', available: true },
+            { type: 'qwen', name: 'Qwen Code', available: true }
         ];
     }
 }

--- a/src/ai-providers/index.ts
+++ b/src/ai-providers/index.ts
@@ -4,3 +4,4 @@ export * from './claudeCodeProvider';
 export * from './geminiCliProvider';
 export * from './copilotCliProvider';
 export * from './codexCliProvider';
+export * from './qwenCliProvider';

--- a/src/ai-providers/qwenCliProvider.ts
+++ b/src/ai-providers/qwenCliProvider.ts
@@ -1,0 +1,240 @@
+import * as vscode from 'vscode';
+import * as fs from 'fs';
+import * as path from 'path';
+import { exec } from 'child_process';
+import { promisify } from 'util';
+import { ConfigManager } from '../core/utils/configManager';
+import { ConfigKeys, Timing } from '../core/constants';
+import { IAIProvider, AIExecutionResult } from './aiProvider';
+
+const execAsync = promisify(exec);
+
+export class QwenCliProvider implements IAIProvider {
+    public readonly name = 'Qwen Code';
+
+    private context: vscode.ExtensionContext;
+    private outputChannel: vscode.OutputChannel;
+    private configManager: ConfigManager;
+
+    constructor(context: vscode.ExtensionContext, outputChannel: vscode.OutputChannel) {
+        this.context = context;
+        this.outputChannel = outputChannel;
+
+        this.configManager = ConfigManager.getInstance();
+        this.configManager.loadSettings();
+        vscode.workspace.onDidChangeConfiguration(e => {
+            if (e.affectsConfiguration(ConfigKeys.namespace)) {
+                this.configManager.loadSettings();
+            }
+        });
+    }
+
+    /**
+     * Check if Qwen Code CLI is installed
+     */
+    async isInstalled(): Promise<boolean> {
+        try {
+            await execAsync('qwen --version');
+            return true;
+        } catch {
+            return false;
+        }
+    }
+
+    /**
+     * Get the CLI command path from settings
+     */
+    private getCliPath(): string {
+        const config = vscode.workspace.getConfiguration('speckit');
+        return config.get<string>('qwenPath', 'qwen');
+    }
+
+    /**
+     * Get whether YOLO mode (--yolo) is enabled
+     */
+    private getYoloMode(): boolean {
+        const config = vscode.workspace.getConfiguration('speckit');
+        return config.get<boolean>('qwenYoloMode', false);
+    }
+
+    /**
+     * Create a temporary file with content
+     */
+    private async createTempFile(content: string, prefix: string = 'prompt'): Promise<string> {
+        const tempDir = this.context.globalStorageUri.fsPath;
+        await vscode.workspace.fs.createDirectory(this.context.globalStorageUri);
+
+        const tempFile = path.join(tempDir, `${prefix}-${Date.now()}.md`);
+        await fs.promises.writeFile(tempFile, content);
+
+        return this.convertPathIfWSL(tempFile);
+    }
+
+    /**
+     * Convert Windows path to WSL path if needed
+     */
+    private convertPathIfWSL(filePath: string): string {
+        if (process.platform === 'win32' && filePath.match(/^[A-Za-z]:\\/)) {
+            let wslPath = filePath.replace(/\\/g, '/');
+            wslPath = wslPath.replace(/^([A-Za-z]):/, (_match, drive) => `/mnt/${drive.toLowerCase()}`);
+            return wslPath;
+        }
+        return filePath;
+    }
+
+    /**
+     * Check if Qwen Code CLI is installed and show helpful error if not
+     */
+    private async ensureInstalled(): Promise<void> {
+        const installed = await this.isInstalled();
+        if (!installed) {
+            const action = await vscode.window.showErrorMessage(
+                'Qwen Code CLI is not installed. Install it with: npm install -g @qwen-code/qwen-code@latest',
+                'Copy Install Command'
+            );
+            if (action === 'Copy Install Command') {
+                await vscode.env.clipboard.writeText('npm install -g @qwen-code/qwen-code@latest');
+                vscode.window.showInformationMessage('Install command copied to clipboard');
+            }
+            throw new Error('Qwen Code CLI is not installed');
+        }
+    }
+
+    /**
+     * Execute a prompt in a visible terminal (split view)
+     * Uses qwen -p "$(cat <tempFile>)" to pass the prompt
+     */
+    async executeInTerminal(prompt: string, title: string = 'SpecKit - Qwen Code'): Promise<vscode.Terminal> {
+        try {
+            await this.ensureInstalled();
+            const cliPath = this.getCliPath();
+            const yoloFlag = this.getYoloMode() ? ' --yolo' : '';
+
+            const tempFilePath = await this.createTempFile(prompt, 'prompt');
+            const command = `${cliPath}${yoloFlag} -p "$(cat "${tempFilePath}")"`;
+
+            const terminal = vscode.window.createTerminal({
+                name: title,
+                cwd: vscode.workspace.workspaceFolders?.[0]?.uri.fsPath,
+                location: {
+                    viewColumn: vscode.ViewColumn.Two
+                }
+            });
+
+            terminal.show();
+
+            const delay = this.configManager.getTerminalDelay();
+            setTimeout(() => {
+                terminal.sendText(command, true);
+            }, delay);
+
+            // Clean up temp file after delay
+            const fileToClean = tempFilePath;
+            setTimeout(async () => {
+                try {
+                    await fs.promises.unlink(fileToClean);
+                    this.outputChannel.appendLine(`[Qwen] Cleaned up prompt file: ${fileToClean}`);
+                } catch (e) {
+                    this.outputChannel.appendLine(`[Qwen] Failed to cleanup temp file: ${e}`);
+                }
+            }, Timing.tempFileCleanupDelay);
+
+            return terminal;
+
+        } catch (error) {
+            this.outputChannel.appendLine(`[Qwen] ERROR: Failed to send to Qwen Code CLI: ${error}`);
+            vscode.window.showErrorMessage(`Failed to run Qwen Code CLI: ${error}`);
+            throw error;
+        }
+    }
+
+    /**
+     * Execute a prompt in headless/background mode
+     */
+    async executeHeadless(prompt: string): Promise<AIExecutionResult> {
+        await this.ensureInstalled();
+
+        this.outputChannel.appendLine(`[QwenCliProvider] Invoking Qwen Code CLI in headless mode`);
+        this.outputChannel.appendLine(`========================================`);
+        this.outputChannel.appendLine(prompt);
+        this.outputChannel.appendLine(`========================================`);
+
+        const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
+        const cwd = workspaceFolder?.uri.fsPath;
+        const cliPath = this.getCliPath();
+        const yoloFlag = this.getYoloMode() ? ' --yolo' : '';
+
+        const tempFilePath = await this.createTempFile(prompt, 'background-prompt');
+        const commandLine = `${cliPath}${yoloFlag} -p "$(cat "${tempFilePath}")"`;
+
+        const terminal = vscode.window.createTerminal({
+            name: 'Qwen Code Background',
+            cwd,
+            hideFromUser: true
+        });
+
+        return new Promise((resolve) => {
+            let shellIntegrationChecks = 0;
+
+            const checkShellIntegration = setInterval(() => {
+                shellIntegrationChecks++;
+
+                if (terminal.shellIntegration) {
+                    clearInterval(checkShellIntegration);
+
+                    const execution = terminal.shellIntegration.executeCommand(commandLine);
+
+                    const disposable = vscode.window.onDidEndTerminalShellExecution(event => {
+                        if (event.terminal === terminal && event.execution === execution) {
+                            disposable.dispose();
+
+                            if (event.exitCode !== 0) {
+                                this.outputChannel.appendLine(`[Qwen] Command failed with exit code: ${event.exitCode}`);
+                                this.outputChannel.appendLine(`[Qwen] Command was: ${commandLine}`);
+                            }
+
+                            resolve({
+                                exitCode: event.exitCode,
+                                output: undefined
+                            });
+
+                            setTimeout(async () => {
+                                terminal.dispose();
+                                try {
+                                    await fs.promises.unlink(tempFilePath);
+                                    this.outputChannel.appendLine(`[Qwen] Cleaned up temp file: ${tempFilePath}`);
+                                } catch (e) {
+                                    this.outputChannel.appendLine(`[Qwen] Failed to cleanup temp file: ${e}`);
+                                }
+                            }, Timing.terminalDisposeDelay);
+                        }
+                    });
+                } else if (shellIntegrationChecks > Timing.shellIntegrationMaxChecks) {
+                    clearInterval(checkShellIntegration);
+                    this.outputChannel.appendLine(`[Qwen] Shell integration not available, using fallback mode`);
+                    terminal.sendText(commandLine);
+
+                    setTimeout(async () => {
+                        resolve({ exitCode: undefined });
+                        terminal.dispose();
+                        try {
+                            await fs.promises.unlink(tempFilePath);
+                        } catch (e) {
+                            // Ignore cleanup errors
+                        }
+                    }, Timing.shellIntegrationFallbackTimeout);
+                }
+            }, Timing.shellIntegrationCheckInterval);
+        });
+    }
+
+    /**
+     * Execute a slash command in terminal
+     * Delegates to executeInTerminal with the slash command as prompt
+     */
+    async executeSlashCommand(command: string, title: string = 'SpecKit - Qwen Code', autoExecute: boolean = true): Promise<vscode.Terminal> {
+        await this.ensureInstalled();
+        const slashCommand = command.startsWith('/') ? command : `/${command}`;
+        return this.executeInTerminal(slashCommand, title);
+    }
+}

--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -56,6 +56,8 @@ export const ConfigKeys = {
     claudePermissionMode: 'speckit.claudePermissionMode',
     geminiInitDelay: 'speckit.geminiInitDelay',
     customCommands: 'speckit.customCommands',
+    qwenPath: 'speckit.qwenPath',
+    qwenYoloMode: 'speckit.qwenYoloMode',
     customWorkflows: 'speckit.customWorkflows',
     defaultWorkflow: 'speckit.defaultWorkflow',
     views: {
@@ -179,6 +181,8 @@ export const FileNames = {
     geminiMd: 'GEMINI.md',
     /** Copilot CLI steering file */
     copilotInstructions: 'copilot-instructions.md',
+    /** Qwen Code steering file */
+    qwenMd: 'QWEN.md',
     /** Skill definition file */
     skillDefinition: 'SKILL.md',
     /** Claude settings file */
@@ -199,6 +203,8 @@ export const Directories = {
     claude: '.claude',
     /** Gemini configuration directory */
     gemini: '.gemini',
+    /** Qwen Code configuration directory */
+    qwen: '.qwen',
     /** SpecKit configuration directory */
     specify: '.specify',
     /** GitHub directory (for Copilot) */

--- a/src/features/agents/agentsExplorerProvider.ts
+++ b/src/features/agents/agentsExplorerProvider.ts
@@ -35,10 +35,11 @@ export class AgentsExplorerProvider extends BaseTreeDataProvider<AgentItem> {
 
         const providerType = getConfiguredProviderType();
 
-        // Gemini has limited agent support
-        if (providerType === 'gemini' && !element) {
+        // Some providers have no agent support (data-driven via PROVIDER_PATHS)
+        const noAgentSupport = !getProviderPaths(providerType).agentsDir;
+        if (noAgentSupport && !element) {
             return [new AgentItem(
-                'Agents not supported for Gemini CLI',
+                'Agents not supported for this provider',
                 vscode.TreeItemCollapsibleState.None,
                 'agent-not-supported'
             )];

--- a/src/features/hooks/hooksExplorerProvider.ts
+++ b/src/features/hooks/hooksExplorerProvider.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
 import * as fs from 'fs';
-import { getConfiguredProviderType } from '../../ai-providers/aiProvider';
+import { getConfiguredProviderType, getProviderPaths } from '../../ai-providers/aiProvider';
 import { BaseTreeDataProvider } from '../../core/providers';
 import type { HookTrigger, HookAction, HookInfo, ClaudeSettingsJson } from '../../core/types/config';
 
@@ -28,10 +28,10 @@ export class HooksExplorerProvider extends BaseTreeDataProvider<HookItem> {
 
         // Hooks are only supported for Claude Code
         const providerType = getConfiguredProviderType();
-        if (providerType !== 'claude' && !element) {
+        if (!getProviderPaths(providerType).supportsHooks && !element) {
             return [
                 new HookItem(
-                    `Hooks not supported for ${providerType === 'gemini' ? 'Gemini CLI' : 'GitHub Copilot CLI'}`,
+                    `Hooks not supported for this provider`,
                     vscode.TreeItemCollapsibleState.None,
                     'hooks-not-supported',
                     'not-supported',

--- a/src/features/mcp/mcpExplorerProvider.ts
+++ b/src/features/mcp/mcpExplorerProvider.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import { exec } from 'child_process';
 import { promisify } from 'util';
-import { getConfiguredProviderType } from '../../ai-providers/aiProvider';
+import { getConfiguredProviderType, getProviderPaths } from '../../ai-providers/aiProvider';
 import { BaseTreeDataProvider } from '../../core/providers';
 
 const execAsync = promisify(exec);
@@ -48,9 +48,7 @@ export class MCPExplorerProvider extends BaseTreeDataProvider<MCPItem> {
             // For non-Claude providers, show info message about MCP config location
             const providerType = getConfiguredProviderType();
             if (providerType !== 'claude') {
-                const configPath = providerType === 'gemini'
-                    ? '~/.gemini/settings.json'
-                    : '~/.copilot/mcp-config.json';
+                const configPath = getProviderPaths(providerType).mcpConfigPath;
                 items.push(new MCPItem(
                     `MCP config: ${configPath}`,
                     vscode.TreeItemCollapsibleState.None,

--- a/src/features/steering/steeringExplorerProvider.ts
+++ b/src/features/steering/steeringExplorerProvider.ts
@@ -212,6 +212,10 @@ export class SteeringExplorerProvider extends BaseTreeDataProvider<SteeringItem>
                 globalPath = null;
                 projectPath = workspaceRoot ? path.join(workspaceRoot, '.github', 'copilot-instructions.md') : null;
                 break;
+            case 'qwen':
+                globalPath = path.join(home, '.qwen', 'QWEN.md');
+                projectPath = workspaceRoot ? path.join(workspaceRoot, 'QWEN.md') : null;
+                break;
         }
 
         return {


### PR DESCRIPTION
## Summary

- Adds **Qwen Code** (`qwen`) as a first-class AI provider alongside Claude, Gemini, Copilot, and Codex
- New `QwenCliProvider` uses `qwen -p "$(cat <tempFile>)"` for terminal and headless execution, with optional `--yolo` flag
- Adds `speckit.qwenPath` and `speckit.qwenYoloMode` VS Code settings
- Adds `docs/providers/qwen-setup.md` setup guide (installation, auth, settings, troubleshooting)

## Provider-agnostic improvements

- **Hooks panel**: replaced hardcoded provider-name ternary with `PROVIDER_PATHS.supportsHooks` check
- **Agents panel**: replaced `providerType === 'gemini'` hardcode with `!PROVIDER_PATHS.agentsDir` check
- **MCP panel**: replaced hardcoded config path ternary with `PROVIDER_PATHS.mcpConfigPath` lookup

## Test plan

- [ ] `npm run compile` passes with no TypeScript errors ✅
- [ ] Select `qwen` in `speckit.aiProvider` → Steering panel shows `QWEN.md` paths
- [ ] Hooks panel shows "Hooks not supported for this provider"
- [ ] Agents panel shows "Agents not supported for this provider"
- [ ] MCP panel shows "MCP config: `.qwen/settings.json`"
- [ ] Run any SpecKit command with `qwen` not installed → error with Copy Install Command button
- [ ] Run with `qwen` installed → split-view terminal runs `qwen -p "$(cat ...)"`
- [ ] Toggle `speckit.qwenYoloMode: true` → `--yolo` appears in the command

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)