### PR TITLE
feat(ai-providers): provider registry pattern, OpenCode support, and step completion inference

### DIFF
--- a/docs/viewer-states.md
+++ b/docs/viewer-states.md
@@ -12,12 +12,15 @@
 > `normalizeSpecContext` at read time.
 >
 > **Badge/pulse/highlight rules**:
-> - Step badge = `completed` if `stepHistory[step].completedAt` is set;
->   `in-progress` if `startedAt` set and `completedAt` null; else
->   `not-started`.
-> - Pulse = the single step whose entry has `startedAt` set and
->   `completedAt` null. **Null when `status ∈ {completed, archived}`.**
-> - Highlight = every step with `completedAt` set, regardless of active tab.
+> - Step badge = `completed` if `stepHistory[step].completedAt` is set
+>   **OR** the step has `startedAt` and precedes `currentStep` in
+>   `STEP_NAMES` ordering (inferred completion — handles external SDD
+>   skills that only emit `startedAt`); `in-progress` if `startedAt`
+>   set and not inferred-completed; else `not-started`.
+> - Pulse = the single step whose entry has `startedAt` set and is not
+>   inferred-completed. **Null when `status ∈ {completed, archived}`.**
+> - Highlight = every step with `completedAt` set or inferred-completed,
+>   regardless of active tab.
 >
 > **Footer scope tooltips**: Every footer button declares
 > `scope: 'spec' | 'step'` and tooltips are auto-suffixed with

--- a/package.json
+++ b/package.json
@@ -527,14 +527,16 @@
             "gemini",
             "copilot",
             "codex",
-            "qwen"
+            "qwen",
+            "opencode"
           ],
           "enumDescriptions": [
             "Claude Code - Full feature support (steering, agents, skills, hooks)",
             "Gemini CLI - Steering support",
             "GitHub Copilot CLI - Steering and agents support",
             "Codex CLI - Steering and skills support",
-            "Qwen Code - Steering support"
+            "Qwen Code - Steering support",
+            "OpenCode - Steering and agents support (AGENTS.md)"
           ],
           "scope": "machine",
           "order": 2,
@@ -570,7 +572,7 @@
           ],
           "scope": "machine",
           "order": 3,
-          "description": "Controls how the AI CLI handles permission prompts. Applies to all providers that support it (Claude, Copilot, Qwen)."
+          "description": "Controls how the AI CLI handles permission prompts. 'interactive' is honored only by providers whose CLI supports interactive prompting (Claude, Gemini, Codex, Qwen, OpenCode). Copilot does not support interactive prompting and will be auto-switched to auto-approve."
         },
         "speckit.geminiPath": {
           "type": "string",

--- a/package.json
+++ b/package.json
@@ -604,6 +604,13 @@
           "order": 6,
           "description": "Path to Qwen Code CLI executable"
         },
+        "speckit.opencodePath": {
+          "type": "string",
+          "default": "opencode",
+          "scope": "machine",
+          "order": 7,
+          "description": "Path to OpenCode CLI executable"
+        },
         "speckit.specDirectories": {
           "type": "array",
           "items": {

--- a/specs/059-hide-launch-prompt/.spec-context.json
+++ b/specs/059-hide-launch-prompt/.spec-context.json
@@ -6,7 +6,7 @@
   "next": "implement",
   "updated": "2026-04-13",
   "selectedAt": "2026-04-13T11:35:05Z",
-  "status": "active",
+  "status": "completed",
   "specName": "Hide Launch Prompt",
   "branch": "main",
   "createdAt": "2026-04-13T11:35:05Z",
@@ -18,10 +18,22 @@
     "specs/059-hide-launch-prompt/tasks.md"
   ],
   "concerns": [
-    {"task": "T003", "note": "Gemini uses interactive REPL; helper pattern would break interactive UX — left unchanged"},
-    {"task": "T004", "note": "Copilot already satisfies R001 via executeInTerminal delegation — no change needed"},
-    {"task": "T005", "note": "Codex uses sed+pipe with local prompt templates; different dispatch model — left unchanged"},
-    {"task": "T006", "note": "Qwen already satisfies R001 via executeInTerminal delegation — no change needed"}
+    {
+      "task": "T003",
+      "note": "Gemini uses interactive REPL; helper pattern would break interactive UX — left unchanged"
+    },
+    {
+      "task": "T004",
+      "note": "Copilot already satisfies R001 via executeInTerminal delegation — no change needed"
+    },
+    {
+      "task": "T005",
+      "note": "Codex uses sed+pipe with local prompt templates; different dispatch model — left unchanged"
+    },
+    {
+      "task": "T006",
+      "note": "Qwen already satisfies R001 via executeInTerminal delegation — no change needed"
+    }
   ],
   "decisions": [
     "Helper signature uses options object with context, outputChannel, terminal, cliInvocation, slashCommand, promptText, autoExecute, logPrefix — supports both slash-prefixed (Claude) and prefix-less (Copilot-style) forms",
@@ -31,20 +43,26 @@
     "T001": {
       "status": "DONE",
       "did": "Added dispatchSlashCommandViaTempFile helper to src/ai-providers/aiProvider.ts with fs/createTempFile/Timing imports",
-      "files": ["src/ai-providers/aiProvider.ts"],
+      "files": [
+        "src/ai-providers/aiProvider.ts"
+      ],
       "concerns": []
     },
     "T002": {
       "status": "DONE",
       "did": "Rewrote Claude's executeSlashCommand to split slash name from args and route via helper so args are written to temp file and dispatched as claude \"/name $(cat <file>)\"",
-      "files": ["src/ai-providers/claudeCodeProvider.ts"],
+      "files": [
+        "src/ai-providers/claudeCodeProvider.ts"
+      ],
       "concerns": []
     },
     "T003": {
       "status": "DONE_WITH_CONCERNS",
       "did": "No code change — Gemini uses interactive REPL mode; slash command text appears in Gemini's UI, not in the shell command line",
       "files": [],
-      "concerns": ["Interactive REPL structurally incompatible with temp-file dispatch pattern"]
+      "concerns": [
+        "Interactive REPL structurally incompatible with temp-file dispatch pattern"
+      ]
     },
     "T004": {
       "status": "DONE",
@@ -56,7 +74,9 @@
       "status": "DONE_WITH_CONCERNS",
       "did": "No code change — Codex uses sed+pipe with local .codex/prompts/*.md templates, a different dispatch model",
       "files": [],
-      "concerns": ["Sed substitution exposes args on the terminal line — separate refactor if tightening needed"]
+      "concerns": [
+        "Sed substitution exposes args on the terminal line — separate refactor if tightening needed"
+      ]
     },
     "T006": {
       "status": "DONE",
@@ -78,10 +98,18 @@
     }
   },
   "stepHistory": {
-    "specify": {"startedAt": "2026-04-13T11:35:05Z"},
-    "plan": {"startedAt": "2026-04-13T11:40:00Z"},
-    "tasks": {"startedAt": "2026-04-13T11:45:00Z"},
-    "implement": {"startedAt": "2026-04-13T12:00:00Z"}
+    "specify": {
+      "startedAt": "2026-04-13T11:35:05Z"
+    },
+    "plan": {
+      "startedAt": "2026-04-13T11:40:00Z"
+    },
+    "tasks": {
+      "startedAt": "2026-04-13T11:45:00Z"
+    },
+    "implement": {
+      "startedAt": "2026-04-13T12:00:00Z"
+    }
   },
   "step_summaries": {
     "specify": {
@@ -98,21 +126,126 @@
         "Temp-file cleanup race with slow shell integration: reuse the proven Timing.tempFileCleanupDelay delay already used by executeInTerminal"
       ]
     },
-    "tasks": {"task_count": 8, "phases": 1}
+    "tasks": {
+      "task_count": 8,
+      "phases": 1
+    }
   },
   "transitions": [
-    {"step": "specify", "substep": "parsing", "from": null, "by": "sdd", "at": "2026-04-13T11:35:05Z"},
-    {"step": "specify", "substep": "exploring", "from": "parsing", "by": "sdd", "at": "2026-04-13T11:35:10Z"},
-    {"step": "specify", "substep": "detecting", "from": "exploring", "by": "sdd", "at": "2026-04-13T11:35:20Z"},
-    {"step": "specify", "substep": "writing-spec", "from": "detecting", "by": "sdd", "at": "2026-04-13T11:35:25Z"},
-    {"step": "specify", "substep": null, "from": "writing-spec", "by": "sdd", "at": "2026-04-13T11:35:30Z"},
-    {"step": "plan", "substep": "loading", "from": {"step": "specify", "substep": null}, "by": "sdd", "at": "2026-04-13T11:40:00Z"},
-    {"step": "plan", "substep": "writing-plan", "from": {"step": "plan", "substep": "loading"}, "by": "sdd", "at": "2026-04-13T11:40:05Z"},
-    {"step": "plan", "substep": null, "from": {"step": "plan", "substep": "writing-plan"}, "by": "sdd", "at": "2026-04-13T11:40:10Z"},
-    {"step": "tasks", "substep": "loading", "from": {"step": "plan", "substep": null}, "by": "sdd", "at": "2026-04-13T11:45:00Z"},
-    {"step": "tasks", "substep": "writing-tasks", "from": {"step": "tasks", "substep": "loading"}, "by": "sdd", "at": "2026-04-13T11:45:05Z"},
-    {"step": "tasks", "substep": null, "from": {"step": "tasks", "substep": "writing-tasks"}, "by": "sdd", "at": "2026-04-13T11:45:10Z"},
-    {"step": "implement", "substep": "phase1", "from": {"step": "tasks", "substep": null}, "by": "sdd", "at": "2026-04-13T12:00:00Z"},
-    {"step": "implement", "substep": "code-review", "from": {"step": "implement", "substep": "phase1"}, "by": "sdd", "at": "2026-04-13T12:05:00Z"}
+    {
+      "step": "specify",
+      "substep": "parsing",
+      "from": null,
+      "by": "sdd",
+      "at": "2026-04-13T11:35:05Z"
+    },
+    {
+      "step": "specify",
+      "substep": "exploring",
+      "from": "parsing",
+      "by": "sdd",
+      "at": "2026-04-13T11:35:10Z"
+    },
+    {
+      "step": "specify",
+      "substep": "detecting",
+      "from": "exploring",
+      "by": "sdd",
+      "at": "2026-04-13T11:35:20Z"
+    },
+    {
+      "step": "specify",
+      "substep": "writing-spec",
+      "from": "detecting",
+      "by": "sdd",
+      "at": "2026-04-13T11:35:25Z"
+    },
+    {
+      "step": "specify",
+      "substep": null,
+      "from": "writing-spec",
+      "by": "sdd",
+      "at": "2026-04-13T11:35:30Z"
+    },
+    {
+      "step": "plan",
+      "substep": "loading",
+      "from": {
+        "step": "specify",
+        "substep": null
+      },
+      "by": "sdd",
+      "at": "2026-04-13T11:40:00Z"
+    },
+    {
+      "step": "plan",
+      "substep": "writing-plan",
+      "from": {
+        "step": "plan",
+        "substep": "loading"
+      },
+      "by": "sdd",
+      "at": "2026-04-13T11:40:05Z"
+    },
+    {
+      "step": "plan",
+      "substep": null,
+      "from": {
+        "step": "plan",
+        "substep": "writing-plan"
+      },
+      "by": "sdd",
+      "at": "2026-04-13T11:40:10Z"
+    },
+    {
+      "step": "tasks",
+      "substep": "loading",
+      "from": {
+        "step": "plan",
+        "substep": null
+      },
+      "by": "sdd",
+      "at": "2026-04-13T11:45:00Z"
+    },
+    {
+      "step": "tasks",
+      "substep": "writing-tasks",
+      "from": {
+        "step": "tasks",
+        "substep": "loading"
+      },
+      "by": "sdd",
+      "at": "2026-04-13T11:45:05Z"
+    },
+    {
+      "step": "tasks",
+      "substep": null,
+      "from": {
+        "step": "tasks",
+        "substep": "writing-tasks"
+      },
+      "by": "sdd",
+      "at": "2026-04-13T11:45:10Z"
+    },
+    {
+      "step": "implement",
+      "substep": "phase1",
+      "from": {
+        "step": "tasks",
+        "substep": null
+      },
+      "by": "sdd",
+      "at": "2026-04-13T12:00:00Z"
+    },
+    {
+      "step": "implement",
+      "substep": "code-review",
+      "from": {
+        "step": "implement",
+        "substep": "phase1"
+      },
+      "by": "sdd",
+      "at": "2026-04-13T12:05:00Z"
+    }
   ]
 }

--- a/specs/060-spec-context-tracking/.spec-context.json
+++ b/specs/060-spec-context-tracking/.spec-context.json
@@ -2,7 +2,7 @@
   "workflow": "speckit",
   "selectedAt": "2026-04-13T13:07:56.000Z",
   "currentStep": "specify",
