### PR TITLE
fix(ux): replace noisy info popups with status bar messages

### DIFF
--- a/specs/017-reduce-popups/plan.md
+++ b/specs/017-reduce-popups/plan.md
@@ -1,0 +1,21 @@
+# Plan: Reduce Noisy Notifications
+
+**Spec**: [spec.md](./spec.md) | **Date**: 2026-03-06
+
+## Approach
+
+Replace 6 noisy `showInformationMessage` calls with `vscode.window.setStatusBarMessage` (auto-dismisses, no modal). Add a single `showStatusBarMessage` helper to `NotificationUtils` so all 5 "copied to clipboard" + "Refining..." calls share one implementation. The `specCommands.ts` case is handled by removing the popup entirely and letting the quick pick open with an empty items array and a descriptive placeholder.
+
+## Files
+
+### Modify
+
+| File | Change |
+|------|--------|
+| `src/core/utils/notificationUtils.ts` | Add `static showStatusBarMessage(text: string, timeoutMs = 3000)` wrapping `vscode.window.setStatusBarMessage` |
+| `src/features/spec-viewer/messageHandlers.ts:257` | Replace `showInformationMessage("Refining line N...")` with `NotificationUtils.showStatusBarMessage(...)` |
+| `src/ai-providers/copilotCliProvider.ts:90` | Replace `showInformationMessage("Install command copied...")` with `NotificationUtils.showStatusBarMessage(...)` |
+| `src/ai-providers/codexCliProvider.ts:115` | Same as above |
+| `src/ai-providers/geminiCliProvider.ts:90` | Same as above |
+| `src/ai-providers/qwenCliProvider.ts:97` | Same as above |
+| `src/features/specs/specCommands.ts:277-280` | Remove the info popup + early return; instead open the quick pick with `placeHolder: "No custom commands configured — add speckit.customCommands in settings"` and an empty items array |

--- a/specs/017-reduce-popups/spec.md
+++ b/specs/017-reduce-popups/spec.md
@@ -1,0 +1,71 @@
+# Spec: Reduce Noisy Notifications
+
+**Branch**: 017-reduce-popups | **Date**: 2026-03-06
+
+## Summary
+
+The extension currently shows ~50 notification popups across 20 files. Most are appropriate, but several fire on frequent low-stakes actions and interrupt the user's flow unnecessarily. This spec audits all notifications and replaces noisy ones with status bar messages or inline feedback.
+
+## Findings
+
+### Notification inventory (~50 calls across 20 files)
+
+| Category | Count | Assessment |
+|----------|-------|------------|
+| `showErrorMessage` | ~22 | Mostly keep — genuine failures |
+| `showInformationMessage` | ~18 | 4-5 are noisy |
+| `showWarningMessage` | ~8 | Keep — all require user confirmation |
+| `showQuickPick` | ~4 | Keep — intentional user input |
+| `showInputBox` | ~2 | Keep — intentional user input |
+
+### Identified noisy notifications
+
+| Location | Message | Problem |
+|----------|---------|---------|
+| `messageHandlers.ts:257` | `"Refining line N..."` | Fires on every inline refine click — high frequency |
+| `copilotCliProvider.ts:90` | `"Install command copied to clipboard"` | Transient success, not an error |
+| `codexCliProvider.ts:115` | `"Install command copied to clipboard"` | Same — 4 provider files repeat this |
+| `geminiCliProvider.ts:90` | `"Install command copied to clipboard"` | Same |
+| `qwenCliProvider.ts:97` | `"Install command copied to clipboard"` | Same |
+| `specCommands.ts:278` | `"No custom commands configured..."` | Informational, could be inline |
+
+### Notifications to keep (do not change)
+
+- All `showErrorMessage` calls (legitimate failure states)
+- All `showWarningMessage` with action buttons (destructive confirmation)
+- All `showQuickPick` / `showInputBox` (intentional user flows)
+- `updateChecker.ts:94` (once per 24h, user-relevant)
+- `extension.ts:189` (first-run onboarding)
+- `notificationUtils.ts` `showPhaseCompleteNotification` (milestone event with action)
+
+## Requirements
+
+- **R001** (MUST): Replace `"Refining line N..."` info popup in `messageHandlers.ts:257` with a status bar message using the existing `StatusBarItem` or `withProgress` in the notification area
+- **R002** (MUST): Replace the 4 "Install command copied to clipboard" info popups across AI provider files with a shared status bar message helper
+- **R003** (MUST): Replace `"No custom commands configured..."` in `specCommands.ts:278` with an inline empty-state message in the quick pick itself (use `placeHolder` text)
+- **R004** (SHOULD): Ensure all transient success messages use auto-dismiss via the existing `NotificationUtils.showAutoDismissNotification` rather than persistent popups
+- **R005** (SHOULD): Add a shared `showStatusBarMessage(text, timeout)` helper to `notificationUtils.ts` to avoid duplicating `vscode.window.setStatusBarMessage` calls
+
+## Scenarios
+
+### Inline refinement no longer shows popup
+
+**When** the user clicks the inline refine button on a spec line
+**Then** a status bar message shows `"Refining line N..."` briefly instead of a modal notification
+
+### Copying install command shows transient status bar feedback
+
+**When** the user copies an AI provider install command
+**Then** the status bar shows `"Install command copied to clipboard"` for 3 seconds instead of a popup
+
+### No custom commands shows inline empty state
+
+**When** the user triggers custom commands and none are configured
+**Then** the quick pick shows an empty state with a descriptive placeholder instead of dismissing with an error popup
+
+## Out of Scope
+
+- Changing any `showErrorMessage` calls (errors should remain visible)
+- Changing any `showWarningMessage` confirmation dialogs
+- Redesigning the notification system architecture
+- Adding new notification preferences/settings

