### PR TITLE
docs: update architecture and how-it-works to match actual codebase

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-This is a VSCode extension called "SpecKit Companion" that enhances AI CLI tools (Claude Code, Gemini CLI, GitHub Copilot CLI) with structured spec-driven development features. The extension provides visual management of specs (requirements, design, tasks) and steering documents.
+This is a VSCode extension called "SpecKit Companion" that enhances AI CLI tools (Claude Code, Gemini CLI, GitHub Copilot CLI, Codex CLI, Qwen CLI) with structured spec-driven development features. The extension provides visual management of specs (requirements, design, tasks) and steering documents.
 
 ## Development Commands
 
@@ -32,9 +32,25 @@ npm run package
 ```
 src/                      # Main extension source (Node.js)
 ├── extension.ts          # Extension entry point, command registration
+├── ai-providers/         # AI provider integrations (8 files)
 ├── core/                 # Core utilities and types
+│   ├── constants, types, fileWatchers, specDirectoryResolver
+│   ├── errors/
+│   ├── managers/
+│   ├── providers/
+│   ├── types/
+│   └── utils/
 ├── features/             # Business logic for features
-├── ai-providers/         # AI provider integrations
+│   ├── agents/
+│   ├── permission/
+│   ├── settings/
+│   ├── skills/
+│   ├── spec-editor/
+│   ├── spec-viewer/
+│   ├── specs/
+│   ├── steering/
+│   ├── workflow-editor/
+│   └── workflows/
 └── speckit/              # SpecKit CLI integration
 
 webview/                  # Webview UI code (browser context)
@@ -44,10 +60,13 @@ webview/                  # Webview UI code (browser context)
 │   ├── markdown/         # Shared markdown utilities
 │   ├── render/           # Shared render utilities
 │   ├── ui/               # Shared UI components
+│   ├── types.ts          # Shared type definitions
 │   └── workflow.ts       # Workflow editor
 └── styles/               # CSS stylesheets
-    ├── spec-viewer/      # Modular CSS partials
+    ├── spec-viewer/      # Modular CSS partials (16 files + index.css)
     ├── spec-editor.css
+    ├── spec-markdown.css
+    ├── spec-viewer.css
     └── workflow.css
 
 assets/                   # Static assets (icons, media)
@@ -123,3 +142,12 @@ npm run test:watch    # Watch mode
 - Webpack 5 for bundling
 - highlight.js (CDN) for syntax highlighting in webviews
 
+
+## Active Technologies
+- TypeScript 5.3+ (ES2022 target, strict mode) + VS Code Extension API (`@types/vscode ^1.84.0`) (044-context-driven-badges)
+- `.spec-context.json` per spec directory (file-based) (044-context-driven-badges)
+- TypeScript 5.3+ (ES2022 target, strict mode) + VS Code Extension API (`@types/vscode ^1.84.0`), Webpack 5 (045-update-docs)
+- File-based (workspace `.claude/`, `specs/`, `.specify/` directories) (045-update-docs)
+
+## Recent Changes
+- 044-context-driven-badges: Added TypeScript 5.3+ (ES2022 target, strict mode) + VS Code Extension API (`@types/vscode ^1.84.0`)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -8,70 +8,124 @@ SpecKit Companion is a VS Code extension that provides a visual interface for sp
 
 ```
 src/
-├── extension.ts          # Main entry point, activation, command registration
-├── commands/             # Command handlers (create spec, refine, etc.)
-├── constants/            # Configuration constants, paths, patterns
-├── features/             # Feature-specific modules
-│   └── permission/       # Permission caching and config reading
-├── providers/            # VS Code tree view and editor providers
-│   ├── specExplorerProvider.ts      # Specs tree view
-│   ├── steeringExplorerProvider.ts  # Steering documents tree view
-│   ├── agentsExplorerProvider.ts    # Agents tree view
-│   ├── hooksExplorerProvider.ts     # Hooks tree view
-│   ├── mcpExplorerProvider.ts       # MCP servers tree view
-│   └── workflow/                    # Custom editor for spec files
-│       ├── workflowEditorProvider.ts
-│       ├── htmlGenerator.ts
-│       └── actionHandlers.ts
-├── services/             # Business logic services
-│   └── promptLoader.ts   # Loads prompt templates
-├── shared/               # Shared types and utilities
-│   └── types/            # TypeScript interfaces
-├── utils/                # Utility functions
-│   ├── notificationUtils.ts
-│   └── updateChecker.ts
-└── watchers/             # File system watchers
-    └── fileWatchers.ts   # Watches .claude/ for changes
+├── extension.ts                # Main entry point, activation, command registration
+├── ai-providers/               # AI provider integrations
+│   ├── aiProvider.ts           # Base provider interface and PROVIDER_PATHS config
+│   ├── aiProviderFactory.ts    # Factory for creating provider instances
+│   ├── claudeCodeProvider.ts   # Claude Code integration
+│   ├── copilotCliProvider.ts   # GitHub Copilot CLI integration
+│   ├── geminiCliProvider.ts    # Gemini CLI integration
+│   ├── codexCliProvider.ts     # Codex CLI integration
+│   ├── qwenCliProvider.ts      # Qwen CLI integration
+│   └── index.ts
+├── core/                       # Core utilities and shared infrastructure
+│   ├── constants.ts
+│   ├── types.ts
+│   ├── fileWatchers.ts         # Watches .claude/ for changes (debounced 1s)
+│   ├── specDirectoryResolver.ts
+│   ├── index.ts
+│   ├── errors/                 # Error types (index.ts)
+│   ├── managers/               # BaseManager.ts, index.ts
+│   ├── providers/              # BaseTreeDataProvider.ts, index.ts
+│   ├── types/                  # config.ts
+│   └── utils/                  # configManager, fileOpener, fileSystemUtils,
+│                               # notificationUtils, sanitize, pathUtils,
+│                               # installUtils, tempFileUtils, terminalUtils, index.ts
+├── features/                   # Feature-specific modules
+│   ├── agents/                 # agentManager.ts, index.ts
+│   ├── permission/             # Permission caching and config reading (index.ts)
+│   ├── settings/               # overviewProvider.ts, index.ts
+│   ├── skills/                 # skillManager.ts, index.ts
+│   ├── spec-editor/            # specEditorProvider.ts, specDraftManager.ts,
+│   │                           # specEditorCommands.ts, tempFileManager.ts, types.ts, index.ts
+│   ├── spec-viewer/            # specViewerProvider.ts, specViewerCommands.ts,
+│   │                           # messageHandlers.ts, documentScanner.ts,
+│   │                           # phaseCalculation.ts, staleness.ts,
+│   │                           # types.ts, utils.ts, html/, __tests__/
+│   ├── specs/                  # specExplorerProvider.ts, specCommands.ts,
+│   │                           # specContextManager.ts, index.ts, __tests__/
+│   ├── steering/               # steeringExplorerProvider.ts, steeringManager.ts,
+│   │                           # steeringCommands.ts, types.ts, index.ts
+│   ├── workflow-editor/        # workflowEditorProvider.ts, workflowEditorCommands.ts,
+│   │                           # workflow/, index.ts
+│   └── workflows/              # workflowManager.ts, workflowSelector.ts,
+│                               # checkpointHandler.ts, types.ts, index.ts
+└── speckit/                    # SpecKit CLI integration
+    ├── detector.ts             # CLI detection (checks `specify` in PATH)
+    ├── cliCommands.ts          # CLI command execution
+    ├── updateChecker.ts
+    ├── taskProgressService.ts
+    ├── utilityCommands.ts
+    └── index.ts
 
