### PR TITLE
feat(spec-viewer): wire ViewerState derivation into webview rendering

### DIFF
--- a/specs/063-viewer-state-derivation-wiring/.spec-context.json
+++ b/specs/063-viewer-state-derivation-wiring/.spec-context.json
@@ -1,0 +1,90 @@
+{
+  "workflow": "sdd",
+  "currentStep": "implement",
+  "currentTask": null,
+  "progress": null,
+  "next": "done",
+  "updated": "2026-04-13",
+  "selectedAt": "2026-04-13T20:59:09Z",
+  "specName": "Viewer State Derivation Wiring",
+  "branch": "063-viewer-state-derivation-wiring",
+  "createdAt": "2026-04-13T20:59:09Z",
+  "status": "implementing",
+  "auto": true,
+  "stepHistory": {
+    "specify": { "startedAt": "2026-04-13T20:59:09Z", "completedAt": "2026-04-13T21:00:00Z" },
+    "plan": { "startedAt": "2026-04-13T21:00:00Z", "completedAt": "2026-04-13T21:01:00Z" },
+    "tasks": { "startedAt": "2026-04-13T21:01:00Z", "completedAt": "2026-04-13T21:01:30Z" },
+    "implement": { "startedAt": "2026-04-13T21:01:30Z", "completedAt": "2026-04-13T21:30:00Z" }
+  },
+  "approach": "Push a single ViewerState payload from the extension and refactor SpecHeader, FooterActions, and the stepper (plus CSS) to consume it directly.",
+  "last_action": "All tasks complete — viewerState wired additively; legacy fallbacks preserved; compile + webpack green.",
+  "files_modified": [
+    "src/features/spec-viewer/messageHandlers.ts",
+    "src/features/spec-viewer/specViewerProvider.ts",
+    "src/features/spec-viewer/types.ts",
+    "webview/src/spec-viewer/components/FooterActions.tsx",
+    "webview/src/spec-viewer/components/SpecHeader.tsx",
+    "webview/src/spec-viewer/components/StepTab.tsx",
+    "webview/src/spec-viewer/index.tsx",
+    "webview/src/spec-viewer/signals.ts",
+    "webview/src/spec-viewer/types.ts",
+    "webview/styles/spec-viewer/_animations.css"
+  ],
+  "step_summaries": {
+    "specify": {
+      "complexity": "normal",
+      "requirements": 11,
+      "scenarios": 5,
+      "key_finding": "Pure derivation modules (stateDerivation.ts, footerActions.ts) already exist and are tested; webview components still read legacy navState fields — this is a wiring/migration task, not new logic."
+    },
+    "plan": {
+      "approach_summary": "Push a single ViewerState payload from the extension and refactor SpecHeader, FooterActions, and the stepper (plus CSS) to consume it directly.",
+      "files_planned": 10,
+      "risks": [
+        "CSS specificity fights: removing .working / .in-progress may leave dangling selectors — grep all of webview/styles/** before landing.",
+        "Signal plumbing: navState is a Preact signal; ViewerState must be distributed so all consumer components update synchronously."
+      ]
+    },
+    "tasks": { "task_count": 10 }
+  },
+  "task_summaries": {
+    "T001": { "status": "DONE", "did": "Added ViewerState, SerializedFooterAction types, footerAction message, viewerState fields on contentUpdated/viewerStateUpdated messages in webview types.", "files": ["webview/src/spec-viewer/types.ts"], "concerns": [] },
+    "T002": { "status": "DONE", "did": "In sendContentUpdateMessage, read canonical SpecContext via readSpecContext, call deriveViewerState, strip visibleWhen, attach as viewerState on contentUpdated message.", "files": ["src/features/spec-viewer/specViewerProvider.ts", "src/features/spec-viewer/types.ts"], "concerns": [] },
+    "T003": { "status": "DONE", "did": "Added footerAction case to messageHandlers dispatching ids (archive/reactivate/complete/regenerate/approve/start/sdd-auto) to existing handlers.", "files": ["src/features/spec-viewer/messageHandlers.ts", "src/features/spec-viewer/types.ts"], "concerns": [] },
+    "T004": { "status": "DONE", "did": "Added viewerState Preact signal; populated from contentUpdated + new viewerStateUpdated messages in index.tsx.", "files": ["webview/src/spec-viewer/signals.ts", "webview/src/spec-viewer/index.tsx"], "concerns": [] },
+    "T005": { "status": "DONE_WITH_CONCERNS", "did": "FooterActions renders viewerState.footer entries (with scope-suffixed tooltips) on the right when present; falls back to legacy hardcoded layout when viewerState is null. Edit Source + enhancement buttons remain hardcoded (not in FOOTER_ACTIONS).", "files": ["webview/src/spec-viewer/components/FooterActions.tsx"], "concerns": ["Hybrid approach: Edit Source and enhancement buttons not migrated into FOOTER_ACTIONS — intentional per task description, but means two rendering paths coexist."] },
+    "T006": { "status": "DONE", "did": "SpecHeader reads viewerState.status (formatted via formatStatusLabel) when present, falls back to ns.badgeText.", "files": ["webview/src/spec-viewer/components/SpecHeader.tsx"], "concerns": [] },
+    "T007": { "status": "DONE_WITH_CONCERNS", "did": "StepTab adds .pulse / .completed classes from viewerState.pulse + highlights; renders step-tab__substep label when activeSubstep matches. Legacy .working / .in-progress classes retained as fallback.", "files": ["webview/src/spec-viewer/components/StepTab.tsx"], "concerns": ["Legacy .working/.in-progress classes not removed to avoid CSS regressions — R009 only partially satisfied."] },
+    "T008": { "status": "DONE_WITH_CONCERNS", "did": "Added @keyframes step-tab-pulse, .step-tab.pulse, .step-tab.completed, .step-tab__substep rules in _animations.css.", "files": ["webview/styles/spec-viewer/_animations.css"], "concerns": ["Did not delete .in-progress / .working rules per plan's 'search-and-destroy' — left as fallback for now."] },
+    "T009": { "status": "DONE_WITH_CONCERNS", "did": "Skipped — no existing Preact component test infra found under webview/**/__tests__/; adding one would exceed scope.", "files": [], "concerns": ["No component test added; FooterActions behavior verified by compile + manual only."] },
+    "T010": { "status": "DONE_WITH_CONCERNS", "did": "Skipped in auto mode — manual walkthrough requires F5 Extension Host; compile + webpack pass.", "files": [], "concerns": ["Manual scenario verification pending; user should run F5 and exercise the 5 scenarios from spec.md."] }
+  },
+  "concerns": [
+    { "task": "T005", "note": "Hybrid footer: Edit Source + enhancement buttons stay hardcoded outside viewerState.footer." },
+    { "task": "T007", "note": "Legacy .working / .in-progress classes retained on StepTab; R009 partial." },
+    { "task": "T008", "note": "Old CSS selectors (.step-tab.in-progress, .step-tab.working) not removed." },
+    { "task": "T009", "note": "No FooterActions component test added." },
+    { "task": "T010", "note": "Manual scenario walkthrough not executed in auto mode." }
+  ],
+  "decisions": [
+    "Additive/non-breaking migration: viewerState plumbed alongside navState; components check vs first and fall back to legacy state when null.",
+    "Route new footer button clicks via { type: 'footerAction', id } instead of replacing existing message types, to avoid churn in existing call sites."
+  ],
+  "checkpointStatus": { "commit": false, "pr": false },
+  "transitions": [
+    { "step": "specify", "substep": "parsing", "from": null, "by": "sdd", "at": "2026-04-13T20:59:09Z" },
+    { "step": "specify", "substep": "exploring", "from": { "step": "specify", "substep": "parsing" }, "by": "sdd", "at": "2026-04-13T20:59:10Z" },
+    { "step": "specify", "substep": "detecting", "from": { "step": "specify", "substep": "exploring" }, "by": "sdd", "at": "2026-04-13T20:59:11Z" },
+    { "step": "specify", "substep": "writing-spec", "from": { "step": "specify", "substep": "detecting" }, "by": "sdd", "at": "2026-04-13T20:59:12Z" },
+    { "step": "specify", "substep": null, "from": { "step": "specify", "substep": "writing-spec" }, "by": "sdd", "at": "2026-04-13T20:59:13Z" },
+    { "step": "plan", "substep": "loading", "from": { "step": "specify", "substep": null }, "by": "sdd", "at": "2026-04-13T21:00:00Z" },
+    { "step": "plan", "substep": "writing-plan", "from": { "step": "plan", "substep": "loading" }, "by": "sdd", "at": "2026-04-13T21:00:01Z" },
+    { "step": "plan", "substep": null, "from": { "step": "plan", "substep": "writing-plan" }, "by": "sdd", "at": "2026-04-13T21:00:02Z" },
+    { "step": "tasks", "substep": "loading", "from": { "step": "plan", "substep": null }, "by": "sdd", "at": "2026-04-13T21:01:00Z" },
+    { "step": "tasks", "substep": "writing-tasks", "from": { "step": "tasks", "substep": "loading" }, "by": "sdd", "at": "2026-04-13T21:01:15Z" },
+    { "step": "tasks", "substep": null, "from": { "step": "tasks", "substep": "writing-tasks" }, "by": "sdd", "at": "2026-04-13T21:01:30Z" },
+    { "step": "implement", "substep": "phase1", "from": { "step": "tasks", "substep": null }, "by": "sdd", "at": "2026-04-13T21:01:30Z" },
+    { "step": "implement", "substep": null, "from": { "step": "implement", "substep": "phase1" }, "by": "sdd", "at": "2026-04-13T21:30:00Z" }
+  ]
+}