--- a/specs/017-reduce-popups/state.json
+++ b/specs/017-reduce-popups/state.json
@@ -1,0 +1,1 @@
+{ "step": "implement", "branch": "017-reduce-popups", "task": null, "updated": "2026-03-06" }

--- a/specs/017-reduce-popups/tasks.md
+++ b/specs/017-reduce-popups/tasks.md
@@ -1,0 +1,35 @@
+# Tasks: Reduce Noisy Notifications
+
+**Plan**: [plan.md](./plan.md) | **Date**: 2026-03-06
+
+## Format
+
+- `[P]` = Can run in parallel  |  `[A]` = Agent-eligible
+
+---
+
+## Phase 1: Core Implementation (Sequential)
+
+- [x] **T001** Add `showStatusBarMessage` helper — `src/core/utils/notificationUtils.ts`
+  - **Do**: Add `static showStatusBarMessage(text: string, timeoutMs = 3000): void` that calls `vscode.window.setStatusBarMessage(text, timeoutMs)`
+  - **Verify**: TypeScript compiles; method is exported from `NotificationUtils`
+
+- [x] **T002** Replace "Refining line..." popup *(depends on T001)* — `src/features/spec-viewer/messageHandlers.ts`
+  - **Do**: At line 257, replace `vscode.window.showInformationMessage(\`Refining line ${lineNum}...\`)` with `NotificationUtils.showStatusBarMessage(\`Refining line ${lineNum}...\`)`; add import if not already present
+  - **Verify**: No `showInformationMessage` call remains in `handleRefineLine`
+
+- [x] **T003** Replace "copied to clipboard" popups in AI providers *(depends on T001)* — `src/ai-providers/`
+  - **Do**: In each of `copilotCliProvider.ts:90`, `codexCliProvider.ts:115`, `geminiCliProvider.ts:90`, `qwenCliProvider.ts:97` replace `vscode.window.showInformationMessage('Install command copied to clipboard')` with `NotificationUtils.showStatusBarMessage('$(check) Install command copied to clipboard')`; add import in each file
+  - **Verify**: All 4 files compile; no `showInformationMessage` calls remain at those lines
+
+- [x] **T004** Replace "No custom commands" popup with quick pick placeholder *(no dependencies)* — `src/features/specs/specCommands.ts`
+  - **Do**: Remove lines 277–280 (the `if (customCommands.length === 0)` early-return block); add `placeHolder: 'No custom commands configured — add speckit.customCommands in settings'` to the existing `showQuickPick` options object (so the picker opens with the placeholder when empty)
+  - **Verify**: When no custom commands are set, quick pick opens (then closes immediately) instead of showing a popup; `npm run compile` passes
+
+---
+
+## Progress
+
+| Phase | Tasks | Status |
+|-------|-------|--------|
+| Phase 1 | T001–T004 | [x] |

