### PR TITLE
feat(spec-viewer): lock future steps while running and add button tooltips

### DIFF
--- a/specs/067-lock-steps-while-running/.spec-context.json
+++ b/specs/067-lock-steps-while-running/.spec-context.json
@@ -1,0 +1,40 @@
+{
+  "workflow": "sdd",
+  "currentStep": "tasks",
+  "currentTask": null,
+  "progress": null,
+  "next": "implement",
+  "updated": "2026-04-13",
+  "selectedAt": "2026-04-14T00:55:27Z",
+  "specName": "Lock Steps While Running",
+  "branch": "main",
+  "createdAt": "2026-04-14T00:55:27Z",
+  "auto": true,
+  "approach": "Derive a single isRunning from existing viewerState signals and thread it into StepTab + FooterActions to disable future tabs and Regenerate/primary buttons; add native title tooltips to all controls.",
+  "step_summaries": {
+    "specify": {
+      "complexity": "normal",
+      "requirements": 7,
+      "scenarios": 4,
+      "key_finding": "StepTab clickability uses isClickable = exists || index===0; footer Regenerate/Approve live in FooterActions.tsx with no running-step awareness; viewerState already exposes activeStep + stepHistory[phase].completedAt."
+    },
+    "plan": {
+      "approach_summary": "Derive isRunning from existing viewerState signals and thread it into StepTab + FooterActions to disable future tabs and Regenerate/primary buttons; add native title tooltips to all controls.",
+      "files_planned": 3,
+      "risks": []
+    }
+  },
+  "transitions": [
+    { "step": "specify", "substep": "parsing", "from": null, "by": "sdd", "at": "2026-04-14T00:55:27Z" },
+    { "step": "specify", "substep": "exploring", "from": { "step": "specify", "substep": "parsing" }, "by": "sdd", "at": "2026-04-14T00:55:27Z" },
+    { "step": "specify", "substep": "detecting", "from": { "step": "specify", "substep": "exploring" }, "by": "sdd", "at": "2026-04-14T00:55:27Z" },
+    { "step": "specify", "substep": "writing-spec", "from": { "step": "specify", "substep": "detecting" }, "by": "sdd", "at": "2026-04-14T00:55:27Z" },
+    { "step": "specify", "substep": null, "from": { "step": "specify", "substep": "writing-spec" }, "by": "sdd", "at": "2026-04-14T00:55:27Z" },
+    { "step": "plan", "substep": "loading", "from": { "step": "specify", "substep": null }, "by": "sdd", "at": "2026-04-14T00:55:27Z" },
+    { "step": "plan", "substep": "writing-plan", "from": { "step": "plan", "substep": "loading" }, "by": "sdd", "at": "2026-04-14T00:55:27Z" },
+    { "step": "plan", "substep": null, "from": { "step": "plan", "substep": "writing-plan" }, "by": "sdd", "at": "2026-04-14T00:55:27Z" },
+    { "step": "tasks", "substep": "loading", "from": { "step": "plan", "substep": null }, "by": "sdd", "at": "2026-04-14T00:55:27Z" },
+    { "step": "tasks", "substep": "writing-tasks", "from": { "step": "tasks", "substep": "loading" }, "by": "sdd", "at": "2026-04-14T00:55:27Z" },
+    { "step": "tasks", "substep": null, "from": { "step": "tasks", "substep": "writing-tasks" }, "by": "sdd", "at": "2026-04-14T00:55:27Z" }
+  ]
+}