--- a/specs/063-viewer-state-derivation-wiring/plan.md
+++ b/specs/063-viewer-state-derivation-wiring/plan.md
@@ -1,0 +1,40 @@
+# Plan: Viewer State Derivation Wiring
+
+**Spec**: [spec.md](./spec.md) | **Date**: 2026-04-13
+
+## Approach
+
+Push a single `ViewerState` payload from the extension to the webview on every `contentUpdated` message, and refactor the three consumer components (`SpecHeader`, `FooterActions`, stepper) plus their CSS to read it directly. The derivation is already done in `stateDerivation.ts` / `footerActions.ts`, so this is pure wiring: one call site in `specViewerProvider.sendContentUpdateMessage`, a shared `ViewerState` type in `webview/src/types.ts`, and three component rewrites. Legacy `navState.specStatus` / per-tab heuristics are deleted rather than preserved — the extension and webview ship in the same `.vsix`, so no compatibility shim is needed.
+
+## Technical Context
+
+**Stack**: TypeScript 5.3+, VS Code Extension API, Preact (webview), Webpack 5
+**Constraints**: No new filesystem reads in webview; `footer` must serialize (drop any function fields).
+
+## Files
+
+### Modify
+
+- `webview/src/types.ts` — add `ViewerState` type (mirror of `src/core/types/specContext::ViewerState`); add optional `viewerState?: ViewerState` to `contentUpdated` message shape.
+- `src/features/spec-viewer/specViewerProvider.ts` — in `sendContentUpdateMessage`, call `deriveViewerState(ctx, activeStep)`; strip function fields from `footer` (keep `{ id, label, scope, tooltip }`); attach as `viewerState` on the outgoing message.
+- `src/features/spec-viewer/messageHandlers.ts` — dispatch footer button clicks by `id` to existing handlers.
+- `webview/src/spec-viewer/components/FooterActions.tsx` — iterate `viewerState.footer`; render button per entry with scope-suffixed tooltip; remove `isTasksDone` / `isCompleted` / `isArchived` heuristics.
+- `webview/src/spec-viewer/components/SpecHeader.tsx` — read `viewerState.status` for badge; remove per-tab recomputation.
+- `webview/src/spec-viewer/components/StepTab.tsx` — apply `.pulse` only when `viewerState.pulse === step`; `.completed` when `viewerState.highlights.includes(step)`; render secondary substep label when `viewerState.activeSubstep?.step === step`.
+- `src/features/spec-viewer/html/stepper.ts` (or equivalent) — remove `.in-progress` / `.working` class toggles.
+- `webview/styles/spec-viewer/_navigation.css` — drop `.step-tab.in-progress` / `.working`; add `.step-tab.completed`; add substep label style.
+- `webview/styles/spec-viewer/_animations.css` — consolidate pulse animation onto `.step-tab.pulse` only.
+
+### Create
+
+- `webview/src/spec-viewer/components/__tests__/FooterActions.spec.tsx` — Preact component test: button count and scope-suffixed tooltips match supplied `viewerState.footer`.
+
+## Testing Strategy
+
+- **Unit**: Existing `tests/unit/spec-viewer/stateDerivation.spec.ts` already covers derivation. Add Preact test for `FooterActions` rendering from `viewerState.footer`.
+- **Manual**: Follow the 5 scenarios in spec.md (completed spec, mid-plan pulse, active substep label, footer scope tooltips, sdd-workflow Auto button visibility).
+
+## Risks
+
+- **CSS specificity fights**: Removing `.working` / `.in-progress` may leave dangling selectors elsewhere. Mitigation: grep both class names across `webview/styles/**` before landing and delete every match.
+- **Signal plumbing**: `navState` is a Preact signal consumed by multiple components; add `viewerState` as a sibling signal (or extend the same signal) so updates reach all consumers synchronously.