-  "status": "active",
+  "status": "completed",
   "specName": "Spec Context Tracking",
   "branch": "060-spec-context-tracking",
   "stepHistory": {

--- a/specs/061-extension-lifecycle-writes/.spec-context.json
+++ b/specs/061-extension-lifecycle-writes/.spec-context.json
@@ -1,6 +1,6 @@
 {
   "workflow": "sdd",
-  "currentStep": "plan",
+  "currentStep": "implement",
   "currentTask": null,
   "progress": "code-review",
   "next": "implement",

--- a/specs/061-extension-lifecycle-writes/.spec-context.json
+++ b/specs/061-extension-lifecycle-writes/.spec-context.json
@@ -1,6 +1,6 @@
 {
   "workflow": "sdd",
-  "currentStep": "implement",
+  "currentStep": "plan",
   "currentTask": null,
   "progress": "code-review",
   "next": "implement",
@@ -18,30 +18,113 @@
     "README.md"
   ],
   "task_summaries": {
-    "T001": { "status": "DONE", "did": "Created stepLifecycle wrapper exposing startStep/completeStep/startSubstep/completeSubstep + setStatus/reactivate; all errors logged-and-swallowed.", "files": ["src/features/specs/stepLifecycle.ts"], "concerns": [] },
-    "T002": { "status": "DONE", "did": "Added BDD specs for stepLifecycle: writer args, log-not-throw on rejection, substep variants.", "files": ["src/features/specs/__tests__/stepLifecycle.test.ts"], "concerns": [] },
-    "T003": { "status": "DONE", "did": "Verified all AI provider executeInTerminal signatures already return Promise<vscode.Terminal>; no change needed.", "files": [], "concerns": ["No code change required — interface already returned vscode.Terminal."] },
-    "T004": { "status": "DONE", "did": "Created terminalStepTracker with track/register; onDidCloseTerminal fires completeStep once and deletes the entry.", "files": ["src/features/specs/terminalStepTracker.ts"], "concerns": [] },
-    "T005": { "status": "DONE", "did": "Tests cover tracked-close, untracked-close no-op, double-close no double-fire, undefined terminal.", "files": ["src/features/specs/__tests__/terminalStepTracker.test.ts", "tests/__mocks__/vscode.ts"], "concerns": [] },
-    "T006": { "status": "DONE", "did": "Wired startStep + trackTerminal into both phase command dispatch and executeWorkflowStep in specCommands.ts.", "files": ["src/features/specs/specCommands.ts"], "concerns": [] },
-    "T007": { "status": "DONE", "did": "Replaced setSpecStatus with canonical setStatus/reactivate in specCommands.ts and messageHandlers.ts; updated tests.", "files": ["src/features/specs/specCommands.ts", "src/features/spec-viewer/messageHandlers.ts", "src/features/spec-viewer/__tests__/messageHandlers.test.ts"], "concerns": [] },
-    "T008": { "status": "DONE", "did": "handleApprove fires completeStep on current step + startStep on next; handleRegenerate fires startStep.", "files": ["src/features/spec-viewer/messageHandlers.ts"], "concerns": ["Substep wrapping with CANONICAL_SUBSTEPS deferred — approve/regenerate don't currently expose multi-phase substep boundaries inside the viewer message handlers."] },
-    "T009": { "status": "DONE", "did": "extension.ts activate registers terminalStepTracker.register and wires lifecycle output channel.", "files": ["src/extension.ts"], "concerns": [] },
-    "T010": { "status": "DONE", "did": "README spec-context section now documents extension-side lifecycle writes.", "files": ["README.md"], "concerns": [] }
+    "T001": {
+      "status": "DONE",
+      "did": "Created stepLifecycle wrapper exposing startStep/completeStep/startSubstep/completeSubstep + setStatus/reactivate; all errors logged-and-swallowed.",
+      "files": [
+        "src/features/specs/stepLifecycle.ts"
+      ],
+      "concerns": []
+    },
+    "T002": {
+      "status": "DONE",
+      "did": "Added BDD specs for stepLifecycle: writer args, log-not-throw on rejection, substep variants.",
+      "files": [
+        "src/features/specs/__tests__/stepLifecycle.test.ts"
+      ],
+      "concerns": []
+    },
+    "T003": {
+      "status": "DONE",
+      "did": "Verified all AI provider executeInTerminal signatures already return Promise<vscode.Terminal>; no change needed.",
+      "files": [],
+      "concerns": [
+        "No code change required — interface already returned vscode.Terminal."
+      ]
+    },
+    "T004": {
+      "status": "DONE",
+      "did": "Created terminalStepTracker with track/register; onDidCloseTerminal fires completeStep once and deletes the entry.",
+      "files": [
+        "src/features/specs/terminalStepTracker.ts"
+      ],
+      "concerns": []
+    },
+    "T005": {
+      "status": "DONE",
+      "did": "Tests cover tracked-close, untracked-close no-op, double-close no double-fire, undefined terminal.",
+      "files": [
+        "src/features/specs/__tests__/terminalStepTracker.test.ts",
+        "tests/__mocks__/vscode.ts"
+      ],
+      "concerns": []
+    },
+    "T006": {
+      "status": "DONE",
+      "did": "Wired startStep + trackTerminal into both phase command dispatch and executeWorkflowStep in specCommands.ts.",
+      "files": [
+        "src/features/specs/specCommands.ts"
+      ],
+      "concerns": []
+    },
+    "T007": {
+      "status": "DONE",
+      "did": "Replaced setSpecStatus with canonical setStatus/reactivate in specCommands.ts and messageHandlers.ts; updated tests.",
+      "files": [
+        "src/features/specs/specCommands.ts",
+        "src/features/spec-viewer/messageHandlers.ts",
+        "src/features/spec-viewer/__tests__/messageHandlers.test.ts"
+      ],
+      "concerns": []
+    },
+    "T008": {
+      "status": "DONE",
+      "did": "handleApprove fires completeStep on current step + startStep on next; handleRegenerate fires startStep.",
+      "files": [
+        "src/features/spec-viewer/messageHandlers.ts"
+      ],
+      "concerns": [
+        "Substep wrapping with CANONICAL_SUBSTEPS deferred — approve/regenerate don't currently expose multi-phase substep boundaries inside the viewer message handlers."
+      ]
+    },
+    "T009": {
+      "status": "DONE",
+      "did": "extension.ts activate registers terminalStepTracker.register and wires lifecycle output channel.",
+      "files": [
+        "src/extension.ts"
+      ],
+      "concerns": []
+    },
+    "T010": {
+      "status": "DONE",
+      "did": "README spec-context section now documents extension-side lifecycle writes.",
+      "files": [
+        "README.md"
+      ],
+      "concerns": []
+    }
   },
   "concerns": [
-    { "task": "T003", "note": "No code change needed; AI providers already return vscode.Terminal." },
-    { "task": "T008", "note": "Substep wrapping with CANONICAL_SUBSTEPS not added — viewer approve/regenerate don't have observable multi-phase boundaries." }
+    {
+      "task": "T003",
+      "note": "No code change needed; AI providers already return vscode.Terminal."
+    },
+    {
+      "task": "T008",
+      "note": "Substep wrapping with CANONICAL_SUBSTEPS not added — viewer approve/regenerate don't have observable multi-phase boundaries."
+    }
   ],
   "decisions": [
-    { "decision": "Added setStatus and reactivate helpers to stepLifecycle.ts (rather than calling writer.updateSpecContext inline at every site) to keep callers one-liners and centralize transition appending." }
+    {
+      "decision": "Added setStatus and reactivate helpers to stepLifecycle.ts (rather than calling writer.updateSpecContext inline at every site) to keep callers one-liners and centralize transition appending."
+    }
   ],
   "last_action": "T010 complete — README updated with extension-side lifecycle writes note",
   "selectedAt": "2026-04-13T20:23:45Z",
   "specName": "Extension Lifecycle Writes",
   "branch": "main",
   "createdAt": "2026-04-13T20:23:45Z",
-  "status": "specified",
+  "status": "completed",
   "approach": "Hook specContextWriter into specCommands.ts dispatch sites and viewer messageHandlers; track spawned terminals so onDidCloseTerminal fires setStepCompleted; route status writes through canonical updateSpecContext.",
   "stepHistory": {
     "specify": {
@@ -74,17 +157,172 @@
     }
   },
   "transitions": [
-    { "step": "specify", "substep": "parsing", "from": null, "by": "sdd", "at": "2026-04-13T20:23:45Z" },
-    { "step": "specify", "substep": "exploring", "from": { "step": "specify", "substep": "parsing" }, "by": "sdd", "at": "2026-04-13T20:23:55Z" },
-    { "step": "specify", "substep": "detecting", "from": { "step": "specify", "substep": "exploring" }, "by": "sdd", "at": "2026-04-13T20:24:05Z" },
-    { "step": "specify", "substep": "writing-spec", "from": { "step": "specify", "substep": "detecting" }, "by": "sdd", "at": "2026-04-13T20:24:15Z" },
-    { "step": "specify", "substep": null, "from": { "step": "specify", "substep": "writing-spec" }, "by": "sdd", "at": "2026-04-13T20:24:30Z" },
-    { "step": "plan", "substep": "loading", "from": { "step": "specify", "substep": null }, "by": "sdd", "at": "2026-04-13T20:25:00Z" },
-    { "step": "plan", "substep": "writing-plan", "from": { "step": "plan", "substep": "loading" }, "by": "sdd", "at": "2026-04-13T20:25:10Z" },
-    { "step": "plan", "substep": null, "from": { "step": "plan", "substep": "writing-plan" }, "by": "sdd", "at": "2026-04-13T20:25:30Z" },
-    { "step": "tasks", "substep": "loading", "from": { "step": "plan", "substep": null }, "by": "sdd", "at": "2026-04-13T20:26:00Z" },
-    { "step": "tasks", "substep": "writing-tasks", "from": { "step": "tasks", "substep": "loading" }, "by": "sdd", "at": "2026-04-13T20:26:10Z" },
-    { "step": "tasks", "substep": null, "from": { "step": "tasks", "substep": "writing-tasks" }, "by": "sdd", "at": "2026-04-13T20:26:30Z" },
-    { "step": "implement", "substep": null, "from": { "step": "tasks", "substep": null }, "by": "sdd", "at": "2026-04-13T20:30:00Z" }
+    {
+      "step": "specify",
+      "substep": "parsing",
+      "from": null,
+      "by": "sdd",
+      "at": "2026-04-13T20:23:45Z"
+    },
+    {
+      "step": "specify",
+      "substep": "exploring",
+      "from": {
+        "step": "specify",
+        "substep": "parsing"
+      },
+      "by": "sdd",
+      "at": "2026-04-13T20:23:55Z"
+    },
+    {
+      "step": "specify",
+      "substep": "detecting",
+      "from": {
+        "step": "specify",
+        "substep": "exploring"
+      },
+      "by": "sdd",
+      "at": "2026-04-13T20:24:05Z"
+    },
+    {
+      "step": "specify",
+      "substep": "writing-spec",
+      "from": {
+        "step": "specify",
+        "substep": "detecting"
+      },
+      "by": "sdd",
+      "at": "2026-04-13T20:24:15Z"
+    },
+    {
+      "step": "specify",
+      "substep": null,
+      "from": {
+        "step": "specify",
+        "substep": "writing-spec"
+      },
+      "by": "sdd",
+      "at": "2026-04-13T20:24:30Z"
+    },
+    {
+      "step": "plan",
+      "substep": "loading",
+      "from": {
+        "step": "specify",
+        "substep": null
+      },
+      "by": "sdd",
+      "at": "2026-04-13T20:25:00Z"
+    },
+    {
+      "step": "plan",
+      "substep": "writing-plan",
+      "from": {
+        "step": "plan",
+        "substep": "loading"
+      },
+      "by": "sdd",
+      "at": "2026-04-13T20:25:10Z"
+    },
+    {
+      "step": "plan",
+      "substep": null,
+      "from": {
+        "step": "plan",
+        "substep": "writing-plan"
+      },
+      "by": "sdd",
+      "at": "2026-04-13T20:25:30Z"
+    },
+    {
+      "step": "tasks",
+      "substep": "loading",
+      "from": {
+        "step": "plan",
+        "substep": null
+      },
+      "by": "sdd",
+      "at": "2026-04-13T20:26:00Z"
+    },
+    {
+      "step": "tasks",
+      "substep": "writing-tasks",
+      "from": {
+        "step": "tasks",
+        "substep": "loading"
+      },
+      "by": "sdd",
+      "at": "2026-04-13T20:26:10Z"
+    },
+    {
+      "step": "tasks",
+      "substep": null,
+      "from": {
+        "step": "tasks",
+        "substep": "writing-tasks"
+      },
+      "by": "sdd",
+      "at": "2026-04-13T20:26:30Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "from": {
+        "step": "tasks",
+        "substep": null
+      },
+      "by": "sdd",
+      "at": "2026-04-13T20:30:00Z"
+    },
+    {
+      "step": "plan",
+      "substep": null,
+      "from": {
+        "step": "implement",
+        "substep": null
+      },
+      "by": "extension",
+      "at": "2026-04-13T23:10:47.665Z"
+    },
+    {
+      "step": "specify",
+      "substep": null,
+      "from": {
+        "step": "plan",
+        "substep": null
+      },
+      "by": "extension",
+      "at": "2026-04-13T23:10:48.667Z"
+    },
+    {
+      "step": "plan",
+      "substep": null,
+      "from": {
+        "step": "specify",
+        "substep": null
+      },
+      "by": "extension",
+      "at": "2026-04-13T23:10:49.460Z"
+    },
+    {
+      "step": "tasks",
+      "substep": null,
+      "from": {
+        "step": "plan",
+        "substep": null
+      },
+      "by": "extension",
+      "at": "2026-04-13T23:10:50.550Z"
+    },
+    {
+      "step": "plan",
+      "substep": null,
+      "from": {
+        "step": "tasks",
+        "substep": null
+      },
+      "by": "extension",
+      "at": "2026-04-13T23:10:56.129Z"
+    }
   ]
 }

--- a/specs/062-ai-prompt-context-prepend/.spec-context.json
+++ b/specs/062-ai-prompt-context-prepend/.spec-context.json
@@ -14,18 +14,53 @@
     "README.md"
   ],
   "task_summaries": {
-    "T001": { "status": "DONE", "did": "Added speckit.aiContextInstructions boolean config (default true) under contributes.configuration.properties", "files": ["package.json"], "concerns": [] },
-    "T002": { "status": "DONE", "did": "Created buildPrompt helper that wraps commands with a marker-delimited preamble listing canonical substeps; returns raw command when config disabled or step unknown", "files": ["src/ai-providers/promptBuilder.ts"], "concerns": [] },
-    "T003": { "status": "DONE", "did": "Added 7 unit tests covering all 4 known steps, opt-out, unknown step, omitted step, path-leakage, and token-budget (<1500 chars)", "files": ["src/ai-providers/__tests__/promptBuilder.test.ts"], "concerns": [] },
-    "T004": { "status": "DONE", "did": "Routed both executeInTerminal dispatch sites in specCommands.ts through buildPrompt; added toWorkspaceRelative helper so only workspace-relative specDir is embedded", "files": ["src/features/specs/specCommands.ts"], "concerns": [] },
-    "T005": { "status": "DONE", "did": "Added AI Context Instructions section to README between Command Format and Spec Directories", "files": ["README.md"], "concerns": [] }
+    "T001": {
+      "status": "DONE",
+      "did": "Added speckit.aiContextInstructions boolean config (default true) under contributes.configuration.properties",
+      "files": [
+        "package.json"
+      ],
+      "concerns": []
+    },
+    "T002": {
+      "status": "DONE",
+      "did": "Created buildPrompt helper that wraps commands with a marker-delimited preamble listing canonical substeps; returns raw command when config disabled or step unknown",
+      "files": [
+        "src/ai-providers/promptBuilder.ts"
+      ],
+      "concerns": []
+    },
+    "T003": {
+      "status": "DONE",
+      "did": "Added 7 unit tests covering all 4 known steps, opt-out, unknown step, omitted step, path-leakage, and token-budget (<1500 chars)",
+      "files": [
+        "src/ai-providers/__tests__/promptBuilder.test.ts"
+      ],
+      "concerns": []
+    },
+    "T004": {
+      "status": "DONE",
+      "did": "Routed both executeInTerminal dispatch sites in specCommands.ts through buildPrompt; added toWorkspaceRelative helper so only workspace-relative specDir is embedded",
+      "files": [
+        "src/features/specs/specCommands.ts"
+      ],
+      "concerns": []
+    },
+    "T005": {
+      "status": "DONE",
+      "did": "Added AI Context Instructions section to README between Command Format and Spec Directories",
+      "files": [
+        "README.md"
+      ],
+      "concerns": []
+    }
   },
   "updated": "2026-04-13",
   "selectedAt": "2026-04-13T20:41:52Z",
   "specName": "AI Prompt Context Prepend",
   "branch": "061-extension-lifecycle-writes",
   "createdAt": "2026-04-13T20:41:52Z",
-  "status": "active",
+  "status": "completed",
   "approach": "Introduce a single promptBuilder helper and route every executeInTerminal caller through it, gated by a new speckit.aiContextInstructions setting.",
   "stepHistory": {
     "specify": {

--- a/specs/063-viewer-state-derivation-wiring/.spec-context.json
+++ b/specs/063-viewer-state-derivation-wiring/.spec-context.json
@@ -9,13 +9,25 @@
   "specName": "Viewer State Derivation Wiring",
   "branch": "063-viewer-state-derivation-wiring",
   "createdAt": "2026-04-13T20:59:09Z",
-  "status": "implementing",
+  "status": "completed",
   "auto": true,
   "stepHistory": {
-    "specify": { "startedAt": "2026-04-13T20:59:09Z", "completedAt": "2026-04-13T21:00:00Z" },
-    "plan": { "startedAt": "2026-04-13T21:00:00Z", "completedAt": "2026-04-13T21:01:00Z" },
-    "tasks": { "startedAt": "2026-04-13T21:01:00Z", "completedAt": "2026-04-13T21:01:30Z" },
-    "implement": { "startedAt": "2026-04-13T21:01:30Z", "completedAt": "2026-04-13T21:30:00Z" }
+    "specify": {
+      "startedAt": "2026-04-13T20:59:09Z",
+      "completedAt": "2026-04-13T21:00:00Z"
+    },
+    "plan": {
+      "startedAt": "2026-04-13T21:00:00Z",
+      "completedAt": "2026-04-13T21:01:00Z"
+    },
+    "tasks": {
+      "startedAt": "2026-04-13T21:01:00Z",
+      "completedAt": "2026-04-13T21:01:30Z"
+    },
+    "implement": {
+      "startedAt": "2026-04-13T21:01:30Z",
+      "completedAt": "2026-04-13T21:30:00Z"
+    }
   },
   "approach": "Push a single ViewerState payload from the extension and refactor SpecHeader, FooterActions, and the stepper (plus CSS) to consume it directly.",
   "last_action": "All tasks complete — viewerState wired additively; legacy fallbacks preserved; compile + webpack green.",
@@ -46,45 +58,258 @@
         "Signal plumbing: navState is a Preact signal; ViewerState must be distributed so all consumer components update synchronously."
       ]
     },
