### PR TITLE
feat(workflows): improve custom workflow UX with dynamic sub-commands and output channel logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,8 @@ Define alternative workflows with different commands for each step:
 }
 ```
 
+Each `step-*` field maps a workflow phase to a custom command. Enhancement buttons in the spec viewer footer are driven by `customCommands` entries with a matching `step` — if none are configured, no button is shown.
+
 When multiple workflows exist, you'll be prompted to choose when starting a new spec.
 
 ## Configuration

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "speckit-companion",
-  "version": "0.5.3",
+  "version": "0.5.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "speckit-companion",
-      "version": "0.5.3",
+      "version": "0.5.6",
       "license": "MIT",
       "dependencies": {
         "js-yaml": "^4.1.0"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "speckit-companion",
   "displayName": "SpecKit Companion",
   "description": "VS Code companion for GitHub SpecKit - spec-driven development with AI assistants",
-  "version": "0.5.3",
+  "version": "0.5.6",
   "license": "MIT",
   "publisher": "alfredoperez",
   "icon": "icon.png",

--- a/src/core/types/config.ts
+++ b/src/core/types/config.ts
@@ -77,6 +77,10 @@ export interface CustomCommandConfig {
     title?: string;
     /** Full slash command (e.g., "/speckit.review") */
     command?: string;
+    /** Workflow step to show this command in: "spec", "plan", "tasks", or "all" */
+    step?: string;
+    /** Tooltip text shown on hover */
+    tooltip?: string;
     /** Whether to append or inject the spec directory */
     requiresSpecDir?: boolean;
     /** Whether to auto-execute in terminal (default: true) */

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -153,7 +153,7 @@ export async function activate(context: vscode.ExtensionContext) {
     setupTasksWatcher(context, outputChannel);
 
     // Validate custom workflows on activation and register change listener
-    validateWorkflowsOnActivation();
+    validateWorkflowsOnActivation(outputChannel);
     context.subscriptions.push(registerWorkflowConfigChangeListener(context));
     outputChannel.appendLine('Custom workflows validated');
 

--- a/src/features/spec-viewer/html/generator.ts
+++ b/src/features/spec-viewer/html/generator.ts
@@ -9,7 +9,7 @@ import {
     DocumentType,
     PhaseInfo,
     SpecStatus,
-    PHASE_ENHANCEMENT_BUTTONS
+    EnhancementButton
 } from '../types';
 import { escapeHtml, escapeHtmlAttribute, generateNonce } from '../utils';
 import { calculateWorkflowPhase } from '../phaseCalculation';
@@ -28,7 +28,8 @@ export function generateHtml(
     specName: string,
     phases: PhaseInfo[],
     taskCompletionPercent: number,
-    specStatus: SpecStatus = 'draft'
+    specStatus: SpecStatus = 'draft',
+    enhancementButton: EnhancementButton | null = null
 ): string {
     // Get URIs for resources
     const styleUri = webview.asWebviewUri(
@@ -52,11 +53,6 @@ export function generateHtml(
     // Get current document for edit button state
     const currentDoc = documents.find(d => d.type === currentDocType);
     const editDisabled = !currentDoc?.exists;
-
-    // Get enhancement button for current phase
-    const enhancementButton = currentDocType === 'spec' || currentDocType === 'plan' || currentDocType === 'tasks'
-        ? PHASE_ENHANCEMENT_BUTTONS[currentDocType]
-        : null;
 
     // Smart CTA button logic:
     // - Show "Generate Plan/Tasks" when next phase doesn't exist yet

--- a/src/features/spec-viewer/types.ts
+++ b/src/features/spec-viewer/types.ts
@@ -115,29 +115,6 @@ export interface EnhancementButton {
     tooltip?: string;
 }
 
-/**
- * Phase-specific enhancement buttons
- */
-export const PHASE_ENHANCEMENT_BUTTONS: Record<CoreDocumentType, EnhancementButton> = {
-    spec: {
-        label: 'Clarify',
-        command: 'speckit.clarify',
-        icon: '❓',
-        tooltip: 'Refine any requirements further'
-    },
-    plan: {
-        label: 'Checklist',
-        command: 'speckit.checklist',
-        icon: '✅',
-        tooltip: 'Generate a checklist for the plan'
-    },
-    tasks: {
-        label: 'Analyze',
-        command: 'speckit.analyze',
-        icon: '🔍',
-        tooltip: 'Analyze task consistency'
-    }
-};
 
 /**
  * State for the spec viewer panel
@@ -206,6 +183,8 @@ export interface FooterState {
     showApproveButton: boolean;
     /** Text for the approve button */
     approveText: string;
+    /** Enhancement button config, or null if none */
+    enhancementButton?: EnhancementButton | null;
 }
 
 /**
@@ -226,6 +205,8 @@ export interface NavState {
     isViewingRelatedDoc: boolean;
     /** Footer button state for dynamic updates */
     footerState?: FooterState;
+    /** Enhancement button config, or null if none */
+    enhancementButton?: EnhancementButton | null;
 }
 
 /**

--- a/src/features/workflows/workflowSelector.ts
+++ b/src/features/workflows/workflowSelector.ts
@@ -136,7 +136,7 @@ function buildWorkflowDetail(workflow: WorkflowConfig): string {
  * @param featureDir Path to feature directory
  * @returns Selected workflow or undefined if cancelled
  */
-export async function getOrSelectWorkflow(featureDir: string): Promise<WorkflowConfig | undefined> {
+export async function getOrSelectWorkflow(featureDir: string, outputChannel?: vscode.OutputChannel): Promise<WorkflowConfig | undefined> {
     // Check if feature has existing workflow
     const existingContext = await getFeatureWorkflow(featureDir);
     if (existingContext) {
@@ -150,15 +150,15 @@ export async function getOrSelectWorkflow(featureDir: string): Promise<WorkflowC
     // Get the configured default workflow
     const config = vscode.workspace.getConfiguration(ConfigKeys.namespace);
     const defaultWorkflowName = config.get<string>('defaultWorkflow', 'default');
-    const workflows = getWorkflows();
+    const workflows = getWorkflows(outputChannel);
 
     // Find the configured default workflow
     let selectedWorkflow = workflows.find(w => w.name === defaultWorkflowName);
 
     if (!selectedWorkflow) {
-        // Configured workflow doesn't exist, warn and fall back
-        vscode.window.showWarningMessage(
-            `Default workflow "${defaultWorkflowName}" not found. Using built-in default.`
+        // Configured workflow doesn't exist, log and fall back silently
+        outputChannel?.appendLine(
+            `[Workflows] Default workflow "${defaultWorkflowName}" not found. Using built-in default.`
         );
         selectedWorkflow = workflows[0];
     }


### PR DESCRIPTION
## What

- Replace popup warnings with output channel logging for non-intrusive activation feedback
- Make footer enhancement buttons dynamic based on active workflow sub-commands
- Add "Workflow Commands" category to Steering Explorer for discoverability

## Why

Custom workflows had UX friction: aggressive popups on activation, always-visible buttons regardless of config, and no way to discover referenced command files.

## Testing

- Extension activates without popup when defaultWorkflow doesn't match
- Enhancement buttons hidden when workflow has no sub-commands, shown when configured
- Steering tree shows Workflow Commands with clickable command files
- `npm run compile` passes clean