### PR TITLE
fix(spec-viewer): reconcile incomplete spec-context, fix disabled buttons

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -48,6 +48,7 @@ src/
 │   │                           # specContextManager.ts (legacy),
 │   │                           # specContextReader.ts, specContextWriter.ts,
 │   │                           # specContextBackfill.ts (060 canonical),
+│   │                           # specContextReconciler.ts (one-time file repair),
 │   │                           # index.ts, __tests__/
 │   ├── steering/               # steeringExplorerProvider.ts, steeringManager.ts,
 │   │                           # steeringCommands.ts, types.ts, index.ts

--- a/docs/viewer-states.md
+++ b/docs/viewer-states.md
@@ -13,14 +13,21 @@
 >
 > **Badge/pulse/highlight rules**:
 > - Step badge = `completed` if `stepHistory[step].completedAt` is set
->   **OR** the step has `startedAt` and precedes `currentStep` in
->   `STEP_NAMES` ordering (inferred completion — handles external SDD
->   skills that only emit `startedAt`); `in-progress` if `startedAt`
->   set and not inferred-completed; else `not-started`.
+>   **OR** the step precedes `currentStep` in `STEP_NAMES` ordering
+>   (inferred completion — handles external tools that advance
+>   `currentStep` without populating per-step history); `in-progress`
+>   if `startedAt` set and not inferred-completed; else `not-started`.
 > - Pulse = the single step whose entry has `startedAt` set and is not
 >   inferred-completed. **Null when `status ∈ {completed, archived}`.**
 > - Highlight = every step with `completedAt` set or inferred-completed,
 >   regardless of active tab.
+>
+> **Reconciliation**: When the extension reads `.spec-context.json` and
+> finds incomplete data (e.g., `currentStep` past steps with no history
+> entries, non-canonical status values), it performs a one-time repair
+> via `specContextReconciler.ts` — backfilling missing stepHistory
+> entries and correcting the status. The file is written back so
+> subsequent reads see clean data without re-inferring.
 >
 > **Viewed step (spec 066)**: Clicking a step tab in the viewer uses the
 > same full-HTML regeneration path as sidebar navigation and does NOT

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "speckit-companion",
-  "version": "0.11.0",
+  "version": "0.11.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "speckit-companion",
-      "version": "0.11.0",
+      "version": "0.11.3",
       "license": "MIT",
       "dependencies": {
         "@preact/signals": "^1.3.4",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "speckit-companion",
   "displayName": "SpecKit Companion",
   "description": "VS Code companion for GitHub SpecKit - spec-driven development with AI assistants",
-  "version": "0.11.0",
+  "version": "0.11.3",
   "license": "MIT",
   "publisher": "alfredoperez",
   "icon": "icon.png",

--- a/src/ai-providers/__tests__/promptBuilder.test.ts
+++ b/src/ai-providers/__tests__/promptBuilder.test.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import { buildPrompt } from '../promptBuilder';
+import { buildPrompt, buildLifecyclePrompt } from '../promptBuilder';
 
 describe('buildPrompt', () => {
     const originalGetConfig = vscode.workspace.getConfiguration;
@@ -78,5 +78,42 @@ describe('buildPrompt', () => {
             const out = buildPrompt({ command: 'x', step, specDir: 'specs/001-demo' });
             expect(out.length).toBeLessThan(1500);
         }
+    });
+
+    it('preamble includes canonical status lifecycle', () => {
+        mockConfig(true);
+        const out = buildPrompt({ command: 'x', step: 'specify', specDir: 'specs/001-demo' });
+        expect(out).toContain('Canonical statuses:');
+        expect(out).toContain('ready-to-implement');
+    });
+});
+
+describe('buildLifecyclePrompt', () => {
+    const originalGetConfig = vscode.workspace.getConfiguration;
+
+    function mockConfig(enabled: boolean): void {
+        (vscode.workspace as unknown as { getConfiguration: unknown }).getConfiguration = jest
+            .fn()
+            .mockReturnValue({ get: jest.fn().mockReturnValue(enabled) });
+    }
+
+    afterEach(() => {
+        (vscode.workspace as unknown as { getConfiguration: unknown }).getConfiguration = originalGetConfig;
+    });
+
+    it('wraps command with lifecycle preamble', () => {
+        mockConfig(true);
+        const out = buildLifecyclePrompt('/sdd:auto "specs/001"', 'specs/001');
+        expect(out).toContain('<!-- speckit-companion:context-update -->');
+        expect(out).toContain('keep');
+        expect(out).toContain('specs/001/.spec-context.json');
+        expect(out).toContain('Canonical statuses:');
+        expect(out).toContain('/sdd:auto "specs/001"');
+    });
+
+    it('returns raw command when disabled', () => {
+        mockConfig(false);
+        const cmd = '/sdd:auto "specs/001"';
+        expect(buildLifecyclePrompt(cmd, 'specs/001')).toBe(cmd);
     });
 });

