### PR TITLE
feat(specs): multi-select bulk status commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -203,6 +203,12 @@
         "icon": "$(archive)"
       },
       {
+        "command": "speckit.reactivate",
+        "title": "Move to Active",
+        "category": "SpecKit",
+        "icon": "$(debug-restart)"
+      },
+      {
         "command": "speckit.steering.create",
         "title": "Create Custom Steering",
         "category": "SpecKit",
@@ -401,12 +407,17 @@
         },
         {
           "command": "speckit.markCompleted",
-          "when": "view == speckit.views.explorer && viewItem == spec",
+          "when": "view == speckit.views.explorer && viewItem == spec && !speckit.specs.selection.allCompleted && !speckit.specs.selection.allArchived",
           "group": "7_modification"
         },
         {
           "command": "speckit.archive",
-          "when": "view == speckit.views.explorer && viewItem == spec",
+          "when": "view == speckit.views.explorer && viewItem == spec && !speckit.specs.selection.allArchived",
+          "group": "7_modification"
+        },
+        {
+          "command": "speckit.reactivate",
+          "when": "view == speckit.views.explorer && viewItem == spec && !speckit.specs.selection.allActive",
           "group": "7_modification"
         },
         {

--- a/specs/062-ai-prompt-context-prepend/.spec-context.json
+++ b/specs/062-ai-prompt-context-prepend/.spec-context.json
@@ -60,7 +60,7 @@
   "specName": "AI Prompt Context Prepend",
   "branch": "061-extension-lifecycle-writes",
   "createdAt": "2026-04-13T20:41:52Z",
-  "status": "completed",
+  "status": "archived",
   "approach": "Introduce a single promptBuilder helper and route every executeInTerminal caller through it, gated by a new speckit.aiContextInstructions setting.",
   "stepHistory": {
     "specify": {
@@ -200,6 +200,16 @@
       },
       "by": "extension",
       "at": "2026-04-13T20:45:54.999Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "from": {
+        "step": "implement",
+        "substep": null
+      },
+      "by": "extension",
+      "at": "2026-04-14T00:02:17.595Z"
     }
   ]
 }

--- a/specs/063-viewer-state-derivation-wiring/.spec-context.json
+++ b/specs/063-viewer-state-derivation-wiring/.spec-context.json
@@ -9,7 +9,7 @@
   "specName": "Viewer State Derivation Wiring",
   "branch": "063-viewer-state-derivation-wiring",
   "createdAt": "2026-04-13T20:59:09Z",
-  "status": "completed",
+  "status": "archived",
   "auto": true,
   "stepHistory": {
     "specify": {
@@ -310,6 +310,16 @@
       },
       "by": "sdd",
       "at": "2026-04-13T21:30:00Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "from": {
+        "step": "implement",
+        "substep": null
+      },
+      "by": "extension",
+      "at": "2026-04-14T00:02:17.595Z"
     }
   ]
 }

--- a/specs/064-provider-registry/.spec-context.json
+++ b/specs/064-provider-registry/.spec-context.json
@@ -6,7 +6,7 @@
   "next": "done",
   "updated": "2026-04-13",
   "selectedAt": "2026-04-13T22:22:52Z",
-  "status": "completed",
+  "status": "archived",
   "specName": "Provider Registry",
   "branch": "main",
   "createdAt": "2026-04-13T22:22:52Z",
@@ -146,6 +146,16 @@
       },
       "by": "sdd",
       "at": "2026-04-13T22:25:20Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "from": {
+        "step": "implement",
+        "substep": null
+      },
+      "by": "extension",
+      "at": "2026-04-14T00:02:17.595Z"
     }
   ]
 }