-webview/                  # Workflow editor webview
-├── src/                  # TypeScript source
-│   ├── workflow.ts       # Main webview entry
-│   ├── render/           # Content rendering
-│   │   └── lineRenderer.ts   # Renders markdown lines with actions
-│   ├── markdown/         # Markdown parsing
-│   │   └── classifier.ts     # Classifies line types
-│   ├── ui/               # UI components
-│   └── types.ts          # Webview types
-└── styles/               # CSS stylesheets
-    ├── workflow.css      # Workflow editor styles
-    └── spec-markdown.css # Spec markdown styles
+webview/
+├── src/                        # TypeScript source (browser context)
+│   ├── spec-viewer/            # Spec viewer webview
+│   │   ├── index.ts
+│   │   ├── actions.ts
+│   │   ├── elements.ts
+│   │   ├── highlighting.ts
+│   │   ├── modal.ts
+│   │   ├── navigation.ts
+│   │   ├── state.ts
+│   │   ├── types.ts
+│   │   ├── markdown/           # Rendering pipeline (renderer, preprocessors, scenarios)
+│   │   └── editor/             # Inline editing (inlineEditor, refinements, lineActions)
+│   ├── spec-editor/            # Spec editor webview (index.ts, types.ts)
+│   ├── markdown/               # Shared markdown utilities (classifier.ts, parser.ts, index.ts)
+│   ├── render/                 # Shared render utilities
+│   │   ├── blockRenderer.ts
+│   │   ├── contentRenderer.ts
+│   │   ├── lineRenderer.ts
+│   │   └── index.ts
+│   ├── ui/                     # Shared UI components (index.ts, inlineEdit.ts, phaseUI.ts, refinePopover.ts)
+│   ├── types.ts
+│   └── workflow.ts             # Workflow editor webview
+└── styles/                     # CSS stylesheets
+    ├── spec-viewer/            # 16 modular CSS partials + index.css
+    ├── spec-editor.css
+    ├── spec-markdown.css
+    ├── spec-viewer.css
+    └── workflow.css
 
-assets/                   # Static assets
-├── icons/                # Extension icons (SVG)
-└── media/                # Media files (images, HTML)
-
-docs/                     # Documentation assets
-└── screenshots/          # README screenshots
+assets/                         # Static assets
+└── icons/                      # Extension icons (SVG)
 ```
 
 ## Key Components
 
 ### Extension Host (Node.js)
 
-**Providers** - Implement VS Code's TreeDataProvider and CustomTextEditorProvider:
-- `SpecExplorerProvider`: Shows specs from `specs/` directory
-- `WorkflowEditorProvider`: Custom editor for spec/plan/tasks.md files
+**Tree View Providers** — Registered in `package.json`, implement `vscode.TreeDataProvider`:
+- `SpecExplorerProvider` (`speckit.views.explorer`): Shows specs from `specs/` directory
+- `SteeringExplorerProvider` (`speckit.views.steering`): Shows steering documents
+- `OverviewProvider` (`speckit.views.settings`): Settings and overview panel
 
-**Watchers** - Monitor file system for changes:
+**Webview Providers** — Implement `vscode.WebviewViewProvider` or `vscode.CustomTextEditorProvider`:
+- `SpecViewerProvider`: Renders spec files with phase stepper, badges, and action buttons
+- `SpecEditorProvider`: Draft editing for spec files
+- `WorkflowEditorProvider`: Custom editor for workflow configuration files
+
+**File Watchers** — Monitor file system for changes:
 - `.claude/` directory changes trigger tree view refreshes
 - Uses debouncing (1 second) to prevent excessive updates
 
-**Commands** - Registered in `package.json`, handled in `commands/`:
-- `speckit.create`, `speckit.specify`, `speckit.plan`, `speckit.tasks`, `speckit.implement`
+**Commands** — Registered in `package.json`, handled per feature module:
+- Pattern: `speckit.{feature}.{action}` (e.g., `speckit.specs.create`, `speckit.specs.plan`)
+
+**AI Providers** — 5 supported providers via `ai-providers/`:
+1. Claude Code (`claudeCodeProvider.ts`)
+2. GitHub Copilot CLI (`copilotCliProvider.ts`)
+3. Gemini CLI (`geminiCliProvider.ts`)
+4. Codex CLI (`codexCliProvider.ts`)
+5. Qwen CLI (`qwenCliProvider.ts`)
+
+**Feature Modules** — 10 modules under `features/`:
+`agents`, `permission`, `settings`, `skills`, `spec-editor`, `spec-viewer`, `specs`, `steering`, `workflow-editor`, `workflows`
 
 ### Webview (Browser)
 
-The workflow editor runs in a VS Code webview (sandboxed browser):
+The spec viewer and workflow editor run in VS Code webviews (sandboxed browser):
 
 ```
 Extension Host                    Webview
@@ -83,22 +137,20 @@ Extension Host                    Webview
      │                               │
 ```
 
-**Message Types** (src/shared/types/MessageTypes.ts):
-- `ExtensionToWebviewMessage`: documentChanged, updatePhaseInfo
-- `WebviewToExtensionMessage`: editSource, removeLine, refineLine, generateContent
+Message routing is handled in `messageHandlers.ts` (spec-viewer) and the workflow editor's action handlers.
 
 ## Data Flow
 
 ### Spec File Opened
 1. VS Code opens `.md` file in `specs/` directory
-2. `WorkflowEditorProvider.resolveCustomTextEditor()` called
-3. HTML generated with phase stepper, content area
+2. `SpecViewerProvider.resolveCustomTextEditor()` called
+3. HTML generated with phase stepper, badges, content area
 4. Webview receives content, renders with action buttons
 
 ### User Clicks "Refine"
 1. Webview posts `refineLine` message with line number and instruction
-2. Extension receives message in `actionHandlers.ts`
-3. Launches Claude Code with refinement prompt
+2. Extension receives message in `messageHandlers.ts`
+3. Launches AI provider CLI with refinement prompt
 4. File updates → `onDidChangeTextDocument` fires
 5. Extension sends `documentChanged` to webview
 6. Webview re-renders content
@@ -109,7 +161,7 @@ The extension calls the SpecKit CLI (`specify`) for:
 - `specify init` - Initialize workspace
 - Slash commands via AI CLI: `/speckit.specify`, `/speckit.plan`, etc.
 
-CLI detection: Checks if `specify` command exists in PATH.
+CLI detection: Checks if `specify` command exists in PATH (`speckit/detector.ts`).
 
 ### Provider-Specific Command Formats
 
@@ -125,5 +177,12 @@ This is configured via the `commandFormat` field in `PROVIDER_PATHS` (`src/ai-pr
 ## State Management
 
 - **In-memory**: Tree view data, webview state