--- a/src/ai-providers/promptBuilder.ts
+++ b/src/ai-providers/promptBuilder.ts
@@ -26,6 +26,13 @@ function isContextInstructionsEnabled(): boolean {
     }
 }
 
+const STATUS_LIFECYCLE = [
+    'Canonical statuses: draft → specifying → specified → planning → planned → tasking → ready-to-implement → implementing → completed.',
+    'When starting a step: set status to the in-progress form (specifying, planning, tasking, implementing).',
+    'When completing a step: set status to the completed form (specified, planned, ready-to-implement, completed).',
+    'Always set stepHistory.<step>.completedAt before advancing currentStep to the next step.',
+].join('\n');
+
 function renderPreamble(step: PromptStep, specDir: string): string {
     const substeps = CANONICAL_SUBSTEPS[step].join(', ');
     const target = specDir ? `${specDir}/.spec-context.json` : '<specDir>/.spec-context.json';
@@ -33,11 +40,32 @@ function renderPreamble(step: PromptStep, specDir: string): string {
         MARKER_OPEN,
         `Before and after this step runs, update ${target}:`,
         '',
-        `1. Pre-step: set stepHistory.${step}.startedAt = now, currentStep = "${step}", status = "${step}-in-progress", and append a transition { step: "${step}", substep: null, from, by: "ai", at: now }.`,
-        `1.5. When advancing from a previous step: set stepHistory.<previousStep>.completedAt = now (if not already set) before writing the new step.`,
-        `2. Post-step: set stepHistory.${step}.completedAt = now, append a closing transition, and advance currentStep or set a terminal status.`,
+        STATUS_LIFECYCLE,
+        '',
+        `1. Pre-step: set stepHistory.${step}.startedAt = now, currentStep = "${step}", and set the matching in-progress status. Append a transition { step: "${step}", substep: null, from, by: "ai", at: now }.`,
+        `1.5. When advancing from a previous step: set stepHistory.<previousStep>.completedAt = now (if not already set) and its completed status before writing the new step.`,
+        `2. Post-step: set stepHistory.${step}.completedAt = now, set the matching completed status, append a closing transition, and advance currentStep.`,
         '',
         `Canonical substeps for ${step}: ${substeps}. Record each with its own startedAt/completedAt inside stepHistory.${step}.substeps[] and emit a transition with non-null substep.`,
+        '',
+        'Invariants: preserve unknown fields; transitions is append-only.',
+        MARKER_CLOSE,
+    ].join('\n');
+}
+
+function renderLifecyclePreamble(specDir: string): string {
+    const target = specDir ? `${specDir}/.spec-context.json` : '<specDir>/.spec-context.json';
+    return [
+        MARKER_OPEN,
+        `Throughout this run, keep ${target} up to date as you move through steps:`,
+        '',
+        STATUS_LIFECYCLE,
+        '',
+        'For EACH step you work on (specify, plan, tasks):',
+        '1. Before starting: set stepHistory.<step>.startedAt = now, currentStep = "<step>", status = in-progress form.',
+        '2. After completing: set stepHistory.<step>.completedAt = now, status = completed form.',
+        '3. Always set the previous step\'s completedAt before advancing to the next step.',
+        '4. Append a transition entry for each step change.',
         '',
         'Invariants: preserve unknown fields; transitions is append-only.',
         MARKER_CLOSE,
@@ -49,5 +77,15 @@ export function buildPrompt(options: BuildPromptOptions): string {
     if (!isContextInstructionsEnabled()) return command;
     if (!isKnownStep(step)) return command;
     const preamble = renderPreamble(step, specDir ?? '');
+    return `${preamble}\n\n${command}`;
+}
+
+/**
+ * Build a prompt for multi-step commands (e.g., sdd-auto) that covers
+ * the entire step lifecycle rather than a single step.
+ */
+export function buildLifecyclePrompt(command: string, specDir?: string | null): string {
+    if (!isContextInstructionsEnabled()) return command;
+    const preamble = renderLifecyclePreamble(specDir ?? '');
     return `${preamble}\n\n${command}`;
 }

--- a/src/features/spec-viewer/messageHandlers.ts
+++ b/src/features/spec-viewer/messageHandlers.ts
@@ -18,6 +18,7 @@ import { getFeatureWorkflow, getWorkflowCommands } from '../workflows';
 import { setStatus, reactivate, startStep, completeStep } from '../specs/stepLifecycle';
 import type { StepName } from '../../core/types/specContext';
 import { formatCommandForProvider } from '../../ai-providers/aiProvider';
+import { buildPrompt, buildLifecyclePrompt } from '../../ai-providers/promptBuilder';
 
 /**
  * Interface for message handler dependencies
@@ -299,8 +300,9 @@ async function executeStepInTerminal(
     const targetPath = instance?.state.changeRoot || specDirectory;
     const label = step.label || step.name;
     const formatted = formatCommandForProvider(step.command);
-    const prompt = `/${formatted} ${targetPath}`;
-    deps.outputChannel.appendLine(`[SpecViewer] Executing step "${label}": ${prompt}`);
+    const rawPrompt = `/${formatted} ${targetPath}`;
+    const prompt = buildPrompt({ command: rawPrompt, step: step.name, specDir: targetPath });
+    deps.outputChannel.appendLine(`[SpecViewer] Executing step "${label}": ${rawPrompt}`);
     await deps.executeInTerminal(prompt);
 }
 
@@ -362,8 +364,10 @@ async function handleClarify(
 
         const targetPath = instance.state.changeRoot || specDirectory;
         const label = entry.title || entry.name || 'Enhancement';
-        const prompt = `${command} "${targetPath}"`;
-        deps.outputChannel.appendLine(`[SpecViewer] Executing enhancement command "${label}": ${prompt}`);
+        const rawPrompt = `${command} "${targetPath}"`;
+        const isMultiStep = command.includes(':auto');
+        const prompt = isMultiStep ? buildLifecyclePrompt(rawPrompt, targetPath) : rawPrompt;
+        deps.outputChannel.appendLine(`[SpecViewer] Executing enhancement command "${label}": ${rawPrompt}`);
         await deps.executeInTerminal(prompt);
         return;
     }
@@ -383,8 +387,10 @@ async function handleClarify(
 
             const targetPath = instance.state.changeRoot || specDirectory;
             const label = wfCmd.title || wfCmd.name || 'Enhancement';
-            const prompt = `${wfCmd.command} "${targetPath}"`;
-            deps.outputChannel.appendLine(`[SpecViewer] Executing workflow command "${label}": ${prompt}`);
+            const rawPrompt = `${wfCmd.command} "${targetPath}"`;
+            const isMultiStep = wfCmd.command.includes(':auto');
+            const prompt = isMultiStep ? buildLifecyclePrompt(rawPrompt, targetPath) : rawPrompt;
+            deps.outputChannel.appendLine(`[SpecViewer] Executing workflow command "${label}": ${rawPrompt}`);
             await deps.executeInTerminal(prompt);
             return;
         }

--- a/src/features/spec-viewer/specViewerProvider.ts
+++ b/src/features/spec-viewer/specViewerProvider.ts
@@ -42,6 +42,7 @@ import { deriveSpecName } from "../specs/specContextManager";
 import { readSpecContext } from "../specs/specContextReader";
 import { writeSpecContext } from "../specs/specContextWriter";
 import { backfillMinimalContext } from "../specs/specContextBackfill";
+import { reconcileAndPersist } from "../specs/specContextReconciler";
 import { deriveViewerState, isStepCompleted } from "./stateDerivation";
 import { StepName, STEP_NAMES, ViewerState as CoreViewerState } from "../../core/types/specContext";
 import {
@@ -60,6 +61,22 @@ export {
   getSpecDirectoryFromPath,
   isSpecDocument,
 } from "./utils";
+
+/**
+ * Map stepHistory keys from step names to tab names so navState lookups
+ * (e.g., `stepHistory[activeStep]`) use consistent keys.
+ */
+function mapStepHistoryKeys(
+  stepHistory?: Record<string, { startedAt?: string; completedAt?: string | null }>
+): Record<string, { completedAt?: string | null }> | undefined {
+  if (!stepHistory) return undefined;
+  const out: Record<string, { completedAt?: string | null }> = {};
+  for (const [step, entry] of Object.entries(stepHistory)) {
+    const tabName = mapSddStepToTab(step) || step;
+    out[tabName] = entry;
+  }
+  return out;
+}
 
 /**
  * Map stepHistory → per-step badge state; alias `specify` → `spec` for
@@ -537,7 +554,7 @@ export class SpecViewerProvider {
         specStatus,
         enhancementButtons,
         stalenessMap,
-        mapSddStepToTab(featureCtx?.currentStep),
+        null,
         computeBadgeText(featureCtx),
         createdDate,
         lastUpdatedDate,
@@ -545,7 +562,7 @@ export class SpecViewerProvider {
         featureCtx?.branch ?? null,
         doc?.filePath ?? null,
         featureCtx?.currentStep ?? doc?.type ?? null,
-        featureCtx?.stepHistory,
+        mapStepHistoryKeys(featureCtx?.stepHistory),
       );
 
       this.outputChannel.appendLine(
@@ -601,7 +618,8 @@ export class SpecViewerProvider {
     if (workflowName) {
       for (const wfCmd of getWorkflowCommands(workflowName)) {
         if (!wfCmd.command) continue;
-        const step = wfCmd.step || "all";
+        const rawStep = wfCmd.step || "all";
+        const step = rawStep === "all" ? "all" : (mapSddStepToTab(rawStep) || rawStep);
         if (step !== docType && step !== "all") continue;
         if (seenCommands.has(wfCmd.command)) continue;
 
@@ -780,8 +798,8 @@ export class SpecViewerProvider {
         stalenessMap,
         specStatus,
         currentTask: featureCtx?.currentTask ?? null,
-        activeStep: mapSddStepToTab(featureCtx?.currentStep),
-        stepHistory: featureCtx?.stepHistory,
+        activeStep: null,
+        stepHistory: mapStepHistoryKeys(featureCtx?.stepHistory),
         badgeText: computeBadgeText(featureCtx),
         createdDate: computeCreatedDate(featureCtx?.stepHistory),
         lastUpdatedDate: computeLastUpdatedDate(featureCtx?.stepHistory),
@@ -804,8 +822,9 @@ export class SpecViewerProvider {
       // serializing footer to strip function fields.
       let viewerState: CoreViewerState | undefined;
       try {
-        const specCtx = await readSpecContext(specDirectory);
+        let specCtx = await readSpecContext(specDirectory);
         if (specCtx) {
+          specCtx = await reconcileAndPersist(specDirectory, specCtx);
           const active: StepName = (STEP_NAMES.includes(specCtx.currentStep as StepName)
             ? (specCtx.currentStep as StepName)
             : 'specify');

--- a/src/features/specs/__tests__/specContextReconciler.test.ts
+++ b/src/features/specs/__tests__/specContextReconciler.test.ts
@@ -1,0 +1,131 @@
+import { reconcile } from '../specContextReconciler';
+import type { SpecContext } from '../../../core/types/specContext';
+
+function makeContext(overrides: Partial<SpecContext> = {}): SpecContext {
+    return {
+        workflow: 'sdd',
+        specName: 'test',
+        branch: 'main',
+        currentStep: 'specify',
+        status: 'draft',
+        stepHistory: {},
+        transitions: [],
+        ...overrides,
+    };
+}
+
+describe('reconcile', () => {
+    it('returns null when context is already clean', () => {
+        const ctx = makeContext({
+            currentStep: 'plan',
+            status: 'planning',
+            stepHistory: {
+                specify: { startedAt: '2026-01-01', completedAt: '2026-01-02' },
+                plan: { startedAt: '2026-01-02', completedAt: null },
+            },
+        });
+        expect(reconcile(ctx)).toBeNull();
+    });
+
+    it('backfills missing stepHistory entries for steps before currentStep', () => {
+        const ctx = makeContext({
+            currentStep: 'tasks',
+            status: 'tasking',
+            stepHistory: {},
+        });
+        const result = reconcile(ctx)!;
+        expect(result).not.toBeNull();
+        expect(result.stepHistory['specify']?.startedAt).toBeTruthy();
+        expect(result.stepHistory['specify']?.completedAt).toBeTruthy();
+        expect(result.stepHistory['plan']?.startedAt).toBeTruthy();
+        expect(result.stepHistory['plan']?.completedAt).toBeTruthy();
+    });
+
+    it('sets completedAt for started steps before currentStep', () => {
+        const ctx = makeContext({
+            currentStep: 'plan',
+            status: 'planning',
+            stepHistory: {
+                specify: { startedAt: '2026-01-01', completedAt: null },
+            },
+        });
+        const result = reconcile(ctx)!;
+        expect(result).not.toBeNull();
+        expect(result.stepHistory['specify']?.completedAt).toBeTruthy();
+    });
+
+    it('backfills startedAt for currentStep if missing', () => {
+        const ctx = makeContext({
+            currentStep: 'tasks',
+            status: 'tasking',
+            stepHistory: {
+                specify: { startedAt: '2026-01-01', completedAt: '2026-01-02' },
+                plan: { startedAt: '2026-01-02', completedAt: '2026-01-03' },
+            },
+        });
+        const result = reconcile(ctx)!;
+        expect(result).not.toBeNull();
+        expect(result.stepHistory['tasks']?.startedAt).toBeTruthy();
+        expect(result.stepHistory['tasks']?.completedAt).toBeNull();
+    });
+
+    it('fixes non-canonical status based on currentStep', () => {
+        const ctx = makeContext({
+            currentStep: 'tasks',
+            status: 'active' as any,
+            stepHistory: {
+                specify: { startedAt: '2026-01-01', completedAt: '2026-01-02' },
+                plan: { startedAt: '2026-01-02', completedAt: '2026-01-03' },
+                tasks: { startedAt: '2026-01-03', completedAt: null },
+            },
+        });
+        const result = reconcile(ctx)!;
+        expect(result).not.toBeNull();
+        expect(result.status).toBe('tasking');
+    });
+
+    it('handles SDD auto scenario: currentStep=tasks, only specify.startedAt', () => {
+        const ctx = makeContext({
+            currentStep: 'tasks',
+            status: 'active' as any,
+            stepHistory: {
+                specify: { startedAt: '2026-01-01', completedAt: null },
+            },
+        });
+        const result = reconcile(ctx)!;
+        expect(result).not.toBeNull();
+        // specify should be completed
+        expect(result.stepHistory['specify']?.completedAt).toBeTruthy();
+        // plan should be backfilled
+        expect(result.stepHistory['plan']?.startedAt).toBeTruthy();
+        expect(result.stepHistory['plan']?.completedAt).toBeTruthy();
+        // tasks should have startedAt
+        expect(result.stepHistory['tasks']?.startedAt).toBeTruthy();
+        // status should be canonical
+        expect(result.status).toBe('tasking');
+    });
+
+    it('does not touch steps after currentStep', () => {
+        const ctx = makeContext({
+            currentStep: 'plan',
+            status: 'planning',
+            stepHistory: {
+                specify: { startedAt: '2026-01-01', completedAt: '2026-01-02' },
+                plan: { startedAt: '2026-01-02', completedAt: null },
+            },
+        });
+        const result = reconcile(ctx);
+        expect(result).toBeNull();
+    });
+
+    it('skips clarify and analyze sub-phases', () => {
+        const ctx = makeContext({
+            currentStep: 'tasks',
+            status: 'tasking',
+            stepHistory: {},
+        });
+        const result = reconcile(ctx)!;
+        expect(result.stepHistory['clarify']).toBeUndefined();
+        expect(result.stepHistory['analyze']).toBeUndefined();
+    });
+});

--- a/src/features/specs/specContextReconciler.ts
+++ b/src/features/specs/specContextReconciler.ts
@@ -1,0 +1,139 @@
+/**
+ * One-time reconciliation for `.spec-context.json`.
+ *
+ * When the extension reads a spec context and finds gaps (e.g., `currentStep`
+ * is past steps that have no `stepHistory` entries), this module repairs the
+ * file once so subsequent reads see clean data.
+ *
+ * Returns the corrected context if changes were made, or `null` if clean.
+ */
+
+import {
+    SpecContext,
+    StepName,
+    StepHistoryEntry,
+    STEP_NAMES,
+    STATUSES,
+    Status,
+} from '../../core/types/specContext';
+import { updateSpecContext } from './specContextWriter';
+
+/** Core steps that correspond to files (skip clarify/analyze sub-phases). */
+const CORE_STEPS: StepName[] = ['specify', 'plan', 'tasks', 'implement'];
+
+function deriveStatusFromCurrentStep(currentStep: StepName): Status {
+    switch (currentStep) {
+        case 'specify':
+        case 'clarify':
+            return 'specifying';
+        case 'plan':
+            return 'planning';
+        case 'tasks':
+        case 'analyze':
+            return 'tasking';
+        case 'implement':
+            return 'implementing';
+    }
+}
+
+function deriveCompletedStatus(currentStep: StepName): Status {
+    switch (currentStep) {
+        case 'specify':
+        case 'clarify':
+            return 'specified';
+        case 'plan':
+            return 'planned';
+        case 'tasks':
+        case 'analyze':
+            return 'ready-to-implement';
+        case 'implement':
+            return 'completed';
+    }
+}
+
+/**
+ * Pure function: detect and fix gaps in a SpecContext.
+ * Returns a corrected copy if changes were needed, or `null` if clean.
+ */
+export function reconcile(ctx: SpecContext): SpecContext | null {
+    let changed = false;
+    let result = { ...ctx, stepHistory: { ...ctx.stepHistory } };
+
+    const currentIdx = STEP_NAMES.indexOf(ctx.currentStep);
+    if (currentIdx < 0) return null;
+
+    const now = new Date().toISOString();
+
+    // Backfill stepHistory for core steps that precede currentStep
+    for (const step of CORE_STEPS) {
+        const stepIdx = STEP_NAMES.indexOf(step);
+        if (stepIdx >= currentIdx) continue; // not before currentStep
+
+        const entry = result.stepHistory[step];
+
+        if (!entry) {
+            // Step has no history at all but workflow moved past it
+            result.stepHistory[step] = {
+                startedAt: now,
+                completedAt: now,
+            } as StepHistoryEntry;
+            changed = true;
+        } else if (!entry.completedAt) {
+            // Step was started but never completed, yet workflow moved past it
+            result.stepHistory[step] = {
+                ...entry,
+                completedAt: now,
+            };
+            changed = true;
+        }
+    }
+
+    // Ensure currentStep itself has startedAt if it has no entry
+    const currentEntry = result.stepHistory[ctx.currentStep];
+    if (!currentEntry && CORE_STEPS.includes(ctx.currentStep)) {
+        result.stepHistory[ctx.currentStep] = {
+            startedAt: now,
+            completedAt: null,
+        } as StepHistoryEntry;
+        changed = true;
+    }
+
+    // Fix non-canonical status
+    if (!(STATUSES as string[]).includes(ctx.status)) {
+        // Determine correct status from currentStep
+        const currentHasCompleted = result.stepHistory[ctx.currentStep]?.completedAt;
+        result = {
+            ...result,
+            status: currentHasCompleted
+                ? deriveCompletedStatus(ctx.currentStep)
+                : deriveStatusFromCurrentStep(ctx.currentStep),
+        };
+        changed = true;
+    }
+
+    return changed ? result : null;
+}
+
+/**
+ * Read, reconcile, and persist a spec context.
+ * Returns the (possibly corrected) context.
+ */
+export async function reconcileAndPersist(
+    specDir: string,
+    ctx: SpecContext
+): Promise<SpecContext> {
+    const fixed = reconcile(ctx);
+    if (!fixed) return ctx;
+
+    try {
+        await updateSpecContext(
+            specDir,
+            () => fixed,
+            fixed
+        );
+    } catch {
+        // Non-fatal — use the corrected context in memory even if write fails
+    }
+
+    return fixed;
+}


### PR DESCRIPTION
## Summary
- Adds one-time file reconciliation when `.spec-context.json` has incomplete stepHistory — backfills missing entries and fixes non-canonical status values, then writes the corrected file back
- Fixes permanently disabled buttons by not setting `navState.activeStep` from `currentStep` (it was always true because the current step rarely has `completedAt`)
- Fixes Auto Mode button appearing on wrong tab by mapping workflow command step names through `mapSddStepToTab`
- Adds `buildLifecyclePrompt` for multi-step commands and wraps approve/regenerate paths with `buildPrompt` so AI gets status instructions on all terminal paths

## Test plan
- [x] All 267 tests pass (11 new)
- [x] Compile clean
- [ ] Manual: open spec with incomplete context → buttons should be clickable
- [ ] Manual: Auto Mode only on Specification tab
- [ ] Manual: reopen viewer → reconciled file should be clean (no re-reconciliation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)