--- a/specs/065-multi-select-specs/.spec-context.json
+++ b/specs/065-multi-select-specs/.spec-context.json
@@ -1,0 +1,310 @@
+{
+  "workflow": "sdd",
+  "currentStep": "plan",
+  "currentTask": "T001",
+  "progress": "phase1",
+  "files_modified": [],
+  "task_summaries": {},
+  "concerns": [],
+  "decisions": [],
+  "last_action": "implement started",
+  "next": "implement",
+  "updated": "2026-04-13",
+  "selectedAt": "2026-04-13T23:43:15Z",
+  "specName": "Multi Select Specs",
+  "branch": "main",
+  "createdAt": "2026-04-13T23:43:15Z",
+  "approach": "Migrate the Specs sidebar to createTreeView with canSelectMany:true and adapt status commands to operate on the full selection, using VS Code context keys for menu visibility.",
+  "step_summaries": {
+    "specify": {
+      "complexity": "normal",
+      "requirements": 6,
+      "scenarios": 4,
+      "key_finding": "sidebar registered via registerTreeDataProvider in extension.ts:118; multi-select requires migrating to createTreeView with canSelectMany:true and updating specCommands.ts bulk handlers."
+    },
+    "plan": {
+      "approach_summary": "Migrate the Specs sidebar to createTreeView with canSelectMany:true and adapt status commands to operate on the full selection, using VS Code context keys for menu visibility.",
+      "files_planned": 5,
+      "risks": [
+        "Context-key staleness: If selection context keys are set only on onDidChangeSelection, a right-click that changes selection may race with menu evaluation.",
+        "Single-item invocation from keyboard/palette: When a command is invoked without a TreeView selection, the items arg is undefined."
+      ]
+    }
+  },
+  "transitions": [
+    {
+      "step": "specify",
+      "substep": "parsing",
+      "from": null,
+      "by": "sdd",
+      "at": "2026-04-13T23:43:15Z"
+    },
+    {
+      "step": "specify",
+      "substep": "exploring",
+      "from": "parsing",
+      "by": "sdd",
+      "at": "2026-04-13T23:43:16Z"
+    },
+    {
+      "step": "specify",
+      "substep": "detecting",
+      "from": "exploring",
+      "by": "sdd",
+      "at": "2026-04-13T23:43:17Z"
+    },
+    {
+      "step": "specify",
+      "substep": "writing-spec",
+      "from": "detecting",
+      "by": "sdd",
+      "at": "2026-04-13T23:43:18Z"
+    },
+    {
+      "step": "specify",
+      "substep": null,
+      "from": "writing-spec",
+      "by": "sdd",
+      "at": "2026-04-13T23:43:19Z"
+    },
+    {
+      "step": "specify",
+      "substep": null,
+      "from": {
+        "step": "specify",
+        "substep": null
+      },
+      "by": "extension",
+      "at": "2026-04-13T23:47:20.442Z"
+    },
+    {
+      "step": "plan",
+      "substep": null,
+      "from": {
+        "step": "specify",
+        "substep": null
+      },
+      "by": "extension",
+      "at": "2026-04-13T23:47:20.444Z"
+    },
+    {
+      "step": "plan",
+      "substep": "loading",
+      "from": {
+        "step": "plan",
+        "substep": null
+      },
+      "by": "sdd",
+      "at": "2026-04-13T23:48:00Z"
+    },
+    {
+      "step": "plan",
+      "substep": "writing-plan",
+      "from": {
+        "step": "plan",
+        "substep": "loading"
+      },
+      "by": "sdd",
+      "at": "2026-04-13T23:48:01Z"
+    },
+    {
+      "step": "plan",
+      "substep": null,
+      "from": {
+        "step": "plan",
+        "substep": "writing-plan"
+      },
+      "by": "sdd",
+      "at": "2026-04-13T23:48:02Z"
+    },
+    {
+      "step": "specify",
+      "substep": null,
+      "from": {
+        "step": "plan",
+        "substep": null
+      },
+      "by": "extension",
+      "at": "2026-04-13T23:50:37.855Z"
+    },
+    {
+      "step": "plan",
+      "substep": null,
+      "from": {
+        "step": "specify",
+        "substep": null
+      },
+      "by": "extension",
+      "at": "2026-04-13T23:50:38.521Z"
+    },
+    {
+      "step": "plan",
+      "substep": null,
+      "from": {
+        "step": "plan",
+        "substep": null
+      },
+      "by": "extension",
+      "at": "2026-04-13T23:50:45.882Z"
+    },
+    {
+      "step": "tasks",
+      "substep": null,
+      "from": {
+        "step": "plan",
+        "substep": null
+      },
+      "by": "extension",
+      "at": "2026-04-13T23:50:45.883Z"
+    },
+    {
+      "step": "plan",
+      "substep": null,
+      "from": {
+        "step": "tasks",
+        "substep": null
+      },
+      "by": "extension",
+      "at": "2026-04-13T23:50:58.738Z"
+    },
+    {
+      "step": "specify",
+      "substep": null,
+      "from": {
+        "step": "plan",
+        "substep": null
+      },
+      "by": "extension",
+      "at": "2026-04-13T23:51:00.397Z"
+    },
+    {
+      "step": "plan",
+      "substep": null,
+      "from": {
+        "step": "specify",
+        "substep": null
+      },
+      "by": "extension",
+      "at": "2026-04-13T23:51:01.739Z"
+    },
+    {
+      "step": "tasks",
+      "substep": "loading",
+      "from": {
+        "step": "plan",
+        "substep": null
+      },
+      "by": "sdd",
+      "at": "2026-04-13T23:52:00Z"
+    },
+    {
+      "step": "tasks",
+      "substep": "writing-tasks",
+      "from": {
+        "step": "tasks",
+        "substep": "loading"
+      },
+      "by": "sdd",
+      "at": "2026-04-13T23:52:01Z"
+    },
+    {
+      "step": "tasks",
+      "substep": null,
+      "from": {
+        "step": "tasks",
+        "substep": "writing-tasks"
+      },
+      "by": "sdd",
+      "at": "2026-04-13T23:52:02Z"
+    },
+    {
+      "step": "plan",
+      "substep": null,
+      "from": {
+        "step": "tasks",
+        "substep": null
+      },
+      "by": "extension",
+      "at": "2026-04-13T23:52:41.187Z"
+    },
+    {
+      "step": "tasks",
+      "substep": null,
+      "from": {
+        "step": "tasks",
+        "substep": null
+      },
+      "by": "extension",
+      "at": "2026-04-13T23:54:52.592Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "from": {
+        "step": "plan",
+        "substep": null
+      },
+      "by": "extension",
+      "at": "2026-04-13T23:54:52.594Z"
+    },
+    {
+      "step": "plan",
+      "substep": null,
+      "from": {
+        "step": "implement",
+        "substep": null
+      },
+      "by": "extension",
+      "at": "2026-04-13T23:56:38.422Z"
+    },
+    {
+      "step": "specify",
+      "substep": null,
+      "from": {
+        "step": "plan",
+        "substep": null
+      },
+      "by": "extension",
+      "at": "2026-04-13T23:56:39.349Z"
+    },
+    {
+      "step": "tasks",
+      "substep": null,
+      "from": {
+        "step": "specify",
+        "substep": null
+      },
+      "by": "extension",
+      "at": "2026-04-13T23:56:40.217Z"
+    },
+    {
+      "step": "plan",
+      "substep": null,
+      "from": {
+        "step": "tasks",
+        "substep": null
+      },
+      "by": "extension",
+      "at": "2026-04-13T23:56:45.242Z"
+    }
+  ],
+  "status": "implementing",
+  "stepHistory": {
+    "specify": {
+      "startedAt": "2026-04-13T23:47:20.442Z",
+      "completedAt": "2026-04-13T23:47:20.442Z"
+    },
+    "plan": {
+      "startedAt": "2026-04-13T23:47:20.444Z",
+      "completedAt": "2026-04-13T23:50:45.882Z"
+    },
+    "tasks": {
+      "startedAt": "2026-04-13T23:50:45.883Z",
+      "completedAt": "2026-04-13T23:54:52.592Z"
+    },
+    "implement": {
+      "startedAt": "2026-04-13T23:54:52.594Z",
+      "completedAt": "2026-04-13T23:56:38.422Z"
+    }
+  }
+}

