### PR TITLE
feat(spec-editor): simplify create spec footer CTA

### DIFF
--- a/src/features/spec-editor/specEditorProvider.ts
+++ b/src/features/spec-editor/specEditorProvider.ts
@@ -490,8 +490,7 @@ Example:
         <footer class="spec-editor-actions">
             <button class="btn-cancel" id="cancelBtn">Cancel</button>
             <div class="action-spacer"></div>
-            <button class="btn-secondary" id="previewBtn">Preview</button>
-            <button class="btn-primary" id="submitBtn">Submit to AI</button>
+            <button class="btn-primary" id="submitBtn">Submit</button>
         </footer>
 
         <div class="keyboard-hints">

--- a/webview/src/spec-editor/index.ts
+++ b/webview/src/spec-editor/index.ts
@@ -32,7 +32,6 @@ function getElements() {
         sizeInfo: document.getElementById('sizeInfo') as HTMLElement,
         loadingOverlay: document.getElementById('loadingOverlay') as HTMLElement,
         submitBtn: document.getElementById('submitBtn') as HTMLButtonElement,
-        previewBtn: document.getElementById('previewBtn') as HTMLButtonElement,
         cancelBtn: document.getElementById('cancelBtn') as HTMLButtonElement,
         attachImageBtn: document.getElementById('attachImageBtn') as HTMLButtonElement,
         loadTemplateBtn: document.getElementById('loadTemplateBtn') as HTMLButtonElement,
@@ -96,12 +95,11 @@ function escapeHtml(text: string): string {
 // ============================================
 
 function setLoading(loading: boolean): void {
-    const { loadingOverlay, submitBtn, previewBtn } = getElements();
+    const { loadingOverlay, submitBtn } = getElements();
     isSubmitting = loading;
 
     loadingOverlay.style.display = loading ? 'flex' : 'none';
     submitBtn.disabled = loading;
-    previewBtn.disabled = loading;
 }
 
 // ============================================
@@ -236,11 +234,6 @@ function setupEventListeners(): void {
             images: attachedImages.map(img => img.id),
             workflow: getSelectedWorkflow()
         });
-    });
-
-    // Preview button
-    elements.previewBtn.addEventListener('click', () => {
-        vscode.postMessage({ type: 'preview' });
     });
 
     // Cancel button


### PR DESCRIPTION
## What

- Rename submit button label from "Submit to AI" to "Submit"
- Remove the Preview button from the Create Spec footer
- Remove preview button element reference, disabled state, and click listener from webview script

## Why

The footer had an unnecessary Preview button cluttering the CTA; Submit already has primary styling so the label just needed trimming.

## Testing

- Open Create Spec window — footer shows only "Cancel" and "Submit"
- Submit button is styled as primary action
- No Preview button visible or functional
- No console errors on load