-    "tasks": { "task_count": 10 }
+    "tasks": {
+      "task_count": 10
+    }
   },
   "task_summaries": {
-    "T001": { "status": "DONE", "did": "Added ViewerState, SerializedFooterAction types, footerAction message, viewerState fields on contentUpdated/viewerStateUpdated messages in webview types.", "files": ["webview/src/spec-viewer/types.ts"], "concerns": [] },
-    "T002": { "status": "DONE", "did": "In sendContentUpdateMessage, read canonical SpecContext via readSpecContext, call deriveViewerState, strip visibleWhen, attach as viewerState on contentUpdated message.", "files": ["src/features/spec-viewer/specViewerProvider.ts", "src/features/spec-viewer/types.ts"], "concerns": [] },
-    "T003": { "status": "DONE", "did": "Added footerAction case to messageHandlers dispatching ids (archive/reactivate/complete/regenerate/approve/start/sdd-auto) to existing handlers.", "files": ["src/features/spec-viewer/messageHandlers.ts", "src/features/spec-viewer/types.ts"], "concerns": [] },
-    "T004": { "status": "DONE", "did": "Added viewerState Preact signal; populated from contentUpdated + new viewerStateUpdated messages in index.tsx.", "files": ["webview/src/spec-viewer/signals.ts", "webview/src/spec-viewer/index.tsx"], "concerns": [] },
-    "T005": { "status": "DONE_WITH_CONCERNS", "did": "FooterActions renders viewerState.footer entries (with scope-suffixed tooltips) on the right when present; falls back to legacy hardcoded layout when viewerState is null. Edit Source + enhancement buttons remain hardcoded (not in FOOTER_ACTIONS).", "files": ["webview/src/spec-viewer/components/FooterActions.tsx"], "concerns": ["Hybrid approach: Edit Source and enhancement buttons not migrated into FOOTER_ACTIONS — intentional per task description, but means two rendering paths coexist."] },
-    "T006": { "status": "DONE", "did": "SpecHeader reads viewerState.status (formatted via formatStatusLabel) when present, falls back to ns.badgeText.", "files": ["webview/src/spec-viewer/components/SpecHeader.tsx"], "concerns": [] },
-    "T007": { "status": "DONE_WITH_CONCERNS", "did": "StepTab adds .pulse / .completed classes from viewerState.pulse + highlights; renders step-tab__substep label when activeSubstep matches. Legacy .working / .in-progress classes retained as fallback.", "files": ["webview/src/spec-viewer/components/StepTab.tsx"], "concerns": ["Legacy .working/.in-progress classes not removed to avoid CSS regressions — R009 only partially satisfied."] },
-    "T008": { "status": "DONE_WITH_CONCERNS", "did": "Added @keyframes step-tab-pulse, .step-tab.pulse, .step-tab.completed, .step-tab__substep rules in _animations.css.", "files": ["webview/styles/spec-viewer/_animations.css"], "concerns": ["Did not delete .in-progress / .working rules per plan's 'search-and-destroy' — left as fallback for now."] },
-    "T009": { "status": "DONE_WITH_CONCERNS", "did": "Skipped — no existing Preact component test infra found under webview/**/__tests__/; adding one would exceed scope.", "files": [], "concerns": ["No component test added; FooterActions behavior verified by compile + manual only."] },
-    "T010": { "status": "DONE_WITH_CONCERNS", "did": "Skipped in auto mode — manual walkthrough requires F5 Extension Host; compile + webpack pass.", "files": [], "concerns": ["Manual scenario verification pending; user should run F5 and exercise the 5 scenarios from spec.md."] }
+    "T001": {
+      "status": "DONE",
+      "did": "Added ViewerState, SerializedFooterAction types, footerAction message, viewerState fields on contentUpdated/viewerStateUpdated messages in webview types.",
+      "files": [
+        "webview/src/spec-viewer/types.ts"
+      ],
+      "concerns": []
+    },
+    "T002": {
+      "status": "DONE",
+      "did": "In sendContentUpdateMessage, read canonical SpecContext via readSpecContext, call deriveViewerState, strip visibleWhen, attach as viewerState on contentUpdated message.",
+      "files": [
+        "src/features/spec-viewer/specViewerProvider.ts",
+        "src/features/spec-viewer/types.ts"
+      ],
+      "concerns": []
+    },
+    "T003": {
+      "status": "DONE",
+      "did": "Added footerAction case to messageHandlers dispatching ids (archive/reactivate/complete/regenerate/approve/start/sdd-auto) to existing handlers.",
+      "files": [
+        "src/features/spec-viewer/messageHandlers.ts",
+        "src/features/spec-viewer/types.ts"
+      ],
+      "concerns": []
+    },
+    "T004": {
+      "status": "DONE",
+      "did": "Added viewerState Preact signal; populated from contentUpdated + new viewerStateUpdated messages in index.tsx.",
+      "files": [
+        "webview/src/spec-viewer/signals.ts",
+        "webview/src/spec-viewer/index.tsx"
+      ],
+      "concerns": []
+    },
+    "T005": {
+      "status": "DONE_WITH_CONCERNS",
+      "did": "FooterActions renders viewerState.footer entries (with scope-suffixed tooltips) on the right when present; falls back to legacy hardcoded layout when viewerState is null. Edit Source + enhancement buttons remain hardcoded (not in FOOTER_ACTIONS).",
+      "files": [
+        "webview/src/spec-viewer/components/FooterActions.tsx"
+      ],
+      "concerns": [
+        "Hybrid approach: Edit Source and enhancement buttons not migrated into FOOTER_ACTIONS — intentional per task description, but means two rendering paths coexist."
+      ]
+    },
+    "T006": {
+      "status": "DONE",
+      "did": "SpecHeader reads viewerState.status (formatted via formatStatusLabel) when present, falls back to ns.badgeText.",
+      "files": [
+        "webview/src/spec-viewer/components/SpecHeader.tsx"
+      ],
+      "concerns": []
+    },
+    "T007": {
+      "status": "DONE_WITH_CONCERNS",
+      "did": "StepTab adds .pulse / .completed classes from viewerState.pulse + highlights; renders step-tab__substep label when activeSubstep matches. Legacy .working / .in-progress classes retained as fallback.",
+      "files": [
+        "webview/src/spec-viewer/components/StepTab.tsx"
+      ],
+      "concerns": [
+        "Legacy .working/.in-progress classes not removed to avoid CSS regressions — R009 only partially satisfied."
+      ]
+    },
+    "T008": {
+      "status": "DONE_WITH_CONCERNS",
+      "did": "Added @keyframes step-tab-pulse, .step-tab.pulse, .step-tab.completed, .step-tab__substep rules in _animations.css.",
+      "files": [
+        "webview/styles/spec-viewer/_animations.css"
+      ],
+      "concerns": [
+        "Did not delete .in-progress / .working rules per plan's 'search-and-destroy' — left as fallback for now."
+      ]
+    },
+    "T009": {
+      "status": "DONE_WITH_CONCERNS",
+      "did": "Skipped — no existing Preact component test infra found under webview/**/__tests__/; adding one would exceed scope.",
+      "files": [],
+      "concerns": [
+        "No component test added; FooterActions behavior verified by compile + manual only."
+      ]
+    },
+    "T010": {
+      "status": "DONE_WITH_CONCERNS",
+      "did": "Skipped in auto mode — manual walkthrough requires F5 Extension Host; compile + webpack pass.",
+      "files": [],
+      "concerns": [
+        "Manual scenario verification pending; user should run F5 and exercise the 5 scenarios from spec.md."
+      ]
+    }
   },
   "concerns": [
-    { "task": "T005", "note": "Hybrid footer: Edit Source + enhancement buttons stay hardcoded outside viewerState.footer." },
-    { "task": "T007", "note": "Legacy .working / .in-progress classes retained on StepTab; R009 partial." },
-    { "task": "T008", "note": "Old CSS selectors (.step-tab.in-progress, .step-tab.working) not removed." },
-    { "task": "T009", "note": "No FooterActions component test added." },
-    { "task": "T010", "note": "Manual scenario walkthrough not executed in auto mode." }
+    {
+      "task": "T005",
+      "note": "Hybrid footer: Edit Source + enhancement buttons stay hardcoded outside viewerState.footer."
+    },
+    {
+      "task": "T007",
+      "note": "Legacy .working / .in-progress classes retained on StepTab; R009 partial."
+    },
+    {
+      "task": "T008",
+      "note": "Old CSS selectors (.step-tab.in-progress, .step-tab.working) not removed."
+    },
+    {
+      "task": "T009",
+      "note": "No FooterActions component test added."
+    },
+    {
+      "task": "T010",
+      "note": "Manual scenario walkthrough not executed in auto mode."
+    }
   ],
   "decisions": [
     "Additive/non-breaking migration: viewerState plumbed alongside navState; components check vs first and fall back to legacy state when null.",
     "Route new footer button clicks via { type: 'footerAction', id } instead of replacing existing message types, to avoid churn in existing call sites."
   ],
-  "checkpointStatus": { "commit": false, "pr": false },
+  "checkpointStatus": {
+    "commit": false,
+    "pr": false
+  },
   "transitions": [
-    { "step": "specify", "substep": "parsing", "from": null, "by": "sdd", "at": "2026-04-13T20:59:09Z" },
-    { "step": "specify", "substep": "exploring", "from": { "step": "specify", "substep": "parsing" }, "by": "sdd", "at": "2026-04-13T20:59:10Z" },
-    { "step": "specify", "substep": "detecting", "from": { "step": "specify", "substep": "exploring" }, "by": "sdd", "at": "2026-04-13T20:59:11Z" },
-    { "step": "specify", "substep": "writing-spec", "from": { "step": "specify", "substep": "detecting" }, "by": "sdd", "at": "2026-04-13T20:59:12Z" },
-    { "step": "specify", "substep": null, "from": { "step": "specify", "substep": "writing-spec" }, "by": "sdd", "at": "2026-04-13T20:59:13Z" },
-    { "step": "plan", "substep": "loading", "from": { "step": "specify", "substep": null }, "by": "sdd", "at": "2026-04-13T21:00:00Z" },
-    { "step": "plan", "substep": "writing-plan", "from": { "step": "plan", "substep": "loading" }, "by": "sdd", "at": "2026-04-13T21:00:01Z" },
-    { "step": "plan", "substep": null, "from": { "step": "plan", "substep": "writing-plan" }, "by": "sdd", "at": "2026-04-13T21:00:02Z" },
-    { "step": "tasks", "substep": "loading", "from": { "step": "plan", "substep": null }, "by": "sdd", "at": "2026-04-13T21:01:00Z" },
-    { "step": "tasks", "substep": "writing-tasks", "from": { "step": "tasks", "substep": "loading" }, "by": "sdd", "at": "2026-04-13T21:01:15Z" },
-    { "step": "tasks", "substep": null, "from": { "step": "tasks", "substep": "writing-tasks" }, "by": "sdd", "at": "2026-04-13T21:01:30Z" },
-    { "step": "implement", "substep": "phase1", "from": { "step": "tasks", "substep": null }, "by": "sdd", "at": "2026-04-13T21:01:30Z" },
-    { "step": "implement", "substep": null, "from": { "step": "implement", "substep": "phase1" }, "by": "sdd", "at": "2026-04-13T21:30:00Z" }
+    {
+      "step": "specify",
+      "substep": "parsing",
+      "from": null,
+      "by": "sdd",
+      "at": "2026-04-13T20:59:09Z"
+    },
+    {
+      "step": "specify",
+      "substep": "exploring",
+      "from": {
+        "step": "specify",
+        "substep": "parsing"
+      },
+      "by": "sdd",
+      "at": "2026-04-13T20:59:10Z"
+    },
+    {
+      "step": "specify",
+      "substep": "detecting",
+      "from": {
+        "step": "specify",
+        "substep": "exploring"
+      },
+      "by": "sdd",
+      "at": "2026-04-13T20:59:11Z"
+    },
+    {
+      "step": "specify",
+      "substep": "writing-spec",
+      "from": {
+        "step": "specify",
+        "substep": "detecting"
+      },
+      "by": "sdd",
+      "at": "2026-04-13T20:59:12Z"
+    },
+    {
+      "step": "specify",
+      "substep": null,
+      "from": {
+        "step": "specify",
+        "substep": "writing-spec"
+      },
+      "by": "sdd",
+      "at": "2026-04-13T20:59:13Z"
+    },
+    {
+      "step": "plan",
+      "substep": "loading",
+      "from": {
+        "step": "specify",
+        "substep": null
+      },
+      "by": "sdd",
+      "at": "2026-04-13T21:00:00Z"
+    },
+    {
+      "step": "plan",
+      "substep": "writing-plan",
+      "from": {
+        "step": "plan",
+        "substep": "loading"
+      },
+      "by": "sdd",
+      "at": "2026-04-13T21:00:01Z"
+    },
+    {
+      "step": "plan",
+      "substep": null,
+      "from": {
+        "step": "plan",
+        "substep": "writing-plan"
+      },
+      "by": "sdd",
+      "at": "2026-04-13T21:00:02Z"
+    },
+    {
+      "step": "tasks",
+      "substep": "loading",
+      "from": {
+        "step": "plan",
+        "substep": null
+      },
+      "by": "sdd",
+      "at": "2026-04-13T21:01:00Z"
+    },
+    {
+      "step": "tasks",
+      "substep": "writing-tasks",
+      "from": {
+        "step": "tasks",
+        "substep": "loading"
+      },
+      "by": "sdd",
+      "at": "2026-04-13T21:01:15Z"
+    },
+    {
+      "step": "tasks",
+      "substep": null,
+      "from": {
+        "step": "tasks",
+        "substep": "writing-tasks"
+      },
+      "by": "sdd",
+      "at": "2026-04-13T21:01:30Z"
+    },
+    {
+      "step": "implement",
+      "substep": "phase1",
+      "from": {
+        "step": "tasks",
+        "substep": null
+      },
+      "by": "sdd",
+      "at": "2026-04-13T21:01:30Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "from": {
+        "step": "implement",
+        "substep": "phase1"
+      },
+      "by": "sdd",
+      "at": "2026-04-13T21:30:00Z"
+    }
   ]
 }

--- a/specs/064-provider-registry/.spec-context.json
+++ b/specs/064-provider-registry/.spec-context.json
@@ -1,0 +1,49 @@
+{
+  "workflow": "sdd",
+  "currentStep": "tasks",
+  "currentTask": null,
+  "progress": null,
+  "next": "implement",
+  "updated": "2026-04-13",
+  "selectedAt": "2026-04-13T22:22:52Z",
+  "status": "active",
+  "specName": "Provider Registry",
+  "branch": "main",
+  "createdAt": "2026-04-13T22:22:52Z",
+  "approach": "Extend PROVIDER_PATHS into the single source of truth for all per-provider behavior and refactor factory, QuickPick, steering sidebar, and permission helpers to derive from it.",
+  "stepHistory": {
+    "specify": { "startedAt": "2026-04-13T22:22:52Z" },
+    "plan": { "startedAt": "2026-04-13T22:24:00Z" },
+    "tasks": { "startedAt": "2026-04-13T22:25:00Z" }
+  },
+  "step_summaries": {
+    "specify": {
+      "complexity": "normal",
+      "requirements": 14,
+      "scenarios": 6,
+      "key_finding": "PROVIDER_PATHS in aiProvider.ts is already a Record<AIProviderType, ProviderPaths> but factory, QuickPick, and steering sidebar maintain parallel hardcoded provider lists instead of deriving from it."
+    },
+    "plan": {
+      "approach_summary": "Extend PROVIDER_PATHS into the single source of truth for all per-provider behavior and refactor factory, QuickPick, steering sidebar, and permission helpers to derive from it.",
+      "files_planned": 14,
+      "risks": [
+        "Renamed steering methods break callers — rename and update every caller in the same commit; rely on tsc to catch stragglers.",
+        "AGENTS.md collision between OpenCode and Codex — accepted; content is provider-agnostic.",
+        "Activation-time validation noise — debounce via globalState or only fire on setting change after activation."
+      ]
+    }
+  },
+  "transitions": [
+    { "step": "specify", "substep": "parsing", "from": null, "by": "sdd", "at": "2026-04-13T22:22:52Z" },
+    { "step": "specify", "substep": "exploring", "from": { "step": "specify", "substep": "parsing" }, "by": "sdd", "at": "2026-04-13T22:23:00Z" },
+    { "step": "specify", "substep": "detecting", "from": { "step": "specify", "substep": "exploring" }, "by": "sdd", "at": "2026-04-13T22:23:10Z" },
+    { "step": "specify", "substep": "writing-spec", "from": { "step": "specify", "substep": "detecting" }, "by": "sdd", "at": "2026-04-13T22:23:20Z" },
+    { "step": "specify", "substep": null, "from": { "step": "specify", "substep": "writing-spec" }, "by": "sdd", "at": "2026-04-13T22:23:30Z" },
+    { "step": "plan", "substep": "loading", "from": { "step": "specify", "substep": null }, "by": "sdd", "at": "2026-04-13T22:24:00Z" },
+    { "step": "plan", "substep": "writing-plan", "from": { "step": "plan", "substep": "loading" }, "by": "sdd", "at": "2026-04-13T22:24:10Z" },
+    { "step": "plan", "substep": null, "from": { "step": "plan", "substep": "writing-plan" }, "by": "sdd", "at": "2026-04-13T22:24:20Z" },
+    { "step": "tasks", "substep": "loading", "from": { "step": "plan", "substep": null }, "by": "sdd", "at": "2026-04-13T22:25:00Z" },
+    { "step": "tasks", "substep": "writing-tasks", "from": { "step": "tasks", "substep": "loading" }, "by": "sdd", "at": "2026-04-13T22:25:10Z" },
+    { "step": "tasks", "substep": null, "from": { "step": "tasks", "substep": "writing-tasks" }, "by": "sdd", "at": "2026-04-13T22:25:20Z" }
+  ]
+}