--- a/specs/065-multi-select-specs/plan.md
+++ b/specs/065-multi-select-specs/plan.md
@@ -1,0 +1,35 @@
+# Plan: Multi Select Specs
+
+**Spec**: [spec.md](./spec.md) | **Date**: 2026-04-13
+
+## Approach
+
+Migrate the Specs sidebar from `registerTreeDataProvider` to `createTreeView` with `canSelectMany: true`, then adapt the three status commands (`markCompleted`, `archive`, `reactivate`) to operate on the full selection. Use VS Code context keys derived from the selection's statuses to drive conditional `when` clauses for context-menu visibility, giving intersection semantics without custom menu code.
+
+## Technical Context
+
+**Stack**: TypeScript 5.3+, VS Code Extension API (`@types/vscode ^1.84.0`)
+**Constraints**: Extension-only change; no `.claude/**` or `.specify/**` edits. Single-select behavior must remain unchanged.
+
+## Files
+
+### Create
+
+- `src/features/specs/selectionContextKeys.ts` — compute and set `speckit.specs.selection.*` VS Code context keys (e.g., `allActive`, `allCompleted`, `allArchived`, `mixed`, `count`) from the tree view's current selection.
+
+### Modify
+
+- `src/extension.ts` — replace `registerTreeDataProvider(Views.explorer, specExplorer)` with `vscode.window.createTreeView(Views.explorer, { treeDataProvider: specExplorer, canSelectMany: true })`; wire `onDidChangeSelection` to the new selection-context-keys module; keep the TreeView in subscriptions.
+- `src/features/specs/specCommands.ts` — change `speckit.markCompleted`, `speckit.archive`, and `speckit.reactivate` (if not yet registered here, add it) to accept `(item, items?)` signature per VS Code multi-select convention, iterate the selection, call `setStatus`/`reactivate` per spec, refresh the tree once, and show a single summary toast (e.g., `"3 specs marked as completed"`; singular form when count is 1).
+- `package.json` — update `menus.view/item/context` entries for the three commands: add `when` clauses gating on the new `speckit.specs.selection.*` context keys so "Mark as Complete" hides when `allCompleted`, "Move to Active" hides when `allActive`, and any status-specific action hides on `mixed` selection where it isn't valid for every selected spec. Register `speckit.reactivate` command contribution if missing.
+- `src/features/specs/specCommands.test.ts` — add tests for bulk handlers: multi-item invocation updates all, single toast, single refresh, single-select fallback unchanged.
+
+## Testing Strategy
+
+- **Unit**: Extend `specCommands.test.ts` — mock `setStatus`/`reactivate` and assert they're called once per selected spec, that `specExplorer.refresh()` is called exactly once per bulk invocation, and that the notification message reflects the count.
+- **Manual**: Launch Extension Development Host, Ctrl/Cmd-click three active specs → "Mark as Complete" → verify single toast, tree refresh, all three move. Right-click two already-completed specs → verify "Mark as Complete" is hidden. Select one active + one completed → verify only actions valid for both appear. Right-click a single item → verify behavior is unchanged.
+
+## Risks
+
+- **Context-key staleness**: If selection context keys are set only on `onDidChangeSelection`, a right-click that changes selection may race with menu evaluation. Mitigation: also update the keys synchronously at the start of each bulk command as a safety net, and rely on VS Code's standard behavior that right-click updates selection before the menu opens.
+- **Single-item invocation from keyboard/palette**: When a command is invoked without a TreeView selection (e.g., Command Palette), the `items` arg is undefined. Mitigation: fall back to `[item]` when `items` is falsy, preserving today's single-spec behavior (R001 scenario: Single-select fallback).