--- a/specs/067-lock-steps-while-running/plan.md
+++ b/specs/067-lock-steps-while-running/plan.md
@@ -1,0 +1,20 @@
+# Plan: Lock Steps While Running
+
+**Spec**: [spec.md](./spec.md) | **Date**: 2026-04-13
+
+## Approach
+
+Derive a single `isRunning` boolean in the viewer parent components from existing signals (`activeStep` + `stepHistory[activeStep].completedAt`). Thread it (or the activeStep id) into StepTab and FooterActions so future/unvisited step tabs and the Regenerate / primary-approve buttons become `disabled` while a step is in-flight. Add `title` tooltip props to every step tab and footer button — native HTML `title` only, no tooltip infra.
+
+## Files
+
+### Modify
+
+- `webview/src/spec-viewer/components/StepTab.tsx` — lock future tabs when activeStep is running; add `title` tooltip describing step and disabled reason.
+- `webview/src/spec-viewer/components/FooterActions.tsx` — compute `isRunning` from viewerState; disable Regenerate, Approve/Complete/Reactivate while running; add `title` to Edit Source, Archive, Regenerate, primary button, and ensure tooltips include disabled reason when applicable.
+- `webview/src/shared/components/Button.tsx` — verify `title` and `disabled` props are forwarded (add if missing).
+
+## Testing Strategy
+
+- **Unit**: Add a StepTab story / test asserting future tabs are `disabled` when `activeStep='plan'` + no completedAt. Add a FooterActions test asserting Regenerate + primary button are disabled when running.
+- **Manual**: Load a spec, trigger plan step, verify tasks tab and Regenerate are dimmed and non-clickable; hover each control to confirm tooltip text.