--- a/specs/064-provider-registry/.spec-context.json
+++ b/specs/064-provider-registry/.spec-context.json
@@ -1,20 +1,26 @@
 {
   "workflow": "sdd",
-  "currentStep": "tasks",
+  "currentStep": "implement",
   "currentTask": null,
   "progress": null,
-  "next": "implement",
+  "next": "done",
   "updated": "2026-04-13",
   "selectedAt": "2026-04-13T22:22:52Z",
-  "status": "active",
+  "status": "completed",
   "specName": "Provider Registry",
   "branch": "main",
   "createdAt": "2026-04-13T22:22:52Z",
   "approach": "Extend PROVIDER_PATHS into the single source of truth for all per-provider behavior and refactor factory, QuickPick, steering sidebar, and permission helpers to derive from it.",
   "stepHistory": {
-    "specify": { "startedAt": "2026-04-13T22:22:52Z" },
-    "plan": { "startedAt": "2026-04-13T22:24:00Z" },
-    "tasks": { "startedAt": "2026-04-13T22:25:00Z" }
+    "specify": {
+      "startedAt": "2026-04-13T22:22:52Z"
+    },
+    "plan": {
+      "startedAt": "2026-04-13T22:24:00Z"
+    },
+    "tasks": {
+      "startedAt": "2026-04-13T22:25:00Z"
+    }
   },
   "step_summaries": {
     "specify": {
@@ -34,16 +40,112 @@
     }
   },
   "transitions": [
-    { "step": "specify", "substep": "parsing", "from": null, "by": "sdd", "at": "2026-04-13T22:22:52Z" },
-    { "step": "specify", "substep": "exploring", "from": { "step": "specify", "substep": "parsing" }, "by": "sdd", "at": "2026-04-13T22:23:00Z" },
-    { "step": "specify", "substep": "detecting", "from": { "step": "specify", "substep": "exploring" }, "by": "sdd", "at": "2026-04-13T22:23:10Z" },
-    { "step": "specify", "substep": "writing-spec", "from": { "step": "specify", "substep": "detecting" }, "by": "sdd", "at": "2026-04-13T22:23:20Z" },
-    { "step": "specify", "substep": null, "from": { "step": "specify", "substep": "writing-spec" }, "by": "sdd", "at": "2026-04-13T22:23:30Z" },
-    { "step": "plan", "substep": "loading", "from": { "step": "specify", "substep": null }, "by": "sdd", "at": "2026-04-13T22:24:00Z" },
-    { "step": "plan", "substep": "writing-plan", "from": { "step": "plan", "substep": "loading" }, "by": "sdd", "at": "2026-04-13T22:24:10Z" },
-    { "step": "plan", "substep": null, "from": { "step": "plan", "substep": "writing-plan" }, "by": "sdd", "at": "2026-04-13T22:24:20Z" },
-    { "step": "tasks", "substep": "loading", "from": { "step": "plan", "substep": null }, "by": "sdd", "at": "2026-04-13T22:25:00Z" },
-    { "step": "tasks", "substep": "writing-tasks", "from": { "step": "tasks", "substep": "loading" }, "by": "sdd", "at": "2026-04-13T22:25:10Z" },
-    { "step": "tasks", "substep": null, "from": { "step": "tasks", "substep": "writing-tasks" }, "by": "sdd", "at": "2026-04-13T22:25:20Z" }
+    {
+      "step": "specify",
+      "substep": "parsing",
+      "from": null,
+      "by": "sdd",
+      "at": "2026-04-13T22:22:52Z"
+    },
+    {
+      "step": "specify",
+      "substep": "exploring",
+      "from": {
+        "step": "specify",
+        "substep": "parsing"
+      },
+      "by": "sdd",
+      "at": "2026-04-13T22:23:00Z"
+    },
+    {
+      "step": "specify",
+      "substep": "detecting",
+      "from": {
+        "step": "specify",
+        "substep": "exploring"
+      },
+      "by": "sdd",
+      "at": "2026-04-13T22:23:10Z"
+    },
+    {
+      "step": "specify",
+      "substep": "writing-spec",
+      "from": {
+        "step": "specify",
+        "substep": "detecting"
+      },
+      "by": "sdd",
+      "at": "2026-04-13T22:23:20Z"
+    },
+    {
+      "step": "specify",
+      "substep": null,
+      "from": {
+        "step": "specify",
+        "substep": "writing-spec"
+      },
+      "by": "sdd",
+      "at": "2026-04-13T22:23:30Z"
+    },
+    {
+      "step": "plan",
+      "substep": "loading",
+      "from": {
+        "step": "specify",
+        "substep": null
+      },
+      "by": "sdd",
+      "at": "2026-04-13T22:24:00Z"
+    },
+    {
+      "step": "plan",
+      "substep": "writing-plan",
+      "from": {
+        "step": "plan",
+        "substep": "loading"
+      },
+      "by": "sdd",
+      "at": "2026-04-13T22:24:10Z"
+    },
+    {
+      "step": "plan",
+      "substep": null,
+      "from": {
+        "step": "plan",
+        "substep": "writing-plan"
+      },
+      "by": "sdd",
+      "at": "2026-04-13T22:24:20Z"
+    },
+    {
+      "step": "tasks",
+      "substep": "loading",
+      "from": {
+        "step": "plan",
+        "substep": null
+      },
+      "by": "sdd",
+      "at": "2026-04-13T22:25:00Z"
+    },
+    {
+      "step": "tasks",
+      "substep": "writing-tasks",
+      "from": {
+        "step": "tasks",
+        "substep": "loading"
+      },
+      "by": "sdd",
+      "at": "2026-04-13T22:25:10Z"
+    },
+    {
+      "step": "tasks",
+      "substep": null,
+      "from": {
+        "step": "tasks",
+        "substep": "writing-tasks"
+      },
+      "by": "sdd",
+      "at": "2026-04-13T22:25:20Z"
+    }
   ]
 }

--- a/specs/064-provider-registry/plan.md
+++ b/specs/064-provider-registry/plan.md
@@ -1,0 +1,58 @@
+# Plan: Provider Registry
+
+**Spec**: [spec.md](./spec.md) | **Date**: 2026-04-13
+
+## Approach
+
+Extend `PROVIDER_PATHS` in `src/ai-providers/aiProvider.ts` into the single source of truth for all per-provider behavior (UI labels, capability flags, permission flags, steering paths) and refactor the factory, QuickPick, steering sidebar, and permission helpers to derive from it instead of holding parallel hardcoded lists. Add OpenCode as the first provider that exercises the registry end-to-end, fix the Copilot interactive-mode silent-failure with a `validatePermissionMode()` notification, and move the spec-editor's Post-Specification instructions into the temp markdown file so the terminal dispatch line stays clean.
+
+## Technical Context
+
+**Stack**: TypeScript 5.3+ (ES2022, strict), VS Code Extension API, Webpack 5
+**Key Dependencies**: none new
+**Constraints**: must not change behavior of existing `formatCommandForProvider` tests; activation must remain non-blocking; no edits to `.claude/**` or `.specify/**` (extension isolation).
+
+## Architecture
+
+```mermaid
+graph LR
+  PP[PROVIDER_PATHS<br/>registry] --> F[aiProviderFactory]
+  PP --> QP[promptForProviderSelection]
+  PP --> SE[steeringExplorerProvider]
+  PP --> SM[steeringManager]
+  PP --> PM[validatePermissionMode]
+  PP --> PF[getPermissionFlagForProvider]
+  F --> OC[openCodeProvider]
+```
+
+## Files
+
+### Create
+
+- `src/ai-providers/openCodeProvider.ts` — `IAIProvider` impl modeled on `qwenCliProvider.ts`; `isInstalled()` shells `opencode --version` and returns false on ENOENT; uses `dispatchSlashCommandViaTempFile` for execution.
+- `src/ai-providers/permissionValidation.ts` — exports `validatePermissionMode(context)` and `getPermissionFlagForProvider(providerType)`; subscribed to `onDidChangeConfiguration` for `speckit.permissionMode` and `speckit.aiProvider`.
+
+### Modify
+
+- `src/ai-providers/aiProvider.ts` — extend `ProviderPaths` with `globalSteeringFile`, `configDir`, `quickPickIcon`, `quickPickDescription`, `supportsInteractivePermissions`, `autoApproveFlag`; populate for all six providers; rewrite `promptForProviderSelection()` to iterate `PROVIDER_PATHS`.
+- `src/ai-providers/aiProviderFactory.ts` — replace `switch` with `PROVIDER_CONSTRUCTORS: Record<AIProviderType, () => IAIProvider>`; derive `getSupportedProviders()` from `Object.keys(PROVIDER_PATHS)`.
+- `src/ai-providers/index.ts` — barrel export for `openCodeProvider` and `permissionValidation`.
+- `src/ai-providers/claudeCodeProvider.ts`, `geminiCliProvider.ts`, `copilotCliProvider.ts`, `codexCliProvider.ts`, `qwenCliProvider.ts` — `getPermissionFlag()` delegates to `getPermissionFlagForProvider(this.type)`.
+- `src/core/constants.ts` — add `OPENCODE: 'opencode'` to `AIProviders`.
+- `src/features/steering/steeringExplorerProvider.ts` — file watchers and section visibility derive from `getProviderPaths()`; remove hardcoded `.claude/` patterns and `providerType === AIProviders.CLAUDE` checks; rename method calls to `createProjectSteeringFile` / `createUserSteeringFile`; remove `getSteeringFilePaths` per-provider switch (resolve via `globalSteeringFile` + `steeringFile`).
+- `src/features/steering/steeringManager.ts` — rename `createProjectClaudeMd` → `createProjectSteeringFile`, `createUserClaudeMd` → `createUserSteeringFile`; update internal references.
+- `src/features/spec-editor/tempFileManager.ts` — add `appendToMarkdownFile(filePath, content)` method.
+- `src/features/spec-editor/specEditorProvider.ts` — append Post-Specification instruction block to the temp `spec.md` via the new method; change dispatched line from `{command} {markdownContent}{specContextInstruction}` to `{command} {tempFilePath}`.
+- `src/extension.ts` — call `validatePermissionMode(context)` after activation; subscribe to setting changes.
+- `package.json` — add `opencode` to `speckit.aiProvider` enum + `enumDescriptions`; clarify `speckit.permissionMode` description re: which providers honor `interactive`.
+
+## Testing Strategy
+
+- **Unit**: existing `formatCommandForProvider.test.ts` must pass unchanged; add a small test that `getSupportedProviders()` returns all `PROVIDER_PATHS` keys and that `getPermissionFlagForProvider('copilot')` returns the auto-approve flag only when mode is `auto-approve`.
+- **Manual (F5)**: walk through each scenario in spec.md — switch providers in settings, verify steering sidebar reloads with correct files/sections; trigger Copilot+interactive warning and confirm "Switch to Auto-Approve" works; trigger spec-editor dispatch and confirm terminal line shows only the temp file path.
+
+## Risks
+
+- **Renamed steering methods break callers**: `createProjectClaudeMd`/`createUserClaudeMd` are wired into command registrations; mitigation — rename and update every caller in the same commit, run `tsc` to catch stragglers.
+- **`AGENTS.md` collision between OpenCode and Codex**: same workspace file reused when switching providers; accepted per spec — content is provider-agnostic.
+- **Activation-time validation noise**: warning toast on every window open if user already chose Copilot+interactive; mitigation — only show when the *combination* is freshly invalid (debounce per-session via `globalState` flag, or only fire on setting change after activation).

