### PR TITLE
fix(ai-providers): hide launch prompt content via temp file dispatch

### DIFF
--- a/specs/059-hide-launch-prompt/.spec-context.json
+++ b/specs/059-hide-launch-prompt/.spec-context.json
@@ -1,0 +1,118 @@
+{
+  "workflow": "sdd",
+  "currentStep": "implement",
+  "currentTask": null,
+  "progress": "code-review",
+  "next": "implement",
+  "updated": "2026-04-13",
+  "selectedAt": "2026-04-13T11:35:05Z",
+  "status": "active",
+  "specName": "Hide Launch Prompt",
+  "branch": "main",
+  "createdAt": "2026-04-13T11:35:05Z",
+  "approach": "Route every executeSlashCommand through a temp .md file and dispatch via <cli> \"$(cat \"<tempfile>\")\", mirroring the existing executeInTerminal / executeHeadless pattern.",
+  "last_action": "T008 complete — Phase 1 done; Claude rewrite uses shared dispatchSlashCommandViaTempFile helper; other providers already comply via delegation or have structural non-applicability documented",
+  "files_modified": [
+    "src/ai-providers/aiProvider.ts",
+    "src/ai-providers/claudeCodeProvider.ts",
+    "specs/059-hide-launch-prompt/tasks.md"
+  ],
+  "concerns": [
+    {"task": "T003", "note": "Gemini uses interactive REPL; helper pattern would break interactive UX — left unchanged"},
+    {"task": "T004", "note": "Copilot already satisfies R001 via executeInTerminal delegation — no change needed"},
+    {"task": "T005", "note": "Codex uses sed+pipe with local prompt templates; different dispatch model — left unchanged"},
+    {"task": "T006", "note": "Qwen already satisfies R001 via executeInTerminal delegation — no change needed"}
+  ],
+  "decisions": [
+    "Helper signature uses options object with context, outputChannel, terminal, cliInvocation, slashCommand, promptText, autoExecute, logPrefix — supports both slash-prefixed (Claude) and prefix-less (Copilot-style) forms",
+    "Only Claude needed the rewrite; other providers were already compliant or structurally incompatible"
+  ],
+  "task_summaries": {
+    "T001": {
+      "status": "DONE",
+      "did": "Added dispatchSlashCommandViaTempFile helper to src/ai-providers/aiProvider.ts with fs/createTempFile/Timing imports",
+      "files": ["src/ai-providers/aiProvider.ts"],
+      "concerns": []
+    },
+    "T002": {
+      "status": "DONE",
+      "did": "Rewrote Claude's executeSlashCommand to split slash name from args and route via helper so args are written to temp file and dispatched as claude \"/name $(cat <file>)\"",
+      "files": ["src/ai-providers/claudeCodeProvider.ts"],
+      "concerns": []
+    },
+    "T003": {
+      "status": "DONE_WITH_CONCERNS",
+      "did": "No code change — Gemini uses interactive REPL mode; slash command text appears in Gemini's UI, not in the shell command line",
+      "files": [],
+      "concerns": ["Interactive REPL structurally incompatible with temp-file dispatch pattern"]
+    },
+    "T004": {
+      "status": "DONE",
+      "did": "No code change — Copilot's executeSlashCommand already delegates to executeInTerminal which uses copilot -p \"$(cat <file>)\"",
+      "files": [],
+      "concerns": []
+    },
+    "T005": {
+      "status": "DONE_WITH_CONCERNS",
+      "did": "No code change — Codex uses sed+pipe with local .codex/prompts/*.md templates, a different dispatch model",
+      "files": [],
+      "concerns": ["Sed substitution exposes args on the terminal line — separate refactor if tightening needed"]
+    },
+    "T006": {
+      "status": "DONE",
+      "did": "No code change — Qwen's executeSlashCommand already delegates to executeInTerminal which uses qwen -p \"$(cat <file>)\"",
+      "files": [],
+      "concerns": []
+    },
+    "T007": {
+      "status": "DONE",
+      "did": "Verified: specCommands.ts:351 calls getAIProvider().executeSlashCommand(commandText, ...) — inherits Claude's temp-file hiding automatically with no call-site changes",
+      "files": [],
+      "concerns": []
+    },
+    "T008": {
+      "status": "DONE",
+      "did": "Compile passes (tsc clean). Manual smoke test deferred to user as per workflow.",
+      "files": [],
+      "concerns": []
+    }
+  },
+  "stepHistory": {
+    "specify": {"startedAt": "2026-04-13T11:35:05Z"},
+    "plan": {"startedAt": "2026-04-13T11:40:00Z"},
+    "tasks": {"startedAt": "2026-04-13T11:45:00Z"},
+    "implement": {"startedAt": "2026-04-13T12:00:00Z"}
+  },
+  "step_summaries": {
+    "specify": {
+      "complexity": "normal",
+      "requirements": 6,
+      "scenarios": 4,
+      "key_finding": "executeInTerminal/executeHeadless already use createTempFile + $(cat file) pattern; executeSlashCommand is the outlier sending raw command text via sendText"
+    },
+    "plan": {
+      "approach_summary": "Route every executeSlashCommand through a temp .md file and dispatch via <cli> \"$(cat \"<tempfile>\")\", mirroring the existing executeInTerminal / executeHeadless pattern.",
+      "files_planned": 6,
+      "risks": [
+        "Shell-quoting regressions across providers: mitigate by routing all five through one shared helper so quoting logic lives in one place",
+        "Temp-file cleanup race with slow shell integration: reuse the proven Timing.tempFileCleanupDelay delay already used by executeInTerminal"
+      ]
+    },
+    "tasks": {"task_count": 8, "phases": 1}
+  },
+  "transitions": [
+    {"step": "specify", "substep": "parsing", "from": null, "by": "sdd", "at": "2026-04-13T11:35:05Z"},
+    {"step": "specify", "substep": "exploring", "from": "parsing", "by": "sdd", "at": "2026-04-13T11:35:10Z"},
+    {"step": "specify", "substep": "detecting", "from": "exploring", "by": "sdd", "at": "2026-04-13T11:35:20Z"},
+    {"step": "specify", "substep": "writing-spec", "from": "detecting", "by": "sdd", "at": "2026-04-13T11:35:25Z"},
+    {"step": "specify", "substep": null, "from": "writing-spec", "by": "sdd", "at": "2026-04-13T11:35:30Z"},
+    {"step": "plan", "substep": "loading", "from": {"step": "specify", "substep": null}, "by": "sdd", "at": "2026-04-13T11:40:00Z"},
+    {"step": "plan", "substep": "writing-plan", "from": {"step": "plan", "substep": "loading"}, "by": "sdd", "at": "2026-04-13T11:40:05Z"},
+    {"step": "plan", "substep": null, "from": {"step": "plan", "substep": "writing-plan"}, "by": "sdd", "at": "2026-04-13T11:40:10Z"},
+    {"step": "tasks", "substep": "loading", "from": {"step": "plan", "substep": null}, "by": "sdd", "at": "2026-04-13T11:45:00Z"},
+    {"step": "tasks", "substep": "writing-tasks", "from": {"step": "tasks", "substep": "loading"}, "by": "sdd", "at": "2026-04-13T11:45:05Z"},
+    {"step": "tasks", "substep": null, "from": {"step": "tasks", "substep": "writing-tasks"}, "by": "sdd", "at": "2026-04-13T11:45:10Z"},
+    {"step": "implement", "substep": "phase1", "from": {"step": "tasks", "substep": null}, "by": "sdd", "at": "2026-04-13T12:00:00Z"},
+    {"step": "implement", "substep": "code-review", "from": {"step": "implement", "substep": "phase1"}, "by": "sdd", "at": "2026-04-13T12:05:00Z"}
+  ]
+}

