### PR TITLE
feat(spec-viewer): always show source file button and add sidebar open source action

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "speckit-companion",
-  "version": "0.5.6",
+  "version": "0.5.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "speckit-companion",
-      "version": "0.5.6",
+      "version": "0.5.7",
       "license": "MIT",
       "dependencies": {
-        "js-yaml": "^4.1.0"
+        "js-yaml": "^4.1.1"
       },
       "devDependencies": {
         "@jest/globals": "^29.7.0",
@@ -6369,9 +6369,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "speckit-companion",
   "displayName": "SpecKit Companion",
   "description": "VS Code companion for GitHub SpecKit - spec-driven development with AI assistants",
-  "version": "0.5.6",
+  "version": "0.5.7",
   "license": "MIT",
   "publisher": "alfredoperez",
   "icon": "icon.png",
@@ -369,6 +369,12 @@
         "title": "View Spec Document",
         "category": "SpecKit",
         "icon": "$(preview)"
+      },
+      {
+        "command": "speckit.openSpecSource",
+        "title": "Open Source File",
+        "category": "SpecKit",
+        "icon": "$(go-to-file)"
       }
     ],
     "menus": {
@@ -429,6 +435,11 @@
           "command": "speckit.steering.delete",
           "when": "view == speckit.views.steering && viewItem == steering-document",
           "group": "7_modification"
+        },
+        {
+          "command": "speckit.openSpecSource",
+          "when": "view == speckit.views.explorer && viewItem =~ /spec-document-/",
+          "group": "inline"
         }
       ],
       "commandPalette": [
@@ -486,6 +497,10 @@
         {
           "command": "speckit.upgradeAll",
           "when": "speckit.detected"
+        },
+        {
+          "command": "speckit.openSpecSource",
+          "when": "false"
         }
       ]
     },
@@ -761,7 +776,7 @@
     "install-local": "npm version patch --no-git-tag-version && npm run package && code --install-extension speckit-companion-$(node -p \"require('./package.json').version\").vsix --force"
   },
   "dependencies": {
-    "js-yaml": "^4.1.0"
+    "js-yaml": "^4.1.1"
   },
   "devDependencies": {
     "@jest/globals": "^29.7.0",

--- a/specs/015-source-button-visibility/plan.md
+++ b/specs/015-source-button-visibility/plan.md
@@ -1,0 +1,21 @@
+# Plan: Always-Visible Source File Button
+
+**Spec**: specs/015-source-button-visibility/spec.md | **Date**: 2026-02-28
+
+## Approach
+
+Instead of hiding the entire footer with `display: none` on completed specs, hide individual buttons except "Edit Source". For the sidebar, register a new command and add an inline action on spec document tree items.
+
+## Files to Change
+
+- `webview/styles/spec-viewer/_footer.css` — Replace blanket footer hide with per-button hiding; keep "Edit Source" visible
+- `src/features/specs/specExplorerProvider.ts` — Add `resourceUri` on spec-document items so the inline action can resolve the file path
+- `package.json` — Register `speckit.openSpecSource` command and add inline action for `view/item/context` on spec-document items
+
+## Phase 1 Tasks
+
+| ID | Do | Verify |
+|----|-----|--------|
+| T001 | In `_footer.css`, replace `body[data-spec-status="spec-completed"] .actions { display: none; }` with rules that hide `.actions-left`, `#regenerate`, and `#approve` individually, keeping `#editSource` visible | Open a completed spec in the viewer — "Edit Source" button visible, other buttons hidden |
+| T002 | In `package.json`, register `speckit.openSpecSource` command with `$(go-to-file)` icon; add `view/item/context` inline entry for `viewItem =~ /spec-document-/` | Command appears in VS Code command palette |
+| T003 | In `specExplorerProvider.ts`, set `resourceUri` on spec-document `SpecItem` instances using the file path; register `speckit.openSpecSource` handler in extension activation that opens the file via `vscode.window.showTextDocument` | Hover over spec/plan/tasks in sidebar — inline icon appears; clicking opens the `.md` file |

--- a/specs/015-source-button-visibility/spec.md
+++ b/specs/015-source-button-visibility/spec.md
@@ -1,0 +1,30 @@
+# Spec: Always-Visible Source File Button
+
+**Branch**: 015-source-button-visibility | **Date**: 2026-02-28
+
+## Summary
+
+The "Edit Source" button in the spec viewer footer is currently hidden when the spec status is "spec-completed" (the entire footer gets `display: none`). This makes it impossible to open the raw markdown file for completed specs. The button should always be visible regardless of completion status. Additionally, an "Open Source" inline action should be added to spec document items in the sidebar tree view for quick access.
+
+## Requirements
+
+- **R001** (MUST): The "Edit Source" button in the spec viewer footer must remain visible and functional when spec status is "spec-completed"
+- **R002** (MUST): Other footer actions (Regenerate, Enhance, Approve/Generate) must still be hidden when spec is completed — only "Edit Source" stays
+- **R003** (SHOULD): Each spec document item (spec, plan, tasks) in the sidebar tree view should have an inline "Open Source" action that opens the raw markdown file in the editor
+
+## Scenarios
+
+### Viewing a completed spec in the viewer
+
+**When** a user opens a spec with status "spec-completed" in the spec viewer
+**Then** the "Edit Source" button is visible and clickable in the footer; other action buttons (Regenerate, Enhance, primary CTA) are hidden
+
+### Opening source from sidebar
+
+**When** a user hovers over a spec document item (spec/plan/tasks) in the sidebar explorer tree
+**Then** an inline "Open Source" icon button appears that opens the raw `.md` file in the VS Code editor
+
+## Out of Scope
+
+- Changing the "Edit Source" button label or behavior (it already works via `editSource` message)
+- Modifying the sidebar context menu (right-click) — only adding an inline hover action

--- a/specs/015-source-button-visibility/state.json
+++ b/specs/015-source-button-visibility/state.json
@@ -1,0 +1,1 @@
+{ "step": "implement", "task": null, "updated": "2026-02-28" }

--- a/specs/015-source-button-visibility/tasks.md
+++ b/specs/015-source-button-visibility/tasks.md
@@ -1,0 +1,15 @@
+# Tasks: Always-Visible Source File Button
+
+## Phase 1 — Core
+
+- [x] **T001** · Keep "Edit Source" visible on completed specs
+  - **Do**: In `webview/styles/spec-viewer/_footer.css`, replace the rule `body[data-spec-status="spec-completed"] .actions { display: none; }` with individual hide rules for `.actions-left`, `#regenerate`, and `#approve` while keeping `#editSource` visible
+  - **Verify**: Open a completed spec in viewer — "Edit Source" is clickable, Regenerate/Enhance/primary CTA are hidden
+
+- [x] **T002** · Register sidebar "Open Source" command
+  - **Do**: In `package.json`, add `speckit.openSpecSource` to `commands` with icon `$(go-to-file)` and title "Open Source File"; add `view/item/context` inline entry with `when: "view == speckit.views.explorer && viewItem =~ /spec-document-/"` and `group: "inline"`
+  - **Verify**: Command visible in palette; inline icon appears on spec document tree items
+
+- [x] **T003** · Implement command handler and wire up tree items
+  - **Do**: In `specExplorerProvider.ts`, set `resourceUri` on spec-document `SpecItem` using `vscode.Uri.file(fullPath)`. In `extension.ts` (or `specCommands.ts`), register `speckit.openSpecSource` handler that opens the file via `vscode.window.showTextDocument`
+  - **Verify**: Click inline icon on any spec/plan/tasks item in sidebar — raw `.md` file opens in editor

--- a/src/features/specs/specCommands.ts
+++ b/src/features/specs/specCommands.ts
@@ -72,6 +72,17 @@ export function registerSpecKitCommands(
         })
     );
 