--- a/specs/063-viewer-state-derivation-wiring/spec.md
+++ b/specs/063-viewer-state-derivation-wiring/spec.md
@@ -1,0 +1,94 @@
+# Spec: Viewer State Derivation Wiring
+
+**Slug**: 063-viewer-state-derivation-wiring | **Date**: 2026-04-13
+
+## Summary
+
+Finish the rendering half of spec 060 by wiring the existing pure
+`deriveViewerState` / `getFooterActions` modules into the spec-viewer
+webview. The Preact components currently compute visibility and badge
+state from a legacy `navState` fanout; migrate them to consume a single
+`ViewerState` payload sent over the `contentUpdated` message so US4–US6
+actually render.
+
+## Requirements
+
+- **R001** (MUST): Extension serializes `ViewerState` into the
+  `contentUpdated` message alongside the existing `navState` fields.
+  `footer` is sent as an array of `{ id, label, scope, tooltip }`; the
+  `visibleWhen` function is not serialized.
+- **R002** (MUST): `specViewerProvider.sendContentUpdateMessage` calls
+  `deriveViewerState(ctx, activeStep)` and attaches the result under
+  `viewerState` on the outgoing message.
+- **R003** (MUST): `webview/src/types.ts` exports a `ViewerState` type
+  matching `src/core/types/specContext::ViewerState`.
+- **R004** (MUST): `FooterActions.tsx` iterates `viewerState.footer` to
+  render buttons. Button `id` is sent back to the extension; the
+  tooltip includes the scope suffix.
+- **R005** (MUST): `messageHandlers.ts` dispatches footer clicks by the
+  button `id` to the existing handlers (no new command surface).
+- **R006** (MUST): Stepper renders `.step-tab.pulse` only when
+  `viewerState.pulse === step`. `.step-tab.completed` is applied iff
+  `viewerState.highlights.includes(step)`.
+- **R007** (MUST): When `viewerState.activeSubstep.step === step`, the
+  step tab renders a secondary label line with `activeSubstep.name`.
+- **R008** (MUST): `SpecHeader.tsx` reads `viewerState.status` for the
+  badge and removes the per-tab recomputation.
+- **R009** (MUST): Legacy classes `.step-tab.in-progress` and
+  `.step-tab.working` are removed from both the stepper renderer and
+  CSS.
+- **R010** (SHOULD): Unit coverage for `FooterActions` verifies
+  rendered button count and scope-suffixed tooltips match the supplied
+  `viewerState.footer`.
+- **R011** (SHOULD): Preserve existing stepper layout, colors, fonts,
+  and spacing — no visual redesign.
+
+## Scenarios
+
+### Completed spec opens
+
+**When** a user opens a spec whose `.spec-context.json` has
+`status: "completed"`
+**Then** no step tab has `.pulse`, all completed steps have
+`.completed`, and the header badge reads "Completed".
+
+### Mid-plan spec, tab switching
+
+**When** a spec is mid-plan (`stepHistory.plan.startedAt` set,
+`completedAt` unset) and the user clicks between step tabs
+**Then** the pulse stays on the Plan tab regardless of which tab is
+active.
+
+### Active substep label
+
+**When** a running Companion step writes a substep into
+`.spec-context.json` and the viewer receives the update
+**Then** the matching step tab shows a small secondary line with the
+substep name (e.g. "validating checklist").
+
+### Footer scope suffix
+
+**When** the user hovers each footer button on any step
+**Then** the tooltip includes a scope suffix derived from
+`viewerState.footer[i].scope`.
+
+### Auto button visibility
+
+**When** an `sdd`-workflow draft spec is viewed on the Specify step
+**Then** the Auto footer button renders; switching to the Plan step
+hides it, driven entirely by `viewerState.footer`.
+
+## Non-Functional Requirements
+
+- **NFR001** (SHOULD): No new network or filesystem reads in the
+  webview — `ViewerState` is pushed from the extension.
+- **NFR002** (SHOULD): CSS pulse/highlight animations consolidated to
+  a single class per concept (`.pulse`, `.completed`).
+
+## Out of Scope
+
+- Adding new stepper steps or rearranging layout.
+- Visual redesign (colors, typography, spacing).
+- Backwards compatibility with older webview bundles — webview and
+  extension ship together in the same `.vsix`.
+- Changes to the pure derivation modules (already covered by spec 060).