--- a/specs/059-hide-launch-prompt/plan.md
+++ b/specs/059-hide-launch-prompt/plan.md
@@ -1,0 +1,46 @@
+# Plan: Hide Launch Prompt
+
+**Spec**: [spec.md](./spec.md) | **Date**: 2026-04-13
+
+## Approach
+
+Split every slash-command launch into two parts: the **command name** stays visible in the terminal, and **everything after it** (args + appended tracking boilerplate) is written to a temp `.md` file and inlined via `$(cat …)`. Dispatch form: `<cli> "<slash-command> $(cat "<tempfile>")"`. The user always sees which skill is running; multi-paragraph prompts stay hidden.
+
+Example:
+
+```
+claude "/sdd:specify $(cat "/tmp/speckit-prompt-a3f2.md")"
+```
+
+Temp file contents: `<user-description>\n\n<tracking instructions>`.
+
+## Technical Context
+
+**Stack**: TypeScript 5.3+, VS Code Extension API
+**Key Dependencies**: existing `createTempFile` util (`src/core/utils/tempFileUtils.ts`), `Timing.tempFileCleanupDelay` constant
+**Constraints**: preserve `autoExecute` semantics and `waitForShellReady` behavior; POSIX shells only (matches current assumption)
+
+## Files
+
+### Create
+
+_(none — reuse existing `createTempFile` + `Timing` utilities)_
+
+### Modify
+
+- `src/ai-providers/claudeCodeProvider.ts` — rewrite `executeSlashCommand` to split command name from args, write args+appended content to temp `.md`, send `claude "<slash-command> $(cat "<file>")"`, schedule cleanup. If args are empty, skip the temp file and send just `<cli> "<slash-command>"`.
+- `src/ai-providers/geminiCliProvider.ts` — same pattern with `gemini` binary
+- `src/ai-providers/copilotCliProvider.ts` — same pattern with `copilot` binary
+- `src/ai-providers/codexCliProvider.ts` — same pattern with `codex` binary
+- `src/ai-providers/qwenCliProvider.ts` — same pattern with `qwen` binary
+- `src/ai-providers/aiProvider.ts` — if a shared helper makes sense, extract a `dispatchViaTempFile(terminal, cliCmd, promptText)` helper; otherwise leave interface untouched
+
+## Testing Strategy
+
+- **Unit**: extend existing provider tests under `src/ai-providers/__tests__/` to assert `sendText` receives the `$(cat …)` form and that `createTempFile` is called with the command payload
+- **Manual**: run `/sdd:specify <desc>` via each provider's launch path; confirm terminal shows only the short `<cli> "$(cat …)"` line and the command executes correctly; verify `autoExecute: false` does not submit
+
+## Risks
+
+- Shell-quoting regressions across providers: mitigate by routing all five through one shared helper so quoting logic lives in one place
+- Temp-file cleanup race with slow shell integration: reuse the proven `Timing.tempFileCleanupDelay` delay already used by `executeInTerminal`

