### PR TITLE
feat(ai-providers): add speckit.commandFormat setting for dot/dash override

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,24 @@ Controls whether AI CLIs run with permission prompts (safe) or bypass them (YOLO
 
 This applies to all providers that support it: Claude (`--permission-mode bypassPermissions`), Copilot (`--yolo`), and Qwen (`--yolo`). Gemini and Codex ignore this setting.
 
+### Command Format
+
+Controls how speckit commands are formatted when sent to AI providers:
+
+```json
+{
+  "speckit.commandFormat": "auto"
+}
+```
+
+| Value | Behavior |
+|-------|----------|
+| `"auto"` | Let the AI provider decide the format (default) |
+| `"dot"` | Always use dot notation (e.g., `speckit.plan`) |
+| `"dash"` | Always use dash notation (e.g., `speckit-plan`) |
+
+Use `auto` unless your speckit version requires a specific command format. Override with `dot` or `dash` when the provider's default doesn't match what your setup expects.
+
 ### Spec Directories
 
 By default, specs live in `specs/`. You can configure multiple directories or use glob patterns:

--- a/package.json
+++ b/package.json
@@ -533,6 +533,23 @@
           "order": 2,
           "description": "AI assistant to use for spec generation"
         },
+        "speckit.commandFormat": {
+          "type": "string",
+          "default": "auto",
+          "enum": [
+            "auto",
+            "dot",
+            "dash"
+          ],
+          "enumDescriptions": [
+            "Use provider default (Claude/Codex → dash, Gemini/Copilot/Qwen → dot)",
+            "Always use dot notation (speckit.plan)",
+            "Always use dash notation (speckit-plan)"
+          ],
+          "scope": "machine",
+          "order": 3,
+          "description": "Command format for speckit commands sent to AI CLI tools. Use 'auto' to let the provider decide, or override to 'dot' (speckit.plan) or 'dash' (speckit-plan) if your speckit version requires a specific format."
+        },
         "speckit.permissionMode": {
           "type": "string",
           "default": "interactive",

--- a/specs/053-command-format-setting/.spec-context.json
+++ b/specs/053-command-format-setting/.spec-context.json
@@ -1,0 +1,13 @@
+{
+  "workflow": "sdd",
+  "selectedAt": "2026-04-09T12:00:00.000Z",
+  "currentStep": "specify",
+  "status": "active",
+  "specName": "Command Format Setting",
+  "branch": "main",
+  "stepHistory": {
+    "specify": {
+      "startedAt": "2026-04-09T12:00:00.000Z"
+    }
+  }
+}

--- a/specs/053-command-format-setting/plan.md
+++ b/specs/053-command-format-setting/plan.md
@@ -1,0 +1,75 @@
+# Plan: Command Format Setting
+
+**Spec**: 053-command-format-setting | **Date**: 2026-04-09
+
+## Approach
+
+Add a `speckit.commandFormat` setting (`auto` | `dot` | `dash`) to `package.json` and update `formatCommandForProvider()` to check the user setting before falling back to the provider default. Minimal change — one new setting, one function update, tests.
+
+## Files to Modify
+
+| File | Change |
+|---|---|
+| `package.json` | Add `speckit.commandFormat` setting with enum `auto`, `dot`, `dash` (default `auto`) |
+| `src/ai-providers/aiProvider.ts` | Update `formatCommandForProvider()` to read user setting first; only use `PROVIDER_PATHS.commandFormat` when `auto` |
+
+## Files to Create
+
+| File | Purpose |
+|---|---|
+| `src/ai-providers/__tests__/formatCommandForProvider.test.ts` | Tests for all three modes: `auto`, `dot`, `dash` across providers |
+
+## Implementation Details
+
+### 1. Register Setting in `package.json`
+
+Add to `contributes.configuration.properties`:
+
+```json
+"speckit.commandFormat": {
+  "type": "string",
+  "default": "auto",
+  "enum": ["auto", "dot", "dash"],
+  "enumDescriptions": [
+    "Use provider default (Claude/Codex → dash, Gemini/Copilot/Qwen → dot)",
+    "Always use dot notation (speckit.plan)",
+    "Always use dash notation (speckit-plan)"
+  ],
+  "scope": "machine",
+  "order": 3,
+  "description": "Command format for speckit commands sent to AI CLI tools. Use 'auto' to let the provider decide, or override to 'dot' (speckit.plan) or 'dash' (speckit-plan) if your speckit version requires a specific format."
+}
+```
+
+### 2. Update `formatCommandForProvider()`
+
+In `src/ai-providers/aiProvider.ts`, read `speckit.commandFormat` from VS Code config at the top of the function. If `dot` or `dash`, use that directly. If `auto`, fall through to existing `PROVIDER_PATHS` logic.
+
+```typescript
+export function formatCommandForProvider(command: string, providerType?: AIProviderType): string {
+    const config = vscode.workspace.getConfiguration('speckit');
+    const userFormat = config.get<string>('commandFormat', 'auto');
+
+    if (userFormat === 'dash') {
+        return command.replace(/^speckit\./, 'speckit-');
+    }
+    if (userFormat === 'dot') {
+        return command; // canonical format is already dot
+    }
+
+    // auto — use provider default
+    const type = providerType ?? getConfiguredProviderType();
+    const { commandFormat } = PROVIDER_PATHS[type];
+    if (commandFormat === 'dash') {
+        return command.replace(/^speckit\./, 'speckit-');
+    }
+    return command;
+}
+```
+
+### 3. Tests
+
+Cover:
+- `dash` override with a dot-default provider (Gemini) → returns dash
+- `dot` override with a dash-default provider (Claude) → returns dot
+- `auto` preserves per-provider behavior for all 5 providers

--- a/specs/053-command-format-setting/spec.md
+++ b/specs/053-command-format-setting/spec.md
@@ -1,0 +1,38 @@
+# Spec: Command Format Setting
+
+**Slug**: 053-command-format-setting | **Date**: 2026-04-09
+
+## Summary
+
+Add a `speckit.commandFormat` VS Code setting that lets users override how speckit commands are formatted (dot vs dash notation) when sent to AI CLI tools. Currently the format is hardcoded per provider in `PROVIDER_PATHS`; users on mismatched spec-kit versions need a manual override.
+
+## Requirements
+
+- **R001** (MUST): Register a `speckit.commandFormat` setting in `package.json` with enum values `auto`, `dot`, `dash` (default: `auto`)
+- **R002** (MUST): When set to `dot`, `formatCommandForProvider()` must always return dot notation (`speckit.plan`) regardless of provider
+- **R003** (MUST): When set to `dash`, `formatCommandForProvider()` must always return dash notation (`speckit-plan`) regardless of provider
+- **R004** (MUST): When set to `auto`, preserve existing provider-based logic from `PROVIDER_PATHS.commandFormat`
+- **R005** (SHOULD): Setting description should explain the dot/dash difference and when users might need to override
+
+## Scenarios
+
+### User overrides to dash notation
+
+**When** user sets `speckit.commandFormat` to `dash` and uses Gemini (which defaults to dot)
+**Then** all commands are formatted as `speckit-plan`, `speckit-specify`, etc.
+
+### User overrides to dot notation
+
+**When** user sets `speckit.commandFormat` to `dot` and uses Claude (which defaults to dash)
+**Then** all commands are formatted as `speckit.plan`, `speckit.specify`, etc.
+
+### Auto mode preserves existing behavior
+
+**When** `speckit.commandFormat` is `auto` (default)
+**Then** Claude/Codex use dash, Gemini/Copilot/Qwen use dot — same as current behavior
+
+## Out of Scope
+
+- Changing the default format for any provider in `PROVIDER_PATHS`
+- Per-provider command format overrides (only a single global override)
+- Migration or deprecation of the `commandFormat` field in `ProviderPaths`

--- a/specs/053-command-format-setting/state.json
+++ b/specs/053-command-format-setting/state.json
@@ -1,0 +1,1 @@
+{ "step": "implement", "task": null, "substep": "commit", "next": null, "updated": "2026-04-09" }

--- a/specs/053-command-format-setting/tasks.md
+++ b/specs/053-command-format-setting/tasks.md
@@ -1,0 +1,54 @@
+# Tasks: Command Format Setting
+
+**Date**: 2026-04-09
+
+## Phase 1 — Core Implementation
+
+### T001: Register `speckit.commandFormat` setting in `package.json` ✅
+
+- **File**: `package.json`
+- Add `speckit.commandFormat` to `contributes.configuration.properties`
+- Enum: `auto`, `dot`, `dash` (default: `auto`)
+- Include `enumDescriptions` explaining each option
+- Set `scope: "machine"`, `order: 3`
+
+**Checkpoint**: `npm run compile` passes; setting visible in VS Code settings UI
+
+---
+
+### T002: Update `formatCommandForProvider()` to respect user setting ✅
+
+- **File**: `src/ai-providers/aiProvider.ts`
+- Read `speckit.commandFormat` from `vscode.workspace.getConfiguration('speckit')`
+- If `dash` → always return dash notation
+- If `dot` → always return dot notation (canonical format)
+- If `auto` → fall through to existing `PROVIDER_PATHS.commandFormat` logic
+
+**Checkpoint**: `npm run compile` passes
+
+---
+
+## Phase 2 — Verification
+
+### T003: Unit tests for `formatCommandForProvider()` — `test-expert` ✅
+
+[P][A]
+
+- **File**: `src/ai-providers/__tests__/formatCommandForProvider.test.ts`
+- Test `dash` override with dot-default provider (Gemini) → returns dash
+- Test `dot` override with dash-default provider (Claude) → returns dot
+- Test `auto` preserves per-provider behavior for all 5 providers
+
+**Checkpoint**: `npm test` passes
+
+---
+
+### T004: Update README documentation — `docs-expert` ✅
+
+[P][A]
+
+- **File**: `README.md`
+- Add `speckit.commandFormat` to the configuration settings table/section
+- Brief description of when users would need to override
+
+**Checkpoint**: README reflects the new setting

--- a/src/ai-providers/__tests__/formatCommandForProvider.test.ts
+++ b/src/ai-providers/__tests__/formatCommandForProvider.test.ts
@@ -1,0 +1,68 @@
+import * as vscode from 'vscode';
+import { formatCommandForProvider, PROVIDER_PATHS } from '../aiProvider';
+import { AIProviders } from '../../core/constants';
+
+describe('formatCommandForProvider', () => {
+    const command = 'speckit.specify';
+
+    function mockCommandFormat(value: string) {
+        (vscode.workspace.getConfiguration as jest.Mock).mockReturnValue({
+            get: jest.fn((key: string, defaultValue?: unknown) => {
+                if (key === 'commandFormat') {
+                    return value;
+                }
+                return defaultValue;
+            }),
+        });
+    }
+
+    describe('when commandFormat is "dash"', () => {
+        beforeEach(() => mockCommandFormat('dash'));
+
+        it('should override a dot-default provider (Gemini) to return dash notation', () => {
+            expect(PROVIDER_PATHS[AIProviders.GEMINI].commandFormat).toBe('dot');
+            expect(formatCommandForProvider(command, AIProviders.GEMINI)).toBe('speckit-specify');
+        });
+
+        it('should keep dash notation for a dash-default provider (Claude)', () => {
+            expect(formatCommandForProvider(command, AIProviders.CLAUDE)).toBe('speckit-specify');
+        });
+    });
+
+    describe('when commandFormat is "dot"', () => {
+        beforeEach(() => mockCommandFormat('dot'));
+
+        it('should override a dash-default provider (Claude) to return dot notation', () => {
+            expect(PROVIDER_PATHS[AIProviders.CLAUDE].commandFormat).toBe('dash');
+            expect(formatCommandForProvider(command, AIProviders.CLAUDE)).toBe('speckit.specify');
+        });
+
+        it('should keep dot notation for a dot-default provider (Gemini)', () => {
+            expect(formatCommandForProvider(command, AIProviders.GEMINI)).toBe('speckit.specify');
+        });
+    });
+
+    describe('when commandFormat is "auto" (default)', () => {
+        beforeEach(() => mockCommandFormat('auto'));
+
+        it('should use dash notation for Claude', () => {
+            expect(formatCommandForProvider(command, AIProviders.CLAUDE)).toBe('speckit-specify');
+        });
+
+        it('should use dash notation for Codex', () => {
+            expect(formatCommandForProvider(command, AIProviders.CODEX)).toBe('speckit-specify');
+        });
+
+        it('should use dot notation for Gemini', () => {
+            expect(formatCommandForProvider(command, AIProviders.GEMINI)).toBe('speckit.specify');
+        });
+
+        it('should use dot notation for Copilot', () => {
+            expect(formatCommandForProvider(command, AIProviders.COPILOT)).toBe('speckit.specify');
+        });
+
+        it('should use dot notation for Qwen', () => {
+            expect(formatCommandForProvider(command, AIProviders.QWEN)).toBe('speckit.specify');
+        });
+    });
+});

--- a/src/ai-providers/aiProvider.ts
+++ b/src/ai-providers/aiProvider.ts
@@ -177,6 +177,17 @@ export const PROVIDER_PATHS: Record<AIProviderType, ProviderPaths> = {
  * E.g., for Claude/Codex: speckit.specify → speckit-specify
  */
 export function formatCommandForProvider(command: string, providerType?: AIProviderType): string {
+    const config = vscode.workspace.getConfiguration('speckit');
+    const userFormat = config.get<string>('commandFormat', 'auto');
+
+    if (userFormat === 'dash') {
+        return command.replace(/^speckit\./, 'speckit-');
+    }
+    if (userFormat === 'dot') {
+        return command;
+    }
+
+    // auto — use provider default
     const type = providerType ?? getConfiguredProviderType();
     const { commandFormat } = PROVIDER_PATHS[type];
     if (commandFormat === 'dash') {


### PR DESCRIPTION
## What

- Add `speckit.commandFormat` setting (`auto`, `dot`, `dash`) to override command notation
- Update `formatCommandForProvider()` to check user setting before provider default
- Add unit tests covering all three modes across all providers
- Document new setting in README

## Why

Users on mismatched speckit versions need to override the hardcoded per-provider command format (dot vs dash notation).

## Testing

- `npm run compile` passes
- All 173 tests pass (9 new for `formatCommandForProvider`)