### PR TITLE
fix(viewer): reduce list item spacing in spec viewer

### DIFF
--- a/specs/056-fix-list-spacing/.spec-context.json
+++ b/specs/056-fix-list-spacing/.spec-context.json
@@ -1,0 +1,13 @@
+{
+  "workflow": "sdd",
+  "selectedAt": "2026-04-10T17:00:00.000Z",
+  "currentStep": "specify",
+  "status": "active",
+  "specName": "Fix List Spacing",
+  "branch": "main",
+  "stepHistory": {
+    "specify": {
+      "startedAt": "2026-04-10T17:00:00.000Z"
+    }
+  }
+}

--- a/specs/056-fix-list-spacing/plan.md
+++ b/specs/056-fix-list-spacing/plan.md
@@ -1,0 +1,14 @@
+# Plan: Fix List Item Spacing
+
+**Spec**: [spec.md](./spec.md) | **Date**: 2026-04-10
+
+## Approach
+
+Tighten list item vertical spacing in the spec viewer by reducing line-height on `li` elements and removing inherited `.line` padding for list items. This is a CSS-only change targeting `_typography.css` and `_line-actions.css`.
+
+## Files to Change
+
+| File | Change |
+|------|--------|
+| `webview/styles/spec-viewer/_typography.css` | Reduce `line-height` on `#markdown-content li` from `--leading-relaxed` (1.625) to `--leading-normal` (1.5) |
+| `webview/styles/spec-viewer/_line-actions.css` | Zero out vertical padding on `li.line` to prevent double-spacing |

--- a/specs/056-fix-list-spacing/spec.md
+++ b/specs/056-fix-list-spacing/spec.md
@@ -1,0 +1,32 @@
+# Spec: Fix List Item Spacing
+
+**Slug**: 056-fix-list-spacing | **Date**: 2026-04-10
+
+## Summary
+
+The spec viewer renders bullet and numbered list items with too much vertical space between them. The gap comes from the combination of `line-height: 1.625` on `li`, `padding: 2px 0` inherited from `.line`, and `margin-bottom: 2px` on `#markdown-content li`. This creates ~15px of visual gap between items which feels loose and wastes vertical space.
+
+## Requirements
+
+- **R001** (MUST): Reduce vertical spacing between list items in the spec viewer so items feel compact
+- **R002** (MUST): Preserve readability — items must not feel cramped or overlap
+- **R003** (MUST): Nested lists must still appear visually indented and distinguishable from parent items
+- **R004** (SHOULD): Spacing should feel consistent with VS Code's native markdown preview density
+
+## Scenarios
+
+### Compact list rendering
+
+**When** a spec with bullet or numbered lists is displayed in the spec viewer
+**Then** list items should have tighter vertical spacing (~8-10px gap instead of ~15px)
+
+### Nested list readability
+
+**When** a list contains nested sub-lists
+**Then** nested items should still be visually grouped under their parent with appropriate indentation and spacing
+
+## Out of Scope
+
+- Task list checkbox styling (separate component with its own spacing)
+- Paragraph spacing changes outside of lists
+- Line-height changes to non-list content

--- a/specs/056-fix-list-spacing/state.json
+++ b/specs/056-fix-list-spacing/state.json
@@ -1,0 +1,1 @@
+{ "step": "implement", "task": null, "substep": "commit", "next": null, "updated": "2026-04-10" }

--- a/specs/056-fix-list-spacing/tasks.md
+++ b/specs/056-fix-list-spacing/tasks.md
@@ -1,0 +1,27 @@
+# Tasks: Fix List Item Spacing
+
+**Plan**: [plan.md](./plan.md) | **Date**: 2026-04-10
+
+## Format
+
+- `[P]` = Can run in parallel  |  `[A]` = Agent-eligible
+
+---
+
+## Phase 1: Core Implementation
+
+- [x] **T001** Reduce li line-height — `webview/styles/spec-viewer/_typography.css`
+  - **Do**: Change `line-height` on `#markdown-content li` from `var(--leading-relaxed)` to `var(--leading-normal)`
+  - **Verify**: List items in spec viewer have tighter spacing
+
+- [x] **T002** Zero li.line padding — `webview/styles/spec-viewer/_line-actions.css`
+  - **Do**: Add `padding-top: 0; padding-bottom: 0;` to the `li.line` rule to override `.line` padding
+  - **Verify**: No extra padding between list items; hover highlight still works
+
+---
+
+## Progress
+
+| Phase | Tasks | Status |
+|-------|-------|--------|
+| Phase 1 | T001–T002 | [x] |

--- a/webview/styles/spec-viewer/_line-actions.css
+++ b/webview/styles/spec-viewer/_line-actions.css
@@ -127,6 +127,8 @@
 
 li.line {
     position: relative;
+    padding-top: 0;
+    padding-bottom: 0;
     padding-right: 0;  /* No extra padding */
     margin: 0;
     min-height: unset;

--- a/webview/styles/spec-viewer/_typography.css
+++ b/webview/styles/spec-viewer/_typography.css
@@ -76,7 +76,7 @@
 
 #markdown-content li {
     margin-bottom: 2px;
-    line-height: var(--leading-relaxed);
+    line-height: var(--leading-normal);
     color: var(--text-body);
 }
 


### PR DESCRIPTION
## What

- Reduce vertical spacing between list items in the spec viewer
- Change `li` line-height from `--leading-relaxed` (1.625) to `--leading-normal` (1.5)
- Zero out inherited `.line` padding on `li.line` elements

## Why

List items had ~15px visual gaps due to compounding line-height, padding, and margin — making lists feel loose and wasting vertical space.

## Testing

- List items in spec viewer have tighter spacing
- No extra padding between list items; hover highlight still works
- Nested lists still visually grouped with appropriate indentation