--- a/specs/065-multi-select-specs/spec.md
+++ b/specs/065-multi-select-specs/spec.md
@@ -1,0 +1,44 @@
+# Spec: Multi Select Specs
+
+**Slug**: 065-multi-select-specs | **Date**: 2026-04-13
+
+## Summary
+
+Enable multi-selection in the Specs sidebar tree so users can change the status of several specs at once (mark complete, archive, reactivate). Context-menu labels must adapt to the current selection — e.g., when all selected specs are already under "Complete", the menu should not offer "Mark as Complete".
+
+## Requirements
+
+- **R001** (MUST): The Specs sidebar tree view supports multi-select (Ctrl/Cmd+click, Shift+click) by enabling `canSelectMany` on the tree view.
+- **R002** (MUST): Bulk status commands (mark complete, archive, reactivate/move to active) operate on every selected spec, not just the right-clicked item.
+- **R003** (MUST): Context-menu actions hide or relabel based on the selection's current statuses — e.g., "Mark as Complete" is not shown when all selected specs are already in the Complete group.
+- **R004** (MUST): When the selection mixes statuses, only actions valid for every selected spec are offered (intersection semantics).
+- **R005** (SHOULD): A single completion toast summarizes the bulk result (e.g., "3 specs marked as completed") instead of one toast per spec.
+- **R006** (SHOULD): The tree view refreshes once after the bulk operation finishes, not once per item.
+
+## Scenarios
+
+### Multi-select and bulk mark complete
+
+**When** the user Ctrl/Cmd-clicks three specs under the Active group and picks "Mark as Complete"
+**Then** all three move to the Complete group, a single summary toast is shown, and the tree refreshes once.
+
+### Selection already under Complete
+
+**When** the user selects two specs that are already under the Complete group and right-clicks
+**Then** the menu does not offer "Mark as Complete"; it offers "Archive" and "Move to Active" instead.
+
+### Mixed-status selection
+
+**When** the user selects one Active and one Completed spec
+**Then** only actions valid for both (e.g., Archive) are shown; status-specific actions like "Mark as Complete" are hidden.
+
+### Single-select fallback
+
+**When** the user right-clicks a single spec without multi-selecting
+**Then** behavior is unchanged from today — the action applies to that one spec.
+
+## Out of Scope
+
+- Bulk rename, bulk delete, or bulk workflow changes.
+- Keyboard shortcut bindings for bulk actions.
+- Drag-and-drop between status groups.