-- **File-based**: `specs/*/`, `.claude/settings/speckit-settings.json`
+- **File-based**: `specs/*/`, `.claude/settings/speckit-settings.json`, `.spec-context.json` per spec directory
 - **VS Code**: Extension context for subscriptions, globalState for persistence
+
+## Extension Points for Contributors
+
+- **Add an AI provider**: Implement the provider interface in `src/ai-providers/`, register in `aiProviderFactory.ts`, add to `PROVIDER_PATHS` in `aiProvider.ts`
+- **Add a feature module**: Create a directory under `src/features/` following the Manager/Provider/Commands pattern; register commands in `extension.ts`
+- **Add a tree view**: Extend `BaseTreeDataProvider`, register in `package.json` under `contributes.views`, activate in `extension.ts`
+- **Add a webview**: Create entry under `webview/src/`, add styles under `webview/styles/`, wire up message handlers in the feature's `messageHandlers.ts`

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -4,7 +4,7 @@ A comprehensive guide to the SpecKit Companion VS Code extension architecture.
 
 ## Overview
 
-SpecKit Companion is a VS Code extension that enhances AI CLI tools (Claude Code, Gemini CLI, GitHub Copilot CLI) with structured spec-driven development features. It provides visual management of specs (requirements, design, tasks) and steering documents.
+SpecKit Companion is a VS Code extension that enhances AI CLI tools (Claude Code, Gemini CLI, GitHub Copilot CLI, Codex CLI, Qwen CLI) with structured spec-driven development features. It provides visual management of specs (requirements, design, tasks) and steering documents.
 
 ### Architecture Diagram
 