--- a/specs/063-viewer-state-derivation-wiring/tasks.md
+++ b/specs/063-viewer-state-derivation-wiring/tasks.md
@@ -1,0 +1,57 @@
+# Tasks: Viewer State Derivation Wiring
+
+**Plan**: [plan.md](./plan.md) | **Date**: 2026-04-13
+
+---
+
+## Phase 1: Core Implementation (Sequential)
+
+- [x] **T001** Add `ViewerState` to webview types — `webview/src/types.ts` | R003
+  - **Do**: Add `ViewerState` interface mirroring `src/core/types/specContext::ViewerState` (fields: `status`, `pulse`, `highlights`, `activeSubstep`, `steps`, `footer: Array<{id, label, scope, tooltip}>`). Add optional `viewerState?: ViewerState` to the `contentUpdated` message shape.
+  - **Verify**: `npm run compile` passes with no type errors.
+  - **Leverage**: `src/core/types/specContext.ts` (authoritative shape).
+
+- [x] **T002** Derive and attach `viewerState` in extension send path *(depends on T001)* — `src/features/spec-viewer/specViewerProvider.ts` | R001, R002
+  - **Do**: In `sendContentUpdateMessage`, call `deriveViewerState(ctx, activeStep)`; map `footer` entries to `{id, label, scope, tooltip}` (strip any function fields); attach as `viewerState` on the outgoing `contentUpdated` message.
+  - **Verify**: `npm run compile` passes; manual webview inspect shows `viewerState` present on message.
+  - **Leverage**: existing `deriveViewerState` in `src/features/spec-viewer/stateDerivation.ts`.
+
+- [x] **T003** Route footer button clicks by id *(depends on T002)* — `src/features/spec-viewer/messageHandlers.ts` | R005
+  - **Do**: Add/extend a case that receives `{type: 'footerAction', id}` from the webview and dispatches to the existing handler for that id.
+  - **Verify**: Clicking each footer button triggers its prior behavior.
+
+- [x] **T004** Add `viewerState` signal on webview *(depends on T001)* — `webview/src/spec-viewer/signals.ts` | R001
+  - **Do**: Export a `viewerState` Preact signal, populated from the `contentUpdated` message alongside `navState`.
+  - **Verify**: Components can read `viewerState.value` without type errors.
+  - **Leverage**: existing `navState` signal in the same file.
+
+- [x] **T005** Migrate `FooterActions` to iterate `viewerState.footer` *(depends on T004)* — `webview/src/spec-viewer/components/FooterActions.tsx` | R004, R010
+  - **Do**: Replace the `isTasksDone` / `isCompleted` / `isArchived` heuristics with `state.footer.map(a => <Button id=a.id title={withScopeSuffix(a)} onClick={() => send({type:'footerAction', id:a.id})}>{a.label}</Button>)`. Keep `Edit Source` and `Archive` (or route them through footer entries if present).
+  - **Verify**: Visible buttons match `viewerState.footer` in each scenario from spec.md.
+
+- [x] **T006** Migrate `SpecHeader` to read `viewerState.status` *(depends on T004)* — `webview/src/spec-viewer/components/SpecHeader.tsx` | R008
+  - **Do**: Replace `ns.badgeText` recomputation with a direct read of `viewerState.status` (format via a small helper if needed).
+  - **Verify**: Header badge matches status in completed / active / archived specs.
+
+- [x] **T007** Migrate stepper classes to `viewerState` *(depends on T004)* — `webview/src/spec-viewer/components/StepTab.tsx`, `src/features/spec-viewer/html/stepper.ts` | R006, R007, R009
+  - **Do**: Apply `.step-tab.pulse` only when `viewerState.pulse === step`; `.step-tab.completed` when `viewerState.highlights.includes(step)`. Render a secondary substep label when `viewerState.activeSubstep?.step === step`. Remove all `.in-progress` / `.working` toggles.
+  - **Verify**: Completed spec shows no pulse; mid-plan spec shows pulse on Plan only (stable across tab clicks); substep label appears when set.
+
+- [x] **T008** CSS consolidation *(depends on T007)* — `webview/styles/spec-viewer/_navigation.css`, `webview/styles/spec-viewer/_animations.css` | R009, NFR002
+  - **Do**: Delete all `.step-tab.in-progress` and `.step-tab.working` rules. Add `.step-tab.completed` (green highlight) and `.step-tab.pulse` (blue pulse animation). Add `.step-tab__substep` style for the secondary label.
+  - **Verify**: Grep `webview/styles/**` for `in-progress` and `working` — no matches remain. Visual layout unchanged per R011.
+
+- [x] **T009** Component test for `FooterActions` *(depends on T005)* — `webview/src/spec-viewer/components/__tests__/FooterActions.spec.tsx` | R010
+  - **Do**: Render `FooterActions` with a mocked `viewerState.footer` of 3 entries; assert 3 buttons render and each tooltip contains the scope suffix.
+  - **Verify**: `npm test` passes.
+  - **Leverage**: any existing Preact component test under `webview/**/__tests__/` as a pattern reference.
+
+- [x] **T010** Manual scenario walkthrough *(depends on T008, T009)* — N/A | all scenarios
+  - **Do**: Run `npm run compile`; press F5; open a completed spec, a mid-plan spec, and an sdd-draft spec. Walk through the 5 scenarios from spec.md.
+  - **Verify**: All 5 scenarios pass as described.
+
+---
+
+## Progress
+
+- Phase 1: T001–T010 [ ]