--- a/src/ai-providers/codexCliProvider.ts
+++ b/src/ai-providers/codexCliProvider.ts
@@ -6,6 +6,7 @@ import { promisify } from 'util';
 import { ConfigManager } from '../core/utils/configManager';
 import { ConfigKeys, Timing } from '../core/constants';
 import { IAIProvider, AIExecutionResult } from './aiProvider';
+import { NotificationUtils } from '../core/utils/notificationUtils';
 
 const execAsync = promisify(exec);
 
@@ -112,7 +113,7 @@ export class CodexCliProvider implements IAIProvider {
             );
             if (action === 'Copy Install Command') {
                 await vscode.env.clipboard.writeText('npm install -g @openai/codex');
-                vscode.window.showInformationMessage('Install command copied to clipboard');
+                NotificationUtils.showStatusBarMessage('$(check) Install command copied to clipboard');
             }
             throw new Error('Codex CLI is not installed');
         }

--- a/src/ai-providers/copilotCliProvider.ts
+++ b/src/ai-providers/copilotCliProvider.ts
@@ -6,6 +6,7 @@ import { promisify } from 'util';
 import { ConfigManager } from '../core/utils/configManager';
 import { ConfigKeys, Timing } from '../core/constants';
 import { IAIProvider, AIExecutionResult } from './aiProvider';
+import { NotificationUtils } from '../core/utils/notificationUtils';
 
 const execAsync = promisify(exec);
 
@@ -87,7 +88,7 @@ export class CopilotCliProvider implements IAIProvider {
             );
             if (action === 'Copy Install Command') {
                 await vscode.env.clipboard.writeText('gh extension install github/gh-copilot');
-                vscode.window.showInformationMessage('Install command copied to clipboard');
+                NotificationUtils.showStatusBarMessage('$(check) Install command copied to clipboard');
             }
             throw new Error('GitHub Copilot CLI is not installed');
         }

--- a/src/ai-providers/geminiCliProvider.ts
+++ b/src/ai-providers/geminiCliProvider.ts
@@ -6,6 +6,7 @@ import { promisify } from 'util';
 import { ConfigManager } from '../core/utils/configManager';
 import { ConfigKeys, Timing } from '../core/constants';
 import { IAIProvider, AIExecutionResult } from './aiProvider';
+import { NotificationUtils } from '../core/utils/notificationUtils';
 
 const execAsync = promisify(exec);
 
@@ -87,7 +88,7 @@ export class GeminiCliProvider implements IAIProvider {
             );
             if (action === 'Copy Install Command') {
                 await vscode.env.clipboard.writeText('npm install -g @google/gemini-cli');
-                vscode.window.showInformationMessage('Install command copied to clipboard');
+                NotificationUtils.showStatusBarMessage('$(check) Install command copied to clipboard');
             }
             throw new Error('Gemini CLI is not installed');
         }

--- a/src/ai-providers/qwenCliProvider.ts
+++ b/src/ai-providers/qwenCliProvider.ts
@@ -6,6 +6,7 @@ import { promisify } from 'util';
 import { ConfigManager } from '../core/utils/configManager';
 import { ConfigKeys, Timing } from '../core/constants';
 import { IAIProvider, AIExecutionResult } from './aiProvider';
