### PR TITLE
fix(spec-viewer): infer step completion without stepHistory entry

### DIFF
--- a/src/features/spec-viewer/__tests__/stateDerivation.test.ts
+++ b/src/features/spec-viewer/__tests__/stateDerivation.test.ts
@@ -1,0 +1,139 @@
+import {
+    isStepCompleted,
+    deriveStepBadges,
+    derivePulse,
+    deriveHighlights,
+    deriveViewerState,
+} from '../stateDerivation';
+import type { SpecContext, StepName } from '../../../core/types/specContext';
+
+// Mock footerActions to avoid pulling in vscode dependency
+jest.mock('../footerActions', () => ({
+    getFooterActions: jest.fn().mockReturnValue([]),
+}));
+
+function makeContext(overrides: Partial<SpecContext> = {}): SpecContext {
+    return {
+        workflow: 'sdd',
+        specName: 'test',
+        branch: 'main',
+        currentStep: 'specify',
+        status: 'draft',
+        stepHistory: {},
+        transitions: [],
+        ...overrides,
+    };
+}
+
+describe('isStepCompleted', () => {
+    it('returns true when step has explicit completedAt', () => {
+        const history = { specify: { startedAt: '2026-01-01', completedAt: '2026-01-02' } };
+        expect(isStepCompleted('specify', 'specify', history)).toBe(true);
+    });
+
+    it('returns true when step has startedAt and precedes currentStep', () => {
+        const history = { specify: { startedAt: '2026-01-01', completedAt: null } };
+        expect(isStepCompleted('specify', 'plan', history)).toBe(true);
+    });
+
+    it('returns true when step has NO history entry but precedes currentStep', () => {
+        expect(isStepCompleted('specify', 'tasks', {})).toBe(true);
+        expect(isStepCompleted('plan', 'tasks', {})).toBe(true);
+    });
+
+    it('returns false for currentStep itself with no history', () => {
+        expect(isStepCompleted('tasks', 'tasks', {})).toBe(false);
+    });
+
+    it('returns false for steps after currentStep', () => {
+        expect(isStepCompleted('tasks', 'specify', {})).toBe(false);
+    });
+
+    it('returns false for currentStep with startedAt but no completedAt', () => {
+        const history = { plan: { startedAt: '2026-01-01', completedAt: null } };
+        expect(isStepCompleted('plan', 'plan', history)).toBe(false);
+    });
+});
+
+describe('deriveStepBadges', () => {
+    it('marks steps before currentStep as completed even without history', () => {
+        const ctx = makeContext({ currentStep: 'tasks', stepHistory: {} });
+        const badges = deriveStepBadges(ctx);
+        expect(badges['specify']).toBe('completed');
+        expect(badges['plan']).toBe('completed');
+        expect(badges['tasks']).toBe('not-started');
+    });
+
+    it('marks step with startedAt at currentStep as in-progress', () => {
+        const ctx = makeContext({
+            currentStep: 'tasks',
+            stepHistory: { tasks: { startedAt: '2026-01-01', completedAt: null } },
+        });
+        const badges = deriveStepBadges(ctx);
+        expect(badges['tasks']).toBe('in-progress');
+    });
+
+    it('marks all steps completed when all have completedAt', () => {
+        const ctx = makeContext({
+            currentStep: 'tasks',
+            stepHistory: {
+                specify: { startedAt: '2026-01-01', completedAt: '2026-01-02' },
+                plan: { startedAt: '2026-01-02', completedAt: '2026-01-03' },
+                tasks: { startedAt: '2026-01-03', completedAt: '2026-01-04' },
+            },
+        });
+        const badges = deriveStepBadges(ctx);
+        expect(badges['specify']).toBe('completed');
+        expect(badges['plan']).toBe('completed');
+        expect(badges['tasks']).toBe('completed');
+    });
+});
+
+describe('derivePulse', () => {
+    it('returns null when no step has startedAt without completion', () => {
+        const ctx = makeContext({ currentStep: 'tasks', stepHistory: {} });
+        expect(derivePulse(ctx)).toBeNull();
+    });
+
+    it('returns the in-progress step', () => {
+        const ctx = makeContext({
+            currentStep: 'plan',
+            status: 'planning',
+            stepHistory: { plan: { startedAt: '2026-01-01', completedAt: null } },
+        });
+        expect(derivePulse(ctx)).toBe('plan');
+    });
+
+    it('returns null for completed/archived specs', () => {
+        const ctx = makeContext({ status: 'completed' });
+        expect(derivePulse(ctx)).toBeNull();
+    });
+});
+
+describe('deriveHighlights', () => {
+    it('includes steps before currentStep even without history', () => {
+        const ctx = makeContext({ currentStep: 'tasks', stepHistory: {} });
+        const highlights = deriveHighlights(ctx);
+        expect(highlights).toContain('specify');
+        expect(highlights).toContain('plan');
+        expect(highlights).not.toContain('tasks');
+    });
+});
+
+describe('deriveViewerState', () => {
+    it('produces correct state for SDD auto incomplete stepHistory', () => {
+        // Simulates what SDD auto leaves behind
+        const ctx = makeContext({
+            currentStep: 'tasks',
+            status: 'implementing', // coerced from "active"
+            stepHistory: { specify: { startedAt: '2026-01-01', completedAt: null } },
+        });
+        const state = deriveViewerState(ctx);
+        expect(state.steps['specify']).toBe('completed');
+        expect(state.steps['plan']).toBe('completed');
+        expect(state.steps['tasks']).toBe('not-started');
+        expect(state.highlights).toContain('specify');
+        expect(state.highlights).toContain('plan');
+        expect(state.pulse).toBeNull();
+    });
+});