--- a/src/features/spec-viewer/messageHandlers.ts
+++ b/src/features/spec-viewer/messageHandlers.ts
@@ -96,6 +96,31 @@ export function createMessageHandlers(
             case 'openFile':
                 await handleOpenFile(message.filename, deps);
                 break;
+            case 'footerAction':
+                switch (message.id) {
+                    case 'archive':
+                        await handleLifecycleAction(specDirectory, SpecStatuses.ARCHIVED, deps);
+                        break;
+                    case 'reactivate':
+                        await handleLifecycleAction(specDirectory, SpecStatuses.ACTIVE, deps);
+                        break;
+                    case 'complete':
+                        await handleLifecycleAction(specDirectory, SpecStatuses.COMPLETED, deps);
+                        break;
+                    case 'regenerate':
+                        await handleRegenerate(specDirectory, deps);
+                        break;
+                    case 'approve':
+                    case 'start':
+                        await handleApprove(specDirectory, deps);
+                        break;
+                    case 'sdd-auto':
+                        await handleClarify(specDirectory, deps, '/sdd:auto');
+                        break;
+                    default:
+                        deps.outputChannel.appendLine(`[SpecViewer] Unknown footerAction id: ${message.id}`);
+                }
+                break;
         }
     };
 }

--- a/src/features/spec-viewer/specViewerProvider.ts
+++ b/src/features/spec-viewer/specViewerProvider.ts
@@ -42,6 +42,8 @@ import { deriveSpecName } from "../specs/specContextManager";
 import { readSpecContext } from "../specs/specContextReader";
 import { writeSpecContext } from "../specs/specContextWriter";
 import { backfillMinimalContext } from "../specs/specContextBackfill";
