### PR TITLE
fix(specs): sort specs by numeric prefix to keep 069 > 068 > 067 order

### DIFF
--- a/src/features/specs/__tests__/specExplorerProvider.test.ts
+++ b/src/features/specs/__tests__/specExplorerProvider.test.ts
@@ -520,6 +520,78 @@ describe('SpecExplorerProvider', () => {
         });
     });
 
+    describe('numeric-prefix sorting', () => {
+        it('sorts numeric-prefixed specs by prefix descending, ignoring birthtime', async () => {
+            (resolveSpecDirectories as jest.Mock).mockResolvedValue([
+                { name: '067-lock-steps', path: 'specs/067-lock-steps' },
+                { name: '069-reveal-folder', path: 'specs/069-reveal-folder' },
+                { name: '068-collapse-toggle', path: 'specs/068-collapse-toggle' },
+            ]);
+            (readSpecContextSync as jest.Mock).mockReturnValue(undefined);
+            (hasDuplicateNames as jest.Mock).mockReturnValue(new Set());
+
+            // Deliberately make birthtime orderings contradict the numeric
+            // prefix — simulates git rebase / checkout resetting birthtime.
+            (mockFs.statSync as jest.Mock).mockImplementation((filePath: string) => {
+                if (filePath.includes('067')) {
+                    return { birthtime: new Date('2025-03-01T00:00:00Z'), mtime: new Date(0) };
+                }
+                if (filePath.includes('069')) {
+                    return { birthtime: new Date('2025-01-01T00:00:00Z'), mtime: new Date(0) };
+                }
+                return { birthtime: new Date('2025-02-01T00:00:00Z'), mtime: new Date(0) };
+            });
+
+            const groups = await provider.getChildren();
+            const specs = await provider.getChildren(groups[0]);
+
+            expect(specs.map((s: any) => s.label)).toEqual([
+                '069-reveal-folder',
+                '068-collapse-toggle',
+                '067-lock-steps',
+            ]);
+        });
+
+        it('falls back to birthtime desc for specs without numeric prefix', async () => {
+            (resolveSpecDirectories as jest.Mock).mockResolvedValue([
+                { name: 'alpha', path: 'specs/alpha' },
+                { name: 'beta', path: 'specs/beta' },
+            ]);
+            (readSpecContextSync as jest.Mock).mockReturnValue(undefined);
+            (hasDuplicateNames as jest.Mock).mockReturnValue(new Set());
+
+            (mockFs.statSync as jest.Mock).mockImplementation((filePath: string) => {
+                if (filePath.includes('alpha')) {
+                    return { birthtime: new Date('2025-01-01T00:00:00Z'), mtime: new Date(0) };
+                }
+                return { birthtime: new Date('2025-03-01T00:00:00Z'), mtime: new Date(0) };
+            });
+
+            const groups = await provider.getChildren();
+            const specs = await provider.getChildren(groups[0]);
+
+            expect(specs.map((s: any) => s.label)).toEqual(['beta', 'alpha']);
+        });
+
+        it('numeric-prefixed specs sort before non-numeric-prefixed specs', async () => {
+            (resolveSpecDirectories as jest.Mock).mockResolvedValue([
+                { name: 'legacy-spec', path: 'specs/legacy-spec' },
+                { name: '001-first', path: 'specs/001-first' },
+            ]);
+            (readSpecContextSync as jest.Mock).mockReturnValue(undefined);
+            (hasDuplicateNames as jest.Mock).mockReturnValue(new Set());
+            (mockFs.statSync as jest.Mock).mockReturnValue({
+                birthtime: new Date('2025-01-01T00:00:00Z'),
+                mtime: new Date(0),
+            });
+
+            const groups = await provider.getChildren();
+            const specs = await provider.getChildren(groups[0]);
+
+            expect(specs.map((s: any) => s.label)).toEqual(['001-first', 'legacy-spec']);
+        });
+    });
+
     describe('active specs birthtime sorting', () => {
         it('should sort active specs by birthtime descending (newest first)', async () => {
             (resolveSpecDirectories as jest.Mock).mockResolvedValue([

--- a/src/features/specs/specExplorerProvider.ts
+++ b/src/features/specs/specExplorerProvider.ts
@@ -109,8 +109,20 @@ export class SpecExplorerProvider extends BaseTreeDataProvider<SpecItem> {
                 }
             }
 
-            // Sort all groups by creation date (newest first)
-            const sortByDateDesc = (a: SpecInfo, b: SpecInfo) => {
+            // Sort: numeric-prefixed specs (e.g. "069-...") by prefix desc —
+            // stable across git operations that rewrite filesystem birthtime.
+            // Specs without a numeric prefix fall back to birthtime desc and
+            // sort after the numeric ones.
+            const extractNumericPrefix = (name: string): number | null => {
+                const match = name.match(/^(\d+)/);
+                return match ? parseInt(match[1], 10) : null;
+            };
+            const sortSpecs = (a: SpecInfo, b: SpecInfo) => {
+                const aNum = extractNumericPrefix(a.name);
+                const bNum = extractNumericPrefix(b.name);
+                if (aNum !== null && bNum !== null) return bNum - aNum;
+                if (aNum !== null) return -1;
+                if (bNum !== null) return 1;
                 try {
                     const aTime = fs.statSync(path.join(basePath, a.path)).birthtime.getTime();
                     const bTime = fs.statSync(path.join(basePath, b.path)).birthtime.getTime();
@@ -119,9 +131,9 @@ export class SpecExplorerProvider extends BaseTreeDataProvider<SpecItem> {
                     return 0;
                 }
             };
-            activeSpecs.sort(sortByDateDesc);
-            completedSpecs.sort(sortByDateDesc);
-            archivedSpecs.sort(sortByDateDesc);
+            activeSpecs.sort(sortSpecs);
+            completedSpecs.sort(sortSpecs);
+            archivedSpecs.sort(sortSpecs);
 
             const items: SpecItem[] = [];
 


### PR DESCRIPTION
## What

The Specs tree sorted by filesystem `birthtime`, which on macOS APFS is rewritten whenever `git switch`, `git rebase`, or `git checkout` recreates the file. That produced surprising orderings like `068 > 069 > 067` right after a rebase — the most-recently-rewritten directory won regardless of its spec number.

This PR: when spec names have a numeric prefix (e.g. `069-reveal-spec-folder`), sort by prefix descending. Specs without a numeric prefix fall back to the old birthtime-desc behavior and sort *after* the numeric ones, so mixed workspaces still render predictably.

## Why

The current order confused me on my own machine right after rebasing `069-reveal-spec-folder` onto main:

```
Active
├── 068-collapse-expand-specs   ← was just rewritten by git → birthtime = now
├── 069-reveal-spec-folder
├── 067-lock-steps-while-running
```

Numeric prefix is a stable identity for SDD specs; birthtime is an implementation detail of the working tree. Sorting by the thing the user actually names the spec matches user expectations.

## Scope

- `src/features/specs/specExplorerProvider.ts` — replaces `sortByDateDesc` with a numeric-prefix-aware variant, applied to Active / Completed / Archived groups.
- `src/features/specs/__tests__/specExplorerProvider.test.ts` — 3 new cases:
  - Pure numeric prefixes sort by prefix desc even when birthtime disagrees
  - Pure non-numeric names fall back to birthtime desc (existing behavior preserved)
  - Mixed: numeric-prefixed specs render before non-numeric ones

## Testing

- [x] `npm run compile` passes
- [x] `npm test` passes — 280/280 (3 new cases)
- [x] Manual: installed locally, confirmed tree order is now `069 > 068 > 067 > 066` in the Active group.