--- a/src/features/spec-viewer/stateDerivation.ts
+++ b/src/features/spec-viewer/stateDerivation.ts
@@ -4,10 +4,10 @@
  * Never touches the filesystem. `deriveStepBadges` uses only `stepHistory`.
  * `pulse` is null when `status` ∈ {completed, archived}.
  *
- * **Inferred completion**: a step is treated as completed when it has
- * `startedAt` set and precedes `currentStep` in `STEP_NAMES` ordering,
- * even if `completedAt` was never explicitly written (common with external
- * SDD skills that only emit `startedAt`).
+ * **Inferred completion**: a step is treated as completed when it precedes
+ * `currentStep` in `STEP_NAMES` ordering, even if it has no `stepHistory`
+ * entry at all (common with external SDD skills that advance `currentStep`
+ * without populating per-step history).
  */
 
 import {
@@ -24,7 +24,7 @@ import { getFooterActions } from './footerActions';
  *
  * A step is completed if:
  * 1. It has explicit `completedAt`, OR
- * 2. It has `startedAt` AND its index in STEP_NAMES is before `currentStep`
+ * 2. Its index in STEP_NAMES is before `currentStep`
  *    (the workflow moved past it — inferred completion).
  */
 export function isStepCompleted(
@@ -33,11 +33,14 @@ export function isStepCompleted(
     stepHistory: Record<string, { startedAt?: string; completedAt?: string | null }>
 ): boolean {
     const entry = stepHistory[step];
-    if (!entry?.startedAt) return false;
-    if (entry.completedAt) return true;
+    if (entry?.completedAt) return true;
     const stepIdx = STEP_NAMES.indexOf(step);
     const currentIdx = STEP_NAMES.indexOf(currentStep);
-    return stepIdx >= 0 && currentIdx >= 0 && stepIdx < currentIdx;
+    // Inferred completion: the workflow moved past this step.
+    if (stepIdx >= 0 && currentIdx >= 0 && stepIdx < currentIdx) return true;
+    // No history entry and not before currentStep → not completed.
+    if (!entry?.startedAt) return false;
+    return false;
 }
 
 export function deriveStepBadges(
@@ -45,13 +48,11 @@ export function deriveStepBadges(
 ): Record<string, StepBadgeState> {
     const out: Record<string, StepBadgeState> = {};
     for (const step of STEP_NAMES) {
-        const entry = ctx.stepHistory[step];
-        if (!entry || !entry.startedAt) {
-            out[step] = 'not-started';
-        } else if (isStepCompleted(step, ctx.currentStep, ctx.stepHistory)) {
+        if (isStepCompleted(step, ctx.currentStep, ctx.stepHistory)) {
             out[step] = 'completed';
         } else {
-            out[step] = 'in-progress';
+            const entry = ctx.stepHistory[step];
+            out[step] = entry?.startedAt ? 'in-progress' : 'not-started';
         }
     }
     return out;

--- a/tests/unit/spec-viewer/stateDerivation.spec.ts
+++ b/tests/unit/spec-viewer/stateDerivation.spec.ts
@@ -169,9 +169,9 @@ describe('isStepCompleted — inferred completion from step ordering', () => {
         expect(isStepCompleted('implement', 'specify', history)).toBe(true);
     });
 
-    it('step with no startedAt → false even if before currentStep', () => {
+    it('step with no startedAt → true if before currentStep (inferred completion)', () => {
         const history = {};
-        expect(isStepCompleted('specify', 'implement', history)).toBe(false);
+        expect(isStepCompleted('specify', 'implement', history)).toBe(true);
     });
 });
 


### PR DESCRIPTION
## Summary
- Broadens `isStepCompleted` to treat any step preceding `currentStep` as completed, even without a `stepHistory` entry
- Fixes broken viewer state when external tools (SDD auto, etc.) advance `currentStep` without populating per-step history
- Fixes wrong badges, pulsing, dashed borders, and disabled Implement button after SDD auto runs

## Test plan
- [x] All 256 existing tests pass
- [x] 14 new tests covering missing-history inference edge cases
- [ ] Manual: run SDD auto on a spec, verify all prior steps show green checks and correct footer buttons

🤖 Generated with [Claude Code](https://claude.com/claude-code)