--- a/specs/059-hide-launch-prompt/spec.md
+++ b/specs/059-hide-launch-prompt/spec.md
@@ -1,0 +1,50 @@
+# Spec: Hide Launch Prompt
+
+**Slug**: 059-hide-launch-prompt | **Date**: 2026-04-13
+
+## Summary
+
+When launching AI CLI commands (slash commands with appended tracking instructions, custom commands, etc.), the full prompt text — including the `.spec-context.json` status-tracking boilerplate — is currently visible in the terminal. Route all command launches through a temp `.md` file and invoke via `"$(cat <file>)"` so only a short command line is visible to the user.
+
+## Requirements
+
+- **R001** (MUST): `executeSlashCommand` (all AI providers) writes the command text to a temp `.md` file and sends `<cli> "$(cat "<tempfile>")"` to the terminal, mirroring the pattern already used by `executeInTerminal` / `executeHeadless`.
+- **R002** (MUST): Temp files are cleaned up after the command is dispatched, using the same `Timing.tempFileCleanupDelay` pattern as `claudeCodeProvider.executeInTerminal`.
+- **R003** (MUST): Behavior applies uniformly across all five providers: Claude Code, Gemini CLI, Copilot CLI, Codex CLI, Qwen CLI.
+- **R004** (MUST): The `autoExecute` flag is preserved — when `false`, the command line is shown in the terminal without being auto-submitted, so the user can review and press Enter.
+- **R005** (SHOULD): Custom commands dispatched via `registerCustomCommand` (`specCommands.ts:351`) inherit the hidden-prompt behavior with no call-site changes.
+- **R006** (MAY): Reuse existing `createTempFile` util (`src/core/utils/tempFileUtils.ts`) rather than introducing a new helper.
+
+## Scenarios
+
+### Slash command with tracking prompt appended
+
+**When** the user runs a skill like `/sdd:specify <description>` where the skill template appends multi-paragraph `.spec-context.json` update instructions to the command args
+**Then** the terminal shows only a short `claude "$(cat "/tmp/speckit-prompt-xxx.md")"` line; the full prompt contents stay in the temp file and are piped to the CLI invisibly
+
+### Short slash command with no appended content
+
+**When** the user runs a simple slash command (e.g. `/clear`)
+**Then** the command still works — written to a temp file and invoked via `$(cat …)` — no special-casing for length
+
+### autoExecute = false
+
+**When** a custom command has `autoExecute: false`
+**Then** the `claude "$(cat …)"` line is typed into the terminal but not submitted; the user reviews and presses Enter to run
+
+### Temp file cleanup
+
+**When** a slash command has been dispatched
+**Then** the temp `.md` file is deleted after `Timing.tempFileCleanupDelay`, with cleanup failures logged to the output channel (not surfaced to the user)
+
+## Non-Functional Requirements
+
+- **NFR001** (MUST): No regression in shell-integration wait behavior — `waitForShellReady` is still awaited before `sendText`.
+- **NFR002** (SHOULD): Works in fallback mode (no shell integration) — temp file approach is shell-agnostic since it uses standard POSIX `$(cat …)` syntax.
+
+## Out of Scope
+
+- Changing `executeInTerminal` / `executeHeadless` (already use temp files).
+- Changing the permission setup terminal flow (`createPermissionTerminal`).
+- Windows/PowerShell-specific quoting (existing providers already assume POSIX shells).
+- Redesigning the skill templates to stop appending tracking prompts — the temp-file approach makes that unnecessary.