@@ -12,7 +12,7 @@ SpecKit Companion is a VS Code extension that enhances AI CLI tools (Claude Code
 graph TB
     subgraph UI["VS Code Extension UI"]
         AB[Activity Bar<br/>SpecKit]
-        TV[Tree Views<br/>Specs | Steering | MCP | Agents | Skills | Hooks]
+        TV[Tree Views<br/>Specs | Steering | Settings]
         CE[Custom Editor<br/>Workflow Editor]
     end
 
@@ -20,13 +20,15 @@ graph TB
         Claude[Claude Code]
         Gemini[Gemini CLI]
         Copilot[Copilot CLI]
+        Codex[Codex CLI]
+        Qwen[Qwen CLI]
     end
 
     subgraph Managers["Feature Managers (Business Logic)"]
         SM[SteeringManager]
         AM[AgentManager]
         SKM[SkillManager]
-        PM[PermissionManager]
+        WM[WorkflowManager]
     end
 
     subgraph Core["Core Utilities & Types"]
@@ -56,6 +58,8 @@ graph TB
 | Claude Code | Full | Full | Full | Full | Full |
 | GitHub Copilot CLI | Full | Full | - | - | Full |
 | Gemini CLI | Full | Limited | - | - | Full |
+| Codex CLI | Full | - | - | - | - |
+| Qwen CLI | Full | - | - | - | - |
 
 ---
 
@@ -69,11 +73,15 @@ src/
 │   ├── aiProviderFactory.ts  # Factory pattern implementation
 │   ├── claudeCodeProvider.ts # Claude Code implementation
 │   ├── geminiCliProvider.ts  # Gemini CLI implementation
-│   └── copilotCliProvider.ts # GitHub Copilot CLI implementation
+│   ├── copilotCliProvider.ts # GitHub Copilot CLI implementation
+│   ├── codexCliProvider.ts   # Codex CLI implementation
+│   ├── qwenCliProvider.ts    # Qwen CLI implementation
+│   └── index.ts
 ├── core/                     # Core utilities & infrastructure
 │   ├── constants.ts          # Commands, ConfigKeys, Views, Timing
 │   ├── types.ts              # Message types (Extension <-> Webview)
 │   ├── fileWatchers.ts       # File system monitoring with debouncing
+│   ├── specDirectoryResolver.ts # Resolves spec directory paths
 │   ├── errors/               # Error handling utilities
 │   │   └── index.ts          # SpecKitError, handleError()
 │   ├── managers/             # Base classes for managers
@@ -89,26 +97,43 @@ src/
 │       ├── fileOpener.ts
 │       └── sanitize.ts
 ├── features/                 # Feature modules (independent)
-│   ├── specs/                # Spec explorer and commands
-│   ├── steering/             # Steering document management
 │   ├── agents/               # Agent discovery and initialization
-│   ├── skills/               # Skill management (Claude only)
-│   ├── hooks/                # Hooks view
-│   ├── mcp/                  # MCP server view
 │   ├── permission/           # Claude permission management
 │   ├── settings/             # Overview/settings provider
-│   └── workflow-editor/      # Custom markdown editor
+│   ├── skills/               # Skill management (Claude only)
+│   ├── spec-editor/          # Spec editor webview
+│   ├── spec-viewer/          # Spec viewer webview (modular)
+│   ├── specs/                # Spec explorer and commands
+│   ├── steering/             # Steering document management
+│   ├── workflow-editor/      # Custom markdown editor webview
+│   └── workflows/            # Workflow management and execution
 └── speckit/                  # SpecKit CLI integration
     ├── detector.ts           # CLI installation detection
     ├── cliCommands.ts        # CLI commands (install, init)
     ├── updateChecker.ts      # Version update detection
-    └── taskProgressService.ts # Tasks.md completion tracking
+    ├── taskProgressService.ts # Tasks.md completion tracking
+    └── utilityCommands.ts    # Utility CLI commands
 
-webview/                      # Workflow editor webview (browser)
+webview/                      # Webview UIs (browser context)
 ├── src/
-│   └── workflow.ts           # Webview TypeScript
+│   ├── spec-viewer/          # Spec viewer webview
+│   │   ├── index.ts, actions.ts, elements.ts, navigation.ts
+│   │   ├── state.ts, types.ts, highlighting.ts, modal.ts
+│   │   ├── markdown/         # Rendering pipeline
+│   │   └── editor/           # Inline editing
+│   ├── spec-editor/          # Spec editor webview
+│   │   └── index.ts, types.ts
+│   ├── markdown/             # Shared markdown utilities
+│   ├── render/               # Shared render utilities
+│   ├── ui/                   # Shared UI components
+│   ├── types.ts
+│   └── workflow.ts           # Workflow editor webview
 └── styles/
-    └── workflow.css          # Theme-aware styles
+    ├── spec-viewer/          # 16 CSS partials + index.css
+    ├── spec-editor.css
+    ├── spec-markdown.css
+    ├── spec-viewer.css
+    └── workflow.css
 ```
 
 ---
@@ -132,21 +157,21 @@ flowchart TD
     G -->|No| H[promptForProviderSelection]
     G -->|Yes| I[AIProviderFactory.getProvider]
     H --> I
-    I --> J[Initialize Managers<br/>Permission, Steering, Agent, Skill]
-    J --> K[Register TreeDataProviders<br/>7 views]
+    I --> J[Initialize Managers<br/>Permission, Steering, Agent, Skill, Workflow]
+    J --> K[Register TreeDataProviders<br/>3 views]
     K --> L[setupFileWatchers]
     L --> M[registerCommands]
 ```
 
-**Key initialization steps (lines 36-174):**
+**Key initialization steps:**
 
-1. **Output Channel** (line 38): Creates "SpecKit Companion" debug channel
-2. **SpecKit Detection** (lines 40-48): Detects CLI and workspace state
-3. **AI Provider Selection** (lines 68-77): Prompts if not configured
-4. **Manager Initialization** (lines 79-92): Creates managers in order
-5. **Provider Registration** (lines 93-113): Registers 7 tree views
-6. **File Watchers** (lines 138-142): Sets up monitoring
-7. **Workflow Editor** (lines 148-155): Conditional custom editor
+1. **Output Channel**: Creates "SpecKit Companion" debug channel
+2. **SpecKit Detection**: Detects CLI and workspace state
+3. **AI Provider Selection**: Prompts if not configured
+4. **Manager Initialization**: Creates managers in order
+5. **Provider Registration**: Registers 3 tree views
+6. **File Watchers**: Sets up monitoring
+7. **Workflow Editor**: Conditional custom editor
 
 ### AI Provider System
 
@@ -219,10 +244,6 @@ All tree views extend `BaseTreeDataProvider<T>` (`core/providers/BaseTreeDataPro
 |---------|----------|---------|
 | `speckit.views.explorer` | SpecExplorerProvider | Specs tree |
 | `speckit.views.steering` | SteeringExplorerProvider | Steering docs |
-| `speckit.views.agents` | AgentsExplorerProvider | Agent files |
-| `speckit.views.skills` | SkillsExplorerProvider | Skills (Claude) |
-| `speckit.views.mcp` | MCPExplorerProvider | MCP servers |
-| `speckit.views.hooks` | HooksExplorerProvider | Hooks |
 | `speckit.views.settings` | OverviewProvider | Settings |
 
 **Base class provides:**
@@ -291,9 +312,11 @@ sequenceDiagram
     Explorer->>UI: Tree view updates
 ```
 
-### 2. Webview Communication (Workflow Editor)
+### 2. Webview Communication
 
-**Files:**
+The extension has three webview UIs: the **Workflow Editor** (`webview/src/workflow.ts`), the **Spec Viewer** (`webview/src/spec-viewer/`), and the **Spec Editor** (`webview/src/spec-editor/`). All use the same message-passing pattern between extension and browser context.
+
+**Files (Workflow Editor example):**
 - `src/features/workflow-editor/workflowEditorProvider.ts`
 - `webview/src/workflow.ts`
 - `src/core/types.ts`
@@ -384,11 +407,21 @@ const debouncedRefresh = (event: string, uri: vscode.Uri) => {
 ### Configuration Keys
 
 ```typescript
-speckit.aiProvider          // 'claude' | 'gemini' | 'copilot'
-speckit.workflowEditor.enabled  // boolean
-speckit.claudePath          // Custom Claude CLI path
-speckit.geminiInitDelay     // Gemini startup delay (ms)
+speckit.aiProvider                    // 'claude' | 'gemini' | 'copilot' | 'codex' | 'qwen'
+speckit.workflowEditor.enabled        // boolean
+speckit.claudePath                    // Custom Claude CLI path
+speckit.geminiPath                    // Custom Gemini CLI path
+speckit.copilotPath                   // Custom Copilot CLI path
+speckit.qwenPath                      // Custom Qwen CLI path
+speckit.geminiInitDelay               // Gemini startup delay (ms)
+speckit.permissionMode                // Permission bypass mode
+speckit.specDirectories               // Additional spec directories
+speckit.customCommands                // Custom command definitions
+speckit.customWorkflows               // Custom workflow definitions
+speckit.defaultWorkflow               // Default workflow name
 speckit.notifications.phaseCompletion // boolean
+speckit.views.steering.visible        // boolean
+speckit.views.settings.visible        // boolean
 ```
 
 ### Timing Constants (milliseconds)
@@ -537,7 +570,7 @@ button.addEventListener('click', () => {
 
 ### Provider-Specific Directories
 
-The extension supports three AI providers, each with its own configuration paths:
+The extension supports five AI providers, each with its own configuration paths:
 
 | Provider | Workspace Dir | Global Dir | Config File |
 |----------|---------------|------------|-------------|
@@ -606,15 +639,15 @@ Workspace Root/
 
 ### Provider Capabilities Matrix
 
-| Feature | Claude Code | Gemini CLI | Copilot CLI |
-|---------|-------------|------------|-------------|
-| Agents | ✓ | ✓ | - |
-| Skills | ✓ | - | - |
-| Hooks | ✓ | - | - |
-| MCP Servers | ✓ | - | - |
-| Steering Docs | ✓ | ✓ | ✓ |
-| Workflow Editor | ✓ | ✓ | ✓ |
-| Permission Bypass | ✓ | - | - |
+| Feature | Claude Code | Gemini CLI | Copilot CLI | Codex CLI | Qwen CLI |
+|---------|-------------|------------|-------------|-----------|----------|
+| Agents | ✓ | ✓ | - | - | - |
+| Skills | ✓ | - | - | - | - |
+| Hooks | ✓ | - | - | - | - |
+| MCP Servers | ✓ | - | - | - | - |
+| Steering Docs | ✓ | ✓ | ✓ | ✓ | ✓ |
+| Workflow Editor | ✓ | ✓ | ✓ | ✓ | ✓ |
+| Permission Bypass | ✓ | - | - | - | - |
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "speckit-companion",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "speckit-companion",
-      "version": "0.9.3",
+      "version": "0.9.4",
       "license": "MIT",
       "dependencies": {
         "js-yaml": "^4.1.1"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "speckit-companion",
   "displayName": "SpecKit Companion",
   "description": "VS Code companion for GitHub SpecKit - spec-driven development with AI assistants",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "license": "MIT",
   "publisher": "alfredoperez",
   "icon": "icon.png",

--- a/specs/045-update-docs/.spec-context.json
+++ b/specs/045-update-docs/.spec-context.json
@@ -1,11 +1,11 @@
 {
   "workflow": "speckit",
-  "selectedAt": "2026-04-05T12:00:00Z",
+  "selectedAt": "2026-04-05T19:37:23.966Z",
   "currentStep": "specify",
   "status": "completed",
   "stepHistory": {
     "specify": {
-      "startedAt": "2026-04-05T12:00:00Z"
+      "startedAt": "2026-04-05T19:37:23.966Z"
     }
   }
 }

--- a/specs/045-update-docs/checklists/requirements.md
+++ b/specs/045-update-docs/checklists/requirements.md
@@ -1,0 +1,35 @@
+# Specification Quality Checklist: Update Architecture & Documentation
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-05
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass. Spec is ready for `/speckit.plan` or `/speckit.tasks`.
+- This is a documentation-only feature — no code changes to the extension itself.

--- a/specs/045-update-docs/data-model.md
+++ b/specs/045-update-docs/data-model.md
@@ -1,0 +1,73 @@
+# Data Model: Update Architecture & Documentation
+
+No new entities or data models. This feature modifies only documentation files.
+
+## Entities Referenced (source of truth)
+
+### Actual src/ Directory Structure
+```
+src/
+├── extension.ts
+├── ai-providers/          (8 files: interface, factory, 5 providers, index)
+├── core/                  (constants, types, fileWatchers, errors/, managers/, providers/, types/, utils/)
+├── features/
+│   ├── agents/            (agentManager, index)
+│   ├── permission/        (index)
+│   ├── settings/          (overviewProvider, index)
+│   ├── skills/            (skillManager, index)
+│   ├── spec-editor/       (specEditorProvider, specDraftManager, specEditorCommands, tempFileManager, types, index)
+│   ├── spec-viewer/       (specViewerProvider, messageHandlers, documentScanner, phaseCalculation, staleness, html/, __tests__/)
+│   ├── specs/             (specExplorerProvider, specCommands, specContextManager, __tests__/)
+│   ├── steering/          (steeringExplorerProvider, steeringManager, steeringCommands, types)
+│   ├── workflow-editor/   (workflowEditorProvider, workflowEditorCommands, workflow/)
+│   └── workflows/         (workflowManager, workflowSelector, checkpointHandler, types)
+└── speckit/               (detector, cliCommands, updateChecker, taskProgressService, utilityCommands)
+```
+
+### Actual webview/ Directory Structure
+```
+webview/
+├── src/
+│   ├── spec-viewer/       (index, actions, elements, highlighting, modal, navigation, state, types, markdown/, editor/)
+│   ├── spec-editor/       (index, types)
+│   ├── markdown/          (classifier, parser, index)
+│   ├── render/            (blockRenderer, contentRenderer, index)
+│   ├── ui/                (index, inlineEdit, phaseUI, refinePopover)
+│   ├── types.ts
+│   └── workflow.ts
+└── styles/
+    ├── spec-viewer/       (17 CSS partials + index.css)
+    ├── spec-editor.css
+    ├── spec-markdown.css
+    ├── spec-viewer.css
+    └── workflow.css
+```
+
+### Registered Tree Views (from package.json)
+1. `speckit.views.explorer` — SpecExplorerProvider
+2. `speckit.views.steering` — SteeringExplorerProvider
+3. `speckit.views.settings` — OverviewProvider
+
+### AI Providers (5 total)
+1. Claude Code — claudeCodeProvider.ts
+2. GitHub Copilot CLI — copilotCliProvider.ts
+3. Gemini CLI — geminiCliProvider.ts
+4. Codex CLI — codexCliProvider.ts
+5. Qwen CLI — qwenCliProvider.ts
+
+### Configuration Keys (from package.json)
+- speckit.aiProvider
+- speckit.workflowEditor.enabled
+- speckit.claudePath
+- speckit.geminiPath
+- speckit.copilotPath
+- speckit.qwenPath
+- speckit.geminiInitDelay
+- speckit.permissionMode
+- speckit.specDirectories
+- speckit.customCommands
+- speckit.customWorkflows
+- speckit.defaultWorkflow
+- speckit.notifications.phaseCompletion
+- speckit.views.steering.visible
+- speckit.views.settings.visible

--- a/specs/045-update-docs/plan.md
+++ b/specs/045-update-docs/plan.md
@@ -1,0 +1,94 @@
+# Implementation Plan: Update Architecture & Documentation
+
+**Branch**: `045-update-docs` | **Date**: 2026-04-05 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/045-update-docs/spec.md`
+
+## Summary
+
+Update all documentation files (`docs/architecture.md`, `docs/how-it-works.md`, `CLAUDE.md`) to accurately reflect the current codebase structure. The primary issues are phantom directories/components that no longer exist, missing feature modules (spec-viewer, spec-editor, workflows), missing AI providers (Codex, Qwen), and incorrect tree view counts (docs say 7, reality is 3).
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.3+ (ES2022 target, strict mode)
+**Primary Dependencies**: VS Code Extension API (`@types/vscode ^1.84.0`), Webpack 5
+**Storage**: File-based (workspace `.claude/`, `specs/`, `.specify/` directories)
+**Testing**: Jest with ts-jest, BDD style
+**Target Platform**: VS Code ^1.84.0
+**Project Type**: VS Code Extension (single project)
+**Performance Goals**: N/A (documentation-only changes)
+**Constraints**: N/A (documentation-only changes)
+**Scale/Scope**: 3 documentation files to update
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Extensibility & Configuration | PASS | Docs will reflect all 5 providers and configuration surface |
+| II. Spec-Driven Workflow | PASS | No workflow changes, docs-only |
+| III. Visual & Interactive | PASS | No UI changes |
+| IV. Modular Architecture | PASS | Docs will accurately describe the modular webview structure |
+
+No violations. All changes are documentation corrections to match existing architecture.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/045-update-docs/
+├── plan.md              # This file
+├── research.md          # Phase 0 output - discrepancy analysis
+├── data-model.md        # Phase 1 output - entity mapping
+├── quickstart.md        # Phase 1 output - implementation guide
+└── tasks.md             # Phase 2 output (created by /speckit.tasks)
+```
+
+### Source Code (files to modify)
+
+```text
+docs/
+├── architecture.md      # Major rewrite - phantom dirs, missing components
+├── how-it-works.md      # Major rewrite - providers, views, structure
+└── viewer-states.md     # No changes needed (already accurate)
+
+CLAUDE.md                # Minor update if needed (already mostly accurate)
+```
+
+**Structure Decision**: No source code changes. All modifications target existing documentation files. CLAUDE.md project structure section is already accurate from recent updates.
+
+## Discrepancy Analysis
+
+### docs/architecture.md — Critical Issues
+
+| Issue | Current (Wrong) | Actual |
+|-------|-----------------|--------|
+| Top-level dirs | `commands/`, `constants/`, `services/`, `shared/`, `watchers/`, `providers/` | `core/`, `features/`, `ai-providers/`, `speckit/` |
+| Features listed | Only `permission/` | 10 modules: agents, permission, settings, skills, spec-editor, spec-viewer, specs, steering, workflow-editor, workflows |
+| Key components | References `agentsExplorerProvider.ts`, `hooksExplorerProvider.ts`, `mcpExplorerProvider.ts` | These files don't exist; actual providers: SpecExplorerProvider, SteeringExplorerProvider, OverviewProvider |
+| Webview structure | Only `workflow.ts` and basic render | Full structure with spec-viewer/, spec-editor/, markdown/, render/, ui/ |
+| CSS structure | Only `workflow.css`, `spec-markdown.css` | Also includes spec-viewer/ partials dir, spec-editor.css, spec-viewer.css |
+
+### docs/how-it-works.md — Critical Issues
+
+| Issue | Current (Wrong) | Actual |
+|-------|-----------------|--------|
+| AI providers | 3 (Claude, Gemini, Copilot) | 5 (+ Codex, Qwen) |
+| Provider files | Missing codexCliProvider.ts, qwenCliProvider.ts | Both exist in src/ai-providers/ |
+| Tree views | 7 views (explorer, steering, agents, skills, mcp, hooks, settings) | 3 views (explorer, steering, settings) |
+| Mermaid diagram | Shows "Specs \| Steering \| MCP \| Agents \| Skills \| Hooks" | Should show "Specs \| Steering \| Settings" |
+| Feature modules | Lists `hooks/`, `mcp/` as feature dirs | These don't exist; missing spec-editor/, spec-viewer/, workflows/ |
+| Provider table | 7 providers listed with phantom views | 3 providers with accurate view IDs |
+| Capabilities matrix | Only 3 providers, missing Codex/Qwen | Need all 5 providers |
+| Activation flow | "Register TreeDataProviders 7 views" | Should be 3 views |
+| Project structure | Missing spec-viewer/, spec-editor/, workflows/ | These are major feature modules |
+| Config keys | Missing speckit.specDirectories, speckit.customWorkflows, speckit.defaultWorkflow, speckit.customCommands, speckit.qwenPath | All exist in package.json |
+
+### CLAUDE.md — Status
+
+Already accurate. The project structure section correctly shows `core/`, `features/`, `ai-providers/`, `speckit/`, and the webview structure with spec-viewer, spec-editor, markdown, render, ui. No changes needed.
+
+## Complexity Tracking
+
+No constitution violations to justify. This is a documentation-only feature with no architectural complexity.

--- a/specs/045-update-docs/quickstart.md
+++ b/specs/045-update-docs/quickstart.md
@@ -1,0 +1,23 @@
+# Quickstart: Update Architecture & Documentation
+
+## Implementation Order
+
+1. **Update `docs/architecture.md`** — largest delta, full rewrite of structure and components
+2. **Update `docs/how-it-works.md`** — targeted fixes to providers, views, structure, capabilities
+3. **Verify `CLAUDE.md`** — confirm no changes needed (already accurate)
+
+## Key Verification Steps
+
+After each file update:
+- Every directory path listed must exist on disk
+- Every class/provider name must exist in codebase
+- Provider count = 5, tree view count = 3
+- Config keys match package.json `contributes.configuration`
+
+## Files to Modify
+
+| File | Scope | Effort |
+|------|-------|--------|
+| `docs/architecture.md` | Full rewrite of structure + components | Medium |
+| `docs/how-it-works.md` | Update providers, views, structure, capabilities matrix, config keys, mermaid diagrams | Medium |
+| `CLAUDE.md` | No changes expected | None |

--- a/specs/045-update-docs/research.md
+++ b/specs/045-update-docs/research.md
@@ -1,0 +1,33 @@
+# Research: Update Architecture & Documentation
+
+## Decision Log
+
+### D1: Scope of architecture.md rewrite
+- **Decision**: Full rewrite of directory structure and key components sections
+- **Rationale**: The current content describes a completely different architecture (pre-refactor). Every directory listed at src/ top-level is wrong except `extension.ts` and `features/`. Patching would be more error-prone than rewriting.
+- **Alternatives**: Incremental patches — rejected because the delta is too large
+
+### D2: Scope of how-it-works.md updates
+- **Decision**: Targeted updates to provider list, tree views, project structure, capabilities matrix, mermaid diagrams, and config keys
+- **Rationale**: The overall document structure (sections, data flow examples, extension points) is still valid. Only factual claims about components/providers/views need correction.
+- **Alternatives**: Full rewrite — rejected, most narrative content is still accurate
+
+### D3: CLAUDE.md changes
+- **Decision**: No changes needed
+- **Rationale**: CLAUDE.md was recently updated (044-context-driven-badges) and already accurately reflects the current structure with core/, features/, ai-providers/, speckit/, and the full webview layout.
+- **Alternatives**: N/A
+
+### D4: Tree view count (3 vs 7)
+- **Decision**: Document 3 registered tree views (explorer, steering, settings)
+- **Rationale**: package.json only registers 3 view IDs. Agents, skills, hooks, and MCP are not separate tree views — they may be commands or integrated into the settings/overview provider.
+- **Alternatives**: None — this is a factual correction
+
+### D5: AI provider capabilities for Codex and Qwen
+- **Decision**: Add Codex and Qwen to the capabilities matrix with accurate flags based on their provider implementations
+- **Rationale**: Both providers exist in src/ai-providers/ with full implementations (codexCliProvider.ts, qwenCliProvider.ts). The capabilities matrix must reflect all 5 providers.
+- **Alternatives**: None — factual correction
+
+### D6: Configuration keys documentation
+- **Decision**: Update config keys section to include all settings from package.json
+- **Rationale**: Several settings added in recent features are missing from docs: speckit.specDirectories, speckit.customWorkflows, speckit.defaultWorkflow, speckit.customCommands, speckit.qwenPath, speckit.permissionMode
+- **Alternatives**: None — factual correction

--- a/specs/045-update-docs/spec.md
+++ b/specs/045-update-docs/spec.md
@@ -1,0 +1,88 @@
+# Feature Specification: Update Architecture & Documentation
+
+**Feature Branch**: `045-update-docs`  
+**Created**: 2026-04-05  
+**Status**: Draft  
+**Input**: User description: "update architecture docs and all docs to match current implementation"
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Developer Onboarding via Architecture Docs (Priority: P1)
+
+A new contributor opens `docs/architecture.md` to understand the project structure before making changes. The document accurately reflects the current directory layout, key classes, and module boundaries so the developer can navigate the codebase confidently.
+
+**Why this priority**: Architecture docs are the first thing contributors read; stale docs cause confusion and wasted time exploring the wrong paths.
+
+**Independent Test**: A developer unfamiliar with the project can read `docs/architecture.md` and correctly identify where to find any feature module, provider, or manager class without needing to search the filesystem.
+
+**Acceptance Scenarios**:
+
+1. **Given** a developer reads `docs/architecture.md`, **When** they look for the project directory tree, **Then** every directory and key file listed matches what actually exists on disk (no phantom directories like `commands/`, `services/`, `shared/`, `watchers/` at top-level; no missing directories like `spec-viewer/`, `spec-editor/`)
+2. **Given** the architecture doc lists key components, **When** a developer looks for a specific provider or manager, **Then** the listed class names and file paths are accurate (e.g., no references to `agentsExplorerProvider.ts`, `hooksExplorerProvider.ts`, or `mcpExplorerProvider.ts` which do not exist)
+
+---
+
+### User Story 2 - Developer Understanding Feature Docs (Priority: P2)
+
+A developer opens `docs/how-it-works.md` to understand the extension's data flow, provider system, and feature modules. The document accurately reflects the current AI providers (including Codex and Qwen), the actual tree views (3 views, not 7), and the correct project structure.
+
+**Why this priority**: The how-it-works doc is the deep-dive reference; inaccuracies here lead to incorrect assumptions about capabilities and integration points.
+
+**Independent Test**: A developer reading `docs/how-it-works.md` can correctly enumerate all supported AI providers, all tree views, and the activation flow without encountering references to non-existent components.
+
+**Acceptance Scenarios**:
+
+1. **Given** `docs/how-it-works.md` lists AI providers, **When** a developer reads the provider section, **Then** all 5 providers are listed (Claude, Copilot, Gemini, Codex, Qwen) and no phantom views (MCP, Hooks, Agents as separate sidebar views) are referenced
+2. **Given** `docs/how-it-works.md` describes the project structure, **When** a developer compares it to the actual filesystem, **Then** the structure matches reality including `spec-viewer/`, `spec-editor/`, `workflows/`, and the full webview structure
+3. **Given** `docs/how-it-works.md` describes the provider capabilities matrix, **When** a developer checks it, **Then** it includes all 5 providers with accurate capability flags
+
+---
+
+### User Story 3 - Contributor Updating CLAUDE.md (Priority: P3)
+
+A contributor reads `CLAUDE.md` to understand the project structure section and follows its guidance for where to place new code. The listed structure matches the actual codebase.
+
+**Why this priority**: CLAUDE.md is referenced by AI tools during development; inaccurate structure info leads to misplaced code suggestions.
+
+**Independent Test**: The project structure in `CLAUDE.md` matches the actual filesystem layout when compared directory-by-directory.
+
+**Acceptance Scenarios**:
+
+1. **Given** `CLAUDE.md` contains a project structure section, **When** compared to the actual `src/` and `webview/` directories, **Then** all listed paths exist and no significant directories are missing
+
+---
+
+### Edge Cases
+
+- What happens when a document references a file that was renamed? All references must use current file paths.
+- How does the spec-viewer modular CSS structure get documented? List the partials directory under `webview/styles/spec-viewer/`.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: `docs/architecture.md` MUST reflect the current `src/` directory structure with accurate paths for `core/`, `features/`, `ai-providers/`, and `speckit/` directories
+- **FR-002**: `docs/architecture.md` MUST NOT reference directories that do not exist (`commands/`, `constants/`, `services/`, `shared/`, `watchers/`, `providers/` at top-level)
+- **FR-003**: `docs/architecture.md` MUST list the correct key components: SpecExplorerProvider, SteeringExplorerProvider, OverviewProvider, SpecViewerProvider, SpecEditorProvider, WorkflowEditorProvider
+- **FR-004**: `docs/how-it-works.md` MUST list all 5 AI providers (Claude, Copilot, Gemini, Codex, Qwen) with accurate capability flags
+- **FR-005**: `docs/how-it-works.md` MUST show 3 tree views (explorer, steering, settings) instead of the incorrect 7 views
+- **FR-006**: `docs/how-it-works.md` MUST include the spec-viewer and spec-editor feature modules in the project structure
+- **FR-007**: `docs/how-it-works.md` MUST accurately describe the webview structure including spec-viewer, spec-editor, and workflow editor webviews
+- **FR-008**: `CLAUDE.md` project structure MUST match the actual `src/` and `webview/` directory layouts
+- **FR-009**: All configuration keys listed in docs MUST include current settings (e.g., `speckit.specDirectories`, `speckit.customWorkflows`, `speckit.defaultWorkflow`, `speckit.customCommands`)
+- **FR-010**: Provider capabilities matrix MUST be updated to include Codex and Qwen providers
+
+### Key Entities
+
+- **Documentation Files**: `docs/architecture.md`, `docs/how-it-works.md`, `docs/viewer-states.md`, `CLAUDE.md` - the files being updated to match reality
+- **Source Modules**: The actual `src/` and `webview/` directory trees that serve as the source of truth
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Every directory path listed in documentation exists in the actual filesystem (0 phantom paths)
+- **SC-002**: Every class/provider name referenced in documentation exists in the codebase (0 phantom references)
+- **SC-003**: All 5 supported AI providers are documented with accurate capability information
+- **SC-004**: The number of tree views documented matches the actual registered views (3 views)
+- **SC-005**: A new contributor can locate any feature module within 30 seconds using only the documentation

--- a/specs/045-update-docs/tasks.md
+++ b/specs/045-update-docs/tasks.md
@@ -1,0 +1,156 @@
+# Tasks: Update Architecture & Documentation
+
+**Input**: Design documents from `/specs/045-update-docs/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, quickstart.md
+
+**Tests**: Not requested. No test tasks included.
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Audit the actual codebase to establish source of truth before modifying any docs
+
+- [x] T001 Audit actual `src/` directory tree and compare against data-model.md entity listing to confirm accuracy
+- [x] T002 Audit actual `webview/` directory tree and compare against data-model.md entity listing to confirm accuracy
+- [x] T003 [P] Audit registered tree views in `package.json` contributes.views section to confirm exactly 3 views
+- [x] T004 [P] Audit AI provider files in `src/ai-providers/` to confirm all 5 providers and their capabilities
+
+**Checkpoint**: Source of truth established - documentation updates can begin
+
+---
+
+## Phase 2: User Story 1 - Developer Onboarding via Architecture Docs (Priority: P1)
+
+**Goal**: Rewrite `docs/architecture.md` so the directory structure and key components accurately reflect the current codebase
+
+**Independent Test**: A developer unfamiliar with the project can read `docs/architecture.md` and correctly identify where to find any feature module, provider, or manager class without searching the filesystem
+
+### Implementation for User Story 1
+
+- [x] T005 [US1] Replace the phantom `src/` directory tree in `docs/architecture.md` with the actual structure: `core/`, `features/` (10 modules), `ai-providers/`, `speckit/`
+- [x] T006 [US1] Replace the phantom `webview/` directory tree in `docs/architecture.md` with the actual structure: `spec-viewer/`, `spec-editor/`, `markdown/`, `render/`, `ui/`, and `styles/` with partials
+- [x] T007 [US1] Remove all phantom component references from `docs/architecture.md` (no `agentsExplorerProvider.ts`, `hooksExplorerProvider.ts`, `mcpExplorerProvider.ts`, no `commands/`, `constants/`, `services/`, `shared/`, `watchers/`, `providers/` top-level dirs)
+- [x] T008 [US1] Update the key components section in `docs/architecture.md` to list actual providers: SpecExplorerProvider, SteeringExplorerProvider, OverviewProvider, SpecViewerProvider, SpecEditorProvider, WorkflowEditorProvider
+- [x] T009 [US1] Update the feature modules listing in `docs/architecture.md` to include all 10 modules: agents, permission, settings, skills, spec-editor, spec-viewer, specs, steering, workflow-editor, workflows
+
+**Checkpoint**: `docs/architecture.md` is fully accurate - every path listed exists on disk, every component named exists in code
+
+---
+
+## Phase 3: User Story 2 - Developer Understanding Feature Docs (Priority: P2)
+
+**Goal**: Update `docs/how-it-works.md` to accurately reflect all 5 AI providers, 3 tree views, correct project structure, and full capabilities matrix
+
+**Independent Test**: A developer reading `docs/how-it-works.md` can correctly enumerate all supported AI providers, all tree views, and the activation flow without encountering references to non-existent components
+
+### Implementation for User Story 2
+
+- [x] T010 [US2] Update the AI providers section in `docs/how-it-works.md` to list all 5 providers: Claude Code, GitHub Copilot CLI, Gemini CLI, Codex CLI, Qwen CLI
+- [x] T011 [US2] Update the provider capabilities matrix in `docs/how-it-works.md` to include Codex and Qwen with accurate capability flags based on their provider implementations in `src/ai-providers/`
+- [x] T012 [US2] Fix the tree views section in `docs/how-it-works.md` from 7 views to 3 views: explorer (SpecExplorerProvider), steering (SteeringExplorerProvider), settings (OverviewProvider)
+- [x] T013 [US2] Update all Mermaid diagrams in `docs/how-it-works.md` to show "Specs | Steering | Settings" instead of "Specs | Steering | MCP | Agents | Skills | Hooks"
+- [x] T014 [US2] Update the project structure section in `docs/how-it-works.md` to include spec-viewer/, spec-editor/, workflows/ feature modules and remove phantom hooks/, mcp/ directories
+- [x] T015 [US2] Update the activation flow description in `docs/how-it-works.md` to say "Register TreeDataProviders 3 views" instead of 7
+- [x] T016 [US2] Update the configuration keys section in `docs/how-it-works.md` to include all settings from `package.json`: speckit.specDirectories, speckit.customWorkflows, speckit.defaultWorkflow, speckit.customCommands, speckit.qwenPath, speckit.permissionMode
+- [x] T017 [US2] Update the webview description in `docs/how-it-works.md` to accurately describe spec-viewer, spec-editor, and workflow editor webviews with their actual file structure
+
+**Checkpoint**: `docs/how-it-works.md` accurately describes all providers, views, and structure
+
+---
+
+## Phase 4: User Story 3 - Contributor Updating CLAUDE.md (Priority: P3)
+
+**Goal**: Verify `CLAUDE.md` project structure matches the actual filesystem layout
+
+**Independent Test**: The project structure in `CLAUDE.md` matches the actual filesystem layout when compared directory-by-directory
+
+### Implementation for User Story 3
+
+- [x] T018 [US3] Verify the project structure section in `CLAUDE.md` matches actual `src/` and `webview/` directories and update if any discrepancies are found
+
+**Checkpoint**: `CLAUDE.md` is verified accurate
+
+---
+
+## Phase 5: Polish & Cross-Cutting Concerns
+
+**Purpose**: Final validation across all documentation files
+
+- [x] T019 Run full validation: confirm every directory path listed across all docs exists on disk (0 phantom paths per SC-001)
+- [x] T020 Run full validation: confirm every class/provider name referenced across all docs exists in codebase (0 phantom references per SC-002)
+- [x] T021 Verify all 5 AI providers are documented with accurate capabilities (SC-003) and tree view count = 3 (SC-004)
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies - can start immediately
+- **US1 - Architecture Docs (Phase 2)**: Depends on Setup audit completion
+- **US2 - How-It-Works Docs (Phase 3)**: Depends on Setup audit completion; independent of US1
+- **US3 - CLAUDE.md (Phase 4)**: Depends on Setup audit completion; independent of US1/US2
+- **Polish (Phase 5)**: Depends on all user stories being complete
+
+### User Story Dependencies
+
+- **User Story 1 (P1)**: Can start after Setup - No dependencies on other stories
+- **User Story 2 (P2)**: Can start after Setup - Independent of US1
+- **User Story 3 (P3)**: Can start after Setup - Independent of US1/US2
+
+### Parallel Opportunities
+
+- T003 and T004 in Setup can run in parallel
+- All three user stories (Phases 2-4) can run in parallel after Setup
+- Within US1: T005-T009 are sequential (all modify same file `docs/architecture.md`)
+- Within US2: T010-T017 are sequential (all modify same file `docs/how-it-works.md`)
+- US3 is a single task
+
+---
+
+## Parallel Example: After Setup
+
+```bash
+# All three user stories can start simultaneously:
+Task: US1 - Rewrite docs/architecture.md (T005-T009)
+Task: US2 - Update docs/how-it-works.md (T010-T017)
+Task: US3 - Verify CLAUDE.md (T018)
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Setup (audit codebase)
+2. Complete Phase 2: User Story 1 (architecture.md rewrite)
+3. **STOP and VALIDATE**: Every path in architecture.md exists on disk
+4. Ship if ready
+
+### Incremental Delivery
+
+1. Complete Setup -> Source of truth established
+2. Add User Story 1 -> architecture.md accurate -> Ship
+3. Add User Story 2 -> how-it-works.md accurate -> Ship
+4. Add User Story 3 -> CLAUDE.md verified -> Ship
+5. Polish -> Full validation across all docs
+
+---
+
+## Notes
+
+- No source code changes — documentation-only feature
+- All modifications target existing files, no new files created
+- CLAUDE.md already accurate per D3 research decision — US3 is verification only
+- Within each user story, tasks are sequential because they modify the same file
+- Parallelism exists across user stories, not within them


### PR DESCRIPTION
## Summary
- Rewrote `docs/architecture.md` directory structure and key components to reflect actual codebase (removed phantom dirs, added all 10 feature modules)
- Updated `docs/how-it-works.md`: 5 AI providers (was 3), 3 tree views (was 7), 15 config keys (was 5), fixed Mermaid diagrams
- Updated `CLAUDE.md` project structure and provider list

## Test plan
- [ ] Every directory path in docs exists on disk (validated: 0 phantom paths)
- [ ] Every class/provider name in docs exists in code (validated: 0 phantom refs)
- [ ] All 5 AI providers documented with accurate capabilities
- [ ] Tree view count = 3 across all docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)