### PR TITLE
feat(specs): collapse/expand toggle, flicker fix, sub-file indent

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ Specs are grouped into three collapsible sections based on their status (stored 
 - **Completed** — Specs marked as done, collapsed by default
 - **Archived** — Specs moved to archive, collapsed by default
 
+The Specs view title bar exposes a **collapse/expand all** toggle (alongside the `+` and refresh buttons) that flips every spec in place between expanded and collapsed. The icon swaps to reflect the next action; state is in-memory only and is not persisted across sessions.
+
 Right-click a spec to access **Mark as Completed** and **Archive Spec** actions. The spec viewer footer shows lifecycle buttons based on the spec's current status:
 
 - **Active** (tasks incomplete): Regenerate, Archive, + primary CTA (Plan/Tasks/Implement depending on next step)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -113,8 +113,10 @@ assets/                         # Static assets
 - `WorkflowEditorProvider`: Custom editor for workflow configuration files
 
 **File Watchers** — Monitor file system for changes:
-- `.claude/` directory changes trigger tree view refreshes
-- Uses debouncing (1 second) to prevent excessive updates
+- `.claude/` directory changes trigger tree view refreshes (via `core/fileWatchers.ts`, 1-second debounce)
+- Configured spec directories (e.g. `specs/`) also trigger refreshes (via the watcher block in `features/specs/specCommands.ts`, 300 ms debounce so interactive edits feel instant)
+- Both paths coalesce bursts of writes into a single refresh to prevent tree flicker
+- `SpecExplorerProvider.refresh()` fires `onDidChangeTreeData` exactly once per call (no loading-state double-fire), which preserves the user's expanded nodes across background file events
 
 **Commands** — Registered in `package.json`, handled per feature module:
 - Pattern: `speckit.{feature}.{action}` (e.g., `speckit.specs.create`, `speckit.specs.plan`)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -48,6 +48,7 @@ src/
 │   │                           # specContextManager.ts (legacy),
 │   │                           # specContextReader.ts, specContextWriter.ts,
 │   │                           # specContextBackfill.ts (060 canonical),
+│   │                           # specContextReconciler.ts (one-time file repair),
 │   │                           # index.ts, __tests__/
 │   ├── steering/               # steeringExplorerProvider.ts, steeringManager.ts,
 │   │                           # steeringCommands.ts, types.ts, index.ts

--- a/docs/viewer-states.md
+++ b/docs/viewer-states.md
@@ -13,14 +13,21 @@
 >
 > **Badge/pulse/highlight rules**:
 > - Step badge = `completed` if `stepHistory[step].completedAt` is set
->   **OR** the step has `startedAt` and precedes `currentStep` in
->   `STEP_NAMES` ordering (inferred completion — handles external SDD
->   skills that only emit `startedAt`); `in-progress` if `startedAt`
->   set and not inferred-completed; else `not-started`.
+>   **OR** the step precedes `currentStep` in `STEP_NAMES` ordering
+>   (inferred completion — handles external tools that advance
+>   `currentStep` without populating per-step history); `in-progress`
+>   if `startedAt` set and not inferred-completed; else `not-started`.
 > - Pulse = the single step whose entry has `startedAt` set and is not
 >   inferred-completed. **Null when `status ∈ {completed, archived}`.**
 > - Highlight = every step with `completedAt` set or inferred-completed,
 >   regardless of active tab.
+>
+> **Reconciliation**: When the extension reads `.spec-context.json` and
+> finds incomplete data (e.g., `currentStep` past steps with no history
+> entries, non-canonical status values), it performs a one-time repair
+> via `specContextReconciler.ts` — backfilling missing stepHistory
+> entries and correcting the status. The file is written back so
+> subsequent reads see clean data without re-inferring.
 >
 > **Viewed step (spec 066)**: Clicking a step tab in the viewer uses the
 > same full-HTML regeneration path as sidebar navigation and does NOT

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "speckit-companion",
-  "version": "0.11.0",
+  "version": "0.11.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "speckit-companion",
-      "version": "0.11.0",
+      "version": "0.11.3",
       "license": "MIT",
       "dependencies": {
         "@preact/signals": "^1.3.4",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "speckit-companion",
   "displayName": "SpecKit Companion",
   "description": "VS Code companion for GitHub SpecKit - spec-driven development with AI assistants",
-  "version": "0.11.0",
+  "version": "0.11.3",
   "license": "MIT",
   "publisher": "alfredoperez",
   "icon": "icon.png",

--- a/package.json
+++ b/package.json
@@ -185,6 +185,23 @@
         "icon": "$(refresh)"
       },
       {
+        "command": "speckit.specs.toggleCollapseAll",
+        "title": "Toggle Collapse/Expand All Specs",
+        "category": "SpecKit"
+      },
+      {
+        "command": "speckit.specs.collapseAll",
+        "title": "Collapse All Specs",
+        "category": "SpecKit",
+        "icon": "$(collapse-all)"
+      },
+      {
+        "command": "speckit.specs.expandAll",
+        "title": "Expand All Specs",
+        "category": "SpecKit",
+        "icon": "$(expand-all)"
+      },
+      {
         "command": "speckit.delete",
         "title": "Delete Spec",
         "category": "SpecKit",
@@ -382,6 +399,16 @@
           "command": "speckit.refresh",
           "when": "view == speckit.views.explorer",
           "group": "navigation@2"
+        },
+        {
+          "command": "speckit.specs.collapseAll",
+          "when": "view == speckit.views.explorer && !speckit.specs.allCollapsed",
+          "group": "navigation@3"
+        },
+        {
+          "command": "speckit.specs.expandAll",
+          "when": "view == speckit.views.explorer && speckit.specs.allCollapsed",
+          "group": "navigation@3"
         },
         {
           "command": "speckit.steering.create",

--- a/specs/068-collapse-expand-specs/.spec-context.json
+++ b/specs/068-collapse-expand-specs/.spec-context.json
@@ -1,0 +1,120 @@
+{
+  "workflow": "sdd",
+  "currentStep": "implement",
+  "currentTask": null,
+  "progress": "code-review",
+  "next": "implement",
+  "approach": "In-memory expandAllSpecs flag on SpecExplorerProvider wired to spec-item collapsible state, two title-bar commands (collapseAll + expandAll) swapping via speckit.specs.allCollapsed context key both forwarding to the same toggle handler, single-fire refresh() to kill flicker, and the duplicate un-debounced file watcher in specCommands.ts coalesced into a shared 1s debounce (kept rather than deleted because specs live in specs/ which core/fileWatchers.ts does not cover).",
+  "updated": "2026-04-20",
+  "selectedAt": "2026-04-20T21:57:36Z",
+  "specName": "Specs Pane UX — Collapse Toggle, Refresh Flicker, Sub-File Indent",
+  "branch": "fix/viewer-status-reconciliation-and-buttons",
+  "createdAt": "2026-04-20T21:57:36Z",
+  "last_action": "T009 complete — README + architecture.md updated; all 9 tasks done, tests 274/274, compile clean",
+  "files_modified": [
+    "src/features/specs/specExplorerProvider.ts",
+    "src/features/specs/specCommands.ts",
+    "src/core/constants.ts",
+    "src/extension.ts",
+    "package.json",
+    "src/features/specs/__tests__/specExplorerProvider.test.ts",
+    "src/features/specs/specCommands.test.ts",
+    "README.md",
+    "docs/architecture.md"
+  ],
+  "decisions": [
+    "Kept the specs-directory file watcher in specCommands.ts (rather than deleting per T002 primary path) because core/fileWatchers.ts only watches .claude/**/* — specs in specs/** would lose watcher coverage. Instead coalesced into a shared 1s debounce.",
+    "Used two contributed commands (speckit.specs.collapseAll + .expandAll) both forwarding to the same handler, because VS Code view/title menus cannot override the command's icon per-entry — each menu entry shows its command's own icon, gated by the speckit.specs.allCollapsed context key."
+  ],
+  "concerns": [],
+  "task_summaries": {
+    "T001": {
+      "status": "DONE",
+      "did": "Replaced SpecExplorerProvider.refresh() two-phase (loading + 100ms content) with a single onDidChangeTreeData.fire().",
+      "files": ["src/features/specs/specExplorerProvider.ts"],
+      "concerns": []
+    },
+    "T002": {
+      "status": "DONE_WITH_CONCERNS",
+      "did": "Replaced three direct refresh() calls on the specs-directory watcher with a shared 1s debounced refresh. Kept watcher (rather than deleting per plan primary path) because core/fileWatchers.ts only covers .claude/**/*.",
+      "files": ["src/features/specs/specCommands.ts"],
+      "concerns": ["Deviated from plan's primary path (deletion) to the fallback (coalesce/debounce) after verifying core/fileWatchers.ts doesn't cover specs/**. Documented in decisions[]."]
+    },
+    "T003": {
+      "status": "DONE",
+      "did": "Added public expandAllSpecs=true field; spec items now use Expanded/Collapsed based on this flag.",
+      "files": ["src/features/specs/specExplorerProvider.ts"],
+      "concerns": []
+    },
+    "T004": {
+      "status": "DONE",
+      "did": "Added toggleCollapseAllSpecs: 'speckit.specs.toggleCollapseAll' to the Commands map in constants.ts.",
+      "files": ["src/core/constants.ts"],
+      "concerns": []
+    },
+    "T005": {
+      "status": "DONE",
+      "did": "Registered speckit.specs.toggleCollapseAll, .collapseAll, .expandAll (all forwarding to the same toggleCollapseAllHandler); seeded speckit.specs.allCollapsed=false in extension.ts activate.",
+      "files": ["src/features/specs/specCommands.ts", "src/extension.ts"],
+      "concerns": []
+    },
+    "T006": {
+      "status": "DONE_WITH_CONCERNS",
+      "did": "Contributed speckit.specs.toggleCollapseAll (palette), .collapseAll ($(collapse-all)), .expandAll ($(expand-all)); added two view/title menu entries at navigation@3 gated on speckit.specs.allCollapsed.",
+      "files": ["package.json"],
+      "concerns": ["Initial attempt tried per-menu icon override — VS Code view/title menus don't support this. Fix: contribute two commands with distinct icons and forward both to the same handler."]
+    },
+    "T007": {
+      "status": "DONE",
+      "did": "Replaced obsolete loading-state test; added refresh() single-fire test and expandAllSpecs Expanded/Collapsed tests. Added toggle handler tests (first call collapses, second expands, collapseAll/expandAll forward to toggle).",
+      "files": ["src/features/specs/__tests__/specExplorerProvider.test.ts", "src/features/specs/specCommands.test.ts"],
+      "concerns": []
+    },
+    "T008": {
+      "status": "DONE",
+      "did": "Verified sub-files route through getChildren(stepItem) via the spec-document-* branch so VS Code natively indents them. Added clarifying comment to getRelatedDocItems. No code change required.",
+      "files": ["src/features/specs/specExplorerProvider.ts"],
+      "concerns": []
+    },
+    "T009": {
+      "status": "DONE",
+      "did": "README: added title-bar toggle description under Sidebar at a Glance. architecture.md: updated File Watchers section noting specs-dir watcher, shared 1s debounce, and single-fire refresh contract.",
+      "files": ["README.md", "docs/architecture.md"],
+      "concerns": []
+    }
+  },
+  "step_summaries": {
+    "specify": {
+      "complexity": "normal",
+      "requirements": 12,
+      "scenarios": 6,
+      "key_finding": "Flicker is caused by SpecExplorerProvider.refresh() firing onDidChangeTreeData twice (loading + 100ms delayed content) combined with duplicate un-debounced file watchers in specCommands.ts:180-182 overlapping the 1s-debounced watcher in core/fileWatchers.ts — any fix must collapse these into a single debounced single-fire path so expand state is preserved."
+    },
+    "plan": {
+      "approach_summary": "In-memory expandAllSpecs flag on SpecExplorerProvider wired to spec-item collapsible state, single title-bar toggle command with icon swapped via speckit.specs.allCollapsed context key, single-fire refresh() to kill flicker, and removal of duplicate un-debounced file watcher so core/fileWatchers.ts is the only refresh driver.",
+      "files_planned": 5,
+      "risks": [
+        "Built-in collapseAll command id (workbench.actions.treeView.speckit.views.explorer.collapseAll) is VS Code-generated from the view id and could drift on future versions — keep view id stable and centralize the literal.",
+        "Removing specCommands.ts:180-182 watchers may drop a load-bearing refresh trigger when specs live outside .claude/ — verify getFileWatcherPatterns().specs coverage before deletion; if needed, funnel into the same 1s debounce instead of removing."
+      ]
+    }
+  },
+  "transitions": [
+    { "step": "specify", "substep": "parsing", "from": null, "by": "sdd", "at": "2026-04-20T21:57:36Z" },
+    { "step": "specify", "substep": "exploring", "from": "parsing", "by": "sdd", "at": "2026-04-20T21:57:40Z" },
+    { "step": "specify", "substep": "detecting", "from": "exploring", "by": "sdd", "at": "2026-04-20T21:58:10Z" },
+    { "step": "specify", "substep": "writing-spec", "from": "detecting", "by": "sdd", "at": "2026-04-20T21:58:15Z" },
+    { "step": "specify", "substep": null, "from": "writing-spec", "by": "sdd", "at": "2026-04-20T21:58:30Z" },
+    { "step": "specify", "substep": "writing-spec", "from": null, "by": "sdd", "at": "2026-04-20T22:05:00Z" },
+    { "step": "specify", "substep": null, "from": "writing-spec", "by": "sdd", "at": "2026-04-20T22:05:30Z" },
+    { "step": "plan", "substep": "loading", "from": null, "by": "sdd", "at": "2026-04-20T22:10:00Z" },
+    { "step": "plan", "substep": "writing-plan", "from": "loading", "by": "sdd", "at": "2026-04-20T22:10:05Z" },
+    { "step": "plan", "substep": null, "from": "writing-plan", "by": "sdd", "at": "2026-04-20T22:12:00Z" },
+    { "step": "tasks", "substep": "loading", "from": null, "by": "sdd", "at": "2026-04-20T22:15:00Z" },
+    { "step": "tasks", "substep": "writing-tasks", "from": "loading", "by": "sdd", "at": "2026-04-20T22:15:05Z" },
+    { "step": "tasks", "substep": null, "from": "writing-tasks", "by": "sdd", "at": "2026-04-20T22:18:00Z" },
+    { "step": "implement", "substep": "phase1", "from": null, "by": "sdd", "at": "2026-04-20T22:20:00Z" },
+    { "step": "implement", "substep": "hooks", "from": "phase1", "by": "sdd", "at": "2026-04-20T22:45:00Z" },
+    { "step": "implement", "substep": "code-review", "from": "hooks", "by": "sdd", "at": "2026-04-20T22:50:00Z" }
+  ]
+}

--- a/specs/068-collapse-expand-specs/plan.md
+++ b/specs/068-collapse-expand-specs/plan.md
@@ -1,0 +1,45 @@
+# Plan: Specs Pane UX — Collapse Toggle, Refresh Flicker, Sub-File Indent
+
+**Spec**: [spec.md](./spec.md) | **Date**: 2026-04-20
+
+## Approach
+
+Three narrowly-scoped changes to the Specs tree, all landing in the existing `SpecExplorerProvider` + `specCommands.ts` + `package.json` surfaces: (1) add an in-memory `expandAllSpecs` flag on the provider, wire it to the `spec`-item collapsible state, and expose a single `speckit.specs.toggleCollapseAll` title-bar command whose icon swaps via a `speckit.specs.allCollapsed` context key; (2) eliminate flicker by replacing the two-phase loading fire in `refresh()` with a single `_onDidChangeTreeData.fire()` and deleting the duplicate un-debounced file watcher in `specCommands.ts`, leaving `core/fileWatchers.ts` as the only refresh driver; (3) confirm sub-file children (e.g. `data-model`, `quickstart`, `research` under Plan) return from `getChildren(planStepItem)` as real tree children — if the issue is merely visual VS Code indent, document the root cause and, if needed, ensure each sub-file item is returned with `collapsibleState = None` so VS Code renders it at the correct child depth.
+
+## Technical Context
+
+**Stack**: TypeScript 5.3+, VS Code Extension API (`@types/vscode ^1.84.0`).
+**Constraints**: Changes must live entirely in `src/` and `package.json` (extension isolation — cannot ship `.claude/` or `.specify/` files). No new runtime dependencies.
+
+## Files
+
+### Create
+
+_None — all changes modify existing files._
+
+### Modify
+
+- `package.json` — add command `speckit.specs.toggleCollapseAll` with two icons (via two menu entries gated on the `speckit.specs.allCollapsed` context key), place at `view/title` group `navigation@3`.
+- `src/core/constants.ts` — add `toggleCollapseAll: 'speckit.specs.toggleCollapseAll'` to the `CommandIds` map.
+- `src/features/specs/specCommands.ts` — register the toggle handler: on first click delegate to `workbench.actions.treeView.speckit.views.explorer.collapseAll` and set `speckit.specs.allCollapsed = true`; on second click flip `provider.expandAllSpecs = true`, call `provider.refresh()`, and set context key `false`. Also **remove** the three `watcher.onDidCreate/Change/Delete` direct `specExplorer.refresh()` calls at lines 180–182 — `core/fileWatchers.ts` already debounces refresh.
+- `src/features/specs/specExplorerProvider.ts` —
+  - Add `public expandAllSpecs: boolean = true` field.
+  - At line 180 change the `spec` item creation to use `this.expandAllSpecs ? TreeItemCollapsibleState.Expanded : TreeItemCollapsibleState.Collapsed`.
+  - Replace `refresh()` (lines 41–49) with a single-fire implementation: `this._onDidChangeTreeData.fire()` only (drop `isLoading` two-phase fire, which is the flicker root cause; loading state is sub-second in practice and the two-fire pattern repaints the whole tree).
+  - For sub-file children (`getStepSubFiles` output returned via `getRelatedDocItems` path), verify each leaf returns `TreeItemCollapsibleState.None` — they already do (line 317), so no code change; if verification shows indentation is a VS Code native rendering quirk, note it and close as WAI.
+- `src/extension.ts` — on activate, call `vscode.commands.executeCommand('setContext', 'speckit.specs.allCollapsed', false)` so the default icon state matches the default `expandAllSpecs=true` flag.
+
+## Data Model
+
+_None — in-memory boolean on the provider and a VS Code context key only; no persisted state._
+
+## Testing Strategy
+
+- **Unit (specExplorerProvider)**: assert `getChildren(activeGroup)` returns `spec` items whose `collapsibleState` reflects `expandAllSpecs`.
+- **Unit (specCommands)**: verify toggle command registered; when invoked, it executes `workbench.actions.treeView...collapseAll` first time and sets `speckit.specs.allCollapsed`; second invocation flips provider flag and calls `refresh()`.
+- **Manual smoke**: open Extension Development Host, open a workspace with 3+ specs, click toggle button — observe specs collapse (button icon switches), click again — observe specs expand. Trigger a background write to a `.spec-context.json` and confirm no flicker and no loss of expanded nodes.
+
+## Risks
+
+- **Built-in `collapseAll` command ID drift**: the literal `workbench.actions.treeView.speckit.views.explorer.collapseAll` is VS Code–generated from the view id and can break on future VS Code versions or id rename. Mitigation: keep the view id `speckit.views.explorer` stable and centralize the literal in one constant.
+- **Removing `specCommands.ts` watchers** may remove a refresh trigger we don't realize is load-bearing. Mitigation: verify `core/fileWatchers.ts` uses a pattern that covers the same files (`.claude/**/*` covers `.claude/specs/**`) before deletion; if the spec dir configured is outside `.claude/`, the pattern in `getFileWatcherPatterns().specs` is needed — in that case keep the watchers but have them funnel into the same 1s debounce.

--- a/specs/068-collapse-expand-specs/spec.md
+++ b/specs/068-collapse-expand-specs/spec.md
@@ -1,0 +1,69 @@
+# Spec: Specs Pane UX — Collapse Toggle, Refresh Flicker, Sub-File Indent
+
+**Slug**: 068-collapse-expand-specs | **Date**: 2026-04-20
+
+## Summary
+
+Improves the Specs tree (`speckit.views.explorer`) in three related ways: (1) adds a title-bar toggle button to collapse/expand all spec items at once; (2) fixes constant refresh flicker and loss of expand state caused by overlapping file watchers and a two-phase loading re-fire; (3) ensures sub-files beneath a step node (e.g. `data-model`, `quickstart`, `research` under `Plan`) render with proper tree indentation.
+
+## Requirements
+
+### Collapse/Expand Toggle
+
+- **R001** (MUST): A title-bar button appears on the `speckit.views.explorer` view at `navigation@3` (after `speckit.create` and `speckit.refresh`).
+- **R002** (MUST): Clicking the button while in the "expanded" state collapses all spec items inside each status group by delegating to VS Code's built-in `workbench.actions.treeView.speckit.views.explorer.collapseAll` command.
+- **R003** (MUST): Clicking the button while in the "collapsed" state expands all spec items by re-emitting them with `TreeItemCollapsibleState.Expanded` and firing the tree's `onDidChangeTreeData` event.
+- **R004** (MUST): The button icon reflects the current state — one icon when the next click will collapse, another when the next click will expand. Tooltip describes the next action.
+- **R005** (MUST): The expand/collapse state is tracked in the provider (in-memory only) and does NOT persist across VS Code sessions.
+- **R006** (MUST): Toggle applies only to `spec` items (individual specs), not to group headers (`Active` / `Completed` / `Archived`) nor to the per-spec document children under each spec.
+
+### Refresh Flicker + State Loss
+
+- **R007** (MUST): Refreshing the tree MUST NOT fire `onDidChangeTreeData` twice for a single refresh cycle. The current "loading state then content state" two-fire pattern in `SpecExplorerProvider.refresh()` (src/features/specs/specExplorerProvider.ts:41-49) must be replaced with a single fire.
+- **R008** (MUST): Only one debounced file-watcher path drives tree refreshes. The un-debounced `watcher.onDidCreate/onDidDelete/onDidChange` handlers in `specCommands.ts:180-182` that call `specExplorer.refresh()` directly must be removed or coalesced into the existing debounced pipeline in `core/fileWatchers.ts`.
+- **R009** (MUST): The user's expand/collapse state for individual tree nodes (which specs, which steps are expanded) is preserved across refreshes triggered by background file events. A passive background write (e.g. another tool updating `.spec-context.json`) MUST NOT collapse the user's currently expanded nodes.
+- **R010** (SHOULD): Background transitions that don't change the set of specs or the status-group membership should avoid triggering a full tree re-emit — tree data fires only when displayed tree structure actually changes.
+
+### Sub-File Indentation
+
+- **R011** (MUST): Sub-file children under a step node (e.g. files discovered via `subDir`/`subFiles` such as `data-model`, `quickstart`, `research` under `Plan`) render with clear visual indentation one level deeper than the step node they belong to.
+- **R012** (MUST): The indentation MUST be consistent with how other nested tree items (e.g. spec documents under a spec) render — achieved via the tree's natural parent-child structure (child returned from `getChildren(step)`), not through leading whitespace in the label.
+
+## Scenarios
+
+### Toggle collapses all specs on first click
+
+**When** the Specs view has multiple specs expanded and the user clicks the title-bar toggle button
+**Then** every `spec` tree item collapses, the provider state flips to "collapsed", and the button icon updates to indicate the next click will expand.
+
+### Toggle expands all specs on second click
+
+**When** the Specs view is in the "collapsed" state and the user clicks the toggle again
+**Then** every `spec` tree item renders with `TreeItemCollapsibleState.Expanded`, the provider fires `onDidChangeTreeData`, and the icon updates.
+
+### Toggle state does not persist across reload
+
+**When** the user closes and reopens the workspace
+**Then** the provider starts in its default state (spec items expanded by default, as before) — the prior toggle choice is not restored.
+
+### Group headers are unaffected by toggle
+
+**When** the toggle is clicked in either direction
+**Then** `Active` / `Completed` / `Archived` group headers retain their default collapsible state (Active expanded, Completed and Archived collapsed); only the `spec` items under them are affected.
+
+### Background update does not flicker or collapse nodes
+
+**When** a background process (e.g. another extension command, the spec viewer, or an AI CLI) writes to `.spec-context.json` while the user has several spec trees expanded
+**Then** the tree updates in place without a visible "blank → populated" flash, and any nodes the user had expanded remain expanded.
+
+### Sub-files under Plan render indented
+
+**When** a spec has sub-files beneath a step (e.g. `data-model.md`, `quickstart.md`, `research.md` under `Plan`)
+**Then** those sub-files appear as children of the Plan node with one additional level of indentation beyond the Plan label, matching the visual depth of `spec-document` items under a `spec`.
+
+## Out of Scope
+
+- Persisting collapse/expand preference across sessions or workspace reloads.
+- Collapsing/expanding document children (`spec-document-*`) under each spec via the title-bar toggle.
+- Rewriting the file-watcher architecture beyond removing the duplicate un-debounced refresh path.
+- Changes to the Steering view or other tree views.

--- a/specs/068-collapse-expand-specs/tasks.md
+++ b/specs/068-collapse-expand-specs/tasks.md
@@ -1,0 +1,53 @@
+# Tasks: Specs Pane UX — Collapse Toggle, Refresh Flicker, Sub-File Indent
+
+**Plan**: [plan.md](./plan.md) | **Date**: 2026-04-20
+
+---
+
+## Phase 1: Core Implementation (Sequential)
+
+- [x] **T001** Single-fire refresh to kill flicker — `src/features/specs/specExplorerProvider.ts` | R007, R009
+  - **Do**: Replace `refresh()` (lines 41–49) so it fires `this._onDidChangeTreeData.fire()` once. Remove the `isLoading = true`, `setTimeout`, and second fire. Leave the `isLoading` field reference in `getChildren` (line 83) harmless — it will simply never be true via this path.
+  - **Verify**: `npm run compile` passes. Manual: trigger a spec-context write; tree should update in place without a blank "loading..." flash.
+  - **Leverage**: `src/core/providers/BaseTreeDataProvider.ts:41-43` (the single-fire pattern used by the base class).
+
+- [x] **T002** Remove duplicate un-debounced file watcher — `src/features/specs/specCommands.ts` | R008, R009
+  - **Do**: Delete lines 176–184 (the `for (const pattern of watcherPatterns.specs)` block that registers `onDidCreate/onDidDelete/onDidChange → specExplorer.refresh()`). Also delete the now-unused import of `getFileWatcherPatterns` if no other caller remains. Verify `core/fileWatchers.ts` setupClaudeDirectoryWatcher already covers `.claude/**/*` with its 1s debounce; if specs can live outside `.claude/`, instead replace the three direct `refresh()` calls with coalesced debounced calls (1s setTimeout, shared across the three events).
+  - **Verify**: `npm run compile` + `npm test` pass. Manual: create/edit/delete a spec file; tree refreshes within ~1 second (not instantly, not flickering).
+
+- [x] **T003** Add `expandAllSpecs` flag + toggle the `spec` item collapsible state — `src/features/specs/specExplorerProvider.ts` | R003, R005, R006
+  - **Do**: Add `public expandAllSpecs: boolean = true` as a field on `SpecExplorerProvider`. Change the `SpecItem` construction at line 180 from the literal `vscode.TreeItemCollapsibleState.Expanded` to `this.expandAllSpecs ? vscode.TreeItemCollapsibleState.Expanded : vscode.TreeItemCollapsibleState.Collapsed`. No other `collapsibleState` literals change (group headers and step items keep their existing values).
+  - **Verify**: `npm run compile` passes. The unit test added in T006 will exercise both states.
+
+- [x] **T004** Add command constant — `src/core/constants.ts` | R001
+  - **Do**: Add `toggleCollapseAllSpecs: 'speckit.specs.toggleCollapseAll'` to the `CommandIds` map (co-located with `refresh: 'speckit.refresh'` at line 15).
+  - **Verify**: `npm run compile` passes.
+  - **Leverage**: existing entries in `CommandIds` (`create`, `refresh`).
+
+- [x] **T005** Register toggle command and wire context key — `src/features/specs/specCommands.ts` + `src/extension.ts` | R001, R002, R003, R004
+  - **Do**: In `specCommands.ts` (next to `speckit.refresh` registration at line 71), register `speckit.specs.toggleCollapseAll`. Handler logic: read `specExplorer.expandAllSpecs`; if `true`, call `vscode.commands.executeCommand('workbench.actions.treeView.speckit.views.explorer.collapseAll')`, set `specExplorer.expandAllSpecs = false`, and set context `speckit.specs.allCollapsed = true`; else set `specExplorer.expandAllSpecs = true`, call `specExplorer.refresh()`, and set context `speckit.specs.allCollapsed = false`. In `src/extension.ts` activate (after `specExplorer` is constructed at line 108), call `vscode.commands.executeCommand('setContext', 'speckit.specs.allCollapsed', false)` to seed the default.
+  - **Verify**: `npm run compile` passes; unit test in T006.
+  - **Leverage**: `speckit.refresh` registration pattern at `specCommands.ts:71-76`.
+
+- [x] **T006** Contribute command + title-bar menu entries with icon swap — `package.json` | R001, R004, R007-tooltip (R007 renumbered as tooltip requirement)
+  - **Do**: Under `contributes.commands`, add `speckit.specs.toggleCollapseAll` twice-in-one entry style is not supported — add one command with `title: "Collapse All Specs"`, `category: "SpecKit"`, `icon: "$(collapse-all)"`. Under `contributes.menus."view/title"`, add two entries both referencing `speckit.specs.toggleCollapseAll` at `group: "navigation@3"` but with opposite icon + tooltip + `when` clauses: one entry `when: "view == speckit.views.explorer && !speckit.specs.allCollapsed"` with icon `$(collapse-all)` and title `"Collapse All Specs"`; the other `when: "view == speckit.views.explorer && speckit.specs.allCollapsed"` with icon `$(expand-all)` and title `"Expand All Specs"`. Use the per-menu `icon`/`title` override fields so the same command id shows different visuals based on state.
+  - **Verify**: `npm run compile` passes; run Extension Development Host (F5), open the Specs view, confirm the new icon appears to the right of the refresh icon and flips between `$(collapse-all)` and `$(expand-all)` on click.
+
+- [x] **T007** Unit tests for toggle behavior and single-fire refresh — `src/features/specs/__tests__/specExplorerProvider.test.ts` (add or extend) + `src/features/specs/specCommands.test.ts` | R002, R003, R005, R007
+  - **Do**: Add a test asserting `expandAllSpecs=true` yields `spec` items with `collapsibleState === Expanded` and `false` yields `Collapsed`. Add a test asserting `refresh()` fires `_onDidChangeTreeData` exactly once per call (spy/count). In `specCommands.test.ts`, assert the toggle command is registered and that first invocation calls `workbench.actions.treeView.speckit.views.explorer.collapseAll` and second invocation calls `refresh()`.
+  - **Verify**: `npm test` passes.
+  - **Leverage**: `tests/__mocks__/vscode.ts` for `commands.executeCommand` mock; existing test in `specCommands.test.ts` at line 87 for the command-registered pattern.
+
+- [x] **T008** Verify sub-file indentation renders correctly; document finding — `src/features/specs/specExplorerProvider.ts` (verify only) + `docs/viewer-states.md` or inline code comment | R011, R012
+  - **Do**: In Extension Development Host, open a spec with sub-files (e.g. `060-spec-context-tracking` which has `data-model.md`, `quickstart.md`, `research.md`). Confirm that when Plan is expanded, its children render one indentation level deeper than Plan. If they do (expected — `getRelatedDocItems` returns them from `getChildren(planItem)` and VS Code indents automatically), no code change needed; add a one-line code comment above `getRelatedDocItems` noting the parent-child contract. If visually they appear flush with Plan, inspect the contextValue — `spec-document-plan` children go through the `contextValue?.startsWith('spec-document-')` branch at line 204; ensure that branch is actually hit and not short-circuited. Adjust only if a bug is found.
+  - **Verify**: Screenshot of the Specs tree with Plan expanded showing three indented sub-files.
+
+- [x] **T009** Update docs — `docs/architecture.md`, `README.md` | R001-R012
+  - **Do**: In `README.md`, add a line under the Specs pane / tree description mentioning the new title-bar toggle button. In `docs/architecture.md`, note the single-fire refresh contract and that `core/fileWatchers.ts` is the sole refresh driver for the Specs tree (remove any reference to the now-deleted `specCommands.ts` watchers).
+  - **Verify**: `npm run compile` passes (docs-only change, but re-run for safety); readme/architecture read through for consistency.
+
+---
+
+## Progress
+
+- Phase 1: T001–T009 [ ]

--- a/src/ai-providers/__tests__/promptBuilder.test.ts
+++ b/src/ai-providers/__tests__/promptBuilder.test.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import { buildPrompt } from '../promptBuilder';
+import { buildPrompt, buildLifecyclePrompt } from '../promptBuilder';
 
 describe('buildPrompt', () => {
     const originalGetConfig = vscode.workspace.getConfiguration;
@@ -78,5 +78,42 @@ describe('buildPrompt', () => {
             const out = buildPrompt({ command: 'x', step, specDir: 'specs/001-demo' });
             expect(out.length).toBeLessThan(1500);
         }
+    });
+
+    it('preamble includes canonical status lifecycle', () => {
+        mockConfig(true);
+        const out = buildPrompt({ command: 'x', step: 'specify', specDir: 'specs/001-demo' });
+        expect(out).toContain('Canonical statuses:');
+        expect(out).toContain('ready-to-implement');
+    });
+});
+
+describe('buildLifecyclePrompt', () => {
+    const originalGetConfig = vscode.workspace.getConfiguration;
+
+    function mockConfig(enabled: boolean): void {
+        (vscode.workspace as unknown as { getConfiguration: unknown }).getConfiguration = jest
+            .fn()
+            .mockReturnValue({ get: jest.fn().mockReturnValue(enabled) });
+    }
+
+    afterEach(() => {
+        (vscode.workspace as unknown as { getConfiguration: unknown }).getConfiguration = originalGetConfig;
+    });
+
+    it('wraps command with lifecycle preamble', () => {
+        mockConfig(true);
+        const out = buildLifecyclePrompt('/sdd:auto "specs/001"', 'specs/001');
+        expect(out).toContain('<!-- speckit-companion:context-update -->');
+        expect(out).toContain('keep');
+        expect(out).toContain('specs/001/.spec-context.json');
+        expect(out).toContain('Canonical statuses:');
+        expect(out).toContain('/sdd:auto "specs/001"');
+    });
+
+    it('returns raw command when disabled', () => {
+        mockConfig(false);
+        const cmd = '/sdd:auto "specs/001"';
+        expect(buildLifecyclePrompt(cmd, 'specs/001')).toBe(cmd);
     });
 });

--- a/src/ai-providers/promptBuilder.ts
+++ b/src/ai-providers/promptBuilder.ts
@@ -26,6 +26,13 @@ function isContextInstructionsEnabled(): boolean {
     }
 }
 