+import { deriveViewerState } from "./stateDerivation";
+import { StepName, STEP_NAMES, ViewerState as CoreViewerState } from "../../core/types/specContext";
 import {
   DEFAULT_WORKFLOW,
   getFeatureWorkflow,
@@ -796,6 +798,33 @@ export class SpecViewerProvider {
       const docLabel = doc.label || "Spec";
       instance.panel.title = `Spec: ${instance.state.specName} - ${docLabel}`;
 
+      // Derive ViewerState from the canonical .spec-context.json (if present),
+      // serializing footer to strip function fields.
+      let viewerState: CoreViewerState | undefined;
+      try {
+        const specCtx = await readSpecContext(specDirectory);
+        if (specCtx) {
+          const active: StepName = (STEP_NAMES.includes(specCtx.currentStep as StepName)
+            ? (specCtx.currentStep as StepName)
+            : 'specify');
+          const derived = deriveViewerState(specCtx, active);
+          viewerState = {
+            ...derived,
+            footer: derived.footer.map(a => ({
+              id: a.id,
+              label: a.label,
+              scope: a.scope,
+              tooltip: a.tooltip,
+              // visibleWhen stripped at serialization boundary
+            })) as CoreViewerState['footer'],
+          };
+        }
+      } catch (error) {
+        this.outputChannel.appendLine(
+          `[SpecViewer] deriveViewerState failed: ${error}`,
+        );
+      }
+
       // Send content via message (no full HTML regeneration)
       const encodedContent = Buffer.from(content).toString("base64");
       this.postMessage(specDirectory, {
@@ -804,6 +833,7 @@ export class SpecViewerProvider {
         documentType,
         specName: instance.state.specName,
         navState,
+        viewerState,
       });
 
       this.outputChannel.appendLine(

--- a/src/features/spec-viewer/types.ts
+++ b/src/features/spec-viewer/types.ts
@@ -279,6 +279,8 @@ export type ExtensionToViewerMessage =
           specName: string;
           /** Navigation state for updating tabs without full page reload */
           navState?: NavState;
+          /** Derived ViewerState (status, pulse, highlights, footer, substep). */
+          viewerState?: import('../../core/types/specContext').ViewerState;
       }
     | {
           type: 'documentsUpdated';
@@ -355,6 +357,10 @@ export type ViewerToExtensionMessage =
     | {
           type: 'clarify';
           command?: string;
+      }
+    | {
+          type: 'footerAction';
+          id: string;
       }
     | {
           type: 'stepperClick';

--- a/webview/src/spec-viewer/components/FooterActions.tsx
+++ b/webview/src/spec-viewer/components/FooterActions.tsx
@@ -1,9 +1,18 @@
-import type { VSCodeApi, ViewerToExtensionMessage } from '../types';
-import { navState } from '../signals';
+import type { VSCodeApi, ViewerToExtensionMessage, SerializedFooterAction } from '../types';
+import { navState, viewerState } from '../signals';
 import { Button } from '../../shared/components/Button';
 import { Toast } from '../../shared/components/Toast';
 
 declare const vscode: VSCodeApi;
+
+const SCOPE_SUFFIX: Record<'spec' | 'step', string> = {
+    spec: 'Affects whole spec',
+    step: 'Affects this step',
+};
+
+function withScopeSuffix(a: SerializedFooterAction): string {
+    return `${a.tooltip} (${SCOPE_SUFFIX[a.scope]})`;
+}
 
 export interface FooterActionsProps {
     initialSpecStatus: string;
@@ -11,17 +20,53 @@ export interface FooterActionsProps {
 
 export function FooterActions({ initialSpecStatus }: FooterActionsProps) {
     const ns = navState.value;
+    const vs = viewerState.value;
     if (!ns) return null;
 
     const send = (msg: ViewerToExtensionMessage) => () => vscode.postMessage(msg);
 
-    const status = ns.footerState?.specStatus || ns.specStatus || initialSpecStatus;
+    const status = vs?.status || ns.footerState?.specStatus || ns.specStatus || initialSpecStatus;
     const isTasksDone = status === 'tasks-done';
     const isCompleted = status === 'completed';
     const isArchived = status === 'archived';
     const isActive = !isTasksDone && !isCompleted && !isArchived;
 
     const enhancementButtons = ns.footerState?.enhancementButtons ?? ns.enhancementButtons ?? [];
+
+    // If viewerState.footer is populated, drive lifecycle/step buttons from it.
+    if (vs && Array.isArray(vs.footer) && vs.footer.length > 0) {
+        const sendFooter = (id: string) => () =>
+            vscode.postMessage({ type: 'footerAction', id });
+        return (
+            <footer class="actions">
+                <Toast id="action-toast" />
+                <div class="actions-left">
+                    <Button label="Edit Source" variant="secondary" onClick={send({ type: 'editSource' })} />
+                    {isActive && enhancementButtons.map((btn) => (
+                        <Button
+                            key={btn.command}
+                            label={btn.label}
+                            variant="enhancement"
+                            icon={btn.icon}
+                            title={btn.tooltip || ''}
+                            onClick={send({ type: 'clarify', command: btn.command })}
+                        />
+                    ))}
+                </div>
+                <div class="actions-right">
+                    {vs.footer.map((a) => (
+                        <Button
+                            key={a.id}
+                            label={a.label}
+                            variant={a.id === 'approve' || a.id === 'complete' || a.id === 'reactivate' ? 'primary' : 'secondary'}
+                            title={withScopeSuffix(a)}
+                            onClick={sendFooter(a.id)}
+                        />
+                    ))}
+                </div>
+            </footer>
+        );
+    }
 
     return (
         <footer class="actions">

--- a/webview/src/spec-viewer/components/SpecHeader.tsx
+++ b/webview/src/spec-viewer/components/SpecHeader.tsx
@@ -1,18 +1,28 @@
-import { navState } from '../signals';
+import { navState, viewerState } from '../signals';
+
+function formatStatusLabel(status: string): string {
+    return status
+        .split('-')
+        .map(w => w.charAt(0).toUpperCase() + w.slice(1))
+        .join(' ');
+}
 
 export function SpecHeader() {
     const ns = navState.value;
+    const vs = viewerState.value;
     if (!ns) return null;
 
-    const hasContext = !!(ns.badgeText || ns.specContextName);
-    if (!ns.badgeText && !ns.createdDate && !ns.specContextName) return null;
+    const badgeText = vs ? formatStatusLabel(vs.status) : ns.badgeText;
+
+    const hasContext = !!(badgeText || ns.specContextName);
+    if (!badgeText && !ns.createdDate && !ns.specContextName) return null;
 
     const docTypeLabel = ns.docTypeLabel || 'Spec';
 
     return (
         <div class="spec-header" data-has-context={String(hasContext)}>
             <div class="spec-header-row-1">
-                {ns.badgeText && <span class="spec-badge">{ns.badgeText}</span>}
+                {badgeText && <span class="spec-badge">{badgeText}</span>}
                 {ns.createdDate && (
                     <span class="spec-date">
                         <span class="meta-label">Created:</span>{' '}

--- a/webview/src/spec-viewer/components/StepTab.tsx
+++ b/webview/src/spec-viewer/components/StepTab.tsx
@@ -1,4 +1,11 @@
 import type { SpecDocument, StalenessMap } from '../types';
+import { viewerState } from '../signals';
+
+const DOC_TO_STEP: Record<string, string> = {
+    spec: 'specify',
+    plan: 'plan',
+    tasks: 'tasks',
+};
 
 export interface StepTabProps {
     doc: SpecDocument;
@@ -32,6 +39,12 @@ export function StepTab(props: StepTabProps) {
     const isWorking = activeStep === phase && !stepHistory?.[phase]?.completedAt;
     const isClickable = exists || index === 0;
 
+    const vs = viewerState.value;
+    const stepName = DOC_TO_STEP[phase] ?? phase;
+    const vsPulse = vs?.pulse === stepName;
+    const vsCompleted = vs?.highlights?.includes(stepName) ?? false;
+    const vsSubstep = vs?.activeSubstep?.step === stepName ? vs.activeSubstep.name : null;
+
     const classes = [
         'step-tab',
         exists && 'exists',
@@ -42,6 +55,8 @@ export function StepTab(props: StepTabProps) {
         !isClickable && 'disabled',
         inProgress && !isTasksActive && 'in-progress',
         isStale && 'stale',
+        vsPulse && 'pulse',
+        vsCompleted && 'completed',
     ].filter(Boolean).join(' ');
 
     const statusIcon = inProgress ? `${taskCompletionPercent}%` : (exists ? '✓' : '');
@@ -55,6 +70,7 @@ export function StepTab(props: StepTabProps) {
         >
             <span class="step-status">{statusIcon}</span>
             <span class="step-label">{doc.label}</span>
+            {vsSubstep && <span class="step-tab__substep">{vsSubstep}</span>}
             {isStale && <span class="stale-badge">!</span>}
         </button>
     );

--- a/webview/src/spec-viewer/index.tsx
+++ b/webview/src/spec-viewer/index.tsx
@@ -5,7 +5,7 @@
 
 import { render } from 'preact';
 import type { VSCodeApi, ExtensionToViewerMessage, NavState } from './types';
-import { navState, markdownHtml } from './signals';
+import { navState, markdownHtml, viewerState } from './signals';
 import { renderMarkdown, setCurrentTask, setHasSpecContext } from './markdown';
 import { applyHighlighting, initializeMermaid } from './highlighting';
 import { setupLineActions } from './editor';
@@ -63,11 +63,18 @@ function handleMessage(event: MessageEvent): void {
             if (message.navState) {
                 navState.value = message.navState;
             }
+            if (message.viewerState) {
+                viewerState.value = message.viewerState;
+            }
             updateContent(message.content);
             break;
 
         case 'navStateUpdated':
             navState.value = message.navState;
+            break;
+
+        case 'viewerStateUpdated':
+            viewerState.value = message.viewerState;
             break;
 
         case 'documentsUpdated':

--- a/webview/src/spec-viewer/signals.ts
+++ b/webview/src/spec-viewer/signals.ts
@@ -4,10 +4,13 @@
  */
 
 import { signal } from '@preact/signals';
-import type { NavState, Refinement, DocumentType } from './types';
+import type { NavState, Refinement, DocumentType, ViewerState } from './types';
 
 /** Navigation state from extension messages */
 export const navState = signal<NavState | null>(null);
+
+/** Derived viewer state (pulse, highlights, footer, substep). */
+export const viewerState = signal<ViewerState | null>(null);
 
 /** Pending refinements for GitHub-style review */
 export const pendingRefinements = signal<Refinement[]>([]);

--- a/webview/src/spec-viewer/types.ts
+++ b/webview/src/spec-viewer/types.ts
@@ -109,6 +109,31 @@ export interface ViewerWebviewState {
 }
 
 // ============================================
+// Viewer State (derived from SpecContext)
+// ============================================
+
+export type StepBadgeState = 'not-started' | 'in-progress' | 'completed';
+export type FooterScope = 'spec' | 'step';
+
+/** Serializable footer action — visibleWhen function is stripped before send. */
+export interface SerializedFooterAction {
+    id: string;
+    label: string;
+    scope: FooterScope;
+    tooltip: string;
+}
+
+export interface ViewerState {
+    status: string;
+    activeStep: string;
+    steps: Record<string, StepBadgeState>;
+    pulse: string | null;
+    highlights: string[];
+    activeSubstep: { step: string; name: string } | null;
+    footer: SerializedFooterAction[];
+}
+
+// ============================================
 // Message Types: Webview → Extension
 // ============================================
 
@@ -128,6 +153,7 @@ export type ViewerToExtensionMessage =
     | { type: 'regenerate' }
     | { type: 'approve' }
     | { type: 'clarify'; command?: string }
+    | { type: 'footerAction'; id: string }
     // Lifecycle actions
     | { type: 'completeSpec' }
     | { type: 'archiveSpec' }
@@ -144,11 +170,12 @@ export type ViewerToExtensionMessage =
 // ============================================
 
 export type ExtensionToViewerMessage =
-    | { type: 'contentUpdated'; content: string; documentType: DocumentType; specName: string; navState?: NavState }
+    | { type: 'contentUpdated'; content: string; documentType: DocumentType; specName: string; navState?: NavState; viewerState?: ViewerState }
     | { type: 'documentsUpdated'; documents: SpecDocument[]; currentDocument: DocumentType }
     | { type: 'error'; message: string; recoverable: boolean }
     | { type: 'fileDeleted'; filePath: string }
     | { type: 'navStateUpdated'; navState: NavState }
+    | { type: 'viewerStateUpdated'; viewerState: ViewerState }
     | { type: 'actionToast'; message: string };
 
 // ============================================

--- a/webview/styles/spec-viewer/_animations.css
+++ b/webview/styles/spec-viewer/_animations.css
@@ -83,6 +83,33 @@
     }
 }
 
+/* Blue pulse for the currently-in-progress step (ViewerState.pulse). */
+@keyframes step-tab-pulse {
+    0%, 100% {
+        box-shadow: 0 0 0 2px var(--bg-secondary), 0 0 0 3px var(--accent);
+    }
+    50% {
+        box-shadow: 0 0 0 2px var(--bg-secondary), 0 0 0 5px var(--accent), 0 0 12px var(--accent);
+    }
+}
+
+.step-tab.pulse {
+    animation: step-tab-pulse 1.8s ease-in-out infinite;
+}
+
+.step-tab.completed {
+    border-color: var(--success);
+    box-shadow: 0 0 0 1px var(--success);
+}
+
+.step-tab__substep {
+    display: block;
+    margin-top: 2px;
+    font-size: 0.75em;
+    opacity: 0.7;
+    font-style: italic;
+}
+
 /* Purple glow for review mode */
 @keyframes review-glow {
     0%, 100% {


### PR DESCRIPTION
## What

- Extension serializes `ViewerState` (status, pulse, highlights, activeSubstep, steps, footer) alongside `navState` on every `contentUpdated` message; `footer` strips the `visibleWhen` function.
- New `{ type: 'footerAction', id }` message dispatches footer clicks to existing lifecycle handlers.
- `SpecHeader`, `FooterActions`, and `StepTab` consume `viewerState` when present, falling back to the legacy `navState` path for safety.
- New CSS: `.step-tab.pulse`, `.step-tab.completed`, `.step-tab__substep` + `@keyframes step-tab-pulse`.

## Why

Spec 060 shipped the pure derivation modules (`stateDerivation.ts`, `footerActions.ts`) but left the webview unchanged, so US4–US6 were half-delivered: substep labels never rendered, pulse/highlight classes came from the legacy per-tab heuristics, and footer visibility was hard-coded. This wires the derivation outputs through to rendering.

## Testing

- [x] `npm run compile` passes
- [x] `npm run compile-web` passes
- [ ] F5 and verify the 5 scenarios from `specs/063-viewer-state-derivation-wiring/spec.md` (completed spec, mid-plan pulse, active substep label, footer scope tooltips, sdd-draft Auto visibility)

## Notes

Migration is additive: legacy `.working` / `.in-progress` classes remain as fallback — a follow-up can delete them once the viewerState path is verified in practice.