--- a/specs/065-multi-select-specs/tasks.md
+++ b/specs/065-multi-select-specs/tasks.md
@@ -1,0 +1,36 @@
+# Tasks: Multi Select Specs
+
+**Plan**: [plan.md](./plan.md) | **Date**: 2026-04-13
+
+---
+
+## Phase 1: Core Implementation (Sequential)
+
+- [x] **T001** Add selection context keys module — `src/features/specs/selectionContextKeys.ts` | R003, R004
+  - **Do**: Create new module exporting `updateSelectionContextKeys(selection: SpecItem[])` that calls `vscode.commands.executeCommand('setContext', ...)` for `speckit.specs.selection.count`, `speckit.specs.selection.allActive`, `speckit.specs.selection.allCompleted`, `speckit.specs.selection.allArchived`, and `speckit.specs.selection.mixed`. Derive booleans from each item's status group.
+  - **Verify**: `npm run compile` succeeds; module exports a single function.
+  - **Leverage**: Inspect existing status derivation in `src/features/specs/specExplorer.ts` (or similar) for how status groups are resolved per item.
+
+- [x] **T002** Migrate sidebar to createTreeView with canSelectMany *(depends on T001)* — `src/extension.ts` | R001, R004
+  - **Do**: Replace `vscode.window.registerTreeDataProvider(Views.explorer, specExplorer)` with `const specsTreeView = vscode.window.createTreeView(Views.explorer, { treeDataProvider: specExplorer, canSelectMany: true })`. Wire `specsTreeView.onDidChangeSelection(e => updateSelectionContextKeys(e.selection))`. Push `specsTreeView` into `context.subscriptions`. Export/pass `specsTreeView` to command registration so bulk handlers can read the current selection as a fallback.
+  - **Verify**: Extension loads in dev host; Ctrl/Cmd+click in the Specs tree selects multiple items; no regressions in single-click behavior.
+
+- [x] **T003** Bulk status command handlers *(depends on T002)* — `src/features/specs/specCommands.ts` | R002, R005, R006
+  - **Do**: Change `speckit.markCompleted`, `speckit.archive`, and `speckit.reactivate` to the `(item, items?: SpecItem[])` signature. Resolve target list as `items ?? (item ? [item] : [])`. Iterate, call existing `setStatus`/`reactivate` per spec, await all, then call `specExplorer.refresh()` exactly once and show one `vscode.window.showInformationMessage` summarizing the count (singular when 1, e.g. `"1 spec marked as completed"` vs `"3 specs marked as completed"`). Also call `updateSelectionContextKeys` synchronously at the start of each handler as a safety net against stale keys. Register `speckit.reactivate` command contribution if missing.
+  - **Verify**: Manual run — multi-select 3 active specs → Mark as Complete → single toast "3 specs marked as completed", tree refreshes once, all 3 move to Complete group.
+  - **Leverage**: Existing single-item handler bodies in `src/features/specs/specCommands.ts`.
+
+- [x] **T004** Context-menu `when` clauses *(depends on T003)* — `package.json` | R003, R004
+  - **Do**: Update `contributes.menus.view/item/context` entries for the three commands. Add `when` clauses using the new context keys: "Mark as Complete" shown when `!speckit.specs.selection.allCompleted && !speckit.specs.selection.allArchived`; "Archive" shown when `!speckit.specs.selection.allArchived`; "Move to Active" shown when `!speckit.specs.selection.allActive`. Ensure `speckit.reactivate` has a command contribution entry if newly added.
+  - **Verify**: Right-click two already-completed specs → "Mark as Complete" is hidden; "Archive" and "Move to Active" appear. Mixed selection shows only Archive.
+
+- [x] **T005** Tests for bulk handlers *(depends on T003)* — `src/features/specs/specCommands.test.ts` | R002, R005, R006
+  - **Do**: Add BDD tests: (a) invoking `markCompleted` with `items` of 3 specs calls `setStatus` 3× and `specExplorer.refresh` once and `showInformationMessage` once with plural message; (b) invoking with only `item` (no `items`) behaves identically to current single-select — `setStatus` once, singular toast; (c) `archive` and `reactivate` follow the same bulk semantics.
+  - **Verify**: `npm test` passes; new tests cover both multi and single-select paths.
+  - **Leverage**: Existing test harness / mocks in `src/features/specs/specCommands.test.ts`; VS Code mock at `tests/__mocks__/vscode.ts` (extend if needed for `showInformationMessage`).
+
+---
+
+## Progress
+
+- Phase 1: T001–T005 [x]

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,7 +5,7 @@ import { IAIProvider, AIProviderFactory, isProviderConfigured, promptForProvider
 
 // Features
 import { SteeringManager, SteeringExplorerProvider, registerSteeringCommands } from './features/steering';
-import { SpecExplorerProvider, registerSpecKitCommands } from './features/specs';
+import { SpecExplorerProvider, registerSpecKitCommands, updateSelectionContextKeys } from './features/specs';
 import { register as registerTerminalStepTracker } from './features/specs/terminalStepTracker';
 import { setLifecycleOutputChannel } from './features/specs/stepLifecycle';
 import { OverviewProvider } from './features/settings';
@@ -113,9 +113,15 @@ export async function activate(context: vscode.ExtensionContext) {
     steeringExplorer.setAgentManager(agentManager);
     steeringExplorer.setSkillManager(skillManager);
 
+    const specsTreeView = vscode.window.createTreeView(Views.explorer, {
+        treeDataProvider: specExplorer,
+        canSelectMany: true,
+    });
+    specsTreeView.onDidChangeSelection(e => updateSelectionContextKeys(e.selection as any));
+
     context.subscriptions.push(
         vscode.window.registerTreeDataProvider(Views.settings, overviewProvider),
-        vscode.window.registerTreeDataProvider(Views.explorer, specExplorer),
+        specsTreeView,
         vscode.window.registerTreeDataProvider(Views.steering, steeringExplorer)
     );
 
@@ -139,7 +145,7 @@ export async function activate(context: vscode.ExtensionContext) {
     // Register all commands
     registerCliCommands(context, specKitDetector);
     registerSteeringCommands(context, steeringManager, steeringExplorer, outputChannel);
-    registerSpecKitCommands(context, specExplorer, outputChannel);
+    registerSpecKitCommands(context, specExplorer, outputChannel, specsTreeView);
     registerUtilityCommands(context, updateChecker, outputChannel);
 
     // Set up file watchers

--- a/src/features/specs/index.ts
+++ b/src/features/specs/index.ts
@@ -1,2 +1,3 @@
 export * from './specExplorerProvider';
 export * from './specCommands';
+export * from './selectionContextKeys';

--- a/src/features/specs/selectionContextKeys.ts
+++ b/src/features/specs/selectionContextKeys.ts
@@ -1,0 +1,37 @@
+import * as vscode from 'vscode';
+import * as path from 'path';
+import { readSpecContextSync } from './specContextManager';
+import { SpecStatuses } from '../../core/constants';
+
+export interface SelectableSpecItem {
+    contextValue?: string;
+    specPath?: string;
+}
+
+function resolveStatus(item: SelectableSpecItem): string {
+    const ws = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+    if (!ws || !item.specPath) return SpecStatuses.ACTIVE;
+    const ctx = readSpecContextSync(path.join(ws, item.specPath));
+    return ctx?.status || SpecStatuses.ACTIVE;
+}
+
+export function updateSelectionContextKeys(selection: readonly SelectableSpecItem[]): void {
+    const specs = (selection || []).filter(i => i?.contextValue === 'spec');
+    const statuses = specs.map(resolveStatus);
+    const count = statuses.length;
+
+    const isCompleted = (s: string) => s === SpecStatuses.COMPLETED;
+    const isArchived = (s: string) => s === SpecStatuses.ARCHIVED;
+    const isActive = (s: string) => !isCompleted(s) && !isArchived(s);
+
+    const allActive = count > 0 && statuses.every(isActive);
+    const allCompleted = count > 0 && statuses.every(isCompleted);
+    const allArchived = count > 0 && statuses.every(isArchived);
+    const mixed = count > 1 && !allActive && !allCompleted && !allArchived;
+
+    vscode.commands.executeCommand('setContext', 'speckit.specs.selection.count', count);
+    vscode.commands.executeCommand('setContext', 'speckit.specs.selection.allActive', allActive);
+    vscode.commands.executeCommand('setContext', 'speckit.specs.selection.allCompleted', allCompleted);
+    vscode.commands.executeCommand('setContext', 'speckit.specs.selection.allArchived', allArchived);
+    vscode.commands.executeCommand('setContext', 'speckit.specs.selection.mixed', mixed);
+}

--- a/src/features/specs/specCommands.test.ts
+++ b/src/features/specs/specCommands.test.ts
@@ -34,6 +34,19 @@ jest.mock('../workflows', () => ({
     executeCheckpointsForTrigger: jest.fn(),
 }));
 
+jest.mock('./stepLifecycle', () => ({
+    startStep: jest.fn(),
+    setStatus: jest.fn().mockResolvedValue(undefined),
+    reactivate: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('./selectionContextKeys', () => ({
+    updateSelectionContextKeys: jest.fn(),
+}));
+
+import { setStatus, reactivate } from './stepLifecycle';
+import { NotificationUtils } from '../../core/utils/notificationUtils';
+
 const mockCommands = vscode.commands as jest.Mocked<typeof vscode.commands>;
 
 // Capture registered command handlers by name
@@ -45,13 +58,15 @@ function captureCommandHandlers(context: vscode.ExtensionContext) {
         return { dispose: jest.fn() };
     });
 
-    const mockExplorer = { refresh: jest.fn() } as any;
+    lastMockExplorer = { refresh: jest.fn() } as any;
     const mockOutputChannel = { appendLine: jest.fn() } as any;
 
-    registerSpecKitCommands(context, mockExplorer, mockOutputChannel);
+    registerSpecKitCommands(context, lastMockExplorer as any, mockOutputChannel);
 
     return handlers;
 }
+
+let lastMockExplorer: { refresh: jest.Mock };
 
 function createMockContext(): vscode.ExtensionContext {
     return {
@@ -64,10 +79,9 @@ beforeEach(() => {
 });
 
 describe('registerSpecKitCommands', () => {
-    it('accepts three parameters without specKitDetector', () => {
-        // The function signature should be (context, specExplorer, outputChannel)
-        // with no specKitDetector parameter. Verify it can be called with exactly 3 args.
-        expect(registerSpecKitCommands.length).toBe(3);
+    it('has no specKitDetector parameter', () => {
+        // Signature is (context, specExplorer, outputChannel, specsTreeView?) — no specKitDetector.
+        expect(registerSpecKitCommands.length).toBe(4);
     });
 
     it('registers the speckit.create command', () => {
@@ -75,6 +89,74 @@ describe('registerSpecKitCommands', () => {
         const handlers = captureCommandHandlers(context);
 
         expect(handlers.has('speckit.create')).toBe(true);
+    });
+});
+
+describe('bulk status command handlers', () => {
+    const originalWorkspaceFolders = (vscode.workspace as any).workspaceFolders;
+
+    beforeEach(() => {
+        (vscode.workspace as any).workspaceFolders = [{ uri: { fsPath: '/ws' } }];
+    });
+
+    afterEach(() => {
+        (vscode.workspace as any).workspaceFolders = originalWorkspaceFolders;
+    });
+
+    const makeItem = (name: string) => ({ label: name, specPath: `specs/${name}`, contextValue: 'spec' });
+
+    it('markCompleted on 3-item selection calls setStatus 3x, refreshes once, shows plural toast', async () => {
+        const context = createMockContext();
+        const handlers = captureCommandHandlers(context);
+        const handler = handlers.get('speckit.markCompleted')!;
+
+        const items = [makeItem('a'), makeItem('b'), makeItem('c')];
+        await handler(items[0], items);
+
+        expect(setStatus).toHaveBeenCalledTimes(3);
+        expect(setStatus).toHaveBeenCalledWith(expect.stringContaining('specs/a'), 'completed');
+        expect(setStatus).toHaveBeenCalledWith(expect.stringContaining('specs/b'), 'completed');
+        expect(setStatus).toHaveBeenCalledWith(expect.stringContaining('specs/c'), 'completed');
+        expect(lastMockExplorer.refresh).toHaveBeenCalledTimes(1);
+        expect(NotificationUtils.showAutoDismissNotification).toHaveBeenCalledTimes(1);
+        expect(NotificationUtils.showAutoDismissNotification).toHaveBeenCalledWith('3 specs marked as completed');
+    });
+
+    it('markCompleted with only item (no items) behaves like single-select with singular toast', async () => {
+        const context = createMockContext();
+        const handlers = captureCommandHandlers(context);
+        const handler = handlers.get('speckit.markCompleted')!;
+
+        await handler(makeItem('x'), undefined);
+
+        expect(setStatus).toHaveBeenCalledTimes(1);
+        expect(lastMockExplorer.refresh).toHaveBeenCalledTimes(1);
+        expect(NotificationUtils.showAutoDismissNotification).toHaveBeenCalledWith('1 spec marked as completed');
+    });
+
+    it('archive follows bulk semantics', async () => {
+        const context = createMockContext();
+        const handlers = captureCommandHandlers(context);
+        const handler = handlers.get('speckit.archive')!;
+
+        await handler(undefined, [makeItem('a'), makeItem('b')]);
+
+        expect(setStatus).toHaveBeenCalledTimes(2);
+        expect(setStatus).toHaveBeenCalledWith(expect.stringContaining('specs/a'), 'archived');
+        expect(lastMockExplorer.refresh).toHaveBeenCalledTimes(1);
+        expect(NotificationUtils.showAutoDismissNotification).toHaveBeenCalledWith('2 specs archived');
+    });
+
+    it('reactivate follows bulk semantics', async () => {
+        const context = createMockContext();
+        const handlers = captureCommandHandlers(context);
+        const handler = handlers.get('speckit.reactivate')!;
+
+        await handler(undefined, [makeItem('a'), makeItem('b'), makeItem('c')]);
+
+        expect(reactivate).toHaveBeenCalledTimes(3);
+        expect(lastMockExplorer.refresh).toHaveBeenCalledTimes(1);
+        expect(NotificationUtils.showAutoDismissNotification).toHaveBeenCalledWith('3 specs moved to active');
     });
 });
 

--- a/src/features/specs/specCommands.ts
+++ b/src/features/specs/specCommands.ts
@@ -17,7 +17,8 @@ import {
     WorkflowConfig,
 } from '../workflows';
 import { updateStepProgress } from './specContextManager';
-import { startStep, setStatus } from './stepLifecycle';
+import { startStep, setStatus, reactivate } from './stepLifecycle';
+import { updateSelectionContextKeys } from './selectionContextKeys';
 import { track as trackTerminal } from './terminalStepTracker';
 import type { StepName } from '../../core/types/specContext';
 
@@ -43,8 +44,19 @@ const LIFECYCLE_STEPS: ReadonlySet<string> = new Set([
 export function registerSpecKitCommands(
     context: vscode.ExtensionContext,
     specExplorer: SpecExplorerProvider,
-    outputChannel: vscode.OutputChannel
+    outputChannel: vscode.OutputChannel,
+    specsTreeView?: vscode.TreeView<any>
 ): void {
+    function resolveTargets(item: SpecTreeItem | undefined, items: SpecTreeItem[] | undefined): SpecTreeItem[] {
+        if (items && items.length > 0) return items;
+        if (item) return [item];
+        const selection = (specsTreeView?.selection || []) as SpecTreeItem[];
+        return selection.filter(s => (s as any)?.contextValue === 'spec');
+    }
+
+    function pluralize(count: number, singular: string, plural: string): string {
+        return count === 1 ? `1 spec ${singular}` : `${count} specs ${plural}`;
+    }
     // SpecKit Create - Open the spec editor webview
     context.subscriptions.push(
         vscode.commands.registerCommand('speckit.create', async () => {
@@ -100,31 +112,64 @@ export function registerSpecKitCommands(
     registerPhaseCommands(context, specExplorer, outputChannel);
     registerCustomCommand(context, outputChannel);
 
+    function specDirFor(item: SpecTreeItem, wsPath: string): string {
+        const relativePath = (item as SpecTreeItem).specPath || `specs/${item.label}`;
+        return path.join(wsPath, relativePath);
+    }
+
+    async function runBulkStatusChange(
+        item: SpecTreeItem | undefined,
+        items: SpecTreeItem[] | undefined,
+        apply: (specDir: string) => Promise<void>,
+        singular: string,
+        plural: string
+    ): Promise<void> {
+        const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
+        if (!workspaceFolder) return;
+        const targets = resolveTargets(item, items);
+        updateSelectionContextKeys(targets as any);
+        if (targets.length === 0) return;
+        await Promise.all(targets.map(t => apply(specDirFor(t, workspaceFolder.uri.fsPath))));
+        specExplorer.refresh();
+        NotificationUtils.showAutoDismissNotification(pluralize(targets.length, singular, plural));
+    }
+
     // Mark as Completed
     context.subscriptions.push(
-        vscode.commands.registerCommand('speckit.markCompleted', async (item: SpecTreeItem) => {
-            const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
-            if (workspaceFolder && item) {
-                const relativePath = (item as SpecTreeItem).specPath || `specs/${item.label}`;
-                const specDir = path.join(workspaceFolder.uri.fsPath, relativePath);
-                await setStatus(specDir, 'completed');
-                specExplorer.refresh();
-                NotificationUtils.showAutoDismissNotification(`Spec "${item.label}" marked as completed`);
-            }
+        vscode.commands.registerCommand('speckit.markCompleted', async (item: SpecTreeItem, items?: SpecTreeItem[]) => {
+            await runBulkStatusChange(
+                item,
+                items,
+                specDir => setStatus(specDir, 'completed'),
+                'marked as completed',
+                'marked as completed'
+            );
         })
     );
 
     // Archive spec
     context.subscriptions.push(
-        vscode.commands.registerCommand('speckit.archive', async (item: SpecTreeItem) => {
-            const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
-            if (workspaceFolder && item) {
-                const relativePath = (item as SpecTreeItem).specPath || `specs/${item.label}`;
-                const specDir = path.join(workspaceFolder.uri.fsPath, relativePath);
-                await setStatus(specDir, 'archived');
-                specExplorer.refresh();
-                NotificationUtils.showAutoDismissNotification(`Spec "${item.label}" archived`);
-            }
+        vscode.commands.registerCommand('speckit.archive', async (item: SpecTreeItem, items?: SpecTreeItem[]) => {
+            await runBulkStatusChange(
+                item,
+                items,
+                specDir => setStatus(specDir, 'archived'),
+                'archived',
+                'archived'
+            );
+        })
+    );
+
+    // Reactivate (Move to Active)
+    context.subscriptions.push(
+        vscode.commands.registerCommand('speckit.reactivate', async (item: SpecTreeItem, items?: SpecTreeItem[]) => {
+            await runBulkStatusChange(
+                item,
+                items,
+                specDir => reactivate(specDir),
+                'moved to active',
+                'moved to active'
+            );
         })
     );
 


### PR DESCRIPTION
## What

- Migrate Specs sidebar to `createTreeView` with `canSelectMany`
- Bulk `markCompleted`/`archive`/`reactivate` handlers with single summary toast + single refresh
- Context-menu `when` clauses driven by selection-status context keys
- Add `speckit.reactivate` command contribution ("Move to Active")

## Why

Let users change status on many specs at once without repeated right-clicks; hide actions that don't apply to the current selection.

## Testing

- Multi-select 3 active specs → Mark Complete → single "3 specs marked as completed" toast, tree refreshes once
- Right-click 2 already-completed specs → "Mark as Complete" hidden; Archive + Move to Active shown
- Select one active + one completed → only Archive shown
- Single right-click → behavior unchanged