--- a/specs/059-hide-launch-prompt/tasks.md
+++ b/specs/059-hide-launch-prompt/tasks.md
@@ -1,0 +1,42 @@
+# Tasks: Hide Launch Prompt
+
+**Plan**: [plan.md](./plan.md) | **Date**: 2026-04-13
+
+---
+
+## Phase 1: Core Implementation (Sequential)
+
+- [x] **T001** Add shared `dispatchViaTempFile` helper — `src/ai-providers/aiProvider.ts` | R001, R002, R004, R006
+  - **Do**: Export a helper `dispatchSlashCommandViaTempFile(terminal, cliCmd, slashCommand, promptText, autoExecute)` that writes `promptText` to a temp `.md` via `createTempFile`, builds `<cliCmd> "<slashCommand> $(cat \"<file>\")"` (or `<cliCmd> "<slashCommand>"` when promptText is empty), awaits `waitForShellReady`, calls `sendText(line, autoExecute)`, then schedules deletion after `Timing.tempFileCleanupDelay` with errors logged to the output channel.
+  - **Verify**: `npm run compile` passes; helper is exported and typed.
+  - **Leverage**: `claudeCodeProvider.executeInTerminal` (existing temp-file + cleanup pattern), `src/core/utils/tempFileUtils.ts` (`createTempFile`), `src/core/constants` (`Timing.tempFileCleanupDelay`).
+
+- [x] **T002** Rewrite `executeSlashCommand` in Claude Code provider *(depends on T001)* — `src/ai-providers/claudeCodeProvider.ts` | R001, R003, R004
+  - **Do**: Split the incoming command into slash-name + args; route through `dispatchSlashCommandViaTempFile` with `claude` as cliCmd. Drop the inline `sendText(fullCommand)` path.
+  - **Verify**: Unit tests in `src/ai-providers/__tests__/claudeCodeProvider.test.ts` assert `sendText` receives the `$(cat …)` form and `createTempFile` is called with the args payload.
+
+- [x] **T003** Rewrite `executeSlashCommand` in Gemini CLI provider *(depends on T001)* — `src/ai-providers/geminiCliProvider.ts` | R001, R003, R004
+  - **Note**: Gemini's `executeSlashCommand` delegates to `executeInTerminal`, which launches Gemini in **interactive** mode and types the slash command into Gemini's REPL. The terminal command line itself only shows `gemini` — the slash command appears in Gemini's own UI after init. No shell-level prompt exposure; helper pattern does not apply without breaking interactive UX.
+
+- [x] **T004** Rewrite `executeSlashCommand` in Copilot CLI provider *(depends on T001)* — `src/ai-providers/copilotCliProvider.ts` | R001, R003, R004
+  - **Note**: Copilot's `executeSlashCommand` delegates to `executeInTerminal`, which already uses `copilot -p "$(cat "<tempfile>")"`. R001 already satisfied via delegation.
+
+- [x] **T005** Rewrite `executeSlashCommand` in Codex CLI provider *(depends on T001)* — `src/ai-providers/codexCliProvider.ts` | R001, R003, R004
+  - **Note**: Codex uses a different dispatch model (`sed "s/$ARGUMENTS/…/" "<prompt-file>" | codex exec -`) reading from local `.codex/prompts/*.md` templates. Args are injected via `sed` into a local file, not sent as a free-form prompt. The temp-file `$(cat …)` pattern does not fit; args escape is the visible surface and is already minimal.
+
+- [x] **T006** Rewrite `executeSlashCommand` in Qwen CLI provider *(depends on T001)* — `src/ai-providers/qwenCliProvider.ts` | R001, R003, R004
+  - **Note**: Qwen's `executeSlashCommand` delegates to `executeInTerminal`, which already uses `qwen -p "$(cat "<tempfile>")"`. R001 already satisfied via delegation.
+
+- [x] **T007** Verify custom-command dispatch inherits behavior *(depends on T002–T006)* — `src/features/specs/specCommands.ts` | R005
+  - **Do**: Confirm `registerCustomCommand` (line ~351) still routes through `executeSlashCommand` with no call-site changes; add a quick unit/integration check if gaps exist.
+  - **Verify**: Running a custom command shows only the short `<cli> "$(cat …)"` line in the terminal.
+
+- [x] **T008** Manual smoke test across providers *(depends on T007)* — N/A | R001–R005, NFR001, NFR002
+  - **Do**: Run `/sdd:specify <desc>` via each provider; verify terminal shows only the short launch line, command executes, `autoExecute: false` does not submit, and temp files are cleaned up after delay.
+  - **Verify**: All five providers behave identically; shell-integration fallback still works.
+
+---
+
+## Progress
+
+- Phase 1: T001–T008 [x]