--- a/specs/064-provider-registry/spec.md
+++ b/specs/064-provider-registry/spec.md
@@ -1,0 +1,79 @@
+# Spec: Provider Registry
+
+**Slug**: 064-provider-registry | **Date**: 2026-04-13
+
+## Summary
+
+Consolidate scattered AI-provider configuration into a single registry so adding a new provider takes ~25 declarative lines instead of touching 6–8 files. Add OpenCode support (#72), fix silent Copilot permission failures in interactive mode (#78), and clean up the spec-editor terminal dispatch by moving Post-Specification instructions into the temp markdown file.
+
+## Requirements
+
+### Phase 1 — Registry pattern
+
+- **R001** (MUST): `ProviderPaths` interface in `src/ai-providers/aiProvider.ts` includes `globalSteeringFile: string | null`, `configDir: string`, `quickPickIcon: string`, `quickPickDescription: string`, `supportsInteractivePermissions: boolean`, and `autoApproveFlag: string` fields, populated for every entry in `PROVIDER_PATHS`.
+- **R002** (MUST): `aiProviderFactory.ts` replaces its switch statement with a `PROVIDER_CONSTRUCTORS: Record<AIProviderType, () => IAIProvider>` lookup, and `getSupportedProviders()` is derived from `Object.keys(PROVIDER_PATHS)`.
+- **R003** (MUST): `promptForProviderSelection()` builds its QuickPick items by iterating `PROVIDER_PATHS`, using each provider's `quickPickIcon`, `displayName`, and `quickPickDescription` — no hardcoded list of providers in the function.
+- **R004** (MUST): `steeringExplorerProvider.ts` file watchers and visibility checks read agent/skill paths from `getProviderPaths()` instead of hardcoded `.claude/...` patterns; sections show or hide based on `providerPaths.agentsDir`/`providerPaths.skillsDir` being non-empty (no `if (providerType === AIProviders.CLAUDE)` checks).
+- **R005** (MUST): `getSteeringFilePaths` resolves global and project steering paths from the new `globalSteeringFile` and existing `steeringFile` fields — the per-provider switch is removed.
+- **R006** (MUST): In `steeringManager.ts`, `createProjectClaudeMd` is renamed to `createProjectSteeringFile` and `createUserClaudeMd` to `createUserSteeringFile`; all call sites (including command registrations in `steeringExplorerProvider.ts`) are updated in the same change so no broken references remain.
+
+### Phase 2 — OpenCode (#72)
+
+- **R007** (MUST): `AIProviders.OPENCODE = 'opencode'` is added to `src/core/constants.ts`, with a corresponding entry in `PROVIDER_PATHS` (steering=`AGENTS.md`, agents=`.opencode/agent/*.md`, config=`.opencode/opencode.jsonc`) and a new `src/ai-providers/openCodeProvider.ts` modeled on `qwenCliProvider.ts`.
+- **R008** (MUST): Adding OpenCode requires only: 1 entry in `PROVIDER_PATHS`, 1 new provider file, 1 line in the factory `PROVIDER_CONSTRUCTORS` lookup, 1 line in the barrel export, 1 entry in the `package.json` `speckit.aiProvider` enum.
+
+### Phase 3 — Clean spec-editor dispatch
+
+- **R009** (MUST): `tempFileManager.ts` exposes an `appendToMarkdownFile(filePath, content)` (or equivalent) method, and `specEditorProvider.ts` appends the Post-Specification instruction block to the temp `spec.md` file rather than to the prompt string.
+- **R010** (MUST): The terminal command dispatched by `specEditorProvider.ts` is of the form `{command} {tempFilePath}` — the markdown content and instruction block no longer appear in the visible terminal line.
+
+### Phase 4 — Permissions (#78)
+
+- **R011** (MUST): A `validatePermissionMode()` function runs during extension activation and on changes to `speckit.permissionMode` or `speckit.aiProvider`. When `interactive` is set but the active provider has `supportsInteractivePermissions: false` and a non-empty `autoApproveFlag`, it shows a warning notification with a "Switch to Auto-Approve" action that updates the setting.
+- **R012** (MUST): A shared `getPermissionFlagForProvider(providerType)` utility returns the appropriate flag using `PROVIDER_PATHS[providerType].autoApproveFlag` and the current permission mode; per-provider `getPermissionFlag()` implementations delegate to it.
+- **R013** (SHOULD): The `speckit.permissionMode` description in `package.json` clarifies which providers support interactive prompting.
+- **R014** (SHOULD): When the registry adds future capability flags (e.g., `supportsHiddenPromptDispatch`), call sites use the flag rather than `if (providerType === AIProviders.X)` checks — this spec establishes the pattern for `supportsInteractivePermissions`.
+
+## Scenarios
+
+### Switching providers updates the steering sidebar
+
+**When** the user changes `speckit.aiProvider` from Claude to Gemini in settings
+**Then** the steering sidebar reloads, file watchers re-bind to `GEMINI.md`/`.gemini/*` paths from `PROVIDER_PATHS`, the Skills section is hidden (Gemini's `skillsDir` is empty), and no hardcoded `.claude/` paths are still being watched.
+
+### Provider selection prompt lists every registered provider
+
+**When** the user runs the "Choose AI Provider" command on a fresh install
+**Then** the QuickPick shows all six providers (Claude, Copilot, Gemini, Codex, Qwen, OpenCode) with each entry's icon and description sourced from the corresponding `PROVIDER_PATHS` entry.
+
+### Adding OpenCode requires only registry edits
+
+**When** a developer follows R008 to add OpenCode
+**Then** OpenCode appears in the QuickPick, its `isInstalled()` returns false gracefully when the CLI is missing, the steering sidebar shows `AGENTS.md` and `.opencode/agent/` agents, and no other source file (factory switches, sidebar conditionals, command registrations) needs to change.
+
+### Copilot + interactive mode warns the user
+
+**When** `speckit.aiProvider` is `copilot` and `speckit.permissionMode` is `interactive`
+**Then** `validatePermissionMode()` shows a warning toast: "Copilot does not support interactive permission prompts. Switch to Auto-Approve?" with an action button; clicking it updates `speckit.permissionMode` to `auto-approve` and the warning is not re-shown until the combination recurs.
+
+### Spec-editor dispatch hides instructions from the terminal
+
+**When** the user triggers a spec-editor AI dispatch
+**Then** the visible terminal line is `<cli> "/sdd:specify <tempFilePath>"` (or the provider-equivalent), the markdown body and the Post-Specification instruction block are written into the temp file, and the AI still receives both when it reads the file.
+
+### AGENTS.md collision is acceptable
+
+**When** both OpenCode and Codex are configured against the same workspace and the user switches between them
+**Then** the same `AGENTS.md` file is reused as the steering file for whichever provider is active — no error, no duplicate-file prompt — because the content is provider-agnostic.
+
+## Non-Functional Requirements
+
+- **NFR001** (SHOULD): Registry refactor preserves existing public behavior — `formatCommandForProvider.test.ts` and other existing tests pass unchanged without modification.
+- **NFR002** (SHOULD): No regression in extension activation time; the validation/warning logic runs after activation completes (not blocking).
+
+## Out of Scope
+
+- A base class or inheritance hierarchy for providers (composition is preferred per spec 04).
+- Visual redesign of the provider selection QuickPick beyond data-driven population.
+- Auto-detection of installed providers on the user's machine.
+- Migrating Gemini and Codex to the hidden-prompt-dispatch helper from #82 (left unchanged per that PR's decision); a `supportsHiddenPromptDispatch` capability flag is noted as a future extension but not implemented here.

--- a/specs/064-provider-registry/tasks.md
+++ b/specs/064-provider-registry/tasks.md
@@ -1,0 +1,69 @@
+# Tasks: Provider Registry
+
+**Plan**: [plan.md](./plan.md) | **Date**: 2026-04-13
+
+---
+
+## Phase 1: Core Implementation (Sequential)
+
+- [x] **T001** Extend ProviderPaths interface and PROVIDER_PATHS entries — `src/ai-providers/aiProvider.ts` | R001
+  - **Do**: Add `globalSteeringFile: string | null`, `configDir: string`, `quickPickIcon: string`, `quickPickDescription: string`, `supportsInteractivePermissions: boolean`, `autoApproveFlag: string` to `ProviderPaths`. Populate all six existing entries (Claude, Gemini, Copilot, Codex, Qwen) — Copilot gets `supportsInteractivePermissions: false` and a non-empty `autoApproveFlag`; others reflect their CLI reality.
+  - **Verify**: `npm run compile` passes; no other file references break (TS will catch missing fields).
+
+- [x] **T002** Add OPENCODE constant + PROVIDER_PATHS entry *(depends on T001)* — `src/core/constants.ts`, `src/ai-providers/aiProvider.ts` | R007
+  - **Do**: Add `OPENCODE: 'opencode'` to `AIProviders`. Add `[AIProviders.OPENCODE]` entry to `PROVIDER_PATHS` with steering=`AGENTS.md`, agentsDir=`.opencode/agent`, agentsPattern=`*.md`, configDir=`.opencode`, mcpConfigPath=`.opencode/opencode.jsonc`, displayName='OpenCode', commandFormat='dot', appropriate icon/description, `supportsInteractivePermissions: true`.
+  - **Verify**: `tsc` passes; `Object.keys(PROVIDER_PATHS).length === 6`.
+
+- [x] **T003** Create OpenCode provider implementation *(depends on T002)* — `src/ai-providers/openCodeProvider.ts`, `src/ai-providers/index.ts` | R007
+  - **Do**: Mirror `qwenCliProvider.ts` structure: `name`, `type = AIProviders.OPENCODE`, `isInstalled()` shells `opencode --version` (graceful ENOENT → false), `executeInTerminal`/`executeSlashCommand` use `dispatchSlashCommandViaTempFile`, `getPermissionFlag()` delegates (placeholder until T010). Add barrel export in `index.ts`.
+  - **Verify**: `tsc` passes; `import { OpenCodeProvider } from './ai-providers'` resolves.
+  - **Leverage**: `src/ai-providers/qwenCliProvider.ts`.
+
+- [x] **T004** Replace factory switch with PROVIDER_CONSTRUCTORS lookup *(depends on T003)* — `src/ai-providers/aiProviderFactory.ts` | R002, R008
+  - **Do**: Define `const PROVIDER_CONSTRUCTORS: Record<AIProviderType, () => IAIProvider> = { [AIProviders.CLAUDE]: () => new ClaudeCodeProvider(), ..., [AIProviders.OPENCODE]: () => new OpenCodeProvider() }`. Rewrite the create function to do `PROVIDER_CONSTRUCTORS[type]()`. Replace any hardcoded `getSupportedProviders()` body with `Object.keys(PROVIDER_PATHS) as AIProviderType[]`.
+  - **Verify**: `tsc` passes; existing factory call sites still resolve all six providers.
+
+- [x] **T005** Make promptForProviderSelection data-driven *(depends on T004)* — `src/ai-providers/aiProvider.ts` | R003
+  - **Do**: Replace the hardcoded QuickPick array in `promptForProviderSelection()` with `Object.entries(PROVIDER_PATHS).map(([type, p]) => ({ label: \`${p.quickPickIcon} ${p.displayName}\`, description: p.quickPickDescription, value: type as AIProviderType }))`.
+  - **Verify**: F5 → run "Choose AI Provider" command → all six providers appear with correct icons/descriptions.
+
+- [x] **T006** Refactor steering sidebar to derive paths from registry *(depends on T005)* — `src/features/steering/steeringExplorerProvider.ts` | R004, R005, R007 (capability checks)
+  - **Do**: Replace hardcoded `.claude/agents`, `.claude/skills` watcher patterns with values from `getProviderPaths()`. Replace `if (providerType === AIProviders.CLAUDE)` visibility checks with `if (providerPaths.agentsDir)` / `if (providerPaths.skillsDir)`. Remove the `getSteeringFilePaths` per-provider switch; resolve global path from `globalSteeringFile` and project from `steeringFile`.
+  - **Verify**: F5 → switch provider Claude→Gemini in settings → sidebar reloads, Skills section hides for Gemini, no `.claude/` watcher remains active.
+
+- [x] **T007** Rename steering manager methods *(depends on T006)* — `src/features/steering/steeringManager.ts`, `src/features/steering/steeringExplorerProvider.ts`, any other callers | R006
+  - **Do**: Rename `createProjectClaudeMd` → `createProjectSteeringFile`, `createUserClaudeMd` → `createUserSteeringFile`. Update all call sites including command registrations in `steeringExplorerProvider.ts`. Use `Grep` for both old names to confirm zero remaining references.
+  - **Verify**: `tsc` passes with zero references to the old names; commands still register.
+
+- [x] **T008** Add appendToMarkdownFile to tempFileManager *(depends on T007)* — `src/features/spec-editor/tempFileManager.ts` | R009
+  - **Do**: Add `async appendToMarkdownFile(filePath: string, content: string): Promise<void>` that does `fs.promises.appendFile(filePath, '\n\n' + content)`.
+  - **Verify**: `tsc` passes; existing temp file callers unaffected.
+
+- [x] **T009** Move Post-Specification instructions into temp file *(depends on T008)* — `src/features/spec-editor/specEditorProvider.ts` | R009, R010
+  - **Do**: After `tempFileManager.createTempFileSet`, call `appendToMarkdownFile(tempPath, specContextInstruction)`. Change the dispatched line from `{command} {markdownContent}{specContextInstruction}` to `{command} {tempFilePath}` (single argument).
+  - **Verify**: F5 → trigger spec-editor dispatch → terminal shows `<cli> "/sdd:specify <tempfile>"` only; the AI still receives full content (open the temp file to confirm append happened before dispatch).
+
+- [x] **T010** Create permission validation + shared flag helper *(depends on T009)* — `src/ai-providers/permissionValidation.ts`, all five existing provider files + `openCodeProvider.ts` | R011, R012
+  - **Do**: Create `permissionValidation.ts` exporting:
+    - `getPermissionFlagForProvider(type: AIProviderType): string` — reads `readPermissionMode()`, returns `PROVIDER_PATHS[type].autoApproveFlag` when mode is `auto-approve` and flag is non-empty, else `''`.
+    - `validatePermissionMode(context: vscode.ExtensionContext): Promise<void>` — when active provider has `supportsInteractivePermissions: false`, mode is `interactive`, and `autoApproveFlag` is non-empty, show warning toast with "Switch to Auto-Approve" button → updates `speckit.permissionMode` global setting.
+    Update each provider's `getPermissionFlag()` to delegate to `getPermissionFlagForProvider(this.type)`.
+  - **Verify**: `tsc` passes; unit-test (or manual) `getPermissionFlagForProvider('copilot')` returns flag only in auto-approve mode.
+
+- [x] **T011** Wire validatePermissionMode into activation + setting changes *(depends on T010)* — `src/extension.ts` | R011
+  - **Do**: After activation completes (non-blocking), call `validatePermissionMode(context)`. Subscribe to `vscode.workspace.onDidChangeConfiguration(e => { if (e.affectsConfiguration('speckit.permissionMode') || e.affectsConfiguration('speckit.aiProvider')) validatePermissionMode(context); })`. Push subscription into `context.subscriptions`. Debounce repeated warnings via a `globalState` flag keyed on `${provider}-${mode}` so the same combo doesn't re-prompt within a session.
+  - **Verify**: F5 → set Copilot + interactive → warning toast appears with action; click "Switch to Auto-Approve" → setting flips, warning gone; reopening window with same combo doesn't re-spam.
+
+- [x] **T012** Update package.json (opencode enum + permission description) *(depends on T011)* — `package.json` | R007, R013
+  - **Do**: Add `'opencode'` to `speckit.aiProvider.enum`; add matching `enumDescriptions` entry. Reword `speckit.permissionMode.description` to clarify that `interactive` is honored only by providers that support interactive permission prompts (e.g., Claude, Gemini); Copilot will be auto-switched.
+  - **Verify**: F5 → settings UI shows OpenCode in dropdown; permissionMode help text updated.
+
+- [x] **T013** Verify existing tests + manual scenario walkthrough *(depends on T012)* | NFR001, NFR002
+  - **Do**: Run `npm test` (existing `formatCommandForProvider.test.ts` and others must pass unchanged). Add a tiny test asserting `getSupportedProviders()` returns all 6 keys and `getPermissionFlagForProvider('copilot')` mode behavior. Then F5 walk through every scenario in spec.md.
+  - **Verify**: `npm test` green; all six spec scenarios behave as described; no regressions in steering sidebar across provider switches.
+
+---
+
+## Progress
+
+- Phase 1: T001–T013 [x]

--- a/src/ai-providers/__tests__/providerRegistry.test.ts
+++ b/src/ai-providers/__tests__/providerRegistry.test.ts
@@ -1,0 +1,52 @@
+import * as vscode from 'vscode';
+import { AIProviderFactory } from '../aiProviderFactory';
+import { PROVIDER_PATHS } from '../aiProvider';
+import { getPermissionFlagForProvider } from '../permissionValidation';
+import { AIProviders } from '../../core/constants';
+
+describe('Provider registry', () => {
+    function mockPermissionMode(value: 'interactive' | 'auto-approve') {
+        (vscode.workspace.getConfiguration as jest.Mock).mockReturnValue({
+            get: jest.fn((key: string, defaultValue?: unknown) => {
+                if (key === 'permissionMode') return value;
+                return defaultValue;
+            }),
+        });
+    }
+
+    describe('AIProviderFactory.getSupportedProviders', () => {
+        it('returns one entry per PROVIDER_PATHS key', () => {
+            const supported = AIProviderFactory.getSupportedProviders();
+            const expectedTypes = Object.keys(PROVIDER_PATHS).sort();
+            expect(supported.map(p => p.type).sort()).toEqual(expectedTypes);
+        });
+
+        it('includes opencode after registry expansion', () => {
+            const types = AIProviderFactory.getSupportedProviders().map(p => p.type);
+            expect(types).toContain(AIProviders.OPENCODE);
+        });
+    });
+
+    describe('getPermissionFlagForProvider', () => {
+        it('returns the auto-approve flag for Copilot when mode is auto-approve', () => {
+            mockPermissionMode('auto-approve');
+            expect(getPermissionFlagForProvider(AIProviders.COPILOT)).toBe('--yolo ');
+        });
+
+        it('returns empty string for Copilot when mode is interactive', () => {
+            mockPermissionMode('interactive');
+            expect(getPermissionFlagForProvider(AIProviders.COPILOT)).toBe('');
+        });
+
+        it('returns empty string for providers without an auto-approve flag (Gemini, Codex)', () => {
+            mockPermissionMode('auto-approve');
+            expect(getPermissionFlagForProvider(AIProviders.GEMINI)).toBe('');
+            expect(getPermissionFlagForProvider(AIProviders.CODEX)).toBe('');
+        });
+
+        it('returns Claude bypass flag in auto-approve mode', () => {
+            mockPermissionMode('auto-approve');
+            expect(getPermissionFlagForProvider(AIProviders.CLAUDE)).toBe('--permission-mode bypassPermissions ');
+        });
+    });
+});

--- a/src/ai-providers/aiProvider.ts
+++ b/src/ai-providers/aiProvider.ts
@@ -138,6 +138,8 @@ export type AIProviderType = typeof AIProviders[keyof typeof AIProviders];
 export interface ProviderPaths {
     /** Main steering file name (e.g., CLAUDE.md, GEMINI.md) */
     steeringFile: string;
+    /** Global steering file name relative to user home, or null if provider has no global file */
+    globalSteeringFile: string | null;
     /** Directory for additional steering files */
     steeringDir: string;
     /** Pattern for steering files in the directory */
@@ -152,12 +154,22 @@ export interface ProviderPaths {
     skillsPattern: string;
     /** Path to MCP config file (relative to home) */
     mcpConfigPath: string;
+    /** Workspace-relative provider config directory (e.g., '.claude', '.gemini') */
+    configDir: string;
     /** Whether hooks are supported */
     supportsHooks: boolean;
     /** Human-readable provider name for UI display */
     displayName: string;
     /** How speckit commands are formatted: 'dot' = speckit.plan, 'dash' = speckit-plan */
     commandFormat: 'dot' | 'dash';
+    /** Codicon string used in the provider QuickPick (e.g. '$(hubot)') */
+    quickPickIcon: string;
+    /** Description text shown in the provider QuickPick */
+    quickPickDescription: string;
+    /** Whether the CLI supports interactive permission prompting */
+    supportsInteractivePermissions: boolean;
+    /** Flag prepended to the CLI invocation when permission mode is 'auto-approve' (empty if none) */
+    autoApproveFlag: string;
 }
 
 /**
@@ -166,6 +178,7 @@ export interface ProviderPaths {
 export const PROVIDER_PATHS: Record<AIProviderType, ProviderPaths> = {
     [AIProviders.CLAUDE]: {
         steeringFile: 'CLAUDE.md',
+        globalSteeringFile: '.claude/CLAUDE.md',
         steeringDir: '.claude/steering',
         steeringPattern: '*.md',
         agentsDir: '.claude/agents',
@@ -173,12 +186,18 @@ export const PROVIDER_PATHS: Record<AIProviderType, ProviderPaths> = {
         skillsDir: '.claude/skills',
         skillsPattern: '*/SKILL.md',
         mcpConfigPath: '.claude/settings.json',
+        configDir: '.claude',
         supportsHooks: true,
         displayName: 'Claude',
         commandFormat: 'dash',
+        quickPickIcon: '$(hubot)',
+        quickPickDescription: 'Full feature support: steering, agents, hooks, and MCP',
+        supportsInteractivePermissions: true,
+        autoApproveFlag: '--permission-mode bypassPermissions ',
     },
     [AIProviders.GEMINI]: {
         steeringFile: 'GEMINI.md',
+        globalSteeringFile: '.gemini/GEMINI.md',
         steeringDir: '', // Gemini uses hierarchical GEMINI.md files
         steeringPattern: 'GEMINI.md',
         agentsDir: '', // Limited agent support
@@ -186,12 +205,18 @@ export const PROVIDER_PATHS: Record<AIProviderType, ProviderPaths> = {
         skillsDir: '', // Not supported
         skillsPattern: '',
         mcpConfigPath: '.gemini/settings.json',
+        configDir: '.gemini',
         supportsHooks: false,
         displayName: 'Gemini',
         commandFormat: 'dot',
+        quickPickIcon: '$(sparkle)',
+        quickPickDescription: 'Steering and MCP support (no agents or hooks)',
+        supportsInteractivePermissions: true,
+        autoApproveFlag: '',
     },
     [AIProviders.COPILOT]: {
         steeringFile: '.github/copilot-instructions.md',
+        globalSteeringFile: null,
         steeringDir: '.github/instructions',
         steeringPattern: '*.instructions.md',
         agentsDir: '.github/agents',
@@ -199,12 +224,18 @@ export const PROVIDER_PATHS: Record<AIProviderType, ProviderPaths> = {
         skillsDir: '', // Not supported
         skillsPattern: '',
         mcpConfigPath: '.copilot/mcp-config.json',
+        configDir: '.github',
         supportsHooks: false,
         displayName: 'Copilot',
         commandFormat: 'dot',
+        quickPickIcon: '$(github)',
+        quickPickDescription: 'Steering, agents, and MCP support (no hooks)',
+        supportsInteractivePermissions: false,
+        autoApproveFlag: '--yolo ',
     },
     [AIProviders.CODEX]: {
         steeringFile: 'AGENTS.md',
+        globalSteeringFile: null,
         steeringDir: '.codex',
         steeringPattern: 'AGENTS.md',
         agentsDir: '', // Codex uses AGENTS.md hierarchy, not separate agents
@@ -212,12 +243,18 @@ export const PROVIDER_PATHS: Record<AIProviderType, ProviderPaths> = {
         skillsDir: '.codex/skills',
         skillsPattern: '*/SKILL.md',
         mcpConfigPath: '~/.codex/config.toml', // Note: home directory, TOML format
+        configDir: '.codex',
         supportsHooks: false,
         displayName: 'Codex',
         commandFormat: 'dash',
+        quickPickIcon: '$(terminal)',
+        quickPickDescription: 'Steering, skills, and MCP support',
+        supportsInteractivePermissions: true,
+        autoApproveFlag: '',
     },
     [AIProviders.QWEN]: {
         steeringFile: 'QWEN.md',
+        globalSteeringFile: '.qwen/QWEN.md',
         steeringDir: '.qwen/steering',
         steeringPattern: '*.md',
         agentsDir: '',
@@ -225,9 +262,33 @@ export const PROVIDER_PATHS: Record<AIProviderType, ProviderPaths> = {
         skillsDir: '',
         skillsPattern: '',
         mcpConfigPath: '.qwen/settings.json',
+        configDir: '.qwen',
         supportsHooks: false,
         displayName: 'Qwen',
         commandFormat: 'dot',
+        quickPickIcon: '$(hubot)',
+        quickPickDescription: 'Steering and MCP support (no agents or hooks)',
+        supportsInteractivePermissions: true,
+        autoApproveFlag: '--yolo ',
+    },
+    [AIProviders.OPENCODE]: {
+        steeringFile: 'AGENTS.md',
+        globalSteeringFile: null,
+        steeringDir: '',
+        steeringPattern: 'AGENTS.md',
+        agentsDir: '.opencode/agent',
+        agentsPattern: '*.md',
+        skillsDir: '',
+        skillsPattern: '',
+        mcpConfigPath: '.opencode/opencode.jsonc',
+        configDir: '.opencode',
+        supportsHooks: false,
+        displayName: 'OpenCode',
+        commandFormat: 'dot',
+        quickPickIcon: '$(code)',
+        quickPickDescription: 'Steering and agents support (AGENTS.md)',
+        supportsInteractivePermissions: true,
+        autoApproveFlag: '',
     },
 };
 
@@ -291,34 +352,16 @@ export function getConfiguredProviderType(): AIProviderType {
  * permission flows.
  */
 export async function promptForProviderSelection(): Promise<AIProviderType | undefined> {
+    const items = (Object.keys(PROVIDER_PATHS) as AIProviderType[]).map(type => {
+        const p = PROVIDER_PATHS[type];
+        return {
+            label: `${p.quickPickIcon} ${p.displayName}`,
+            description: p.quickPickDescription,
+            value: type,
+        };
+    });
     const selection = await vscode.window.showQuickPick(
-        [
-            {
-                label: '$(hubot) Claude Code',
-                description: 'Full feature support: steering, agents, hooks, and MCP',
-                value: AIProviders.CLAUDE as AIProviderType
-            },
-            {
-                label: '$(github) GitHub Copilot CLI',
-                description: 'Steering, agents, and MCP support (no hooks)',
-                value: AIProviders.COPILOT as AIProviderType
-            },
-            {
-                label: '$(sparkle) Gemini CLI',
-                description: 'Steering and MCP support (no agents or hooks)',
-                value: AIProviders.GEMINI as AIProviderType
-            },
-            {
-                label: '$(terminal) Codex CLI',
-                description: 'Steering, skills, and MCP support',
-                value: AIProviders.CODEX as AIProviderType
-            },
-            {
-                label: '$(hubot) Qwen Code',
-                description: 'Steering and MCP support (no agents or hooks)',
-                value: AIProviders.QWEN as AIProviderType
-            }
-        ],
+        items,
         {
             placeHolder: 'Select your AI coding assistant',
             title: 'SpecKit Companion - Choose AI Provider',

--- a/src/ai-providers/aiProviderFactory.ts
+++ b/src/ai-providers/aiProviderFactory.ts
@@ -1,11 +1,26 @@
 import * as vscode from 'vscode';
-import { IAIProvider, AIProviderType, getConfiguredProviderType } from './aiProvider';
+import { IAIProvider, AIProviderType, getConfiguredProviderType, PROVIDER_PATHS } from './aiProvider';
 import { ClaudeCodeProvider } from './claudeCodeProvider';
 import { GeminiCliProvider } from './geminiCliProvider';
 import { CopilotCliProvider } from './copilotCliProvider';
 import { CodexCliProvider } from './codexCliProvider';
 import { QwenCliProvider } from './qwenCliProvider';
+import { OpenCodeProvider } from './openCodeProvider';
 import { AIProviders } from '../core/constants';
+
+type ProviderConstructor = (
+    context: vscode.ExtensionContext,
+    outputChannel: vscode.OutputChannel
+) => IAIProvider;
+
+const PROVIDER_CONSTRUCTORS: Record<AIProviderType, ProviderConstructor> = {
+    [AIProviders.CLAUDE]: (ctx, out) => new ClaudeCodeProvider(ctx, out),
+    [AIProviders.GEMINI]: (ctx, out) => new GeminiCliProvider(ctx, out),
+    [AIProviders.COPILOT]: (ctx, out) => new CopilotCliProvider(ctx, out),
+    [AIProviders.CODEX]: (ctx, out) => new CodexCliProvider(ctx, out),
+    [AIProviders.QWEN]: (ctx, out) => new QwenCliProvider(ctx, out),
+    [AIProviders.OPENCODE]: (ctx, out) => new OpenCodeProvider(ctx, out),
+};
 
 /**
  * Factory for creating AI provider instances based on configuration
@@ -13,76 +28,43 @@ import { AIProviders } from '../core/constants';
 export class AIProviderFactory {
     private static providers: Map<AIProviderType, IAIProvider> = new Map();
 
-    /**
-     * Get the configured AI provider instance
-     */
     static getProvider(
         context: vscode.ExtensionContext,
         outputChannel: vscode.OutputChannel
     ): IAIProvider {
-        const providerType = getConfiguredProviderType();
-        return this.getProviderByType(providerType, context, outputChannel);
+        return this.getProviderByType(getConfiguredProviderType(), context, outputChannel);
     }
 
-    /**
-     * Get a specific AI provider by type
-     */
     static getProviderByType(
         type: AIProviderType,
         context: vscode.ExtensionContext,
         outputChannel: vscode.OutputChannel
     ): IAIProvider {
-        // Return cached instance if available
         const cached = this.providers.get(type);
-        if (cached) {
-            return cached;
-        }
+        if (cached) return cached;
 
-        // Create new instance
+        const ctor = PROVIDER_CONSTRUCTORS[type];
         let provider: IAIProvider;
-
-        switch (type) {
-            case AIProviders.CLAUDE:
-                provider = new ClaudeCodeProvider(context, outputChannel);
-                break;
-            case AIProviders.GEMINI:
-                provider = new GeminiCliProvider(context, outputChannel);
-                break;
-            case AIProviders.COPILOT:
-                provider = new CopilotCliProvider(context, outputChannel);
-                break;
-            case AIProviders.CODEX:
-                provider = new CodexCliProvider(context, outputChannel);
-                break;
-            case AIProviders.QWEN:
-                provider = new QwenCliProvider(context, outputChannel);
-                break;
-            default:
-                outputChannel.appendLine(`[AIProviderFactory] Unknown provider type: ${type}, falling back to Claude Code`);
-                provider = new ClaudeCodeProvider(context, outputChannel);
+        if (ctor) {
+            provider = ctor(context, outputChannel);
+        } else {
+            outputChannel.appendLine(`[AIProviderFactory] Unknown provider type: ${type}, falling back to Claude Code`);
+            provider = PROVIDER_CONSTRUCTORS[AIProviders.CLAUDE](context, outputChannel);
         }
 
         this.providers.set(type, provider);
         return provider;
     }
 
-    /**
-     * Clear cached providers (useful for testing or config changes)
-     */
     static clearCache(): void {
         this.providers.clear();
     }
 
-    /**
-     * Get all supported provider types
-     */
     static getSupportedProviders(): { type: AIProviderType; name: string; available: boolean }[] {
-        return [
-            { type: AIProviders.CLAUDE, name: 'Claude Code', available: true },
-            { type: AIProviders.GEMINI, name: 'Gemini CLI', available: true },
-            { type: AIProviders.COPILOT, name: 'GitHub Copilot CLI', available: true },
-            { type: AIProviders.CODEX, name: 'Codex CLI', available: true },
-            { type: AIProviders.QWEN, name: 'Qwen Code', available: true }
-        ];
+        return (Object.keys(PROVIDER_PATHS) as AIProviderType[]).map(type => ({
+            type,
+            name: PROVIDER_PATHS[type].displayName,
+            available: true,
+        }));
     }
 }

--- a/src/ai-providers/claudeCodeProvider.ts
+++ b/src/ai-providers/claudeCodeProvider.ts
@@ -6,7 +6,8 @@ import { ConfigManager } from '../core/utils/configManager';
 import { AIProviders, Timing } from '../core/constants';
 import { waitForShellReady, executeCommandInHiddenTerminal } from '../core/utils/terminalUtils';
 import { createTempFile } from '../core/utils/tempFileUtils';
-import { IAIProvider, AIExecutionResult, readPermissionMode, dispatchSlashCommandViaTempFile } from './aiProvider';
+import { IAIProvider, AIExecutionResult, dispatchSlashCommandViaTempFile } from './aiProvider';
+import { getPermissionFlagForProvider } from './permissionValidation';
 
 const execAsync = promisify(exec);
 
@@ -39,7 +40,7 @@ export class ClaudeCodeProvider implements IAIProvider {
     }
 
     getPermissionFlag(): string {
-        return readPermissionMode() === 'auto-approve' ? '--permission-mode bypassPermissions ' : '';
+        return getPermissionFlagForProvider(this.type);
     }
 
     /**
@@ -198,7 +199,7 @@ export class ClaudeCodeProvider implements IAIProvider {
 
         terminal.show();
         await waitForShellReady(terminal);
-        const permissionFlag = readPermissionMode() === 'auto-approve' ? '--permission-mode bypassPermissions ' : '';
+        const permissionFlag = getPermissionFlagForProvider(AIProviders.CLAUDE);
         terminal.sendText(
             `claude ${permissionFlag}`.trim(),
             true

--- a/src/ai-providers/codexCliProvider.ts
+++ b/src/ai-providers/codexCliProvider.ts
@@ -9,6 +9,7 @@ import { waitForShellReady, executeCommandInHiddenTerminal } from '../core/utils
 import { createTempFile } from '../core/utils/tempFileUtils';
 import { ensureCliInstalled } from '../core/utils/installUtils';
 import { IAIProvider, AIExecutionResult } from './aiProvider';
+import { getPermissionFlagForProvider } from './permissionValidation';
 
 const execAsync = promisify(exec);
 
@@ -29,7 +30,7 @@ export class CodexCliProvider implements IAIProvider {
     }
 
     getPermissionFlag(): string {
-        return '';
+        return getPermissionFlagForProvider(this.type);
     }
 
     /**

--- a/src/ai-providers/copilotCliProvider.ts
+++ b/src/ai-providers/copilotCliProvider.ts
@@ -7,7 +7,8 @@ import { AIProviders, CLIDefaults, Timing } from '../core/constants';
 import { waitForShellReady, executeCommandInHiddenTerminal } from '../core/utils/terminalUtils';
 import { createTempFile } from '../core/utils/tempFileUtils';
 import { ensureCliInstalled } from '../core/utils/installUtils';
-import { IAIProvider, AIExecutionResult, readPermissionMode } from './aiProvider';
+import { IAIProvider, AIExecutionResult } from './aiProvider';
+import { getPermissionFlagForProvider } from './permissionValidation';
 
 const execAsync = promisify(exec);
 
@@ -53,7 +54,7 @@ export class CopilotCliProvider implements IAIProvider {
     }
 
     getPermissionFlag(): string {
-        return readPermissionMode() === 'auto-approve' ? '--yolo ' : '';
+        return getPermissionFlagForProvider(this.type);
     }
 
     /**

--- a/src/ai-providers/geminiCliProvider.ts
+++ b/src/ai-providers/geminiCliProvider.ts
@@ -7,6 +7,7 @@ import { waitForShellReady, executeCommandInHiddenTerminal } from '../core/utils
 import { createTempFile } from '../core/utils/tempFileUtils';
 import { ensureCliInstalled } from '../core/utils/installUtils';
 import { IAIProvider, AIExecutionResult } from './aiProvider';
+import { getPermissionFlagForProvider } from './permissionValidation';
 
 const execAsync = promisify(exec);
 
@@ -31,7 +32,7 @@ export class GeminiCliProvider implements IAIProvider {
     }
 
     getPermissionFlag(): string {
-        return '';
+        return getPermissionFlagForProvider(this.type);
     }
 
     /**

--- a/src/ai-providers/index.ts
+++ b/src/ai-providers/index.ts
@@ -5,3 +5,5 @@ export * from './geminiCliProvider';
 export * from './copilotCliProvider';
 export * from './codexCliProvider';
 export * from './qwenCliProvider';
+export * from './openCodeProvider';
+export * from './permissionValidation';

--- a/src/ai-providers/openCodeProvider.ts
+++ b/src/ai-providers/openCodeProvider.ts
@@ -10,11 +10,9 @@ import { ensureCliInstalled } from '../core/utils/installUtils';
 import { IAIProvider, AIExecutionResult } from './aiProvider';
 import { getPermissionFlagForProvider } from './permissionValidation';
 
-const execAsync = promisify(exec);
-
-export class QwenCliProvider implements IAIProvider {
-    public readonly name = 'Qwen Code';
-    public readonly type = AIProviders.QWEN;
+export class OpenCodeProvider implements IAIProvider {
+    public readonly name = 'OpenCode';
+    public readonly type = AIProviders.OPENCODE;
 
     private context: vscode.ExtensionContext;
     private outputChannel: vscode.OutputChannel;
@@ -28,47 +26,34 @@ export class QwenCliProvider implements IAIProvider {
         this.configManager.loadSettings();
     }
 
-    /**
-     * Check if Qwen Code CLI is installed
-     */
     async isInstalled(): Promise<boolean> {
         try {
-            await execAsync('qwen --version');
+            await promisify(exec)('opencode --version');
             return true;
         } catch {
             return false;
         }
     }
 
-    /**
-     * Get the CLI command path from settings
-     */
     private getCliPath(): string {
         const config = vscode.workspace.getConfiguration('speckit');
-        return config.get<string>('qwenPath', 'qwen');
+        return config.get<string>('opencodePath', 'opencode');
     }
 
     getPermissionFlag(): string {
         return getPermissionFlagForProvider(this.type);
     }
 
-    /**
-     * Check if Qwen Code CLI is installed and show helpful error if not
-     */
     private async ensureInstalled(): Promise<void> {
         await ensureCliInstalled(
-            'Qwen Code CLI',
-            'npm install -g @qwen-code/qwen-code@latest',
-            'qwen --version',
+            'OpenCode CLI',
+            'npm install -g opencode-ai',
+            'opencode --version',
             this.outputChannel
         );
     }
 
-    /**
-     * Execute a prompt in a visible terminal (split view)
-     * Uses qwen -p "$(cat <tempFile>)" to pass the prompt
-     */
-    async executeInTerminal(prompt: string, title: string = 'SpecKit - Qwen Code'): Promise<vscode.Terminal> {
+    async executeInTerminal(prompt: string, title: string = 'SpecKit - OpenCode'): Promise<vscode.Terminal> {
         try {
             await this.ensureInstalled();
             const cliPath = this.getCliPath();
@@ -79,49 +64,40 @@ export class QwenCliProvider implements IAIProvider {
             const terminal = vscode.window.createTerminal({
                 name: title,
                 cwd: vscode.workspace.workspaceFolders?.[0]?.uri.fsPath,
-                location: {
-                    viewColumn: vscode.ViewColumn.Two
-                }
+                location: { viewColumn: vscode.ViewColumn.Two }
             });
 
             terminal.show();
-
             await waitForShellReady(terminal);
             terminal.sendText(command, true);
 
-            // Clean up temp file after delay
             const fileToClean = tempFilePath;
             setTimeout(async () => {
                 try {
                     await fs.promises.unlink(fileToClean);
-                    this.outputChannel.appendLine(`[Qwen] Cleaned up prompt file: ${fileToClean}`);
+                    this.outputChannel.appendLine(`[OpenCode] Cleaned up prompt file: ${fileToClean}`);
                 } catch (e) {
-                    this.outputChannel.appendLine(`[Qwen] Failed to cleanup temp file: ${e}`);
+                    this.outputChannel.appendLine(`[OpenCode] Failed to cleanup temp file: ${e}`);
                 }
             }, Timing.tempFileCleanupDelay);
 
             return terminal;
-
         } catch (error) {
-            this.outputChannel.appendLine(`[Qwen] ERROR: Failed to send to Qwen Code CLI: ${error}`);
-            vscode.window.showErrorMessage(`Failed to run Qwen Code CLI: ${error}`);
+            this.outputChannel.appendLine(`[OpenCode] ERROR: ${error}`);
+            vscode.window.showErrorMessage(`Failed to run OpenCode CLI: ${error}`);
             throw error;
         }
     }
 
-    /**
-     * Execute a prompt in headless/background mode
-     */
     async executeHeadless(prompt: string): Promise<AIExecutionResult> {
         await this.ensureInstalled();
 
-        this.outputChannel.appendLine(`[QwenCliProvider] Invoking Qwen Code CLI in headless mode`);
+        this.outputChannel.appendLine(`[OpenCodeProvider] Invoking OpenCode CLI in headless mode`);
         this.outputChannel.appendLine(`========================================`);
         this.outputChannel.appendLine(prompt);
         this.outputChannel.appendLine(`========================================`);
 
-        const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
-        const cwd = workspaceFolder?.uri.fsPath;
+        const cwd = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
         const cliPath = this.getCliPath();
         const permissionFlag = this.getPermissionFlag();
         const tempFilePath = await createTempFile(this.context, prompt, 'background-prompt', true);
@@ -130,19 +106,15 @@ export class QwenCliProvider implements IAIProvider {
         return executeCommandInHiddenTerminal({
             commandLine,
             cwd,
-            terminalName: 'Qwen Code Background',
+            terminalName: 'OpenCode Background',
             outputChannel: this.outputChannel,
-            logPrefix: 'Qwen',
+            logPrefix: 'OpenCode',
             tempFilePath,
             logCommandOnFailure: true
         });
     }
 
-    /**
-     * Execute a slash command in terminal
-     * Delegates to executeInTerminal with the slash command as prompt
-     */
-    async executeSlashCommand(command: string, title: string = 'SpecKit - Qwen Code', autoExecute: boolean = true): Promise<vscode.Terminal> {
+    async executeSlashCommand(command: string, title: string = 'SpecKit - OpenCode', _autoExecute: boolean = true): Promise<vscode.Terminal> {
         await this.ensureInstalled();
         const slashCommand = command.startsWith('/') ? command : `/${command}`;
         return this.executeInTerminal(slashCommand, title);

--- a/src/ai-providers/permissionValidation.ts
+++ b/src/ai-providers/permissionValidation.ts
@@ -1,0 +1,48 @@
+import * as vscode from 'vscode';
+import {
+    AIProviderType,
+    PROVIDER_PATHS,
+    getConfiguredProviderType,
+    readPermissionMode,
+} from './aiProvider';
+
+const SUPPRESSED_KEY = 'speckit.permissionValidation.suppressed';
+
+export function getPermissionFlagForProvider(type: AIProviderType): string {
+    const flag = PROVIDER_PATHS[type]?.autoApproveFlag ?? '';
+    if (!flag) return '';
+    return readPermissionMode() === 'auto-approve' ? flag : '';
+}
+
+export async function validatePermissionMode(context: vscode.ExtensionContext): Promise<void> {
+    const providerType = getConfiguredProviderType();
+    const paths = PROVIDER_PATHS[providerType];
+    if (!paths) return;
+
+    const mode = readPermissionMode();
+    const needsWarning =
+        mode === 'interactive' &&
+        paths.supportsInteractivePermissions === false &&
+        paths.autoApproveFlag.length > 0;
+
+    if (!needsWarning) return;
+
+    const comboKey = `${providerType}-${mode}`;
+    const suppressed = context.globalState.get<string>(SUPPRESSED_KEY);
+    if (suppressed === comboKey) return;
+
+    const action = await vscode.window.showWarningMessage(
+        `${paths.displayName} does not support interactive permission prompts. Switch to Auto-Approve?`,
+        'Switch to Auto-Approve',
+        'Keep Interactive'
+    );
+
+    if (action === 'Switch to Auto-Approve') {
+        await vscode.workspace
+            .getConfiguration('speckit')
+            .update('permissionMode', 'auto-approve', vscode.ConfigurationTarget.Global);
+        await context.globalState.update(SUPPRESSED_KEY, undefined);
+    } else {
+        await context.globalState.update(SUPPRESSED_KEY, comboKey);
+    }
+}

--- a/src/ai-providers/promptBuilder.ts
+++ b/src/ai-providers/promptBuilder.ts
@@ -34,6 +34,7 @@ function renderPreamble(step: PromptStep, specDir: string): string {
         `Before and after this step runs, update ${target}:`,
         '',
         `1. Pre-step: set stepHistory.${step}.startedAt = now, currentStep = "${step}", status = "${step}-in-progress", and append a transition { step: "${step}", substep: null, from, by: "ai", at: now }.`,
+        `1.5. When advancing from a previous step: set stepHistory.<previousStep>.completedAt = now (if not already set) before writing the new step.`,
         `2. Post-step: set stepHistory.${step}.completedAt = now, append a closing transition, and advance currentStep or set a terminal status.`,
         '',
         `Canonical substeps for ${step}: ${substeps}. Record each with its own startedAt/completedAt inside stepHistory.${step}.substeps[] and emit a transition with non-null substep.`,

--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -246,6 +246,7 @@ export const AIProviders = {
     COPILOT: 'copilot',
     CODEX: 'codex',
     QWEN: 'qwen',
+    OPENCODE: 'opencode',
 } as const;
 
 /**

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 
 // AI Providers
-import { IAIProvider, AIProviderFactory, isProviderConfigured, promptForProviderSelection } from './ai-providers';
+import { IAIProvider, AIProviderFactory, isProviderConfigured, promptForProviderSelection, validatePermissionMode } from './ai-providers';
 
 // Features
 import { SteeringManager, SteeringExplorerProvider, registerSteeringCommands } from './features/steering';
@@ -190,8 +190,17 @@ export async function activate(context: vscode.ExtensionContext) {
                     vscode.commands.executeCommand('workbench.action.reloadWindow');
                 }
             }
+            if (
+                e.affectsConfiguration('speckit.permissionMode') ||
+                e.affectsConfiguration('speckit.aiProvider')
+            ) {
+                void validatePermissionMode(context);
+            }
         })
     );
+
+    // Validate provider/permission combination after activation completes (non-blocking)
+    setTimeout(() => { void validatePermissionMode(context); }, 0);
 }
 
 /**

--- a/src/features/spec-editor/specEditorProvider.ts
+++ b/src/features/spec-editor/specEditorProvider.ts
@@ -256,20 +256,13 @@ export class SpecEditorProvider {
             // Get AI provider and execute
             const provider = AIProviderFactory.getProvider(this.context, this.outputChannel);
 
-            // Generate markdown with the content and image references
-            const markdownContent = await this.tempFileManager.generateMarkdown(
-                tempFileSet.id,
-                content,
-                images
-            );
-
             // Use custom command if provided, otherwise workflow's specify command
             const command = customCommand ? `/${customCommand}` : workflow.stepSpecify;
 
-            // Append instruction to write .spec-context.json so the AI provider
-            // persists workflow state for badge/date display in the spec viewer.
+            // Append the .spec-context.json instructions to the temp markdown
+            // file so the AI reads them, without polluting the visible terminal
+            // with the full instruction block.
             const specContextInstruction = [
-                '',
                 '## Post-Specification: Update .spec-context.json',
                 '',
                 'After writing the spec file, create or update `.spec-context.json` in the same feature directory with:',
@@ -296,8 +289,13 @@ export class SpecEditorProvider {
                 'IMPORTANT: Only update the `.spec-context.json` for the spec being created or edited. Do NOT modify `.spec-context.json` files in other spec directories.',
             ].join('\n');
 
-            const prompt = `${command} ${markdownContent}${specContextInstruction}`;
-            this.outputChannel.appendLine(`[SpecEditor] Using command: ${command}`);
+            await this.tempFileManager.appendToMarkdownFile(
+                tempFileSet.markdownFilePath,
+                specContextInstruction
+            );
+
+            const prompt = `${command} ${tempFileSet.markdownFilePath}`;
+            this.outputChannel.appendLine(`[SpecEditor] Using command: ${command} (temp file: ${tempFileSet.markdownFilePath})`);
 
             // Execute in terminal
             await provider.executeInTerminal(prompt, 'SpecKit - New Spec');

--- a/src/features/spec-editor/tempFileManager.ts
+++ b/src/features/spec-editor/tempFileManager.ts
@@ -397,4 +397,19 @@ export class TempFileManager {
         const manifest = await this.readManifest();
         return manifest.files[tempFileId]?.markdownFilePath;
     }
+
+    /**
+     * Append additional content to an existing markdown file (used for
+     * trailing instruction blocks the AI should read but the terminal
+     * shouldn't display).
+     */
+    async appendToMarkdownFile(filePath: string, content: string): Promise<void> {
+        const uri = vscode.Uri.file(filePath);
+        const existing = await vscode.workspace.fs.readFile(uri);
+        const merged = Buffer.concat([
+            Buffer.from(existing),
+            Buffer.from('\n\n' + content, 'utf-8'),
+        ]);
+        await vscode.workspace.fs.writeFile(uri, merged);
+    }
 }

--- a/src/features/spec-viewer/footerActions.ts
+++ b/src/features/spec-viewer/footerActions.ts
@@ -8,6 +8,7 @@
  */
 
 import { FooterAction, SpecContext, StepName } from '../../core/types/specContext';
+import { isStepCompleted } from './stateDerivation';
 
 const SCOPE_SUFFIX: Record<'spec' | 'step', string> = {
     spec: 'Affects whole spec',
@@ -68,7 +69,7 @@ export const FOOTER_ACTIONS: FooterAction[] = [
         tooltip: 'Approve this step and continue',
         visibleWhen: (ctx, step) => {
             const entry = ctx.stepHistory[step];
-            return !!entry?.startedAt && !entry?.completedAt;
+            return !!entry?.startedAt && !isStepCompleted(step, ctx.currentStep, ctx.stepHistory);
         },
     },
     {

--- a/src/features/spec-viewer/html/navigation.ts
+++ b/src/features/spec-viewer/html/navigation.ts
@@ -4,6 +4,8 @@
  */
 
 import { SpecDocument, DocumentType, StalenessMap } from '../types';
+import { isStepCompleted } from '../stateDerivation';
+import { StepName } from '../../../core/types/specContext';
 
 /**
  * Generate the unified navigation bar (merged tabs + stepper)
@@ -38,7 +40,8 @@ export function generateCompactNav(
 
         const isStale = stalenessMap?.[phase]?.isStale ?? false;
 
-        const isWorking = activeStep === phase && !stepHistory?.[phase]?.completedAt;
+        const isWorking = activeStep === phase &&
+            !(stepHistory && activeStep && isStepCompleted(phase as StepName, activeStep as StepName, stepHistory));
 
         const classes = [
             'step-tab',

--- a/src/features/spec-viewer/phaseCalculation.ts
+++ b/src/features/spec-viewer/phaseCalculation.ts
@@ -26,7 +26,7 @@ export function calculatePhases(
     const isCompletedByContext = (step: string): boolean | null => {
         if (!stepHistoryBadges) return null;
         const s = stepHistoryBadges[step];
-        if (s === undefined) return null;
+        if (s === undefined) return false; // step not in history = not completed (no file-existence fallback)
         return s === 'completed';
     };
     // Default behavior: 4-phase stepper

--- a/src/features/spec-viewer/specViewerProvider.ts
+++ b/src/features/spec-viewer/specViewerProvider.ts
@@ -42,7 +42,7 @@ import { deriveSpecName } from "../specs/specContextManager";
 import { readSpecContext } from "../specs/specContextReader";
 import { writeSpecContext } from "../specs/specContextWriter";
 import { backfillMinimalContext } from "../specs/specContextBackfill";
-import { deriveViewerState } from "./stateDerivation";
+import { deriveViewerState, isStepCompleted } from "./stateDerivation";
 import { StepName, STEP_NAMES, ViewerState as CoreViewerState } from "../../core/types/specContext";
 import {
   DEFAULT_WORKFLOW,
@@ -66,12 +66,14 @@ export {
  * compatibility with the 4-phase fallback stepper.
  */
 function deriveStepBadgesWithAlias(
-  stepHistory: Record<string, { startedAt?: string; completedAt?: string | null }>
+  stepHistory: Record<string, { startedAt?: string; completedAt?: string | null }>,
+  currentStep?: string
 ): Record<string, 'not-started' | 'in-progress' | 'completed'> {
   const out: Record<string, 'not-started' | 'in-progress' | 'completed'> = {};
+  const cs = (currentStep ?? 'specify') as StepName;
   for (const [step, entry] of Object.entries(stepHistory)) {
     if (!entry?.startedAt) out[step] = 'not-started';
-    else if (entry.completedAt) out[step] = 'completed';
+    else if (isStepCompleted(step as StepName, cs, stepHistory)) out[step] = 'completed';
     else out[step] = 'in-progress';
   }
   if (out['specify'] && !out['spec']) out['spec'] = out['specify'];
@@ -468,7 +470,7 @@ export class SpecViewerProvider {
 
       // Calculate phases — reuse stepHistory from the single featureCtx read (US2).
       const stepBadges = featureCtx?.stepHistory
-        ? deriveStepBadgesWithAlias(featureCtx.stepHistory)
+        ? deriveStepBadgesWithAlias(featureCtx.stepHistory, featureCtx.currentStep)
         : undefined;
       const phases = calculatePhases(
         documents,

--- a/src/features/spec-viewer/stateDerivation.ts
+++ b/src/features/spec-viewer/stateDerivation.ts
@@ -3,6 +3,11 @@
  *
  * Never touches the filesystem. `deriveStepBadges` uses only `stepHistory`.
  * `pulse` is null when `status` ∈ {completed, archived}.
+ *
+ * **Inferred completion**: a step is treated as completed when it has
+ * `startedAt` set and precedes `currentStep` in `STEP_NAMES` ordering,
+ * even if `completedAt` was never explicitly written (common with external
+ * SDD skills that only emit `startedAt`).
  */
 
 import {
@@ -14,6 +19,27 @@ import {
 } from '../../core/types/specContext';
 import { getFooterActions } from './footerActions';
 
+/**
+ * Determine whether a step should be treated as completed.
+ *
+ * A step is completed if:
+ * 1. It has explicit `completedAt`, OR
+ * 2. It has `startedAt` AND its index in STEP_NAMES is before `currentStep`
+ *    (the workflow moved past it — inferred completion).
+ */
+export function isStepCompleted(
+    step: StepName,
+    currentStep: StepName,
+    stepHistory: Record<string, { startedAt?: string; completedAt?: string | null }>
+): boolean {
+    const entry = stepHistory[step];
+    if (!entry?.startedAt) return false;
+    if (entry.completedAt) return true;
+    const stepIdx = STEP_NAMES.indexOf(step);
+    const currentIdx = STEP_NAMES.indexOf(currentStep);
+    return stepIdx >= 0 && currentIdx >= 0 && stepIdx < currentIdx;
+}
+
 export function deriveStepBadges(
     ctx: SpecContext
 ): Record<string, StepBadgeState> {
@@ -22,7 +48,7 @@ export function deriveStepBadges(
         const entry = ctx.stepHistory[step];
         if (!entry || !entry.startedAt) {
             out[step] = 'not-started';
-        } else if (entry.completedAt) {
+        } else if (isStepCompleted(step, ctx.currentStep, ctx.stepHistory)) {
             out[step] = 'completed';
         } else {
             out[step] = 'in-progress';
@@ -37,7 +63,7 @@ export function derivePulse(ctx: SpecContext): StepName | null {
     }
     for (const step of STEP_NAMES) {
         const entry = ctx.stepHistory[step];
-        if (entry?.startedAt && !entry.completedAt) {
+        if (entry?.startedAt && !isStepCompleted(step, ctx.currentStep, ctx.stepHistory)) {
             return step;
         }
     }
@@ -45,7 +71,7 @@ export function derivePulse(ctx: SpecContext): StepName | null {
 }
 
 export function deriveHighlights(ctx: SpecContext): StepName[] {
-    return STEP_NAMES.filter(s => !!ctx.stepHistory[s]?.completedAt);
+    return STEP_NAMES.filter(s => isStepCompleted(s, ctx.currentStep, ctx.stepHistory));
 }
 
 export function deriveActiveSubstep(

--- a/src/features/specs/specExplorerProvider.ts
+++ b/src/features/specs/specExplorerProvider.ts
@@ -16,6 +16,8 @@ import {
 import { resolveSpecDirectories, hasDuplicateNames, deriveChangeRoot, type SpecDirectoryInfo } from '../../core/specDirectoryResolver';
 import { SpecStatuses, WorkflowSteps } from '../../core/constants';
 import { readSpecContextSync } from './specContextManager';
+import { isStepCompleted } from '../spec-viewer/stateDerivation';
+import { StepName, STEP_NAMES } from '../../core/types/specContext';
 
 export interface SpecInfo {
     name: string;
@@ -584,7 +586,9 @@ class SpecItem extends vscode.TreeItem {
             // Apply step status colors from specContext (only for active specs — completed specs use the green beaker)
             if (specContext && documentType && specContext.status !== SpecStatuses.COMPLETED && specContext.status !== SpecStatuses.ARCHIVED) {
                 const stepHistory = specContext.stepHistory;
-                if (stepHistory?.[documentType]?.completedAt) {
+                const stepName = documentType as StepName;
+                const cs = (specContext.currentStep ?? 'specify') as StepName;
+                if (stepHistory && STEP_NAMES.includes(stepName) && isStepCompleted(stepName, cs, stepHistory)) {
                     this.iconPath = new vscode.ThemeIcon('pass', new vscode.ThemeColor('testing.iconPassed'));
                 } else if (specContext.currentStep === documentType) {
                     this.iconPath = new vscode.ThemeIcon('circle-filled', new vscode.ThemeColor('charts.blue'));

--- a/src/features/steering/steeringCommands.ts
+++ b/src/features/steering/steeringCommands.ts
@@ -30,11 +30,11 @@ export function registerSteeringCommands(
         }),
 
         vscode.commands.registerCommand('speckit.steering.createUserRule', async () => {
-            await steeringManager.createUserClaudeMd();
+            await steeringManager.createUserSteeringFile();
         }),
 
         vscode.commands.registerCommand('speckit.steering.createProjectRule', async () => {
-            await steeringManager.createProjectClaudeMd();
+            await steeringManager.createProjectSteeringFile();
         }),
 
         vscode.commands.registerCommand('speckit.steering.refresh', async () => {

--- a/src/features/steering/steeringExplorerProvider.ts
+++ b/src/features/steering/steeringExplorerProvider.ts
@@ -39,57 +39,69 @@ export class SteeringExplorerProvider extends BaseTreeDataProvider<SteeringItem>
     }
 
     private setupAgentFileWatchers(): void {
+        const providerPaths = getProviderPaths();
         const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
-        if (workspaceFolder) {
+        if (workspaceFolder && providerPaths.agentsDir) {
+            const pattern = providerPaths.agentsPattern || '*.md';
             this.agentProjectWatcher = vscode.workspace.createFileSystemWatcher(
-                new vscode.RelativePattern(workspaceFolder, '.claude/agents/**/*.md')
+                new vscode.RelativePattern(workspaceFolder, `${providerPaths.agentsDir}/**/${pattern}`)
             );
             this.agentProjectWatcher.onDidCreate(() => this._onDidChangeTreeData.fire());
             this.agentProjectWatcher.onDidChange(() => this._onDidChangeTreeData.fire());
             this.agentProjectWatcher.onDidDelete(() => this._onDidChangeTreeData.fire());
         }
 
-        const userAgentsPath = path.join(os.homedir(), '.claude/agents');
-        try {
-            this.agentUserWatcher = vscode.workspace.createFileSystemWatcher(
-                new vscode.RelativePattern(userAgentsPath, '**/*.md')
-            );
-            this.agentUserWatcher.onDidCreate(() => this._onDidChangeTreeData.fire());
-            this.agentUserWatcher.onDidChange(() => this._onDidChangeTreeData.fire());
-            this.agentUserWatcher.onDidDelete(() => this._onDidChangeTreeData.fire());
-        } catch { /* user dir may not exist */ }
+        if (providerPaths.agentsDir) {
+            const userAgentsPath = path.join(os.homedir(), providerPaths.agentsDir);
+            try {
+                const pattern = providerPaths.agentsPattern || '*.md';
+                this.agentUserWatcher = vscode.workspace.createFileSystemWatcher(
+                    new vscode.RelativePattern(userAgentsPath, `**/${pattern}`)
+                );
+                this.agentUserWatcher.onDidCreate(() => this._onDidChangeTreeData.fire());
+                this.agentUserWatcher.onDidChange(() => this._onDidChangeTreeData.fire());
+                this.agentUserWatcher.onDidDelete(() => this._onDidChangeTreeData.fire());
+            } catch { /* user dir may not exist */ }
+        }
     }
 
     private setupSkillFileWatchers(): void {
+        const providerPaths = getProviderPaths();
         const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
-        if (workspaceFolder) {
+        if (workspaceFolder && providerPaths.skillsDir) {
             this.skillProjectWatcher = vscode.workspace.createFileSystemWatcher(
-                new vscode.RelativePattern(workspaceFolder, '.claude/skills/**/SKILL.md')
+                new vscode.RelativePattern(workspaceFolder, `${providerPaths.skillsDir}/**/SKILL.md`)
             );
             this.skillProjectWatcher.onDidCreate(() => this._onDidChangeTreeData.fire());
             this.skillProjectWatcher.onDidChange(() => this._onDidChangeTreeData.fire());
             this.skillProjectWatcher.onDidDelete(() => this._onDidChangeTreeData.fire());
         }
 
-        const userSkillsPath = path.join(os.homedir(), '.claude/skills');
-        try {
-            this.skillUserWatcher = vscode.workspace.createFileSystemWatcher(
-                new vscode.RelativePattern(userSkillsPath, '**/SKILL.md')
-            );
-            this.skillUserWatcher.onDidCreate(() => this._onDidChangeTreeData.fire());
-            this.skillUserWatcher.onDidChange(() => this._onDidChangeTreeData.fire());
-            this.skillUserWatcher.onDidDelete(() => this._onDidChangeTreeData.fire());
-        } catch { /* user dir may not exist */ }
+        if (providerPaths.skillsDir) {
+            const userSkillsPath = path.join(os.homedir(), providerPaths.skillsDir);
+            try {
+                this.skillUserWatcher = vscode.workspace.createFileSystemWatcher(
+                    new vscode.RelativePattern(userSkillsPath, '**/SKILL.md')
+                );
+                this.skillUserWatcher.onDidCreate(() => this._onDidChangeTreeData.fire());
+                this.skillUserWatcher.onDidChange(() => this._onDidChangeTreeData.fire());
+                this.skillUserWatcher.onDidDelete(() => this._onDidChangeTreeData.fire());
+            } catch { /* user dir may not exist */ }
+        }
 
-        const pluginsPath = path.join(os.homedir(), '.claude/plugins');
-        try {
-            this.skillPluginsWatcher = vscode.workspace.createFileSystemWatcher(
-                new vscode.RelativePattern(pluginsPath, 'installed_plugins.json')
-            );
-            this.skillPluginsWatcher.onDidCreate(() => this._onDidChangeTreeData.fire());
-            this.skillPluginsWatcher.onDidChange(() => this._onDidChangeTreeData.fire());
-            this.skillPluginsWatcher.onDidDelete(() => this._onDidChangeTreeData.fire());
-        } catch { /* plugins dir may not exist */ }
+        // Plugins watcher is Claude-specific (no provider equivalent currently)
+        const providerType = getConfiguredProviderType();
+        if (providerType === AIProviders.CLAUDE) {
+            const pluginsPath = path.join(os.homedir(), '.claude/plugins');
+            try {
+                this.skillPluginsWatcher = vscode.workspace.createFileSystemWatcher(
+                    new vscode.RelativePattern(pluginsPath, 'installed_plugins.json')
+                );
+                this.skillPluginsWatcher.onDidCreate(() => this._onDidChangeTreeData.fire());
+                this.skillPluginsWatcher.onDidChange(() => this._onDidChangeTreeData.fire());
+                this.skillPluginsWatcher.onDidDelete(() => this._onDidChangeTreeData.fire());
+            } catch { /* plugins dir may not exist */ }
+        }
     }
 
     dispose(): void {
@@ -170,35 +182,33 @@ export class SteeringExplorerProvider extends BaseTreeDataProvider<SteeringItem>
                 this.context
             ));
 
-            // Add create buttons for missing files (Claude only for now)
-            if (providerType === AIProviders.CLAUDE) {
-                if (!globalExists) {
-                    items.push(new SteeringItem(
-                        'Create Global Rule',
-                        vscode.TreeItemCollapsibleState.None,
-                        TreeItemContext.createGlobal,
-                        '',
-                        this.context,
-                        {
-                            command: 'speckit.steering.createUserRule',
-                            title: 'Create Global CLAUDE.md'
-                        }
-                    ));
-                }
+            // Add create buttons for missing files (only providers that own a steering file)
+            if (providerPaths.globalSteeringFile && !globalExists) {
+                items.push(new SteeringItem(
+                    'Create Global Rule',
+                    vscode.TreeItemCollapsibleState.None,
+                    TreeItemContext.createGlobal,
+                    '',
+                    this.context,
+                    {
+                        command: 'speckit.steering.createUserRule',
+                        title: `Create Global ${providerPaths.steeringFile}`
+                    }
+                ));
+            }
 
-                if (vscode.workspace.workspaceFolders && !projectExists) {
-                    items.push(new SteeringItem(
-                        'Create Project Rule',
-                        vscode.TreeItemCollapsibleState.None,
-                        TreeItemContext.createProject,
-                        '',
-                        this.context,
-                        {
-                            command: 'speckit.steering.createProjectRule',
-                            title: 'Create Project CLAUDE.md'
-                        }
-                    ));
-                }
+            if (vscode.workspace.workspaceFolders && providerPaths.steeringFile && !projectExists) {
+                items.push(new SteeringItem(
+                    'Create Project Rule',
+                    vscode.TreeItemCollapsibleState.None,
+                    TreeItemContext.createProject,
+                    '',
+                    this.context,
+                    {
+                        command: 'speckit.steering.createProjectRule',
+                        title: `Create Project ${providerPaths.steeringFile}`
+                    }
+                ));
             }
 
             return items;
@@ -254,37 +264,21 @@ export class SteeringExplorerProvider extends BaseTreeDataProvider<SteeringItem>
     /**
      * Get provider-specific steering file paths
      */
-    private getSteeringFilePaths(providerType: AIProviderType, providerPaths: ReturnType<typeof getProviderPaths>): {
+    private getSteeringFilePaths(_providerType: AIProviderType, providerPaths: ReturnType<typeof getProviderPaths>): {
         globalPath: string | null;
         projectPath: string | null;
         globalExists: boolean;
         projectExists: boolean;
     } {
-        const home = process.env.HOME || '';
+        const home = os.homedir();
         const workspaceRoot = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath || '';
 
-        let globalPath: string | null = null;
-        let projectPath: string | null = null;
-
-        switch (providerType) {
-            case AIProviders.CLAUDE:
-                globalPath = path.join(home, '.claude', 'CLAUDE.md');
-                projectPath = workspaceRoot ? path.join(workspaceRoot, 'CLAUDE.md') : null;
-                break;
-            case AIProviders.GEMINI:
-                globalPath = path.join(home, '.gemini', 'GEMINI.md');
-                projectPath = workspaceRoot ? path.join(workspaceRoot, 'GEMINI.md') : null;
-                break;
-            case AIProviders.COPILOT:
-                // Copilot doesn't have a global file in the same way
-                globalPath = null;
-                projectPath = workspaceRoot ? path.join(workspaceRoot, '.github', 'copilot-instructions.md') : null;
-                break;
-            case AIProviders.QWEN:
-                globalPath = path.join(home, '.qwen', 'QWEN.md');
-                projectPath = workspaceRoot ? path.join(workspaceRoot, 'QWEN.md') : null;
-                break;
-        }
+        const globalPath = providerPaths.globalSteeringFile
+            ? path.join(home, providerPaths.globalSteeringFile)
+            : null;
+        const projectPath = workspaceRoot
+            ? path.join(workspaceRoot, providerPaths.steeringFile)
+            : null;
 
         return {
             globalPath,

--- a/src/features/steering/steeringManager.ts
+++ b/src/features/steering/steeringManager.ts
@@ -168,7 +168,7 @@ Analyze the document and:
         }
     }
 
-    async createProjectClaudeMd() {
+    async createProjectSteeringFile() {
         const terminal = vscode.window.createTerminal({
             name: 'Claude Code - Init',
             cwd: vscode.workspace.workspaceFolders?.[0]?.uri.fsPath,
@@ -185,7 +185,7 @@ Analyze the document and:
         terminal.sendText(`claude ${permissionFlag}"/init"`);
     }
 
-    async createUserClaudeMd() {
+    async createUserSteeringFile() {
         const claudeDir = path.join(process.env.HOME || '', '.claude');
         const filePath = path.join(claudeDir, 'CLAUDE.md');
 

--- a/tests/unit/spec-viewer/stateDerivation.spec.ts
+++ b/tests/unit/spec-viewer/stateDerivation.spec.ts
@@ -4,6 +4,7 @@ import {
     deriveHighlights,
     deriveViewerState,
     deriveActiveSubstep,
+    isStepCompleted,
 } from '../../../src/features/spec-viewer/stateDerivation';
 import { SpecContext } from '../../../src/core/types/specContext';
 
@@ -60,8 +61,9 @@ describe('deriveStepBadges (US2 — history-driven, no file existence)', () => {
         expect(deriveStepBadges(ctx).plan).toBe('not-started');
     });
 
-    it('startedAt set + completedAt null → in-progress', () => {
+    it('startedAt set + completedAt null on currentStep → in-progress', () => {
         const ctx = baseCtx({
+            currentStep: 'plan',
             stepHistory: {
                 plan: { startedAt: '2026-04-01T00:00:00Z', completedAt: null },
             },
@@ -134,5 +136,110 @@ describe('deriveActiveSubstep (US4)', () => {
 
     it('returns null when no substep is active', () => {
         expect(deriveActiveSubstep(baseCtx())).toBeNull();
+    });
+});
+
+describe('isStepCompleted — inferred completion from step ordering', () => {
+    it('step before currentStep with startedAt but no completedAt → true', () => {
+        const history = {
+            specify: { startedAt: 't1', completedAt: null },
+            plan: { startedAt: 't2', completedAt: null },
+        };
+        expect(isStepCompleted('specify', 'plan', history)).toBe(true);
+    });
+
+    it('step at currentStep with startedAt but no completedAt → false', () => {
+        const history = {
+            plan: { startedAt: 't1', completedAt: null },
+        };
+        expect(isStepCompleted('plan', 'plan', history)).toBe(false);
+    });
+
+    it('step after currentStep with startedAt but no completedAt → false', () => {
+        const history = {
+            tasks: { startedAt: 't1', completedAt: null },
+        };
+        expect(isStepCompleted('tasks', 'plan', history)).toBe(false);
+    });
+
+    it('step with explicit completedAt → true regardless of ordering', () => {
+        const history = {
+            implement: { startedAt: 't1', completedAt: 't2' },
+        };
+        expect(isStepCompleted('implement', 'specify', history)).toBe(true);
+    });
+
+    it('step with no startedAt → false even if before currentStep', () => {
+        const history = {};
+        expect(isStepCompleted('specify', 'implement', history)).toBe(false);
+    });
+});
+
+describe('deriveStepBadges — inferred completion', () => {
+    it('currentStep=implement, all steps startedAt only → specify/plan/tasks completed, implement in-progress', () => {
+        const ctx = baseCtx({
+            currentStep: 'implement',
+            stepHistory: {
+                specify: { startedAt: 't1', completedAt: null },
+                plan: { startedAt: 't2', completedAt: null },
+                tasks: { startedAt: 't3', completedAt: null },
+                implement: { startedAt: 't4', completedAt: null },
+            },
+        });
+        const badges = deriveStepBadges(ctx);
+        expect(badges.specify).toBe('completed');
+        expect(badges.plan).toBe('completed');
+        expect(badges.tasks).toBe('completed');
+        expect(badges.implement).toBe('in-progress');
+    });
+
+    it('currentStep=tasks, specify and plan startedAt only → both completed', () => {
+        const ctx = baseCtx({
+            currentStep: 'tasks',
+            stepHistory: {
+                specify: { startedAt: 't1', completedAt: null },
+                plan: { startedAt: 't2', completedAt: null },
+                tasks: { startedAt: 't3', completedAt: null },
+            },
+        });
+        const badges = deriveStepBadges(ctx);
+        expect(badges.specify).toBe('completed');
+        expect(badges.plan).toBe('completed');
+        expect(badges.tasks).toBe('in-progress');
+    });
+});
+
+describe('derivePulse — inferred completion suppresses pulse on past steps', () => {
+    it('does not pulse a step that has been passed by currentStep', () => {
+        const ctx = baseCtx({
+            status: 'implementing',
+            currentStep: 'implement',
+            stepHistory: {
+                specify: { startedAt: 'a', completedAt: null },
+                plan: { startedAt: 'b', completedAt: null },
+                tasks: { startedAt: 'c', completedAt: null },
+                implement: { startedAt: 'd', completedAt: null },
+            },
+        });
+        expect(derivePulse(ctx)).toBe('implement');
+    });
+});
+
+describe('deriveHighlights — includes inferred-completed steps', () => {
+    it('highlights steps before currentStep even without completedAt', () => {
+        const ctx = baseCtx({
+            currentStep: 'implement',
+            stepHistory: {
+                specify: { startedAt: 'a', completedAt: null },
+                plan: { startedAt: 'b', completedAt: null },
+                tasks: { startedAt: 'c', completedAt: null },
+                implement: { startedAt: 'd', completedAt: null },
+            },
+        });
+        const highlights = deriveHighlights(ctx);
+        expect(highlights).toContain('specify');
+        expect(highlights).toContain('plan');
+        expect(highlights).toContain('tasks');
+        expect(highlights).not.toContain('implement');
     });
 });


### PR DESCRIPTION
## What

- Consolidate `PROVIDER_PATHS` as the single source of truth for all per-provider behavior — factory, QuickPick, steering sidebar, and permission flags all derive from it
- Add OpenCode as the 6th supported provider (#72)
- Fix Copilot + interactive mode silent permission failure with `validatePermissionMode` warning (#78)
- Move spec-editor Post-Specification instructions into temp markdown file so terminal dispatch stays clean
- Rename `createProjectClaudeMd`/`createUserClaudeMd` to provider-agnostic `createProjectSteeringFile`/`createUserSteeringFile`
- Fix step completion inference: steps before `currentStep` with `startedAt` are treated as completed even without explicit `completedAt` (handles SDD skills that only write `startedAt`)
- Fix `phaseCalculation` file-existence fallback producing false green checkmarks when stepHistory badges exist but a step is missing
- Update sidebar icons, viewer stepper, footer buttons, and navigation tabs to use shared `isStepCompleted` helper

## Why

Adding a new provider required touching 6-8 files with parallel switch/case statements. The registry pattern reduces this to ~25 declarative lines per provider. Step completion state was incorrect because external SDD skills never write `completedAt`, causing the viewer to show in-progress badges for completed steps.

## Testing

- All 236 tests pass (15 new: 6 provider registry + 9 step completion inference)
- `npm run compile` clean
- F5 walkthrough: provider switching, QuickPick, sidebar sections, Copilot permission warning, spec-editor dispatch, step completion badges

Closes #72, closes #78