### PR TITLE
feat(specs): extension-side lifecycle writes for .spec-context.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,6 +363,17 @@ The full JSON Schema lives at
 `src/core/types/spec-context.schema.json` and
 `specs/060-spec-context-tracking/contracts/spec-context.schema.json`.
 
+### Extension-side lifecycle writes
+
+The extension itself records `stepHistory[step].startedAt` /
+`completedAt` and the canonical `status` whenever a step is dispatched
+(via the SpecKit commands or the viewer's Approve / Regenerate buttons),
+and when a spawned terminal closes — independent of AI cooperation. Spec
+status changes (`Mark as Completed`, `Archive`, `Reactivate`) write the
+canonical status and append a transition entry, no longer relying on the
+legacy `setSpecStatus` path. Write failures log to the SpecKit output
+channel without blocking dispatch.
+
 ### Invariants
 
 - Unknown top-level fields are preserved across writes.

--- a/specs/061-extension-lifecycle-writes/.spec-context.json
+++ b/specs/061-extension-lifecycle-writes/.spec-context.json
@@ -1,0 +1,90 @@
+{
+  "workflow": "sdd",
+  "currentStep": "implement",
+  "currentTask": null,
+  "progress": "code-review",
+  "next": "implement",
+  "updated": "2026-04-13",
+  "files_modified": [
+    "src/features/specs/stepLifecycle.ts",
+    "src/features/specs/terminalStepTracker.ts",
+    "src/features/specs/__tests__/stepLifecycle.test.ts",
+    "src/features/specs/__tests__/terminalStepTracker.test.ts",
+    "src/features/specs/specCommands.ts",
+    "src/features/spec-viewer/messageHandlers.ts",
+    "src/features/spec-viewer/__tests__/messageHandlers.test.ts",
+    "src/extension.ts",
+    "tests/__mocks__/vscode.ts",
+    "README.md"
+  ],
+  "task_summaries": {
+    "T001": { "status": "DONE", "did": "Created stepLifecycle wrapper exposing startStep/completeStep/startSubstep/completeSubstep + setStatus/reactivate; all errors logged-and-swallowed.", "files": ["src/features/specs/stepLifecycle.ts"], "concerns": [] },
+    "T002": { "status": "DONE", "did": "Added BDD specs for stepLifecycle: writer args, log-not-throw on rejection, substep variants.", "files": ["src/features/specs/__tests__/stepLifecycle.test.ts"], "concerns": [] },
+    "T003": { "status": "DONE", "did": "Verified all AI provider executeInTerminal signatures already return Promise<vscode.Terminal>; no change needed.", "files": [], "concerns": ["No code change required — interface already returned vscode.Terminal."] },
+    "T004": { "status": "DONE", "did": "Created terminalStepTracker with track/register; onDidCloseTerminal fires completeStep once and deletes the entry.", "files": ["src/features/specs/terminalStepTracker.ts"], "concerns": [] },
+    "T005": { "status": "DONE", "did": "Tests cover tracked-close, untracked-close no-op, double-close no double-fire, undefined terminal.", "files": ["src/features/specs/__tests__/terminalStepTracker.test.ts", "tests/__mocks__/vscode.ts"], "concerns": [] },
+    "T006": { "status": "DONE", "did": "Wired startStep + trackTerminal into both phase command dispatch and executeWorkflowStep in specCommands.ts.", "files": ["src/features/specs/specCommands.ts"], "concerns": [] },
+    "T007": { "status": "DONE", "did": "Replaced setSpecStatus with canonical setStatus/reactivate in specCommands.ts and messageHandlers.ts; updated tests.", "files": ["src/features/specs/specCommands.ts", "src/features/spec-viewer/messageHandlers.ts", "src/features/spec-viewer/__tests__/messageHandlers.test.ts"], "concerns": [] },
+    "T008": { "status": "DONE", "did": "handleApprove fires completeStep on current step + startStep on next; handleRegenerate fires startStep.", "files": ["src/features/spec-viewer/messageHandlers.ts"], "concerns": ["Substep wrapping with CANONICAL_SUBSTEPS deferred — approve/regenerate don't currently expose multi-phase substep boundaries inside the viewer message handlers."] },
+    "T009": { "status": "DONE", "did": "extension.ts activate registers terminalStepTracker.register and wires lifecycle output channel.", "files": ["src/extension.ts"], "concerns": [] },
+    "T010": { "status": "DONE", "did": "README spec-context section now documents extension-side lifecycle writes.", "files": ["README.md"], "concerns": [] }
+  },
+  "concerns": [
+    { "task": "T003", "note": "No code change needed; AI providers already return vscode.Terminal." },
+    { "task": "T008", "note": "Substep wrapping with CANONICAL_SUBSTEPS not added — viewer approve/regenerate don't have observable multi-phase boundaries." }
+  ],
+  "decisions": [
+    { "decision": "Added setStatus and reactivate helpers to stepLifecycle.ts (rather than calling writer.updateSpecContext inline at every site) to keep callers one-liners and centralize transition appending." }
+  ],
+  "last_action": "T010 complete — README updated with extension-side lifecycle writes note",
+  "selectedAt": "2026-04-13T20:23:45Z",
+  "specName": "Extension Lifecycle Writes",
+  "branch": "main",
+  "createdAt": "2026-04-13T20:23:45Z",
+  "status": "specified",
+  "approach": "Hook specContextWriter into specCommands.ts dispatch sites and viewer messageHandlers; track spawned terminals so onDidCloseTerminal fires setStepCompleted; route status writes through canonical updateSpecContext.",
+  "stepHistory": {
+    "specify": {
+      "startedAt": "2026-04-13T20:23:45Z",
+      "completedAt": "2026-04-13T20:24:30Z"
+    },
+    "plan": {
+      "startedAt": "2026-04-13T20:25:00Z",
+      "completedAt": "2026-04-13T20:25:30Z"
+    },
+    "tasks": {
+      "startedAt": "2026-04-13T20:26:00Z",
+      "completedAt": "2026-04-13T20:26:30Z"
+    }
+  },
+  "step_summaries": {
+    "specify": {
+      "complexity": "normal",
+      "requirements": 10,
+      "scenarios": 7,
+      "key_finding": "executeInTerminal in specCommands.ts is the single step-dispatch site; lifecycle writes must hook there and in viewer messageHandlers, not in .claude/.specify templates."
+    },
+    "plan": {
+      "approach_summary": "Hook specContextWriter into specCommands.ts dispatch sites and viewer messageHandlers; track spawned terminals so onDidCloseTerminal fires setStepCompleted; route status writes through canonical updateSpecContext.",
+      "files_planned": 9,
+      "risks": [
+        "Provider signature change: making executeInTerminal return vscode.Terminal touches every AI provider; mitigate by keeping return optional.",
+        "Legacy setSpecStatus callers outside touched files could break; mitigate by grepping before delete or leaving a shim."
+      ]
+    }
+  },
+  "transitions": [
+    { "step": "specify", "substep": "parsing", "from": null, "by": "sdd", "at": "2026-04-13T20:23:45Z" },
+    { "step": "specify", "substep": "exploring", "from": { "step": "specify", "substep": "parsing" }, "by": "sdd", "at": "2026-04-13T20:23:55Z" },
+    { "step": "specify", "substep": "detecting", "from": { "step": "specify", "substep": "exploring" }, "by": "sdd", "at": "2026-04-13T20:24:05Z" },
+    { "step": "specify", "substep": "writing-spec", "from": { "step": "specify", "substep": "detecting" }, "by": "sdd", "at": "2026-04-13T20:24:15Z" },
+    { "step": "specify", "substep": null, "from": { "step": "specify", "substep": "writing-spec" }, "by": "sdd", "at": "2026-04-13T20:24:30Z" },
+    { "step": "plan", "substep": "loading", "from": { "step": "specify", "substep": null }, "by": "sdd", "at": "2026-04-13T20:25:00Z" },
+    { "step": "plan", "substep": "writing-plan", "from": { "step": "plan", "substep": "loading" }, "by": "sdd", "at": "2026-04-13T20:25:10Z" },
+    { "step": "plan", "substep": null, "from": { "step": "plan", "substep": "writing-plan" }, "by": "sdd", "at": "2026-04-13T20:25:30Z" },
+    { "step": "tasks", "substep": "loading", "from": { "step": "plan", "substep": null }, "by": "sdd", "at": "2026-04-13T20:26:00Z" },
+    { "step": "tasks", "substep": "writing-tasks", "from": { "step": "tasks", "substep": "loading" }, "by": "sdd", "at": "2026-04-13T20:26:10Z" },
+    { "step": "tasks", "substep": null, "from": { "step": "tasks", "substep": "writing-tasks" }, "by": "sdd", "at": "2026-04-13T20:26:30Z" },
+    { "step": "implement", "substep": null, "from": { "step": "tasks", "substep": null }, "by": "sdd", "at": "2026-04-13T20:30:00Z" }
+  ]
+}

--- a/specs/061-extension-lifecycle-writes/plan.md
+++ b/specs/061-extension-lifecycle-writes/plan.md
@@ -1,0 +1,59 @@
+# Plan: Extension-Side Lifecycle Writes for .spec-context.json
+
+**Spec**: [spec.md](./spec.md) | **Date**: 2026-04-13
+
+## Approach
+
+Hook the existing `specContextWriter` (`setStepStarted` / `setStepCompleted` / `setSubstepStarted` / `setSubstepCompleted`) into the two extension-owned dispatch surfaces: the `speckit.<step>` command handlers in `specCommands.ts`, and the viewer message handlers (`approve`, `regenerate`, `completeSpec`, `archiveSpec`, `reactivateSpec`). A small `terminalStepTracker` map remembers which step a spawned terminal was launched for, so `vscode.window.onDidCloseTerminal` can fire `setStepCompleted` even when the AI never writes the file. All status writes route through `updateSpecContext` using the canonical vocabulary, retiring the legacy `setSpecStatus` writer.
+
+## Technical Context
+
+**Stack**: TypeScript 5.3+, VS Code Extension API (`@types/vscode ^1.84.0`)
+**Key Dependencies**: existing `specContextWriter` (atomic rename + append-only transitions), `transitionLogger`, `CANONICAL_SUBSTEPS` from `core/types/specContext.ts`
+**Constraints**: write failures must log-and-continue (R002); no edits under `.claude/**` or `.specify/**` (R010); writes must be append-safe against concurrent AI writes (R007).
+
+## Architecture
+
+```mermaid
+graph LR
+  Cmd[speckit.&lt;step&gt; command] --> Lifecycle[stepLifecycle.startStep]
+  Lifecycle --> Writer[specContextWriter]
+  Cmd --> Term[executeInTerminal]
+  Term --> Tracker[terminalStepTracker]
+  Close[onDidCloseTerminal] --> Tracker
+  Tracker --> Lifecycle2[stepLifecycle.completeStep]
+  Viewer[messageHandlers approve/regenerate/status] --> Lifecycle
+  Lifecycle2 --> Writer
+```
+
+## Files
+
+### Create
+
+- `src/features/specs/stepLifecycle.ts` — thin wrapper exposing `startStep(specDir, step, by)` / `completeStep(specDir, step, by)` / `startSubstep` / `completeSubstep` that swallow + log errors per R002, so callers stay one-liners.
+- `src/features/specs/terminalStepTracker.ts` — `Map<vscode.Terminal, { specDir, step }>` plus `track(terminal, specDir, step)` and `onDidCloseTerminal` listener that resolves to `completeStep`. Registered once in `extension.ts` activate.
+- `src/features/specs/__tests__/stepLifecycle.test.ts` — BDD specs for write-then-dispatch ordering and log-and-continue on writer failure.
+- `src/features/specs/__tests__/terminalStepTracker.test.ts` — verifies close event triggers `setStepCompleted` for the tracked step.
+
+### Modify
+
+- `src/features/specs/specCommands.ts` — before each `executeInTerminal` for `specify|plan|tasks|implement|clarify|analyze`, call `stepLifecycle.startStep(specDir, step, 'extension')` and pass the returned terminal (from a refactored `executeInTerminal` that returns `vscode.Terminal`) to `terminalStepTracker.track`. Replace `setSpecStatus(...COMPLETED|ARCHIVED)` calls with `updateSpecContext` writes using canonical status.
+- `src/ai-providers/*` (the providers backing `executeInTerminal`) — return the spawned `vscode.Terminal` so the tracker can register it. Minimal signature change; no behavioral change for existing callers that ignore the return value.
+- `src/features/spec-viewer/messageHandlers.ts` — `approve` → `setStepCompleted(step, 'extension')`; `regenerate` → `setStepStarted(step, 'extension')`; `completeSpec` / `archiveSpec` / `reactivateSpec` → canonical-status writes via `updateSpecContext` (drop `setSpecStatus` import). Wrap multi-phase approve/regenerate flows with `setSubstepStarted` / `setSubstepCompleted` using `CANONICAL_SUBSTEPS`.
+- `src/extension.ts` — register the `terminalStepTracker` close listener once during `activate`, push its disposable into `context.subscriptions`.
+- `src/features/specs/specContextManager.ts` — keep `setSpecStatus` only if other callers remain; otherwise mark deprecated and remove. Verify no other importers before deleting.
+
+## Data Model
+
+No schema changes. Reuses existing `SpecContext.stepHistory[step] = { startedAt, completedAt }`, the canonical `status` derivation from `currentStep`, and the append-only `transitions` array — all already shipped in spec 060.
+
+## Testing Strategy
+
+- **Unit**: Jest BDD specs for `stepLifecycle` (writer called with correct args; errors logged not thrown) and `terminalStepTracker` (close event → `completeStep`; untracked terminal close is a no-op).
+- **Integration**: Extend `specCommands.test.ts` to assert `setStepStarted` is called before `executeInTerminal`, and that the sequence still completes when the writer rejects. Extend `messageHandlers.test.ts` for approve/regenerate/status canonical writes.
+- **Edge cases**: terminal reuse across two consecutive step launches (only last close fires completion — covered by approve/regenerate fallback per R009 spirit); concurrent AI write landing in the same second (atomic rename + append-only transitions guarantee no loss).
+
+## Risks
+
+- **Provider signature change**: making `executeInTerminal` return `vscode.Terminal` touches every AI provider. Mitigation: keep return optional (`Promise<vscode.Terminal | void>`) so providers that can't easily expose the terminal still compile; tracker simply skips registration when undefined.
+- **Legacy `setSpecStatus` callers outside the touched files**: removing it could break callers we missed. Mitigation: grep before delete; if non-trivial, leave the function as a thin shim that delegates to canonical `updateSpecContext`.

--- a/specs/061-extension-lifecycle-writes/spec.md
+++ b/specs/061-extension-lifecycle-writes/spec.md
@@ -1,0 +1,64 @@
+# Spec: Extension-Side Lifecycle Writes for .spec-context.json
+
+**Slug**: 061-extension-lifecycle-writes | **Date**: 2026-04-13
+
+## Summary
+
+Wire `.spec-context.json` lifecycle writes (step start/complete, substeps, canonical status) directly into the extension's command handlers and viewer message handlers. Spec 060 shipped the reader/writer/backfill plumbing but never called it at step-launch time, so timestamps and transitions depend entirely on the AI CLI cooperating. This spec makes the extension itself the source of truth, guaranteeing the lifecycle is recorded even when the AI never touches the file.
+
+## Requirements
+
+- **R001** (MUST): Each `speckit.<step>` command (`specify`, `plan`, `tasks`, `implement`, `clarify`, `analyze`) calls `setStepStarted(step, 'extension')` on the target spec's `.spec-context.json` before dispatching the prompt to the terminal.
+- **R002** (MUST): Step-start writes happen synchronously relative to the command handler — a failure to dispatch the terminal prompt must not prevent the write, and a write failure must be logged but must not block the dispatch.
+- **R003** (MUST): When the terminal spawned for a step closes (`vscode.window.onDidCloseTerminal` for a terminal tracked by the extension), call `setStepCompleted(step, 'extension')` for the step that terminal was launched for.
+- **R004** (MUST): The viewer Approve action, when received via `messageHandlers`, writes `setStepCompleted(step, 'extension')` for the step being approved.
+- **R005** (MUST): The viewer Regenerate action writes `setStepStarted(step, 'extension')` so the step history reflects the re-open.
+- **R006** (MUST): `completeSpec`, `archiveSpec`, and `reactivateSpec` message handlers use the canonical status vocabulary (`completed`, `archived`, and the active-state derivation from `currentStep`) — not the legacy `active|completed|archived` strings written by the current `setSpecStatus`.
+- **R007** (MUST): All writes use the existing atomic-rename + append-only-transitions writer (`writeSpecContext` / `updateSpecContext`); no raw `fs.writeFile` of `.spec-context.json`.
+- **R008** (SHOULD): Where the extension runs its own multi-phase checks (checklist validation, regenerate, approve), emit `setSubstepStarted` / `setSubstepCompleted` with names from `CANONICAL_SUBSTEPS`.
+- **R009** (SHOULD): `fileWatchers.ts` may watch for the step's expected output file (`plan.md`, `tasks.md`, etc.) and fire `setStepCompleted` as a fallback when terminal-close detection misses. Polish, not blocker.
+- **R010** (MUST): No edits to `.claude/**` or `.specify/**`. All behavior lives under `src/**`.
+
+## Scenarios
+
+### Step launch records `startedAt` before AI runs
+
+**When** the user triggers `speckit.plan` on spec `061-extension-lifecycle-writes`
+**Then** `specs/061-extension-lifecycle-writes/.spec-context.json` has `stepHistory.plan.startedAt` set and a new `transitions` entry with `step: "plan"`, `by: "extension"` — visible in the sidebar/header before the AI terminal responds.
+
+### Terminal close records `completedAt`
+
+**When** the terminal spawned by `speckit.plan` closes (AI finished, user closed it, or process exited)
+**Then** the handler writes `stepHistory.plan.completedAt` via `setStepCompleted(..., 'extension')` and appends a matching transition. Status derives to `planned`.
+
+### Viewer Approve writes completion
+
+**When** the user clicks Approve in the spec viewer for the `tasks` step
+**Then** `messageHandlers` calls `setStepCompleted('tasks', 'extension')`; status becomes `ready-to-implement`; the stepper visibly advances without waiting for the AI.
+
+### Viewer Regenerate re-opens a step
+
+**When** the user clicks Regenerate on `plan`
+**Then** `setStepStarted('plan', 'extension')` runs, `stepHistory.plan.completedAt` is cleared via a fresh entry, status returns to `planning`, and a transition is appended.
+
+### Canonical status from status commands
+
+**When** the user clicks Complete/Archive/Reactivate in the viewer
+**Then** the message handler writes canonical status (`completed`, `archived`, or the active-state status derived from current step) through `updateSpecContext`, replacing the legacy `setSpecStatus` write.
+
+### AI also writes — no corruption
+
+**When** both the extension and the AI CLI write `.spec-context.json` for the same step within the same second
+**Then** both writes succeed (atomic rename), `transitions` contains both append entries in the order they landed, `stepHistory[step]` reflects the later timestamp, and no entry is lost or rewritten.
+
+### Terminal reuse
+
+**When** the user runs `speckit.specify` then immediately `speckit.plan` in the same reused terminal
+**Then** `setStepStarted` fires at each command invocation (not tied to terminal lifecycle). `setStepCompleted` is best-effort: if `onDidCloseTerminal` only fires once at the end, only the last step gets a close-driven completion — approve/regenerate/output-file fallbacks cover the earlier ones.
+
+## Out of Scope
+
+- AI-side cooperation. If the AI also writes lifecycle data, the reader tolerates it; if it doesn't, this spec still guarantees the record.
+- Webview renderer polish (substep labels, pulse animations, footer scope tooltips) — tracked in a sibling spec.
+- Output-file watcher auto-completion is optional polish (R009) — the spec ships without it if terminal-close + viewer Approve prove sufficient.
+- Prompt-text guidance asking the AI to annotate substeps — that belongs to surface #2 and is a separate spec.

--- a/specs/061-extension-lifecycle-writes/tasks.md
+++ b/specs/061-extension-lifecycle-writes/tasks.md
@@ -1,0 +1,63 @@
+# Tasks: Extension-Side Lifecycle Writes for .spec-context.json
+
+**Plan**: [plan.md](./plan.md) | **Date**: 2026-04-13
+
+---
+
+## Phase 1: Core Implementation (Sequential)
+
+- [x] **T001** Add `stepLifecycle` wrapper — `src/features/specs/stepLifecycle.ts` | R001, R002, R007, R008
+  - **Do**: Create module exporting `startStep(specDir, step, by)`, `completeStep(specDir, step, by)`, `startSubstep(specDir, step, substep, by)`, `completeSubstep(specDir, step, substep, by)`. Each delegates to `specContextWriter` and wraps in try/catch that logs to `console.error` (and `vscode.window` output channel if available) without rethrowing.
+  - **Verify**: `npm run compile` passes; module can be imported.
+  - **Leverage**: `src/features/specs/specContextWriter.ts` (existing `setStepStarted`/`setStepCompleted` signatures).
+
+- [x] **T002** Test `stepLifecycle` — `src/features/specs/__tests__/stepLifecycle.test.ts` | R002
+  - **Do**: BDD specs covering: writer called with correct args; writer rejection is logged not thrown; substep variants pass the canonical name through.
+  - **Verify**: `npm test -- stepLifecycle` passes.
+  - **Leverage**: `src/features/specs/__tests__/specContextManager.test.ts` (mock pattern for writer).
+
+- [x] **T003** Make `executeInTerminal` return the spawned terminal — `src/ai-providers/*` | R003
+  - **Do**: Change provider interface so `executeInTerminal(prompt, name)` returns `Promise<vscode.Terminal | undefined>`. Update each provider implementation to return the `vscode.Terminal` it created (or `undefined` if it cannot). Existing void-return callers continue to work.
+  - **Verify**: `npm run compile` passes; existing tests still pass.
+  - **Leverage**: current `executeInTerminal` implementations in `src/ai-providers/`.
+
+- [x] **T004** Add `terminalStepTracker` — `src/features/specs/terminalStepTracker.ts` | R003
+  - **Do**: Module owning a `Map<vscode.Terminal, { specDir: string; step: string }>`. Export `track(terminal, specDir, step)` and `register(context: vscode.ExtensionContext)` that subscribes `vscode.window.onDidCloseTerminal` and, on close, looks up the terminal, calls `stepLifecycle.completeStep(specDir, step, 'extension')`, then deletes the entry. No-op when terminal is not tracked.
+  - **Verify**: `npm run compile` passes.
+  - **Leverage**: T001 wrapper.
+
+- [x] **T005** Test `terminalStepTracker` — `src/features/specs/__tests__/terminalStepTracker.test.ts` | R003
+  - **Do**: Mock `vscode.window.onDidCloseTerminal`; verify tracked-close fires `setStepCompleted` once with correct args; untracked-close is a no-op; double-close on same terminal does not double-fire.
+  - **Verify**: `npm test -- terminalStepTracker` passes.
+  - **Leverage**: `tests/__mocks__/vscode.ts`.
+
+- [x] **T006** Wire step-start + tracker into `specCommands.ts` — `src/features/specs/specCommands.ts` | R001, R002, R003, R007
+  - **Do**: For each `speckit.<step>` command (`specify`, `plan`, `tasks`, `implement`, `clarify`, `analyze`), before `executeInTerminal`: call `stepLifecycle.startStep(specDir, step, 'extension')`. Capture the terminal returned and call `terminalStepTracker.track(terminal, specDir, step)` when defined. Order: write first, then dispatch — write failure must not block dispatch (already covered by T001 swallow).
+  - **Verify**: `npm run compile`; manual run in Extension Development Host shows `stepHistory.<step>.startedAt` populated immediately.
+  - **Leverage**: existing dispatch pattern in `specCommands.ts:186` and `:245`.
+
+- [x] **T007** Replace legacy `setSpecStatus` with canonical `updateSpecContext` writes — `src/features/specs/specCommands.ts` and `src/features/spec-viewer/messageHandlers.ts` | R006, R007
+  - **Do**: In `specCommands.ts:90` (`completeSpec`) and `:104` (`archiveSpec`), and in the `messageHandlers.ts` `completeSpec` / `archiveSpec` / `reactivateSpec` handlers, swap `setSpecStatus(...)` for `updateSpecContext(specDir, ctx => ({ ...ctx, status: 'completed' | 'archived', updated: today }))` plus a transition entry. For `reactivateSpec`, derive status from `currentStep` (canonical active-state derivation). Remove the `setSpecStatus` import where no callers remain. If callers remain elsewhere, leave the import; do NOT delete `setSpecStatus` itself yet.
+  - **Verify**: `npm run compile`; existing `messageHandlers.test.ts` updated and passes.
+  - **Leverage**: `src/features/specs/specContextWriter.ts` `updateSpecContext` and `transitionLogger.ts`.
+
+- [x] **T008** Wire viewer Approve/Regenerate to lifecycle — `src/features/spec-viewer/messageHandlers.ts` | R004, R005, R008
+  - **Do**: In `handleApprove`, after computing the approved step, call `stepLifecycle.completeStep(specDir, step, 'extension')`. In `handleRegenerate`, call `stepLifecycle.startStep(specDir, step, 'extension')` (this rewrites `stepHistory[step].startedAt` and clears `completedAt` per writer semantics). Wrap multi-phase work with `startSubstep`/`completeSubstep` using names from `CANONICAL_SUBSTEPS`.
+  - **Verify**: `npm test -- messageHandlers` passes; manual: clicking Approve advances stepper without waiting for AI.
+  - **Leverage**: `CANONICAL_SUBSTEPS` in `src/core/types/specContext.ts`.
+
+- [x] **T009** Register tracker in extension activate — `src/extension.ts` | R003
+  - **Do**: Import `terminalStepTracker.register` and call it once in `activate(context)`, pushing the returned disposable into `context.subscriptions`.
+  - **Verify**: `npm run compile`; Extension Development Host launches without errors; closing a step terminal writes `completedAt`.
+  - **Leverage**: existing `context.subscriptions.push(...)` pattern in `extension.ts`.
+
+- [x] **T010** Update README — `README.md` | docs
+  - **Do**: Add a short note under the lifecycle/spec-context section that the extension itself now records `startedAt`/`completedAt` and canonical status — independent of AI cooperation.
+  - **Verify**: README renders correctly; section reflects new behavior.
+  - **Leverage**: existing spec-context section in `README.md`.
+
+---
+
+## Progress
+
+- Phase 1: T001–T010 [x]

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,6 +6,8 @@ import { IAIProvider, AIProviderFactory, isProviderConfigured, promptForProvider
 // Features
 import { SteeringManager, SteeringExplorerProvider, registerSteeringCommands } from './features/steering';
 import { SpecExplorerProvider, registerSpecKitCommands } from './features/specs';
+import { register as registerTerminalStepTracker } from './features/specs/terminalStepTracker';
+import { setLifecycleOutputChannel } from './features/specs/stepLifecycle';
 import { OverviewProvider } from './features/settings';
 import { AgentManager } from './features/agents';
 import { SkillManager } from './features/skills';
@@ -34,6 +36,8 @@ export async function activate(context: vscode.ExtensionContext) {
     // Create output channel for debugging
     outputChannel = vscode.window.createOutputChannel('SpecKit Companion');
     context.subscriptions.push(outputChannel);
+    setLifecycleOutputChannel(outputChannel);
+    context.subscriptions.push(registerTerminalStepTracker(context));
 
     // Initialize SpecKit detector
     const specKitDetector = SpecKitDetector.getInstance();

--- a/src/features/spec-viewer/__tests__/messageHandlers.test.ts
+++ b/src/features/spec-viewer/__tests__/messageHandlers.test.ts
@@ -3,7 +3,15 @@ import { createMessageHandlers, MessageHandlerDependencies } from '../messageHan
 
 // Mock specContextManager
 jest.mock('../../specs/specContextManager', () => ({
-    setSpecStatus: jest.fn().mockResolvedValue(undefined),
+    updateStepProgress: jest.fn().mockResolvedValue(undefined),
+}));
+
+// Mock stepLifecycle (canonical writer wrappers)
+jest.mock('../../specs/stepLifecycle', () => ({
+    setStatus: jest.fn().mockResolvedValue(undefined),
+    reactivate: jest.fn().mockResolvedValue(undefined),
+    startStep: jest.fn().mockResolvedValue(undefined),
+    completeStep: jest.fn().mockResolvedValue(undefined),
 }));
 
 // Mock notificationUtils
@@ -20,7 +28,7 @@ jest.mock('../../workflows', () => ({
     getWorkflowCommands: jest.fn().mockReturnValue([]),
 }));
 
-import { setSpecStatus } from '../../specs/specContextManager';
+import { setStatus, reactivate } from '../../specs/stepLifecycle';
 import { NotificationUtils } from '../../../core/utils/notificationUtils';
 import { getFeatureWorkflow, getWorkflowCommands } from '../../workflows';
 
@@ -67,7 +75,7 @@ describe('messageHandlers - lifecycle actions', () => {
 
             await handler({ type: 'completeSpec' } as any);
 
-            expect(setSpecStatus).toHaveBeenCalledWith(SPEC_DIR, 'completed');
+            expect(setStatus).toHaveBeenCalledWith(SPEC_DIR, 'completed');
         });
 
         it('should refresh the sidebar tree after setting status', async () => {
@@ -107,7 +115,7 @@ describe('messageHandlers - lifecycle actions', () => {
 
             await handler({ type: 'completeSpec' } as any);
 
-            expect(setSpecStatus).not.toHaveBeenCalled();
+            expect(setStatus).not.toHaveBeenCalled();
         });
     });
 
@@ -118,7 +126,7 @@ describe('messageHandlers - lifecycle actions', () => {
 
             await handler({ type: 'archiveSpec' } as any);
 
-            expect(setSpecStatus).toHaveBeenCalledWith(SPEC_DIR, 'archived');
+            expect(setStatus).toHaveBeenCalledWith(SPEC_DIR, 'archived');
         });
 
         it('should refresh the sidebar tree after setting status', async () => {
@@ -152,13 +160,13 @@ describe('messageHandlers - lifecycle actions', () => {
     });
 
     describe('reactivateSpec', () => {
-        it('should call setSpecStatus with active', async () => {
+        it('should call reactivate (canonical in-progress derivation)', async () => {
             const deps = createMockDeps();
             const handler = createMessageHandlers(SPEC_DIR, deps);
 
             await handler({ type: 'reactivateSpec' } as any);
 
-            expect(setSpecStatus).toHaveBeenCalledWith(SPEC_DIR, 'active');
+            expect(reactivate).toHaveBeenCalledWith(SPEC_DIR);
         });
 
         it('should refresh the sidebar tree after setting status', async () => {

--- a/src/features/spec-viewer/messageHandlers.ts
+++ b/src/features/spec-viewer/messageHandlers.ts
@@ -15,7 +15,9 @@ import { NotificationUtils } from '../../core/utils/notificationUtils';
 import type { CustomCommandConfig } from '../../core/types/config';
 import type { WorkflowStepConfig } from '../workflows/types';
 import { getFeatureWorkflow, getWorkflowCommands } from '../workflows';
-import { setSpecStatus, updateStepProgress } from '../specs/specContextManager';
+import { updateStepProgress } from '../specs/specContextManager';
+import { setStatus, reactivate, startStep, completeStep } from '../specs/stepLifecycle';
+import type { StepName } from '../../core/types/specContext';
 import { formatCommandForProvider } from '../../ai-providers/aiProvider';
 
 /**
@@ -199,8 +201,24 @@ async function handleRegenerate(
     const currentStep = steps.find(s => s.name === docType);
 
     if (currentStep) {
+        if (isLifecycleStep(docType)) {
+            await startStep(specDirectory, docType as StepName, 'extension');
+        }
         await executeStepInTerminal(currentStep, specDirectory, deps);
     }
+}
+
+const LIFECYCLE_STEP_NAMES: ReadonlySet<string> = new Set([
+    'specify',
+    'clarify',
+    'plan',
+    'tasks',
+    'analyze',
+    'implement',
+]);
+
+function isLifecycleStep(name: string): boolean {
+    return LIFECYCLE_STEP_NAMES.has(name);
 }
 
 /**
@@ -228,14 +246,25 @@ async function handleApprove(
         }
     }
 
+    // Mark the currently-viewed step as completed (independent of AI cooperation).
+    if (isLifecycleStep(docType)) {
+        await completeStep(specDirectory, docType as StepName, 'extension');
+    }
+
     if (currentIndex >= 0 && currentIndex < navSteps.length - 1) {
         // Execute next step's command
         const nextStep = navSteps[currentIndex + 1];
+        if (isLifecycleStep(nextStep.name)) {
+            await startStep(specDirectory, nextStep.name as StepName, 'extension');
+        }
         await executeStepInTerminal(nextStep, specDirectory, deps);
     } else if (currentIndex === navSteps.length - 1) {
         // Last navigable step: find the actionOnly implement step
         const implementStep = steps.find(s => s.actionOnly);
         if (implementStep) {
+            if (isLifecycleStep(implementStep.name)) {
+                await startStep(specDirectory, implementStep.name as StepName, 'extension');
+            }
             await executeStepInTerminal(implementStep, specDirectory, deps);
         }
     }
@@ -274,7 +303,11 @@ async function handleLifecycleAction(
     const label = status === SpecStatuses.ACTIVE ? 'reactivated' : status;
     deps.outputChannel.appendLine(`[SpecViewer] Setting spec status to ${status}: ${specDirectory}`);
 
-    await setSpecStatus(specDirectory, status);
+    if (status === SpecStatuses.ACTIVE) {
+        await reactivate(specDirectory);
+    } else {
+        await setStatus(specDirectory, status as 'completed' | 'archived');
+    }
     await vscode.commands.executeCommand('speckit.refresh');
     await deps.updateContent(specDirectory, instance.state.currentDocument);
 

--- a/src/features/specs/__tests__/stepLifecycle.test.ts
+++ b/src/features/specs/__tests__/stepLifecycle.test.ts
@@ -1,0 +1,100 @@
+import {
+    startStep,
+    completeStep,
+    startSubstep,
+    completeSubstep,
+} from '../stepLifecycle';
+
+const SPEC_DIR = '/workspace/specs/061-extension-lifecycle-writes';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+const mockUpdateSpecContext: jest.Mock<any, any> = jest.fn();
+const mockSetStepStarted: jest.Mock<any, any> = jest.fn();
+const mockSetStepCompleted: jest.Mock<any, any> = jest.fn();
+const mockSetSubstepStarted: jest.Mock<any, any> = jest.fn();
+const mockSetSubstepCompleted: jest.Mock<any, any> = jest.fn();
+
+jest.mock('../specContextWriter', () => ({
+    updateSpecContext: (...args: unknown[]) => mockUpdateSpecContext(...args),
+    setStepStarted: (...args: unknown[]) => mockSetStepStarted(...args),
+    setStepCompleted: (...args: unknown[]) => mockSetStepCompleted(...args),
+    setSubstepStarted: (...args: unknown[]) => mockSetSubstepStarted(...args),
+    setSubstepCompleted: (...args: unknown[]) => mockSetSubstepCompleted(...args),
+}));
+
+describe('stepLifecycle', () => {
+    let consoleErrorSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+        mockUpdateSpecContext.mockReset().mockResolvedValue(undefined);
+        mockSetStepStarted.mockClear();
+        mockSetStepCompleted.mockClear();
+        mockSetSubstepStarted.mockClear();
+        mockSetSubstepCompleted.mockClear();
+        consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+    });
+
+    afterEach(() => {
+        consoleErrorSpy.mockRestore();
+    });
+
+    describe('startStep', () => {
+        it('delegates to writer with step + by', async () => {
+            await startStep(SPEC_DIR, 'plan', 'extension');
+            expect(mockUpdateSpecContext).toHaveBeenCalledTimes(1);
+            const [dir, mutate] = mockUpdateSpecContext.mock.calls[0];
+            expect(dir).toBe(SPEC_DIR);
+            mutate({ stepHistory: {}, transitions: [] });
+            expect(mockSetStepStarted).toHaveBeenCalledWith(
+                expect.any(Object),
+                'plan',
+                'extension'
+            );
+        });
+
+        it('logs and does not throw when writer rejects', async () => {
+            mockUpdateSpecContext.mockRejectedValueOnce(new Error('disk full'));
+            await expect(startStep(SPEC_DIR, 'plan', 'extension')).resolves.toBeUndefined();
+            expect(consoleErrorSpy).toHaveBeenCalled();
+        });
+    });
+
+    describe('completeStep', () => {
+        it('delegates to writer with step + by', async () => {
+            await completeStep(SPEC_DIR, 'tasks', 'extension');
+            const [, mutate] = mockUpdateSpecContext.mock.calls[0];
+            mutate({ stepHistory: {}, transitions: [] });
+            expect(mockSetStepCompleted).toHaveBeenCalledWith(
+                expect.any(Object),
+                'tasks',
+                'extension'
+            );
+        });
+    });
+
+    describe('substep variants', () => {
+        it('startSubstep passes the canonical substep name through', async () => {
+            await startSubstep(SPEC_DIR, 'plan', 'research', 'extension');
+            const [, mutate] = mockUpdateSpecContext.mock.calls[0];
+            mutate({ stepHistory: {}, transitions: [] });
+            expect(mockSetSubstepStarted).toHaveBeenCalledWith(
+                expect.any(Object),
+                'plan',
+                'research',
+                'extension'
+            );
+        });
+
+        it('completeSubstep passes the canonical substep name through', async () => {
+            await completeSubstep(SPEC_DIR, 'plan', 'design', 'extension');
+            const [, mutate] = mockUpdateSpecContext.mock.calls[0];
+            mutate({ stepHistory: {}, transitions: [] });
+            expect(mockSetSubstepCompleted).toHaveBeenCalledWith(
+                expect.any(Object),
+                'plan',
+                'design',
+                'extension'
+            );
+        });
+    });
+});

--- a/src/features/specs/__tests__/terminalStepTracker.test.ts
+++ b/src/features/specs/__tests__/terminalStepTracker.test.ts
@@ -1,0 +1,54 @@
+import * as vscode from 'vscode';
+import { track, register, _resetForTests } from '../terminalStepTracker';
+
+const mockCompleteStep = jest.fn().mockResolvedValue(undefined);
+
+jest.mock('../stepLifecycle', () => ({
+    completeStep: (...args: unknown[]) => mockCompleteStep(...args),
+}));
+
+describe('terminalStepTracker', () => {
+    let listener: ((t: vscode.Terminal) => void | Promise<void>) | undefined;
+
+    beforeEach(() => {
+        _resetForTests();
+        mockCompleteStep.mockClear();
+        listener = undefined;
+        (vscode.window.onDidCloseTerminal as jest.Mock).mockReset().mockImplementation(
+            (cb: (t: vscode.Terminal) => void) => {
+                listener = cb;
+                return { dispose: jest.fn() };
+            }
+        );
+        register({} as vscode.ExtensionContext);
+    });
+
+    it('fires completeStep once when a tracked terminal closes', async () => {
+        const term = {} as vscode.Terminal;
+        track(term, '/specs/foo', 'plan');
+        await listener!(term);
+        expect(mockCompleteStep).toHaveBeenCalledTimes(1);
+        expect(mockCompleteStep).toHaveBeenCalledWith('/specs/foo', 'plan', 'extension');
+    });
+
+    it('is a no-op when an untracked terminal closes', async () => {
+        const term = {} as vscode.Terminal;
+        await listener!(term);
+        expect(mockCompleteStep).not.toHaveBeenCalled();
+    });
+
+    it('does not double-fire on a second close of the same terminal', async () => {
+        const term = {} as vscode.Terminal;
+        track(term, '/specs/foo', 'tasks');
+        await listener!(term);
+        await listener!(term);
+        expect(mockCompleteStep).toHaveBeenCalledTimes(1);
+    });
+
+    it('does nothing when track() is called with undefined terminal', async () => {
+        track(undefined, '/specs/foo', 'plan');
+        const other = {} as vscode.Terminal;
+        await listener!(other);
+        expect(mockCompleteStep).not.toHaveBeenCalled();
+    });
+});

--- a/src/features/specs/specCommands.ts
+++ b/src/features/specs/specCommands.ts
@@ -4,7 +4,7 @@ import { getAIProvider } from '../../extension';
 import { SpecExplorerProvider } from './specExplorerProvider';
 import { NotificationUtils } from '../../core/utils/notificationUtils';
 import type { CustomCommandConfig, SpecTreeItem } from '../../core/types/config';
-import { Commands, ConfigKeys, SpecStatuses, WorkflowSteps } from '../../core/constants';
+import { Commands, ConfigKeys, WorkflowSteps } from '../../core/constants';
 import { formatCommandForProvider } from '../../ai-providers/aiProvider';
 import { isInsideSpecDirectory, getFileWatcherPatterns } from '../../core/specDirectoryResolver';
 import {
@@ -15,7 +15,19 @@ import {
     WorkflowStep,
     WorkflowConfig,
 } from '../workflows';
-import { updateStepProgress, setSpecStatus } from './specContextManager';
+import { updateStepProgress } from './specContextManager';
+import { startStep, setStatus } from './stepLifecycle';
+import { track as trackTerminal } from './terminalStepTracker';
+import type { StepName } from '../../core/types/specContext';
+
+const LIFECYCLE_STEPS: ReadonlySet<string> = new Set([
+    'specify',
+    'plan',
+    'tasks',
+    'implement',
+    'clarify',
+    'analyze',
+]);
 
 /**
  * Register SpecKit workflow commands (create, specify, plan, tasks, etc.)
@@ -87,7 +99,7 @@ export function registerSpecKitCommands(
             if (workspaceFolder && item) {
                 const relativePath = (item as SpecTreeItem).specPath || `specs/${item.label}`;
                 const specDir = path.join(workspaceFolder.uri.fsPath, relativePath);
-                await setSpecStatus(specDir, SpecStatuses.COMPLETED);
+                await setStatus(specDir, 'completed');
                 specExplorer.refresh();
                 NotificationUtils.showAutoDismissNotification(`Spec "${item.label}" marked as completed`);
             }
@@ -101,7 +113,7 @@ export function registerSpecKitCommands(
             if (workspaceFolder && item) {
                 const relativePath = (item as SpecTreeItem).specPath || `specs/${item.label}`;
                 const specDir = path.join(workspaceFolder.uri.fsPath, relativePath);
-                await setSpecStatus(specDir, SpecStatuses.ARCHIVED);
+                await setStatus(specDir, 'archived');
                 specExplorer.refresh();
                 NotificationUtils.showAutoDismissNotification(`Spec "${item.label}" archived`);
             }
@@ -183,7 +195,13 @@ function registerPhaseCommands(
                 if (refinementContext) {
                     prompt += refinementContext;
                 }
-                await getAIProvider().executeInTerminal(prompt, `SpecKit - ${cmd.title}`);
+                if (LIFECYCLE_STEPS.has(cmd.name)) {
+                    await startStep(targetDir, cmd.name as StepName, 'extension');
+                }
+                const terminal = await getAIProvider().executeInTerminal(prompt, `SpecKit - ${cmd.title}`);
+                if (LIFECYCLE_STEPS.has(cmd.name)) {
+                    trackTerminal(terminal, targetDir, cmd.name as StepName);
+                }
             })
         );
     }
@@ -242,7 +260,13 @@ async function executeWorkflowStep(
         prompt += refinementContext;
     }
 
-    await getAIProvider().executeInTerminal(prompt, `SpecKit - ${title}`);
+    if (LIFECYCLE_STEPS.has(step)) {
+        await startStep(targetDir, step as StepName, 'extension');
+    }
+    const terminal = await getAIProvider().executeInTerminal(prompt, `SpecKit - ${title}`);
+    if (LIFECYCLE_STEPS.has(step)) {
+        trackTerminal(terminal, targetDir, step as StepName);
+    }
 
     // Execute checkpoints after implement step
     if (step === WorkflowSteps.IMPLEMENT) {

--- a/src/features/specs/stepLifecycle.ts
+++ b/src/features/specs/stepLifecycle.ts
@@ -1,0 +1,190 @@
+/**
+ * Thin wrapper around `specContextWriter` that the extension uses to record
+ * step/substep lifecycle transitions in `.spec-context.json` independently of
+ * AI cooperation. All errors are logged-and-swallowed (R002) so dispatch is
+ * never blocked by a write failure.
+ */
+
+import * as path from 'path';
+import * as vscode from 'vscode';
+import {
+    SpecContext,
+    StepName,
+    TransitionBy,
+} from '../../core/types/specContext';
+import {
+    appendTransition,
+    setStepStarted,
+    setStepCompleted,
+    setSubstepStarted,
+    setSubstepCompleted,
+    updateSpecContext,
+} from './specContextWriter';
+import { Status } from '../../core/types/specContext';
+import { deriveSpecName } from './specContextManager';
+
+let outputChannel: vscode.OutputChannel | undefined;
+
+/** Optional: register an output channel for lifecycle log messages. */
+export function setLifecycleOutputChannel(channel: vscode.OutputChannel): void {
+    outputChannel = channel;
+}
+
+function logError(action: string, err: unknown): void {
+    const msg = `[stepLifecycle] ${action} failed: ${err instanceof Error ? err.message : String(err)}`;
+    // eslint-disable-next-line no-console
+    console.error(msg);
+    outputChannel?.appendLine(msg);
+}
+
+function buildFallback(specDir: string, step: StepName): SpecContext {
+    return {
+        workflow: 'speckit',
+        specName: deriveSpecName(specDir),
+        branch: '',
+        currentStep: step,
+        status: 'draft',
+        stepHistory: {},
+        transitions: [],
+    };
+}
+
+export async function startStep(
+    specDir: string,
+    step: StepName,
+    by: TransitionBy
+): Promise<void> {
+    try {
+        await updateSpecContext(
+            specDir,
+            ctx => setStepStarted(ctx, step, by),
+            buildFallback(specDir, step)
+        );
+    } catch (err) {
+        logError(`startStep(${path.basename(specDir)}, ${step})`, err);
+    }
+}
+
+export async function completeStep(
+    specDir: string,
+    step: StepName,
+    by: TransitionBy
+): Promise<void> {
+    try {
+        await updateSpecContext(
+            specDir,
+            ctx => setStepCompleted(ctx, step, by),
+            buildFallback(specDir, step)
+        );
+    } catch (err) {
+        logError(`completeStep(${path.basename(specDir)}, ${step})`, err);
+    }
+}
+
+export async function startSubstep(
+    specDir: string,
+    step: StepName,
+    substep: string,
+    by: TransitionBy
+): Promise<void> {
+    try {
+        await updateSpecContext(
+            specDir,
+            ctx => setSubstepStarted(ctx, step, substep, by),
+            buildFallback(specDir, step)
+        );
+    } catch (err) {
+        logError(`startSubstep(${path.basename(specDir)}, ${step}/${substep})`, err);
+    }
+}
+
+/** Set canonical status (e.g., 'completed' | 'archived'). Logs a transition. */
+export async function setStatus(
+    specDir: string,
+    status: Status,
+    by: TransitionBy = 'extension'
+): Promise<void> {
+    try {
+        await updateSpecContext(
+            specDir,
+            ctx => {
+                const at = new Date().toISOString();
+                const next = appendTransition(
+                    { ...ctx, status },
+                    {
+                        step: ctx.currentStep,
+                        substep: null,
+                        from: { step: ctx.currentStep, substep: null },
+                        by,
+                        at,
+                    }
+                );
+                return next;
+            },
+            buildFallback(specDir, 'specify')
+        );
+    } catch (err) {
+        logError(`setStatus(${path.basename(specDir)}, ${status})`, err);
+    }
+}
+
+/** Reactivate: derive in-progress status from `currentStep`. */
+export async function reactivate(
+    specDir: string,
+    by: TransitionBy = 'extension'
+): Promise<void> {
+    try {
+        await updateSpecContext(
+            specDir,
+            ctx => {
+                const status = deriveInProgressStatus(ctx.currentStep);
+                const at = new Date().toISOString();
+                return appendTransition(
+                    { ...ctx, status },
+                    {
+                        step: ctx.currentStep,
+                        substep: null,
+                        from: { step: ctx.currentStep, substep: null },
+                        by,
+                        at,
+                    }
+                );
+            },
+            buildFallback(specDir, 'specify')
+        );
+    } catch (err) {
+        logError(`reactivate(${path.basename(specDir)})`, err);
+    }
+}
+
+function deriveInProgressStatus(step: StepName): Status {
+    switch (step) {
+        case 'specify':
+        case 'clarify':
+            return 'specifying';
+        case 'plan':
+            return 'planning';
+        case 'tasks':
+        case 'analyze':
+            return 'tasking';
+        case 'implement':
+            return 'implementing';
+    }
+}
+
+export async function completeSubstep(
+    specDir: string,
+    step: StepName,
+    substep: string,
+    by: TransitionBy
+): Promise<void> {
+    try {
+        await updateSpecContext(
+            specDir,
+            ctx => setSubstepCompleted(ctx, step, substep, by),
+            buildFallback(specDir, step)
+        );
+    } catch (err) {
+        logError(`completeSubstep(${path.basename(specDir)}, ${step}/${substep})`, err);
+    }
+}

--- a/src/features/specs/terminalStepTracker.ts
+++ b/src/features/specs/terminalStepTracker.ts
@@ -1,0 +1,44 @@
+/**
+ * Tracks which spec/step a spawned terminal is associated with so that
+ * `vscode.window.onDidCloseTerminal` can fire `stepLifecycle.completeStep`
+ * when the AI never wrote `.spec-context.json` itself.
+ */
+
+import * as vscode from 'vscode';
+import { StepName } from '../../core/types/specContext';
+import { completeStep } from './stepLifecycle';
+
+interface Tracked {
+    specDir: string;
+    step: StepName;
+}
+
+const tracked = new Map<vscode.Terminal, Tracked>();
+
+/** Associate a terminal with a spec/step so close → completeStep. */
+export function track(
+    terminal: vscode.Terminal | undefined,
+    specDir: string,
+    step: StepName
+): void {
+    if (!terminal) return;
+    tracked.set(terminal, { specDir, step });
+}
+
+/**
+ * Subscribe to terminal-close events. Returns a disposable that the caller
+ * pushes into `context.subscriptions`.
+ */
+export function register(_context: vscode.ExtensionContext): vscode.Disposable {
+    return vscode.window.onDidCloseTerminal(async terminal => {
+        const entry = tracked.get(terminal);
+        if (!entry) return;
+        tracked.delete(terminal);
+        await completeStep(entry.specDir, entry.step, 'extension');
+    });
+}
+
+/** Test helper — clears all tracked terminals. */
+export function _resetForTests(): void {
+    tracked.clear();
+}

--- a/tests/__mocks__/vscode.ts
+++ b/tests/__mocks__/vscode.ts
@@ -111,6 +111,7 @@ export const window = {
     showTextDocument: jest.fn(),
     activeTextEditor: undefined as any,
     createTerminal: jest.fn().mockReturnValue({ show: jest.fn(), sendText: jest.fn() }),
+    onDidCloseTerminal: jest.fn().mockReturnValue({ dispose: jest.fn() }),
     createOutputChannel: jest.fn().mockReturnValue({
         appendLine: jest.fn(),
         show: jest.fn(),


### PR DESCRIPTION
## What

- Extension now records `stepHistory[step].startedAt` / `completedAt` and canonical `status` whenever a step is dispatched (commands or viewer Approve/Regenerate), independent of AI cooperation.
- New `terminalStepTracker` fires `completeStep` on `onDidCloseTerminal` for tracked terminals.
- `setSpecStatus` calls in `specCommands.ts` and `messageHandlers.ts` replaced with canonical `setStatus`/`reactivate` helpers that route through `specContextWriter.updateSpecContext` and append a transition entry.

## Why

The viewer needs lifecycle truth even when the AI never writes `.spec-context.json` (R001/R002/R003).

## Testing

- `npm run compile` clean
- `npx jest` — 214 tests pass (5 new for stepLifecycle, 4 new for terminalStepTracker)
- Manual: launching a step now populates `startedAt` immediately; closing the terminal writes `completedAt`.