--- a/specs/067-lock-steps-while-running/spec.md
+++ b/specs/067-lock-steps-while-running/spec.md
@@ -1,0 +1,50 @@
+# Spec: Lock Steps While Running
+
+**Slug**: 067-lock-steps-while-running | **Date**: 2026-04-13
+
+## Summary
+
+While a workflow step is actively running (e.g. the planning agent is executing), the viewer currently lets the user click ahead into future step tabs (like "tasks") and press footer actions like "Regenerate". This spec locks those controls while a step is in-flight and adds tooltips to the step tabs and footer buttons so their purpose is discoverable.
+
+## Requirements
+
+- **R001** (MUST): While a step is running (viewerState reports `activeStep === phase` and that step has no `completedAt`), step tabs for phases that come AFTER the running step and whose document does not yet exist MUST be non-clickable and visually disabled.
+- **R002** (MUST): While a step is running, the footer "Regenerate" button MUST be disabled (non-clickable, visually dimmed).
+- **R003** (MUST): While a step is running, the footer primary action ("Approve" / "Complete" / "Reactivate") MUST be disabled.
+- **R004** (MUST): Every footer action button (Edit Source, Archive, Regenerate, Approve/Complete/Reactivate, enhancement buttons) MUST have a `title` tooltip describing what it does.
+- **R005** (MUST): Every step tab MUST have a `title` tooltip describing the step (e.g. "Specify — define requirements", "Plan — design approach", "Tasks — break into work items", "Implement — execute and ship"), including the running/disabled reason when applicable.
+- **R006** (SHOULD): The currently-viewing step tab MUST remain clickable (to re-focus its document) even while it is the running step.
+- **R007** (SHOULD): Disabled buttons during a running step SHOULD expose a tooltip explaining the reason (e.g. "Disabled while {step} is running").
+
+## Scenarios
+
+### Planning is running
+
+**When** viewerState reports `activeStep: "plan"` with no `completedAt` and the user views the plan document
+**Then** the "tasks" step tab is not clickable, the "Regenerate" footer button is disabled, and the primary approve/complete button is disabled. Hovering any of them shows a tooltip explaining why.
+
+### Step completes
+
+**When** the running step finishes (stepHistory[phase].completedAt is set)
+**Then** all previously-locked tabs and footer buttons return to their normal enabled/disabled state based on existing logic.
+
+### Hover discoverability
+
+**When** the user hovers any step tab or footer action button
+**Then** a native tooltip appears describing the control's purpose.
+
+### Re-click current running step
+
+**When** the running step is also the currently-viewed step
+**Then** the user can still click its tab (it's the current view) — only FUTURE steps are locked.
+
+## Non-Functional Requirements
+
+- **NFR001** (MUST): Lock state must derive from existing viewerState / stepHistory signals — no new polling.
+- **NFR002** (SHOULD): Tooltips must be plain `title` attributes (no custom tooltip infra) to keep the change minimal.
+
+## Out of Scope
+
+- Redesigning the footer action set or tab visuals beyond disabled styling.
+- Blocking keyboard shortcuts or command-palette commands (only the viewer UI controls are in scope).
+- Changing backend/agent behavior — this is viewer-UI only.

--- a/specs/067-lock-steps-while-running/tasks.md
+++ b/specs/067-lock-steps-while-running/tasks.md
@@ -1,0 +1,28 @@
+# Tasks: Lock Steps While Running
+
+**Plan**: [plan.md](./plan.md) | **Date**: 2026-04-13
+
+---
+
+## Phase 1: Core Implementation (Sequential)
+
+- [x] **T001** Lock future step tabs while a step is running + add tooltips — `webview/src/spec-viewer/components/StepTab.tsx` | R001, R005, R006, R007
+  - **Do**: In `StepTab.tsx`, compute `anyStepRunning` from `activeStep` + `stepHistory[activeStep]?.completedAt` (passed via props or read from `viewerState`). For tabs whose `phase !== activeStep` AND whose `index > indexOf(activeStep)` AND whose doc does not exist, force `isClickable = false` and add `'locked'` class. Add a `title` attribute to the `<button>` describing the step (map: specify→"Specify — define requirements", plan→"Plan — design approach", tasks→"Tasks — break into work items", implement→"Implement — execute and ship"). When locked, append ` (disabled while ${activeStep} is running)` to the title.
+  - **Verify**: `npm run compile` passes; hovering a locked tab shows the reason tooltip; clicking it does nothing.
+  - **Leverage**: existing `isClickable` / `disabled` wiring at StepTab.tsx:41,71.
+
+- [x] **T002** Disable Regenerate + primary action while running, add button tooltips *(depends on T001)* — `webview/src/spec-viewer/components/FooterActions.tsx` | R002, R003, R004, R007
+  - **Do**: Derive `isRunning = !!(vs?.activeStep && !vs?.stepHistory?.[vs.activeStep]?.completedAt)` (or equivalent from navState/viewerState). Pass `disabled={isRunning}` to Regenerate and the primary Approve/Complete/Reactivate buttons. Add `title` to each button: Edit Source="Open the raw markdown in an editor", Archive="Archive this spec", Regenerate="Regenerate the current step from scratch", Approve/Complete/Reactivate=their existing intent string. When `isRunning` is true, append ` (disabled while ${activeStep} is running)` to the disabled buttons' titles.
+  - **Verify**: `npm run compile` passes; while a step runs the Regenerate and primary buttons are dimmed, non-clickable, and hover shows the reason tooltip; once `stepHistory[step].completedAt` is set, both re-enable.
+  - **Leverage**: pattern already in use for `title={withScopeSuffix(a)}` at FooterActions.tsx:62.
+
+- [x] **T003** Confirm Button forwards `disabled`/`title` + add disabled styling if needed *(depends on T002)* — `webview/src/shared/components/Button.tsx`, `webview/styles/spec-viewer/_footer.css` | R002, R003, R007
+  - **Do**: Verify Button spreads `...rest` so `disabled` and `title` pass through (already true at Button.tsx:14). Ensure `button[disabled]` in `_footer.css` has visible dimmed styling (opacity 0.5, cursor not-allowed); add the rule if missing.
+  - **Verify**: disabled buttons render visibly dimmed; storybook (if applicable) unchanged.
+  - **Leverage**: existing `.step-tab.disabled` styling in `webview/styles/spec-viewer/_tabs.css` for visual parity.
+
+---
+
+## Progress
+
+- Phase 1: T001–T003 [ ]

--- a/webview/src/shared/components/Button.tsx
+++ b/webview/src/shared/components/Button.tsx
@@ -6,6 +6,7 @@ export interface ButtonProps extends Omit<JSX.HTMLAttributes<HTMLButtonElement>,
     label: string;
     variant?: ButtonVariant;
     icon?: string;
+    disabled?: boolean;
 }
 
 export function Button({ label, variant = 'secondary', icon, class: cls, ...rest }: ButtonProps) {

--- a/webview/src/spec-viewer/components/FooterActions.tsx
+++ b/webview/src/spec-viewer/components/FooterActions.tsx
@@ -25,6 +25,12 @@ export function FooterActions({ initialSpecStatus }: FooterActionsProps) {
 
     const send = (msg: ViewerToExtensionMessage) => () => vscode.postMessage(msg);
 
+    // A step is "running" when activeStep is set but its stepHistory entry has no completedAt.
+    const runningStep = ns.activeStep ?? null;
+    const isRunning = !!(runningStep && !ns.stepHistory?.[runningStep]?.completedAt);
+    const runLockSuffix = isRunning ? ` (disabled while ${runningStep} is running)` : '';
+    const withLock = (label: string) => `${label}${runLockSuffix}`;
+
     const status = vs?.status || ns.footerState?.specStatus || ns.specStatus || initialSpecStatus;
     const isTasksDone = status === 'tasks-done';
     const isCompleted = status === 'completed';
@@ -41,60 +47,115 @@ export function FooterActions({ initialSpecStatus }: FooterActionsProps) {
             <footer class="actions">
                 <Toast id="action-toast" />
                 <div class="actions-left">
-                    <Button label="Edit Source" variant="secondary" onClick={send({ type: 'editSource' })} />
+                    <Button
+                        label="Edit Source"
+                        variant="secondary"
+                        title="Open the raw markdown in an editor"
+                        onClick={send({ type: 'editSource' })}
+                    />
                     {isActive && enhancementButtons.map((btn) => (
                         <Button
                             key={btn.command}
                             label={btn.label}
                             variant="enhancement"
                             icon={btn.icon}
-                            title={btn.tooltip || ''}
+                            title={btn.tooltip || btn.label}
                             onClick={send({ type: 'clarify', command: btn.command })}
                         />
                     ))}
                 </div>
                 <div class="actions-right">
-                    {vs.footer.map((a) => (
-                        <Button
-                            key={a.id}
-                            label={a.label}
-                            variant={a.id === 'approve' || a.id === 'complete' || a.id === 'reactivate' ? 'primary' : 'secondary'}
-                            title={withScopeSuffix(a)}
-                            onClick={sendFooter(a.id)}
-                        />
-                    ))}
+                    {vs.footer.map((a) => {
+                        const isPrimary = a.id === 'approve' || a.id === 'complete' || a.id === 'reactivate';
+                        const isRegenerate = a.id === 'regenerate';
+                        const disabled = isRunning && (isPrimary || isRegenerate);
+                        const baseTitle = withScopeSuffix(a);
+                        return (
+                            <Button
+                                key={a.id}
+                                label={a.label}
+                                variant={isPrimary ? 'primary' : 'secondary'}
+                                title={disabled ? withLock(baseTitle) : baseTitle}
+                                disabled={disabled}
+                                onClick={sendFooter(a.id)}
+                            />
+                        );
+                    })}
                 </div>
             </footer>
         );
     }
 
+    const regenerateTitle = isRunning
+        ? withLock('Regenerate the current step from scratch')
+        : 'Regenerate the current step from scratch';
+    const approveTitle = isRunning
+        ? withLock('Approve and advance to the next step')
+        : 'Approve and advance to the next step';
+
     return (
         <footer class="actions">
             <Toast id="action-toast" />
             <div class="actions-left">
-                <Button label="Edit Source" variant="secondary" onClick={send({ type: 'editSource' })} />
-                {!isArchived && <Button label="Archive" variant="secondary" onClick={send({ type: 'archiveSpec' })} />}
+                <Button
+                    label="Edit Source"
+                    variant="secondary"
+                    title="Open the raw markdown in an editor"
+                    onClick={send({ type: 'editSource' })}
+                />
+                {!isArchived && (
+                    <Button
+                        label="Archive"
+                        variant="secondary"
+                        title="Archive this spec"
+                        onClick={send({ type: 'archiveSpec' })}
+                    />
+                )}
                 {isActive && enhancementButtons.map((btn) => (
                     <Button
                         key={btn.command}
                         label={btn.label}
                         variant="enhancement"
                         icon={btn.icon}
-                        title={btn.tooltip || ''}
+                        title={btn.tooltip || btn.label}
                         onClick={send({ type: 'clarify', command: btn.command })}
                     />
                 ))}
             </div>
             <div class="actions-right">
                 {isArchived || isCompleted ? (
-                    <Button label="Reactivate" variant="primary" onClick={send({ type: 'reactivateSpec' })} />
+                    <Button
+                        label="Reactivate"
+                        variant="primary"
+                        title={isRunning ? withLock('Reactivate this spec') : 'Reactivate this spec'}
+                        disabled={isRunning}
+                        onClick={send({ type: 'reactivateSpec' })}
+                    />
                 ) : isTasksDone ? (
-                    <Button label="Complete" variant="primary" onClick={send({ type: 'completeSpec' })} />
+                    <Button
+                        label="Complete"
+                        variant="primary"
+                        title={isRunning ? withLock('Mark this spec complete') : 'Mark this spec complete'}
+                        disabled={isRunning}
+                        onClick={send({ type: 'completeSpec' })}
+                    />
                 ) : (
                     <>
-                        <Button label="Regenerate" variant="secondary" onClick={send({ type: 'regenerate' })} />
+                        <Button
+                            label="Regenerate"
+                            variant="secondary"
+                            title={regenerateTitle}
+                            disabled={isRunning}
+                            onClick={send({ type: 'regenerate' })}
+                        />
                         {ns.footerState?.showApproveButton && (
-                            <Button label={ns.footerState.approveText} variant="primary" onClick={send({ type: 'approve' })} />
+                            <Button
+                                label={ns.footerState.approveText}
+                                variant="primary"
+                                title={approveTitle}
+                                disabled={isRunning}
+                                onClick={send({ type: 'approve' })}
+                            />
                         )}
                     </>
                 )}

--- a/webview/src/spec-viewer/components/NavigationBar.tsx
+++ b/webview/src/spec-viewer/components/NavigationBar.tsx
@@ -17,6 +17,15 @@ export function NavigationBar() {
         : undefined;
     const parentPhaseForRelated = viewingRelatedDoc?.parentStep || coreDocs?.[0]?.type || 'spec';
 
+    // Index of the step currently running (activeStep with no completedAt).
+    // Future tabs beyond this index get locked while the step is in-flight.
+    const runningStepIndex = (() => {
+        if (!activeStep) return null;
+        if (stepHistory?.[activeStep]?.completedAt) return null;
+        const idx = coreDocs.findIndex(d => d.type === activeStep);
+        return idx >= 0 ? idx : null;
+    })();
+
     const handleClick = (phase: string) => {
         vscode.postMessage({ type: 'stepperClick', phase });
     };
@@ -43,6 +52,7 @@ export function NavigationBar() {
                                 stepHistory={stepHistory}
                                 stalenessMap={stalenessMap}
                                 hasRelatedChildren={hasRelatedChildren}
+                                runningStepIndex={runningStepIndex}
                                 onClick={handleClick}
                             />
                             {i < coreDocs.length - 1 && (

--- a/webview/src/spec-viewer/components/StepTab.tsx
+++ b/webview/src/spec-viewer/components/StepTab.tsx
@@ -7,6 +7,13 @@ const DOC_TO_STEP: Record<string, string> = {
     tasks: 'tasks',
 };
 
+const STEP_TOOLTIPS: Record<string, string> = {
+    spec: 'Specify — define requirements and scenarios',
+    plan: 'Plan — design the implementation approach',
+    tasks: 'Tasks — break the plan into work items',
+    done: 'Implement — execute and ship',
+};
+
 export interface StepTabProps {
     doc: SpecDocument;
     index: number;
@@ -20,13 +27,14 @@ export interface StepTabProps {
     stepHistory?: Record<string, { completedAt?: string | null }>;
     stalenessMap?: StalenessMap;
     hasRelatedChildren?: boolean;
+    runningStepIndex?: number | null;
     onClick: (phase: string) => void;
 }
 
 export function StepTab(props: StepTabProps) {
     const { doc, index, totalSteps, currentDoc, workflowPhase,
         taskCompletionPercent, isViewingRelatedDoc, parentPhaseForRelated,
-        activeStep, stepHistory, stalenessMap, hasRelatedChildren, onClick } = props;
+        activeStep, stepHistory, stalenessMap, hasRelatedChildren, runningStepIndex, onClick } = props;
 
     const phase = doc.type;
     const exists = doc.exists || !!hasRelatedChildren;
@@ -38,7 +46,11 @@ export function StepTab(props: StepTabProps) {
     const isTasksActive = isLastStep && isViewing && inProgress;
     const isStale = stalenessMap?.[phase]?.isStale ?? false;
     const isWorking = activeStep === phase && !stepHistory?.[phase]?.completedAt;
-    const isClickable = exists || index === 0;
+    const isLocked = runningStepIndex != null
+        && index > runningStepIndex
+        && !isViewing
+        && !stepDocExists;
+    const isClickable = (exists || index === 0) && !isLocked;
 
     const vs = viewerState.value;
     const stepName = DOC_TO_STEP[phase] ?? phase;
@@ -64,10 +76,16 @@ export function StepTab(props: StepTabProps) {
     // R003/R004: only show ✓ when the step's document actually exists.
     const statusIcon = inProgress ? `${taskCompletionPercent}%` : (stepDocExists ? '✓' : '');
 
+    const baseTooltip = STEP_TOOLTIPS[phase] ?? doc.label;
+    const tooltip = isLocked
+        ? `${baseTooltip} (disabled while ${activeStep} is running)`
+        : baseTooltip;
+
     return (
         <button
             class={classes}
             data-phase={phase}
+            title={tooltip}
             disabled={!isClickable}
             onClick={() => isClickable && phase !== 'done' && onClick(phase)}
         >

--- a/webview/styles/spec-viewer/_footer.css
+++ b/webview/styles/spec-viewer/_footer.css
@@ -92,6 +92,16 @@
     color: var(--text-primary);
 }
 
+/* Disabled state for all footer buttons (e.g. while a step is running) */
+.actions button:disabled,
+.actions button[disabled] {
+    opacity: 0.4;
+    cursor: not-allowed;
+    pointer-events: none;
+    transform: none;
+    box-shadow: none;
+}
+
 /* ============================================
    Action Toast (floating)
    ============================================ */


### PR DESCRIPTION
## What

- Lock future step tabs (beyond the currently-running step) while a step is in-flight, so users can't jump ahead into an unready phase.
- Disable the footer Regenerate and primary Approve/Complete/Reactivate buttons while a step is running.
- Add native `title` tooltips to every step tab and footer action button, with a "disabled while {step} is running" suffix when applicable.

## Why

While a step like plan is running, future tabs (tasks) and Regenerate remained clickable, letting users stomp on in-flight work. Tooltips improve button discoverability.

## Testing

- `npm run compile` — passes
- `npx webpack --mode=production` — passes
- Manual: load a spec, trigger a plan run, verify the tasks tab + Regenerate + primary button dim and reject clicks; hover each for tooltip text; once stepHistory[step].completedAt is set, they re-enable.