### PR TITLE
fix(ai-providers): route slash commands cleanly by passing preamble via --append-system-prompt

### DIFF
--- a/src/ai-providers/claudeCodeProvider.ts
+++ b/src/ai-providers/claudeCodeProvider.ts
@@ -51,14 +51,42 @@ export class ClaudeCodeProvider implements IAIProvider {
     }
 
     /**
+     * Split a prompt that contains the speckit-companion context-update preamble
+     * into a system-level preamble (passed via --append-system-prompt) and a
+     * clean user message (typically just a slash command). Keeping the preamble
+     * out of the user message lets Claude CLI route slash commands correctly
+     * and keeps the terminal view focused on what the user actually invoked.
+     */
+    private splitPreambleFromPrompt(prompt: string): { systemPrompt: string | null; userPrompt: string } {
+        const MARKER_CLOSE = '<!-- /speckit-companion:context-update -->';
+        const idx = prompt.indexOf(MARKER_CLOSE);
+        if (idx === -1) {
+            return { systemPrompt: null, userPrompt: prompt };
+        }
+        const end = idx + MARKER_CLOSE.length;
+        return {
+            systemPrompt: prompt.slice(0, end).trim(),
+            userPrompt: prompt.slice(end).trim(),
+        };
+    }
+
+    /**
      * Execute a prompt in a visible terminal (split view)
      */
     async executeInTerminal(prompt: string, title: string = 'SpecKit - Claude Code'): Promise<vscode.Terminal> {
         try {
+            const { systemPrompt, userPrompt } = this.splitPreambleFromPrompt(prompt);
 
-            const promptFilePath = await this.createPromptFile(prompt, 'prompt');
+            const promptFilePath = await this.createPromptFile(userPrompt, 'prompt');
+            const systemPromptFilePath = systemPrompt
+                ? await this.createPromptFile(systemPrompt, 'system-prompt')
+                : null;
+
             const permissionFlag = this.getPermissionFlag();
-            const command = `claude ${permissionFlag}"$(cat "${promptFilePath}")"`;
+            const systemPromptFlag = systemPromptFilePath
+                ? `--append-system-prompt "$(cat "${systemPromptFilePath}")" `
+                : '';
+            const command = `claude ${systemPromptFlag}${permissionFlag}"$(cat "${promptFilePath}")"`;
 
             const terminal = vscode.window.createTerminal({
                 name: title,
@@ -73,13 +101,16 @@ export class ClaudeCodeProvider implements IAIProvider {
             await waitForShellReady(terminal);
             terminal.sendText(command, true);
 
-            // Clean up temp file after delay
+            // Clean up temp files after delay
             setTimeout(async () => {
-                try {
-                    await fs.promises.unlink(promptFilePath);
-                    this.outputChannel.appendLine(`Cleaned up prompt file: ${promptFilePath}`);
-                } catch (e) {
-                    this.outputChannel.appendLine(`Failed to cleanup temp file: ${e}`);
+                for (const path of [promptFilePath, systemPromptFilePath]) {
+                    if (!path) continue;
+                    try {
+                        await fs.promises.unlink(path);
+                        this.outputChannel.appendLine(`Cleaned up prompt file: ${path}`);
+                    } catch (e) {
+                        this.outputChannel.appendLine(`Failed to cleanup temp file: ${e}`);
+                    }
                 }
             }, Timing.tempFileCleanupDelay);
 
@@ -104,9 +135,18 @@ export class ClaudeCodeProvider implements IAIProvider {
         const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
         const cwd = workspaceFolder?.uri.fsPath;
 
-        const promptFilePath = await this.createPromptFile(prompt, 'background-prompt');
+        const { systemPrompt, userPrompt } = this.splitPreambleFromPrompt(prompt);
+
+        const promptFilePath = await this.createPromptFile(userPrompt, 'background-prompt');
+        const systemPromptFilePath = systemPrompt
+            ? await this.createPromptFile(systemPrompt, 'background-system-prompt')
+            : null;
+
         const permissionFlag = this.getPermissionFlag();
-        const commandLine = `claude ${permissionFlag}"$(cat "${promptFilePath}")"`;
+        const systemPromptFlag = systemPromptFilePath
+            ? `--append-system-prompt "$(cat "${systemPromptFilePath}")" `
+            : '';
+        const commandLine = `claude ${systemPromptFlag}${permissionFlag}"$(cat "${promptFilePath}")"`;
 
         return executeCommandInHiddenTerminal({
             commandLine,
@@ -115,6 +155,16 @@ export class ClaudeCodeProvider implements IAIProvider {
             outputChannel: this.outputChannel,
             logPrefix: 'Claude',
             tempFilePath: promptFilePath,
+            cleanupFn: systemPromptFilePath
+                ? async () => {
+                    try {
+                        await fs.promises.unlink(systemPromptFilePath);
+                        this.outputChannel.appendLine(`Cleaned up system prompt file: ${systemPromptFilePath}`);
+                    } catch (e) {
+                        this.outputChannel.appendLine(`Failed to cleanup system prompt file: ${e}`);
+                    }
+                }
+                : undefined,
             logCommandOnFailure: true
         });
     }


### PR DESCRIPTION
## What

When the extension dispatches a slash command with an AI-context preamble (spec viewer → Plan/Tasks/Implement buttons), the preamble and the slash command were concatenated into a single user message. That broke slash-command routing in Claude CLI, because Claude only routes `/command` when the user message *starts* with `/` — a preamble before it makes the whole thing a normal chat message.

This PR splits the preamble out on the `<!-- /speckit-companion:context-update -->` marker and passes it via `claude --append-system-prompt "$(cat <preamble.tmp>)"`, while the user message becomes just the slash command.

## Why

Concrete failure observed on spec 069 (`/speckit-plan <path>`):

1. Terminal showed the whole preamble as a wall of text before the slash command.
2. Claude CLI didn't route `/speckit-plan` (wasn't the first character of the message).
3. The model fell back to invoke `sdd:plan` — a different, model-invocable skill — because the workspace's `.claude/skills/speckit-plan/` has `disable-model-invocation: true`.
4. `sdd:plan` expects its own context/transition shape, ran partially, and stalled without writing `plan.md` or a closing transition.

After this change:
- Terminal shows `claude … /speckit-plan <path>` — clean, the slash command is the only user-visible token.
- Claude CLI routes the slash command to the registered `speckit-plan` skill.
- Lifecycle invariants still reach the model, but as system-level context rather than inline user input.

## Changes

- `src/ai-providers/claudeCodeProvider.ts`
  - New `splitPreambleFromPrompt(prompt)` helper splits on the close marker.
  - `executeInTerminal` writes two temp files (preamble + user prompt), passes preamble via `--append-system-prompt "$(cat …)"`, cleans both up after the delay.
  - `executeHeadless` (background) gets the same split; cleanup for the secondary file goes through `executeCommandInHiddenTerminal`'s existing `cleanupFn` hook.
  - Prompts without the marker keep the previous inline behavior.

## Scope

Only Claude. Other providers (Gemini, Copilot, Codex, Qwen, OpenCode) don't have an equivalent `--append-system-prompt` flag, so they continue to receive the preamble inline — same behavior as before this PR. If any of them later gain a system-prompt flag, the same split pattern can be copied into their provider.

## Testing

- [x] `npm run compile` passes
- [x] `npm test` passes — 277/277 (no new tests; the split is a string-level change with no testable interface beyond what existing tests already cover)
- [x] Manual: installed locally (v0.11.4), dispatched Plan on spec 069 — terminal showed only `claude … /speckit-plan <path>`, Claude CLI loaded the `speckit-plan` skill directly, no more fallback to `sdd:plan`.

## Follow-ups (not in this PR)

- Extension-side write of `stepHistory.<step>.completedAt` when the terminal step finishes — currently relies on the AI following the preamble. With the preamble now system-level, the AI may still skip it; ideally the extension detects step-end via shell integration or explicit signal. Worth its own spec.