+import { NotificationUtils } from '../core/utils/notificationUtils';
 
 const execAsync = promisify(exec);
 
@@ -94,7 +95,7 @@ export class QwenCliProvider implements IAIProvider {
             );
             if (action === 'Copy Install Command') {
                 await vscode.env.clipboard.writeText('npm install -g @qwen-code/qwen-code@latest');
-                vscode.window.showInformationMessage('Install command copied to clipboard');
+                NotificationUtils.showStatusBarMessage('$(check) Install command copied to clipboard');
             }
             throw new Error('Qwen Code CLI is not installed');
         }

--- a/src/core/utils/notificationUtils.ts
+++ b/src/core/utils/notificationUtils.ts
@@ -44,6 +44,15 @@ export class NotificationUtils {
     }
 
     /**
+     * Show a transient status bar message that auto-dismisses
+     * @param text - The message to display (supports codicons e.g. "$(check) Done")
+     * @param timeoutMs - Duration in milliseconds (default: 3000ms)
+     */
+    static showStatusBarMessage(text: string, timeoutMs = 3000): void {
+        vscode.window.setStatusBarMessage(text, timeoutMs);
+    }
+
+    /**
      * Show a phase completion notification with action to open the tasks file
      * @param specName - Name of the spec (e.g., "remove-invoice-filters")
      * @param phaseName - Name of the completed phase (e.g., "Foundational")

--- a/src/features/spec-viewer/messageHandlers.ts
+++ b/src/features/spec-viewer/messageHandlers.ts
@@ -11,6 +11,7 @@ import {
     DocumentType,
 } from './types';
 import { ConfigKeys } from '../../core/constants';
+import { NotificationUtils } from '../../core/utils/notificationUtils';
 import type { CustomCommandConfig } from '../../core/types/config';
 
 /**
@@ -254,7 +255,7 @@ async function handleRefineLine(
 ): Promise<void> {
     deps.outputChannel.appendLine(`[SpecViewer] Refine line ${lineNum}: ${instruction}`);
     // TODO: Implement AI-based refinement
-    vscode.window.showInformationMessage(`Refining line ${lineNum}...`);
+    NotificationUtils.showStatusBarMessage(`$(sync~spin) Refining line ${lineNum}...`);
 }
 
 /**

--- a/src/features/specs/specCommands.ts
+++ b/src/features/specs/specCommands.ts
@@ -274,11 +274,6 @@ function registerCustomCommand(
         vscode.commands.registerCommand(Commands.customCommand, async (specDir?: string) => {
             const customCommands = loadCustomCommands();
 
-            if (customCommands.length === 0) {
-                vscode.window.showInformationMessage('No custom commands configured. Add speckit.customCommands in settings.');
-                return;
-            }
-
             const selection = await vscode.window.showQuickPick(
                 customCommands.map(command => ({
                     label: command.label,
@@ -287,7 +282,9 @@ function registerCustomCommand(
                 })),
                 {
                     title: 'Run SpecKit Custom Command',
-                    placeHolder: 'Select a custom command'
+                    placeHolder: customCommands.length === 0
+                        ? 'No custom commands configured — add speckit.customCommands in settings'
+                        : 'Select a custom command'
                 }
             );
 


### PR DESCRIPTION
## What

- Add `NotificationUtils.showStatusBarMessage()` helper wrapping `vscode.window.setStatusBarMessage`
- Replace "Refining line N..." modal popup with transient status bar message
- Replace "Install command copied to clipboard" modal in 4 AI provider files with status bar message
- Remove early-return popup for empty custom commands; show descriptive placeholder in quick pick instead

## Why

Several info notifications fired on frequent low-stakes actions, interrupting user flow on every inline refine click and every install command copy.

## Testing

- Click inline refine in spec viewer → status bar shows message, no popup
- Copy install command in any AI provider → status bar shows `$(check)` message, no popup
- Trigger custom commands with none configured → quick pick opens with descriptive placeholder