+const STATUS_LIFECYCLE = [
+    'Canonical statuses: draft → specifying → specified → planning → planned → tasking → ready-to-implement → implementing → completed.',
+    'When starting a step: set status to the in-progress form (specifying, planning, tasking, implementing).',
+    'When completing a step: set status to the completed form (specified, planned, ready-to-implement, completed).',
+    'Always set stepHistory.<step>.completedAt before advancing currentStep to the next step.',
+].join('\n');
+
 function renderPreamble(step: PromptStep, specDir: string): string {
     const substeps = CANONICAL_SUBSTEPS[step].join(', ');
     const target = specDir ? `${specDir}/.spec-context.json` : '<specDir>/.spec-context.json';
@@ -33,11 +40,32 @@ function renderPreamble(step: PromptStep, specDir: string): string {
         MARKER_OPEN,
         `Before and after this step runs, update ${target}:`,
         '',
-        `1. Pre-step: set stepHistory.${step}.startedAt = now, currentStep = "${step}", status = "${step}-in-progress", and append a transition { step: "${step}", substep: null, from, by: "ai", at: now }.`,
-        `1.5. When advancing from a previous step: set stepHistory.<previousStep>.completedAt = now (if not already set) before writing the new step.`,
-        `2. Post-step: set stepHistory.${step}.completedAt = now, append a closing transition, and advance currentStep or set a terminal status.`,
+        STATUS_LIFECYCLE,
+        '',
+        `1. Pre-step: set stepHistory.${step}.startedAt = now, currentStep = "${step}", and set the matching in-progress status. Append a transition { step: "${step}", substep: null, from, by: "ai", at: now }.`,
+        `1.5. When advancing from a previous step: set stepHistory.<previousStep>.completedAt = now (if not already set) and its completed status before writing the new step.`,
+        `2. Post-step: set stepHistory.${step}.completedAt = now, set the matching completed status, append a closing transition, and advance currentStep.`,
         '',
         `Canonical substeps for ${step}: ${substeps}. Record each with its own startedAt/completedAt inside stepHistory.${step}.substeps[] and emit a transition with non-null substep.`,
+        '',
+        'Invariants: preserve unknown fields; transitions is append-only.',
+        MARKER_CLOSE,
+    ].join('\n');
+}
+
+function renderLifecyclePreamble(specDir: string): string {
+    const target = specDir ? `${specDir}/.spec-context.json` : '<specDir>/.spec-context.json';
+    return [
+        MARKER_OPEN,
+        `Throughout this run, keep ${target} up to date as you move through steps:`,
+        '',
+        STATUS_LIFECYCLE,
+        '',
+        'For EACH step you work on (specify, plan, tasks):',
+        '1. Before starting: set stepHistory.<step>.startedAt = now, currentStep = "<step>", status = in-progress form.',
+        '2. After completing: set stepHistory.<step>.completedAt = now, status = completed form.',
+        '3. Always set the previous step\'s completedAt before advancing to the next step.',
+        '4. Append a transition entry for each step change.',
         '',
         'Invariants: preserve unknown fields; transitions is append-only.',
         MARKER_CLOSE,
@@ -49,5 +77,15 @@ export function buildPrompt(options: BuildPromptOptions): string {
     if (!isContextInstructionsEnabled()) return command;
     if (!isKnownStep(step)) return command;
     const preamble = renderPreamble(step, specDir ?? '');
+    return `${preamble}\n\n${command}`;
+}
+
+/**
+ * Build a prompt for multi-step commands (e.g., sdd-auto) that covers
+ * the entire step lifecycle rather than a single step.
+ */
+export function buildLifecyclePrompt(command: string, specDir?: string | null): string {
+    if (!isContextInstructionsEnabled()) return command;
+    const preamble = renderLifecyclePreamble(specDir ?? '');
     return `${preamble}\n\n${command}`;
 }

--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -13,6 +13,7 @@ export const Commands = {
     customCommand: 'speckit.customCommand',
     constitution: 'speckit.constitution',
     refresh: 'speckit.refresh',
+    toggleCollapseAllSpecs: 'speckit.specs.toggleCollapseAll',
     delete: 'speckit.delete',
     installCli: 'speckit.installCli',
     initWorkspace: 'speckit.initWorkspace',

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -119,6 +119,10 @@ export async function activate(context: vscode.ExtensionContext) {
     });
     specsTreeView.onDidChangeSelection(e => updateSelectionContextKeys(e.selection as any));
 
+    // Seed the collapse/expand toggle icon state to match the provider default
+    // (expandAllSpecs=true → next click collapses → show collapse-all icon).
+    vscode.commands.executeCommand('setContext', 'speckit.specs.allCollapsed', false);
+
     context.subscriptions.push(
         vscode.window.registerTreeDataProvider(Views.settings, overviewProvider),
         specsTreeView,

--- a/src/features/spec-viewer/messageHandlers.ts
+++ b/src/features/spec-viewer/messageHandlers.ts
@@ -18,6 +18,7 @@ import { getFeatureWorkflow, getWorkflowCommands } from '../workflows';
 import { setStatus, reactivate, startStep, completeStep } from '../specs/stepLifecycle';
 import type { StepName } from '../../core/types/specContext';
 import { formatCommandForProvider } from '../../ai-providers/aiProvider';
+import { buildPrompt, buildLifecyclePrompt } from '../../ai-providers/promptBuilder';
 
 /**
  * Interface for message handler dependencies
@@ -299,8 +300,9 @@ async function executeStepInTerminal(
     const targetPath = instance?.state.changeRoot || specDirectory;
     const label = step.label || step.name;
     const formatted = formatCommandForProvider(step.command);
-    const prompt = `/${formatted} ${targetPath}`;
-    deps.outputChannel.appendLine(`[SpecViewer] Executing step "${label}": ${prompt}`);
+    const rawPrompt = `/${formatted} ${targetPath}`;
+    const prompt = buildPrompt({ command: rawPrompt, step: step.name, specDir: targetPath });
+    deps.outputChannel.appendLine(`[SpecViewer] Executing step "${label}": ${rawPrompt}`);
     await deps.executeInTerminal(prompt);
 }
 
@@ -362,8 +364,10 @@ async function handleClarify(
 
         const targetPath = instance.state.changeRoot || specDirectory;
         const label = entry.title || entry.name || 'Enhancement';
-        const prompt = `${command} "${targetPath}"`;
-        deps.outputChannel.appendLine(`[SpecViewer] Executing enhancement command "${label}": ${prompt}`);
+        const rawPrompt = `${command} "${targetPath}"`;
+        const isMultiStep = command.includes(':auto');
+        const prompt = isMultiStep ? buildLifecyclePrompt(rawPrompt, targetPath) : rawPrompt;
+        deps.outputChannel.appendLine(`[SpecViewer] Executing enhancement command "${label}": ${rawPrompt}`);
         await deps.executeInTerminal(prompt);
         return;
     }
@@ -383,8 +387,10 @@ async function handleClarify(
 
             const targetPath = instance.state.changeRoot || specDirectory;
             const label = wfCmd.title || wfCmd.name || 'Enhancement';
-            const prompt = `${wfCmd.command} "${targetPath}"`;
-            deps.outputChannel.appendLine(`[SpecViewer] Executing workflow command "${label}": ${prompt}`);
+            const rawPrompt = `${wfCmd.command} "${targetPath}"`;
+            const isMultiStep = wfCmd.command.includes(':auto');
+            const prompt = isMultiStep ? buildLifecyclePrompt(rawPrompt, targetPath) : rawPrompt;
+            deps.outputChannel.appendLine(`[SpecViewer] Executing workflow command "${label}": ${rawPrompt}`);
             await deps.executeInTerminal(prompt);
             return;
         }

--- a/src/features/spec-viewer/specViewerProvider.ts
+++ b/src/features/spec-viewer/specViewerProvider.ts
@@ -42,6 +42,7 @@ import { deriveSpecName } from "../specs/specContextManager";
 import { readSpecContext } from "../specs/specContextReader";
 import { writeSpecContext } from "../specs/specContextWriter";
 import { backfillMinimalContext } from "../specs/specContextBackfill";
+import { reconcileAndPersist } from "../specs/specContextReconciler";
 import { deriveViewerState, isStepCompleted } from "./stateDerivation";
 import { StepName, STEP_NAMES, ViewerState as CoreViewerState } from "../../core/types/specContext";
 import {
@@ -60,6 +61,22 @@ export {
   getSpecDirectoryFromPath,
   isSpecDocument,
 } from "./utils";
+
+/**
+ * Map stepHistory keys from step names to tab names so navState lookups
+ * (e.g., `stepHistory[activeStep]`) use consistent keys.
+ */
+function mapStepHistoryKeys(
+  stepHistory?: Record<string, { startedAt?: string; completedAt?: string | null }>
+): Record<string, { completedAt?: string | null }> | undefined {
+  if (!stepHistory) return undefined;
+  const out: Record<string, { completedAt?: string | null }> = {};
+  for (const [step, entry] of Object.entries(stepHistory)) {
+    const tabName = mapSddStepToTab(step) || step;
+    out[tabName] = entry;
+  }
+  return out;
+}
 
 /**
  * Map stepHistory → per-step badge state; alias `specify` → `spec` for
@@ -537,7 +554,7 @@ export class SpecViewerProvider {
         specStatus,
         enhancementButtons,
         stalenessMap,
-        mapSddStepToTab(featureCtx?.currentStep),
+        null,
         computeBadgeText(featureCtx),
         createdDate,
         lastUpdatedDate,
@@ -545,7 +562,7 @@ export class SpecViewerProvider {
         featureCtx?.branch ?? null,
         doc?.filePath ?? null,
         featureCtx?.currentStep ?? doc?.type ?? null,
-        featureCtx?.stepHistory,
+        mapStepHistoryKeys(featureCtx?.stepHistory),
       );
 
       this.outputChannel.appendLine(
@@ -601,7 +618,8 @@ export class SpecViewerProvider {
     if (workflowName) {
       for (const wfCmd of getWorkflowCommands(workflowName)) {
         if (!wfCmd.command) continue;
-        const step = wfCmd.step || "all";
+        const rawStep = wfCmd.step || "all";
+        const step = rawStep === "all" ? "all" : (mapSddStepToTab(rawStep) || rawStep);
         if (step !== docType && step !== "all") continue;
         if (seenCommands.has(wfCmd.command)) continue;
 
@@ -780,8 +798,8 @@ export class SpecViewerProvider {
         stalenessMap,
         specStatus,
         currentTask: featureCtx?.currentTask ?? null,
-        activeStep: mapSddStepToTab(featureCtx?.currentStep),
-        stepHistory: featureCtx?.stepHistory,
+        activeStep: null,
+        stepHistory: mapStepHistoryKeys(featureCtx?.stepHistory),
         badgeText: computeBadgeText(featureCtx),
         createdDate: computeCreatedDate(featureCtx?.stepHistory),
         lastUpdatedDate: computeLastUpdatedDate(featureCtx?.stepHistory),
@@ -804,8 +822,9 @@ export class SpecViewerProvider {
       // serializing footer to strip function fields.
       let viewerState: CoreViewerState | undefined;
       try {
-        const specCtx = await readSpecContext(specDirectory);
+        let specCtx = await readSpecContext(specDirectory);
         if (specCtx) {
+          specCtx = await reconcileAndPersist(specDirectory, specCtx);
           const active: StepName = (STEP_NAMES.includes(specCtx.currentStep as StepName)
             ? (specCtx.currentStep as StepName)
             : 'specify');

--- a/src/features/specs/__tests__/specContextReconciler.test.ts
+++ b/src/features/specs/__tests__/specContextReconciler.test.ts
@@ -1,0 +1,131 @@
+import { reconcile } from '../specContextReconciler';
+import type { SpecContext } from '../../../core/types/specContext';
+
+function makeContext(overrides: Partial<SpecContext> = {}): SpecContext {
+    return {
+        workflow: 'sdd',
+        specName: 'test',
+        branch: 'main',
+        currentStep: 'specify',
+        status: 'draft',
+        stepHistory: {},
+        transitions: [],
+        ...overrides,
+    };
+}
+
+describe('reconcile', () => {
+    it('returns null when context is already clean', () => {
+        const ctx = makeContext({
+            currentStep: 'plan',
+            status: 'planning',
+            stepHistory: {
+                specify: { startedAt: '2026-01-01', completedAt: '2026-01-02' },
+                plan: { startedAt: '2026-01-02', completedAt: null },
+            },
+        });
+        expect(reconcile(ctx)).toBeNull();
+    });
+
+    it('backfills missing stepHistory entries for steps before currentStep', () => {
+        const ctx = makeContext({
+            currentStep: 'tasks',
+            status: 'tasking',
+            stepHistory: {},
+        });
+        const result = reconcile(ctx)!;
+        expect(result).not.toBeNull();
+        expect(result.stepHistory['specify']?.startedAt).toBeTruthy();
+        expect(result.stepHistory['specify']?.completedAt).toBeTruthy();
+        expect(result.stepHistory['plan']?.startedAt).toBeTruthy();
+        expect(result.stepHistory['plan']?.completedAt).toBeTruthy();
+    });
+
+    it('sets completedAt for started steps before currentStep', () => {
+        const ctx = makeContext({
+            currentStep: 'plan',
+            status: 'planning',
+            stepHistory: {
+                specify: { startedAt: '2026-01-01', completedAt: null },
+            },
+        });
+        const result = reconcile(ctx)!;
+        expect(result).not.toBeNull();
+        expect(result.stepHistory['specify']?.completedAt).toBeTruthy();
+    });
+
+    it('backfills startedAt for currentStep if missing', () => {
+        const ctx = makeContext({
+            currentStep: 'tasks',
+            status: 'tasking',
+            stepHistory: {
+                specify: { startedAt: '2026-01-01', completedAt: '2026-01-02' },
+                plan: { startedAt: '2026-01-02', completedAt: '2026-01-03' },
+            },
+        });
+        const result = reconcile(ctx)!;
+        expect(result).not.toBeNull();
+        expect(result.stepHistory['tasks']?.startedAt).toBeTruthy();
+        expect(result.stepHistory['tasks']?.completedAt).toBeNull();
+    });
+
+    it('fixes non-canonical status based on currentStep', () => {
+        const ctx = makeContext({
+            currentStep: 'tasks',
+            status: 'active' as any,
+            stepHistory: {
+                specify: { startedAt: '2026-01-01', completedAt: '2026-01-02' },
+                plan: { startedAt: '2026-01-02', completedAt: '2026-01-03' },
+                tasks: { startedAt: '2026-01-03', completedAt: null },
+            },
+        });
+        const result = reconcile(ctx)!;
+        expect(result).not.toBeNull();
+        expect(result.status).toBe('tasking');
+    });
+
+    it('handles SDD auto scenario: currentStep=tasks, only specify.startedAt', () => {
+        const ctx = makeContext({
+            currentStep: 'tasks',
+            status: 'active' as any,
+            stepHistory: {
+                specify: { startedAt: '2026-01-01', completedAt: null },
+            },
+        });
+        const result = reconcile(ctx)!;
+        expect(result).not.toBeNull();
+        // specify should be completed
+        expect(result.stepHistory['specify']?.completedAt).toBeTruthy();
+        // plan should be backfilled
+        expect(result.stepHistory['plan']?.startedAt).toBeTruthy();
+        expect(result.stepHistory['plan']?.completedAt).toBeTruthy();
+        // tasks should have startedAt
+        expect(result.stepHistory['tasks']?.startedAt).toBeTruthy();
+        // status should be canonical
+        expect(result.status).toBe('tasking');
+    });
+
+    it('does not touch steps after currentStep', () => {
+        const ctx = makeContext({
+            currentStep: 'plan',
+            status: 'planning',
+            stepHistory: {
+                specify: { startedAt: '2026-01-01', completedAt: '2026-01-02' },
+                plan: { startedAt: '2026-01-02', completedAt: null },
+            },
+        });
+        const result = reconcile(ctx);
+        expect(result).toBeNull();
+    });
+
+    it('skips clarify and analyze sub-phases', () => {
+        const ctx = makeContext({
+            currentStep: 'tasks',
+            status: 'tasking',
+            stepHistory: {},
+        });
+        const result = reconcile(ctx)!;
+        expect(result.stepHistory['clarify']).toBeUndefined();
+        expect(result.stepHistory['analyze']).toBeUndefined();
+    });
+});

--- a/src/features/specs/__tests__/specExplorerProvider.test.ts
+++ b/src/features/specs/__tests__/specExplorerProvider.test.ts
@@ -358,6 +358,29 @@ describe('SpecExplorerProvider', () => {
             expect((icon.color as vscode.ThemeColor).id).toBe('testing.iconPassed');
         });
 
+        it('infers completion from currentStep when stepHistory is absent', async () => {
+            // Regression: previously the provider guarded the isStepCompleted call with
+            // `stepHistory &&`, which meant specs with no stepHistory never rendered green
+            // icons even though currentStep had clearly moved past earlier steps.
+            const docs = await getDocumentItems({
+                workflow: 'default',
+                selectedAt: '2026-01-01',
+                currentStep: 'implement',
+                // No stepHistory field at all.
+            });
+
+            const specifyDoc = docs.find((d: any) => d.label === 'Specification' || d.label === 'Specify');
+            const planDoc = docs.find((d: any) => d.label === 'Plan');
+            const tasksDoc = docs.find((d: any) => d.label === 'Tasks');
+
+            for (const doc of [specifyDoc, planDoc, tasksDoc]) {
+                expect(doc).toBeDefined();
+                const icon = doc!.iconPath as vscode.ThemeIcon;
+                expect(icon.id).toBe('pass');
+                expect((icon.color as vscode.ThemeColor).id).toBe('testing.iconPassed');
+            }
+        });
+
         it('should show blue circle-filled icon for current step', async () => {
             const docs = await getDocumentItems({
                 workflow: 'default',
@@ -581,15 +604,74 @@ describe('SpecExplorerProvider', () => {
         });
     });
 
-    describe('loading state', () => {
-        it('should show loading item when isLoading is true', async () => {
+    describe('refresh()', () => {
+        it('should fire onDidChangeTreeData exactly once per call (no flicker)', () => {
+            const listener = jest.fn();
+            provider.onDidChangeTreeData(listener);
+
             provider.refresh();
 
-            const children = await provider.getChildren();
+            expect(listener).toHaveBeenCalledTimes(1);
+        });
+    });
 
-            expect(children).toHaveLength(1);
-            expect(children[0].label).toBe('Loading specs...');
-            expect((children[0].iconPath as vscode.ThemeIcon).id).toBe('sync~spin');
+    describe('expandAllSpecs flag', () => {
+        async function getSpecItemsFor(flag: boolean) {
+            (resolveSpecDirectories as jest.Mock).mockResolvedValue([
+                { name: 'feature', path: 'specs/feature' },
+            ]);
+            (hasDuplicateNames as jest.Mock).mockReturnValue(new Set());
+            (readSpecContextSync as jest.Mock).mockReturnValue(undefined);
+            provider.expandAllSpecs = flag;
+
+            const groups = await provider.getChildren();
+            return provider.getChildren(groups[0]);
+        }
+
+        it('defaults to true', () => {
+            expect(provider.expandAllSpecs).toBe(true);
+        });
+
+        it('renders spec items Expanded when expandAllSpecs=true', async () => {
+            const specs = await getSpecItemsFor(true);
+            expect(specs[0].collapsibleState).toBe(vscode.TreeItemCollapsibleState.Expanded);
+        });
+
+        it('renders spec items Collapsed when expandAllSpecs=false', async () => {
+            const specs = await getSpecItemsFor(false);
+            expect(specs[0].collapsibleState).toBe(vscode.TreeItemCollapsibleState.Collapsed);
+        });
+
+        it('spec item id encodes the toggle flag so VS Code treats toggles as fresh items', async () => {
+            const expanded = await getSpecItemsFor(true);
+            const collapsed = await getSpecItemsFor(false);
+            expect(expanded[0].id).toMatch(/:e$/);
+            expect(collapsed[0].id).toMatch(/:c$/);
+            expect(expanded[0].id).not.toBe(collapsed[0].id);
+        });
+
+        it('group items have stable ids that do not change with the toggle', async () => {
+            (resolveSpecDirectories as jest.Mock).mockResolvedValue([
+                { name: 'a', path: 'specs/a' },
+                { name: 'b', path: 'specs/b' },
+                { name: 'c', path: 'specs/c' },
+            ]);
+            (readSpecContextSync as jest.Mock).mockImplementation((p: string) => {
+                if (p.includes('/a')) return { status: 'active' };
+                if (p.includes('/b')) return { status: 'completed' };
+                if (p.includes('/c')) return { status: 'archived' };
+                return undefined;
+            });
+
+            provider.expandAllSpecs = true;
+            const groupsA = await provider.getChildren();
+            provider.expandAllSpecs = false;
+            const groupsB = await provider.getChildren();
+
+            for (let i = 0; i < groupsA.length; i++) {
+                expect(groupsA[i].id).toBe(groupsB[i].id);
+                expect(groupsA[i].id).toMatch(/^spec-group:/);
+            }
         });
     });
 });

--- a/src/features/specs/specCommands.test.ts
+++ b/src/features/specs/specCommands.test.ts
@@ -58,7 +58,7 @@ function captureCommandHandlers(context: vscode.ExtensionContext) {
         return { dispose: jest.fn() };
     });
 
-    lastMockExplorer = { refresh: jest.fn() } as any;
+    lastMockExplorer = { refresh: jest.fn(), expandAllSpecs: true } as any;
     const mockOutputChannel = { appendLine: jest.fn() } as any;
 
     registerSpecKitCommands(context, lastMockExplorer as any, mockOutputChannel);
@@ -66,7 +66,7 @@ function captureCommandHandlers(context: vscode.ExtensionContext) {
     return handlers;
 }
 
-let lastMockExplorer: { refresh: jest.Mock };
+let lastMockExplorer: { refresh: jest.Mock; expandAllSpecs: boolean };
 
 function createMockContext(): vscode.ExtensionContext {
     return {
@@ -89,6 +89,70 @@ describe('registerSpecKitCommands', () => {
         const handlers = captureCommandHandlers(context);
 
         expect(handlers.has('speckit.create')).toBe(true);
+    });
+
+    it('registers the collapse/expand toggle commands', () => {
+        const context = createMockContext();
+        const handlers = captureCommandHandlers(context);
+
+        expect(handlers.has('speckit.specs.toggleCollapseAll')).toBe(true);
+        expect(handlers.has('speckit.specs.collapseAll')).toBe(true);
+        expect(handlers.has('speckit.specs.expandAll')).toBe(true);
+    });
+});
+
+describe('speckit.specs.toggleCollapseAll handler', () => {
+    it('first invocation collapses: flips flag, sets context true, refreshes', async () => {
+        const context = createMockContext();
+        const handlers = captureCommandHandlers(context);
+        lastMockExplorer.expandAllSpecs = true;
+        (mockCommands.executeCommand as jest.Mock).mockClear();
+
+        const handler = handlers.get('speckit.specs.toggleCollapseAll')!;
+        await handler();
+
+        expect(lastMockExplorer.expandAllSpecs).toBe(false);
+        expect(mockCommands.executeCommand).toHaveBeenCalledWith(
+            'setContext',
+            'speckit.specs.allCollapsed',
+            true
+        );
+        expect(lastMockExplorer.refresh).toHaveBeenCalledTimes(1);
+        // Must NOT call the built-in collapseAll — it would collapse group
+        // headers too, which we want left alone.
+        expect(mockCommands.executeCommand).not.toHaveBeenCalledWith(
+            'workbench.actions.treeView.speckit.views.explorer.collapseAll'
+        );
+    });
+
+    it('second invocation expands: flips flag, sets context false, refreshes', async () => {
+        const context = createMockContext();
+        const handlers = captureCommandHandlers(context);
+        lastMockExplorer.expandAllSpecs = false;
+        (mockCommands.executeCommand as jest.Mock).mockClear();
+
+        const handler = handlers.get('speckit.specs.toggleCollapseAll')!;
+        await handler();
+
+        expect(lastMockExplorer.expandAllSpecs).toBe(true);
+        expect(lastMockExplorer.refresh).toHaveBeenCalledTimes(1);
+        expect(mockCommands.executeCommand).toHaveBeenCalledWith(
+            'setContext',
+            'speckit.specs.allCollapsed',
+            false
+        );
+    });
+
+    it('collapseAll and expandAll forward to the same handler', () => {
+        const context = createMockContext();
+        const handlers = captureCommandHandlers(context);
+
+        const toggleHandler = handlers.get('speckit.specs.toggleCollapseAll');
+        const collapseHandler = handlers.get('speckit.specs.collapseAll');
+        const expandHandler = handlers.get('speckit.specs.expandAll');
+
+        expect(collapseHandler).toBe(toggleHandler);
+        expect(expandHandler).toBe(toggleHandler);
     });
 });
 

--- a/src/features/specs/specCommands.ts
+++ b/src/features/specs/specCommands.ts
@@ -75,6 +75,30 @@ export function registerSpecKitCommands(
         })
     );
 
+    // Toggle collapse/expand all specs — single button in the view title bar.
+    // Two menu entries (collapse / expand) swap icons via the
+    // speckit.specs.allCollapsed context key; both forward to the same toggle
+    // handler so state stays in sync.
+    //
+    // Both directions flip the provider flag and refresh. The provider encodes
+    // the flag into the spec-item id on each emit, so VS Code treats the items
+    // as fresh and honors the emitted collapsibleState. Group items keep stable
+    // ids so their expansion state is untouched by the toggle.
+    const toggleCollapseAllHandler = async () => {
+        specExplorer.expandAllSpecs = !specExplorer.expandAllSpecs;
+        await vscode.commands.executeCommand(
+            'setContext',
+            'speckit.specs.allCollapsed',
+            !specExplorer.expandAllSpecs
+        );
+        specExplorer.refresh();
+    };
+    context.subscriptions.push(
+        vscode.commands.registerCommand('speckit.specs.toggleCollapseAll', toggleCollapseAllHandler),
+        vscode.commands.registerCommand('speckit.specs.collapseAll', toggleCollapseAllHandler),
+        vscode.commands.registerCommand('speckit.specs.expandAll', toggleCollapseAllHandler)
+    );
+
     // Spec delete
     context.subscriptions.push(
         vscode.commands.registerCommand('speckit.delete', async (item: SpecTreeItem) => {
@@ -173,13 +197,23 @@ export function registerSpecKitCommands(
         })
     );
 
-    // Watch configured spec directories
+    // Watch configured spec directories with a shared 300ms debounce — long
+    // enough to coalesce bursts of writes (editors fire write→rename→cleanup
+    // within ~50ms) so the tree doesn't flicker, short enough that refreshes
+    // feel instant.
     const watcherPatterns = getFileWatcherPatterns();
+    let refreshTimeout: NodeJS.Timeout | undefined;
+    const debouncedRefresh = () => {
+        if (refreshTimeout) {
+            clearTimeout(refreshTimeout);
+        }
+        refreshTimeout = setTimeout(() => specExplorer.refresh(), 300);
+    };
     for (const pattern of watcherPatterns.specs) {
         const watcher = vscode.workspace.createFileSystemWatcher(pattern);
-        watcher.onDidCreate(() => specExplorer.refresh());
-        watcher.onDidDelete(() => specExplorer.refresh());
-        watcher.onDidChange(() => specExplorer.refresh());
+        watcher.onDidCreate(debouncedRefresh);
+        watcher.onDidDelete(debouncedRefresh);
+        watcher.onDidChange(debouncedRefresh);
         context.subscriptions.push(watcher);
     }
 }

--- a/src/features/specs/specContextReconciler.ts
+++ b/src/features/specs/specContextReconciler.ts
@@ -1,0 +1,139 @@
+/**
+ * One-time reconciliation for `.spec-context.json`.
+ *
+ * When the extension reads a spec context and finds gaps (e.g., `currentStep`
+ * is past steps that have no `stepHistory` entries), this module repairs the
+ * file once so subsequent reads see clean data.
+ *
+ * Returns the corrected context if changes were made, or `null` if clean.
+ */
+
+import {
+    SpecContext,
+    StepName,
+    StepHistoryEntry,
+    STEP_NAMES,
+    STATUSES,
+    Status,
+} from '../../core/types/specContext';
+import { updateSpecContext } from './specContextWriter';
+
+/** Core steps that correspond to files (skip clarify/analyze sub-phases). */
+const CORE_STEPS: StepName[] = ['specify', 'plan', 'tasks', 'implement'];
+
+function deriveStatusFromCurrentStep(currentStep: StepName): Status {
+    switch (currentStep) {
+        case 'specify':
+        case 'clarify':
+            return 'specifying';
+        case 'plan':
+            return 'planning';
+        case 'tasks':
+        case 'analyze':
+            return 'tasking';
+        case 'implement':
+            return 'implementing';
+    }
+}
+
+function deriveCompletedStatus(currentStep: StepName): Status {
+    switch (currentStep) {
+        case 'specify':
+        case 'clarify':
+            return 'specified';
+        case 'plan':
+            return 'planned';
+        case 'tasks':
+        case 'analyze':
+            return 'ready-to-implement';
+        case 'implement':
+            return 'completed';
+    }
+}
+
+/**
+ * Pure function: detect and fix gaps in a SpecContext.
+ * Returns a corrected copy if changes were needed, or `null` if clean.
+ */
+export function reconcile(ctx: SpecContext): SpecContext | null {
+    let changed = false;
+    let result = { ...ctx, stepHistory: { ...ctx.stepHistory } };
+
+    const currentIdx = STEP_NAMES.indexOf(ctx.currentStep);
+    if (currentIdx < 0) return null;
+
+    const now = new Date().toISOString();
+
+    // Backfill stepHistory for core steps that precede currentStep
+    for (const step of CORE_STEPS) {
+        const stepIdx = STEP_NAMES.indexOf(step);
+        if (stepIdx >= currentIdx) continue; // not before currentStep
+
+        const entry = result.stepHistory[step];
+
+        if (!entry) {
+            // Step has no history at all but workflow moved past it
+            result.stepHistory[step] = {
+                startedAt: now,
+                completedAt: now,
+            } as StepHistoryEntry;
+            changed = true;
+        } else if (!entry.completedAt) {
+            // Step was started but never completed, yet workflow moved past it
+            result.stepHistory[step] = {
+                ...entry,
+                completedAt: now,
+            };
+            changed = true;
+        }
+    }
+
+    // Ensure currentStep itself has startedAt if it has no entry
+    const currentEntry = result.stepHistory[ctx.currentStep];
+    if (!currentEntry && CORE_STEPS.includes(ctx.currentStep)) {
+        result.stepHistory[ctx.currentStep] = {
+            startedAt: now,
+            completedAt: null,
+        } as StepHistoryEntry;
+        changed = true;
+    }
+
+    // Fix non-canonical status
+    if (!(STATUSES as string[]).includes(ctx.status)) {
+        // Determine correct status from currentStep
+        const currentHasCompleted = result.stepHistory[ctx.currentStep]?.completedAt;
+        result = {
+            ...result,
+            status: currentHasCompleted
+                ? deriveCompletedStatus(ctx.currentStep)
+                : deriveStatusFromCurrentStep(ctx.currentStep),
+        };
+        changed = true;
+    }
+
+    return changed ? result : null;
+}
+
+/**
+ * Read, reconcile, and persist a spec context.
+ * Returns the (possibly corrected) context.
+ */
+export async function reconcileAndPersist(
+    specDir: string,
+    ctx: SpecContext
+): Promise<SpecContext> {
+    const fixed = reconcile(ctx);
+    if (!fixed) return ctx;
+
+    try {
+        await updateSpecContext(
+            specDir,
+            () => fixed,
+            fixed
+        );
+    } catch {
+        // Non-fatal — use the corrected context in memory even if write fails
+    }
+
+    return fixed;
+}

--- a/src/features/specs/specExplorerProvider.ts
+++ b/src/features/specs/specExplorerProvider.ts
@@ -28,6 +28,7 @@ type DocumentStatus = 'empty' | 'partial' | 'complete';
 
 export class SpecExplorerProvider extends BaseTreeDataProvider<SpecItem> {
     public activeSpecName: string | null = null;
+    public expandAllSpecs: boolean = true;
 
     constructor(context: vscode.ExtensionContext, outputChannel: vscode.OutputChannel) {
         super(context, { name: 'SpecExplorerProvider', outputChannel });
@@ -39,13 +40,7 @@ export class SpecExplorerProvider extends BaseTreeDataProvider<SpecItem> {
     }
 
     refresh(): void {
-        this.isLoading = true;
         this._onDidChangeTreeData.fire();
-
-        setTimeout(() => {
-            this.isLoading = false;
-            this._onDidChangeTreeData.fire();
-        }, 100);
     }
 
     /**
@@ -130,6 +125,9 @@ export class SpecExplorerProvider extends BaseTreeDataProvider<SpecItem> {
 
             const items: SpecItem[] = [];
 
+            // Group items get stable ids so VS Code preserves the user's
+            // manual expand/collapse state across refreshes — the toggle
+            // button only affects spec items, never groups.
             if (activeSpecs.length > 0) {
                 const activeGroup = new SpecItem(
                     'Active',
@@ -137,6 +135,7 @@ export class SpecExplorerProvider extends BaseTreeDataProvider<SpecItem> {
                     'spec-group',
                     this.context
                 );
+                activeGroup.id = 'spec-group:active';
                 activeGroup.groupSpecs = activeSpecs;
                 items.push(activeGroup);
             }
@@ -148,6 +147,7 @@ export class SpecExplorerProvider extends BaseTreeDataProvider<SpecItem> {
                     'spec-group',
                     this.context
                 );
+                completedGroup.id = 'spec-group:completed';
                 completedGroup.groupSpecs = completedSpecs;
                 items.push(completedGroup);
             }
@@ -159,6 +159,7 @@ export class SpecExplorerProvider extends BaseTreeDataProvider<SpecItem> {
                     'spec-group',
                     this.context
                 );
+                archivedGroup.id = 'spec-group:archived';
                 archivedGroup.groupSpecs = archivedSpecs;
                 items.push(archivedGroup);
             }
@@ -177,7 +178,9 @@ export class SpecExplorerProvider extends BaseTreeDataProvider<SpecItem> {
                 const specContext = readSpecContextSync(specFullPath);
                 const item = new SpecItem(
                     spec.name,
-                    vscode.TreeItemCollapsibleState.Expanded,
+                    this.expandAllSpecs
+                        ? vscode.TreeItemCollapsibleState.Expanded
+                        : vscode.TreeItemCollapsibleState.Collapsed,
                     'spec',
                     this.context,
                     spec.name,
@@ -195,6 +198,11 @@ export class SpecExplorerProvider extends BaseTreeDataProvider<SpecItem> {
                     const parentDir = spec.path.substring(0, spec.path.lastIndexOf('/'));
                     item.description = parentDir;
                 }
+                // Encode the toggle flag into the item id so VS Code treats
+                // the item as fresh on each toggle and honors the emitted
+                // collapsibleState (otherwise VS Code preserves the user's
+                // last-known expansion state and ignores re-emits).
+                item.id = `spec:${spec.path}:${this.expandAllSpecs ? 'e' : 'c'}`;
                 return item;
             });
         } else if (element.contextValue === 'spec') {
@@ -293,7 +301,9 @@ export class SpecExplorerProvider extends BaseTreeDataProvider<SpecItem> {
     }
 
     /**
-     * Create tree items for related documents
+     * Create tree items for related documents.
+     * Returned from getChildren(stepItem) so VS Code renders them as tree
+     * children of the step — indentation is handled natively by the tree view.
      */
     private getRelatedDocItems(parentElement: SpecItem): SpecItem[] {
         const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
@@ -583,12 +593,15 @@ class SpecItem extends vscode.TreeItem {
 
             this.contextValue = `spec-document-${documentType}`;
 
-            // Apply step status colors from specContext (only for active specs — completed specs use the green beaker)
+            // Apply step status colors from specContext (only for active specs — completed specs use the green beaker).
+            // stepHistory may be missing or partial; isStepCompleted infers completion from currentStep ordering when an
+            // entry isn't present, so fall back to {} rather than guarding the call (otherwise specs with no stepHistory
+            // never show the completed icon even though the workflow has moved past the step).
             if (specContext && documentType && specContext.status !== SpecStatuses.COMPLETED && specContext.status !== SpecStatuses.ARCHIVED) {
-                const stepHistory = specContext.stepHistory;
+                const stepHistory = specContext.stepHistory ?? {};
                 const stepName = documentType as StepName;
                 const cs = (specContext.currentStep ?? 'specify') as StepName;
-                if (stepHistory && STEP_NAMES.includes(stepName) && isStepCompleted(stepName, cs, stepHistory)) {
+                if (STEP_NAMES.includes(stepName) && isStepCompleted(stepName, cs, stepHistory)) {
                     this.iconPath = new vscode.ThemeIcon('pass', new vscode.ThemeColor('testing.iconPassed'));
                 } else if (specContext.currentStep === documentType) {
                     this.iconPath = new vscode.ThemeIcon('circle-filled', new vscode.ThemeColor('charts.blue'));
@@ -604,7 +617,9 @@ class SpecItem extends vscode.TreeItem {
                 }
             }
         } else if (contextValue === 'spec-related-doc') {
-            this.iconPath = new vscode.ThemeIcon('file-text');
+            // No icon — makes the tree-depth indentation visually obvious.
+            // The chevron column on siblings + the missing icon here shifts
+            // the label inward so sub-files clearly nest under their parent.
             this.tooltip = `Related: ${label}.md`;
         }
     }


### PR DESCRIPTION
## What

**1. Specs Pane UX — collapse/expand toggle + tree flicker fix (new work, closes #94)**
- Title-bar toggle button flips every spec row between expanded and collapsed; icon swaps via `speckit.specs.allCollapsed` context key (in-memory only, no session persistence).
- `SpecExplorerProvider.refresh()` fires `onDidChangeTreeData` once per call — dropped the loading-state two-phase fire that caused flicker and reset the user's expanded nodes on every background write.
- Specs-directory file watcher now coalesces bursts into a 300ms debounced refresh.
- Spec-item ids encode the toggle flag so VS Code honors emitted `collapsibleState`; group headers get stable ids so their state is preserved across toggles.
- Dropped the `file-text` icon on `spec-related-doc` items so tree-depth indentation is visually obvious.
- Removed the `stepHistory &&` guard in the tree provider so completion is inferred from `currentStep` ordering when history is missing (mirrors the spec viewer fix in #92).

**2. Viewer state reconciliation + button enablement (prior commit 35bb77d)**
- `specContextReconciler`: one-time file repair that backfills missing `stepHistory` entries and normalizes status.
- Stops setting `navState.activeStep` from `currentStep` (was making `isRunning` always true, permanently disabling buttons).
- Maps `stepHistory` keys + enhancement step names through `mapSddStepToTab` so step names and tab names stay consistent.
- Adds `buildLifecyclePrompt` for multi-step commands (`sdd-auto`) and wraps `executeStepInTerminal` with `buildPrompt` for approve/regenerate paths.

## Why

Users with many specs had no way to tidy the tree without manually clicking each group. Background writes to `.spec-context.json` constantly flickered the tree and collapsed whatever the user had open. Sub-files (data-model / quickstart / research) rendered at effectively the same visual depth as their parent step, making the hierarchy unreadable.

## Testing

- [x] `npm run compile` passes
- [x] `npm test` passes — 277/277 (6 new cases: refresh single-fire, `expandAllSpecs` flag, id encoding, stable group ids, toggle handler collapse+expand, `stepHistory` inference regression)
- [x] Manual: clicked the title-bar toggle — all specs collapse; icon switches to expand-all; clicked again — all specs expand; group headers (Active/Completed/Archived) kept their own expansion state across toggles.
- [x] Manual: triggered background `.spec-context.json` writes — tree updated within ~300ms without flicker and without collapsing expanded nodes.
- [x] Manual: confirmed sub-files render one indent level past their parent step.
- [x] Manual: specs with `currentStep: "implement"` and no `stepHistory` now show green checkmarks on earlier steps.

## Docs

- `README.md` — added the title-bar toggle to "Sidebar at a Glance".
- `docs/architecture.md` — updated File Watchers section (300ms specs-dir debounce, single-fire refresh contract).

Closes #94