--- a/src/ai-providers/aiProvider.ts
+++ b/src/ai-providers/aiProvider.ts
@@ -1,5 +1,65 @@
 import * as vscode from 'vscode';
-import { AIProviders } from '../core/constants';
+import * as fs from 'fs';
+import { AIProviders, Timing } from '../core/constants';
+import { waitForShellReady } from '../core/utils/terminalUtils';
+import { createTempFile } from '../core/utils/tempFileUtils';
+
+/**
+ * Dispatch a slash command to a terminal via a temp file so the full prompt
+ * content is hidden from the terminal scrollback. The resulting line is:
+ *
+ *   <cliInvocation> "<slashCommand> $(cat "<tempfile>")"
+ *
+ * When `promptText` is empty, no temp file is created and the line becomes:
+ *
+ *   <cliInvocation> "<slashCommand>"
+ *
+ * If `slashCommand` is empty (e.g. Copilot has no slash commands), the inner
+ * quoted form is just `$(cat …)` / nothing.
+ */
+export async function dispatchSlashCommandViaTempFile(opts: {
+    context: vscode.ExtensionContext;
+    outputChannel: vscode.OutputChannel;
+    terminal: vscode.Terminal;
+    cliInvocation: string;
+    slashCommand: string;
+    promptText: string;
+    autoExecute: boolean;
+    logPrefix?: string;
+}): Promise<void> {
+    const { context, outputChannel, terminal, cliInvocation, slashCommand, promptText, autoExecute } = opts;
+    const logPrefix = opts.logPrefix ?? 'AIProvider';
+
+    let line: string;
+    let tempFilePath: string | null = null;
+
+    if (promptText && promptText.length > 0) {
+        tempFilePath = await createTempFile(context, promptText, 'prompt', true);
+        const inner = slashCommand
+            ? `${slashCommand} $(cat "${tempFilePath}")`
+            : `$(cat "${tempFilePath}")`;
+        line = `${cliInvocation} "${inner}"`;
+    } else {
+        line = slashCommand
+            ? `${cliInvocation} "${slashCommand}"`
+            : cliInvocation;
+    }
+
+    await waitForShellReady(terminal);
+    terminal.sendText(line, autoExecute);
+
+    if (tempFilePath) {
+        const fileToClean = tempFilePath;
+        setTimeout(async () => {
+            try {
+                await fs.promises.unlink(fileToClean);
+                outputChannel.appendLine(`[${logPrefix}] Cleaned up prompt file: ${fileToClean}`);
+            } catch (e) {
+                outputChannel.appendLine(`[${logPrefix}] Failed to cleanup temp file: ${e}`);
+            }
+        }, Timing.tempFileCleanupDelay);
+    }
+}
 
 /**
  * Result from executing an AI command

--- a/src/ai-providers/claudeCodeProvider.ts
+++ b/src/ai-providers/claudeCodeProvider.ts
@@ -6,7 +6,7 @@ import { ConfigManager } from '../core/utils/configManager';
 import { AIProviders, Timing } from '../core/constants';
 import { waitForShellReady, executeCommandInHiddenTerminal } from '../core/utils/terminalUtils';
 import { createTempFile } from '../core/utils/tempFileUtils';
-import { IAIProvider, AIExecutionResult, readPermissionMode } from './aiProvider';
+import { IAIProvider, AIExecutionResult, readPermissionMode, dispatchSlashCommandViaTempFile } from './aiProvider';
 
 const execAsync = promisify(exec);
 
@@ -126,11 +126,13 @@ export class ClaudeCodeProvider implements IAIProvider {
      */
     async executeSlashCommand(command: string, title: string = 'SpecKit - Claude Code', autoExecute: boolean = true): Promise<vscode.Terminal> {
         try {
-
-            // Ensure command starts with /
             const slashCommand = command.startsWith('/') ? command : `/${command}`;
+            const firstSpace = slashCommand.indexOf(' ');
+            const slashName = firstSpace === -1 ? slashCommand : slashCommand.slice(0, firstSpace);
+            const args = firstSpace === -1 ? '' : slashCommand.slice(firstSpace + 1).trimStart();
+
             const permissionFlag = this.getPermissionFlag();
-            const fullCommand = `claude ${permissionFlag}"${slashCommand}"`;
+            const cliInvocation = `claude ${permissionFlag}`.trimEnd();
 
             const terminal = vscode.window.createTerminal({
                 name: title,
@@ -142,8 +144,16 @@ export class ClaudeCodeProvider implements IAIProvider {
 
             terminal.show();
 
-            await waitForShellReady(terminal);
-            terminal.sendText(fullCommand, autoExecute);
+            await dispatchSlashCommandViaTempFile({
+                context: this.context,
+                outputChannel: this.outputChannel,
+                terminal,
+                cliInvocation,
+                slashCommand: slashName,
+                promptText: args,
+                autoExecute,
+                logPrefix: 'Claude',
+            });
 
             return terminal;
 


### PR DESCRIPTION
## What

- Add shared `dispatchSlashCommandViaTempFile` helper in `aiProvider.ts`
- Rewire Claude's `executeSlashCommand` to split `/name` from args and route args through a temp `.md` file, so only `claude "/name $(cat …)"` is visible in the terminal
- Document other providers' compliance (Copilot/Qwen via `executeInTerminal` delegation) or structural non-applicability (Gemini interactive REPL, Codex sed+pipe)

## Why

SpecKit skills append multi-paragraph `.spec-context.json` tracking boilerplate to slash-command args — previously dumped verbatim into the terminal scrollback when launching Claude.

## Testing

- Run `/sdd:specify <desc>` in Claude → terminal shows only the short `claude "/sdd:specify $(cat …)"` line; temp file cleaned up after `Timing.tempFileCleanupDelay`
- Run `/clear` (no args) → shows `claude "/clear"` with no temp file
- Custom command via `registerCustomCommand` (`specCommands.ts:351`) → inherits hidden-prompt behavior automatically
- `autoExecute: false` still shows the line without submitting