+    // Open source file from sidebar inline action
+    context.subscriptions.push(
+        vscode.commands.registerCommand('speckit.openSpecSource', async (item: vscode.TreeItem) => {
+            const uri = item?.resourceUri;
+            if (uri) {
+                const doc = await vscode.workspace.openTextDocument(uri);
+                await vscode.window.showTextDocument(doc);
+            }
+        })
+    );
+
     // Register phase commands
     registerPhaseCommands(context, outputChannel);
     registerCustomCommand(context, outputChannel);

--- a/src/features/specs/specExplorerProvider.ts
+++ b/src/features/specs/specExplorerProvider.ts
@@ -336,6 +336,14 @@ class SpecItem extends vscode.TreeItem {
             this.tooltip = `${documentType}: ${specName}/${label} — ${statusLabel}`;
 
             this.contextValue = `spec-document-${documentType}`;
+
+            // Set resourceUri so inline actions can resolve the file path
+            if (filePath) {
+                const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
+                if (workspaceFolder) {
+                    this.resourceUri = vscode.Uri.file(path.join(workspaceFolder.uri.fsPath, filePath));
+                }
+            }
         } else if (contextValue === 'spec-related-doc') {
             this.iconPath = new vscode.ThemeIcon('file-text');
             const statusIndicator = status ? STATUS_INDICATORS[status] : STATUS_INDICATORS.empty;

--- a/webview/styles/spec-viewer/_footer.css
+++ b/webview/styles/spec-viewer/_footer.css
@@ -99,7 +99,9 @@
    State-based hiding (completed specs)
    ============================================ */
 
-/* Hide entire footer when spec is completed */
-body[data-spec-status="spec-completed"] .actions {
+/* Hide action buttons except "Edit Source" when spec is completed */
+body[data-spec-status="spec-completed"] .actions-left,
+body[data-spec-status="spec-completed"] #regenerate,
+body[data-spec-status="spec-completed"] #approve {
     display: none;
 }


### PR DESCRIPTION
## What

- Keep "Edit Source" button visible in spec viewer footer even when spec is completed
- Add inline "Open Source File" action on spec document items in the sidebar tree

## Why

The entire footer was hidden on completed specs, making it impossible to open the raw markdown file for review or editing.

## Testing

- Open a completed spec in viewer — "Edit Source" visible, other buttons hidden
- Hover spec/plan/tasks in sidebar — inline icon appears; clicking opens the .md file