### PR TITLE
feat(specs): reveal spec folder in OS file browser

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -180,6 +180,7 @@ npm run test:watch    # Watch mode
 - N/A (rendering-only change) (055-fix-bullet-rendering)
 - TypeScript 5.3+ (ES2022, strict) + VS Code Extension API (`@types/vscode ^1.84.0`), Preact (webview) (060-spec-context-tracking)
 - File-based — `.spec-context.json` per spec dir under workspace `.claude/specs/` (060-spec-context-tracking)
+- N/A (filesystem reveal only; no persisted state) (069-reveal-spec-folder)
 
 ## Recent Changes
 - 044-context-driven-badges: Added TypeScript 5.3+ (ES2022 target, strict mode) + VS Code Extension API (`@types/vscode ^1.84.0`)

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Specs are grouped into three collapsible sections based on their status (stored 
 
 The Specs view title bar exposes a **collapse/expand all** toggle (alongside the `+` and refresh buttons) that flips every spec in place between expanded and collapsed. The icon swaps to reflect the next action; state is in-memory only and is not persisted across sessions.
 
-Right-click a spec to access **Mark as Completed** and **Archive Spec** actions. The spec viewer footer shows lifecycle buttons based on the spec's current status:
+Right-click a spec to access **Mark as Completed**, **Archive Spec**, and **Reveal in File Explorer** (opens the spec's folder in Finder / File Explorer / the default file manager) actions. The spec viewer footer shows lifecycle buttons based on the spec's current status:
 
 - **Active** (tasks incomplete): Regenerate, Archive, + primary CTA (Plan/Tasks/Implement depending on next step)
 - **Active** (tasks 100% complete): Archive + Complete (primary)

--- a/package.json
+++ b/package.json
@@ -386,6 +386,11 @@
         "title": "Open Source File",
         "category": "SpecKit",
         "icon": "$(go-to-file)"
+      },
+      {
+        "command": "speckit.specs.reveal",
+        "title": "Reveal in File Explorer",
+        "category": "SpecKit"
       }
     ],
     "menus": {
@@ -446,6 +451,11 @@
           "command": "speckit.reactivate",
           "when": "view == speckit.views.explorer && viewItem == spec && !speckit.specs.selection.allActive",
           "group": "7_modification"
+        },
+        {
+          "command": "speckit.specs.reveal",
+          "when": "view == speckit.views.explorer && viewItem == spec",
+          "group": "navigation@99"
         },
         {
           "command": "speckit.steering.refine",

--- a/specs/069-reveal-spec-folder/.spec-context.json
+++ b/specs/069-reveal-spec-folder/.spec-context.json
@@ -1,0 +1,279 @@
+{
+  "workflow": "speckit",
+  "selectedAt": "2026-04-20T23:17:26Z",
+  "currentStep": "implement",
+  "currentTask": null,
+  "progress": null,
+  "next": "implement",
+  "updated": "2026-04-21T00:20:00.000Z",
+  "status": "completed",
+  "specName": "Reveal Spec Folder",
+  "branch": "069-reveal-spec-folder",
+  "approach": "Register a speckit.specs.reveal command in src/features/specs/specCommands.ts that resolves SpecTreeItem.specPath (fallback specs/<label>) to an absolute Uri, stats the folder, and delegates to VS Code's built-in revealFileInOS command. Contribute the command plus a view/item/context entry gated to view == speckit.views.explorer && viewItem == spec in package.json.",
+  "step_summaries": {
+    "plan": {
+      "approach_summary": "Add speckit.specs.reveal command wired to revealFileInOS via the specs tree context menu, gated to viewItem == spec. Pre-stat the folder so missing-folder cases surface a clear error within 1s (SC-004). No new module, no new setting, no external contract — ~20 LOC + tests in existing files.",
+      "files_planned": 3,
+      "risks": [
+        "Silent no-op on some Linux desktops: revealFileInOS relies on the host; minimal Linux environments without a default file manager may silently do nothing. Mitigation: pre-stat the path so the folder-missing case is always surfaced; accept that truly-no-file-manager systems remain a host-level gap out of our scope.",
+        "Menu label is static ('Reveal in File Explorer') across OSes. Cosmetic only — a future polish could add per-OS title overrides via osx/linux/windows keys in contributes.commands."
+      ]
+    }
+  },
+  "stepHistory": {
+    "specify": {
+      "startedAt": "2026-04-20T23:17:26Z",
+      "completedAt": "2026-04-21T00:01:25.560Z"
+    },
+    "plan": {
+      "startedAt": "2026-04-21T00:01:25.564Z",
+      "completedAt": "2026-04-21T00:05:00.000Z",
+      "substeps": [
+        {
+          "name": "research",
+          "startedAt": "2026-04-21T00:01:30.000Z",
+          "completedAt": "2026-04-21T00:03:00.000Z"
+        },
+        {
+          "name": "design",
+          "startedAt": "2026-04-21T00:03:00.000Z",
+          "completedAt": "2026-04-21T00:05:00.000Z"
+        }
+      ]
+    },
+    "tasks": {
+      "startedAt": "2026-04-21T00:04:47.921Z",
+      "completedAt": "2026-04-21T00:07:55.859Z",
+      "substeps": [
+        {
+          "name": "generate",
+          "startedAt": "2026-04-21T00:06:00.000Z",
+          "completedAt": "2026-04-21T00:07:00.000Z"
+        }
+      ]
+    },
+    "implement": {
+      "startedAt": "2026-04-21T00:07:55.861Z",
+      "completedAt": "2026-04-21T00:20:00.000Z",
+      "substeps": [
+        {
+          "name": "run-tests",
+          "startedAt": "2026-04-21T00:18:00.000Z",
+          "completedAt": "2026-04-21T00:19:30.000Z"
+        }
+      ]
+    }
+  },
+  "transitions": [
+    {
+      "step": "specify",
+      "substep": null,
+      "from": {
+        "step": "specify",
+        "substep": null
+      },
+      "by": "extension",
+      "at": "2026-04-20T23:30:23.486Z"
+    },
+    {
+      "step": "plan",
+      "substep": null,
+      "from": {
+        "step": "specify",
+        "substep": null
+      },
+      "by": "extension",
+      "at": "2026-04-20T23:30:23.487Z"
+    },
+    {
+      "step": "plan",
+      "substep": "loading",
+      "from": {
+        "step": "plan",
+        "substep": null
+      },
+      "by": "sdd",
+      "at": "2026-04-20T23:47:04.100Z"
+    },
+    {
+      "step": "plan",
+      "substep": "research",
+      "from": {
+        "step": "plan",
+        "substep": "loading"
+      },
+      "by": "sdd",
+      "at": "2026-04-20T23:47:04.200Z"
+    },
+    {
+      "step": "plan",
+      "substep": "writing-plan",
+      "from": {
+        "step": "plan",
+        "substep": "research"
+      },
+      "by": "sdd",
+      "at": "2026-04-20T23:47:04.500Z"
+    },
+    {
+      "step": "plan",
+      "substep": "design",
+      "from": {
+        "step": "plan",
+        "substep": "writing-plan"
+      },
+      "by": "sdd",
+      "at": "2026-04-20T23:47:04.600Z"
+    },
+    {
+      "step": "plan",
+      "substep": null,
+      "from": {
+        "step": "plan",
+        "substep": "design"
+      },
+      "by": "sdd",
+      "at": "2026-04-20T23:47:05.000Z"
+    },
+    {
+      "step": "specify",
+      "substep": null,
+      "from": {
+        "step": "specify",
+        "substep": null
+      },
+      "by": "extension",
+      "at": "2026-04-21T00:01:25.560Z"
+    },
+    {
+      "step": "plan",
+      "substep": null,
+      "from": {
+        "step": "plan",
+        "substep": null
+      },
+      "by": "extension",
+      "at": "2026-04-21T00:01:25.564Z"
+    },
+    {
+      "step": "plan",
+      "substep": "research",
+      "from": {
+        "step": "plan",
+        "substep": null
+      },
+      "by": "ai",
+      "at": "2026-04-21T00:01:30.000Z"
+    },
+    {
+      "step": "plan",
+      "substep": "design",
+      "from": {
+        "step": "plan",
+        "substep": "research"
+      },
+      "by": "ai",
+      "at": "2026-04-21T00:03:00.000Z"
+    },
+    {
+      "step": "plan",
+      "substep": null,
+      "from": {
+        "step": "plan",
+        "substep": "design"
+      },
+      "by": "ai",
+      "at": "2026-04-21T00:05:00.000Z"
+    },
+    {
+      "step": "tasks",
+      "substep": null,
+      "from": {
+        "step": "plan",
+        "substep": null
+      },
+      "by": "ai",
+      "at": "2026-04-21T00:05:00.000Z"
+    },
+    {
+      "step": "tasks",
+      "substep": null,
+      "from": {
+        "step": "tasks",
+        "substep": null
+      },
+      "by": "extension",
+      "at": "2026-04-21T00:04:47.921Z"
+    },
+    {
+      "step": "tasks",
+      "substep": "generate",
+      "from": {
+        "step": "tasks",
+        "substep": null
+      },
+      "by": "ai",
+      "at": "2026-04-21T00:06:00.000Z"
+    },
+    {
+      "step": "tasks",
+      "substep": null,
+      "from": {
+        "step": "tasks",
+        "substep": "generate"
+      },
+      "by": "ai",
+      "at": "2026-04-21T00:07:00.000Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "from": {
+        "step": "tasks",
+        "substep": null
+      },
+      "by": "ai",
+      "at": "2026-04-21T00:07:00.000Z"
+    },
+    {
+      "step": "tasks",
+      "substep": null,
+      "from": {
+        "step": "tasks",
+        "substep": null
+      },
+      "by": "extension",
+      "at": "2026-04-21T00:07:55.859Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "from": {
+        "step": "implement",
+        "substep": null
+      },
+      "by": "extension",
+      "at": "2026-04-21T00:07:55.861Z"
+    },
+    {
+      "step": "implement",
+      "substep": "run-tests",
+      "from": {
+        "step": "implement",
+        "substep": null
+      },
+      "by": "ai",
+      "at": "2026-04-21T00:18:00.000Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "from": {
+        "step": "implement",
+        "substep": "run-tests"
+      },
+      "by": "ai",
+      "at": "2026-04-21T00:20:00.000Z"
+    }
+  ]
+}

--- a/specs/069-reveal-spec-folder/checklists/requirements.md
+++ b/specs/069-reveal-spec-folder/checklists/requirements.md
@@ -1,0 +1,35 @@
+# Specification Quality Checklist: Reveal Spec Folder in OS File Browser
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-20
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Items marked incomplete require spec updates before `/speckit.clarify` or `/speckit.plan`
+- All items pass on first validation pass. Spec is scoped tightly to one user story and uses platform-neutral language (OS file browser) rather than naming specific APIs.

--- a/specs/069-reveal-spec-folder/data-model.md
+++ b/specs/069-reveal-spec-folder/data-model.md
@@ -1,0 +1,55 @@
+# Phase 1 Data Model: Reveal Spec Folder in OS File Browser
+
+**Feature**: 069-reveal-spec-folder
+**Date**: 2026-04-20
+
+This feature introduces no new persisted data, no new schema, and no changes to
+`.spec-context.json`. It reuses one existing in-memory entity.
+
+## Entity: SpecTreeItem (existing)
+
+**Source**: `src/core/types/config.ts`
+
+```ts
+export interface SpecTreeItem {
+    label: string;
+    specPath?: string;   // workspace-relative path, e.g. "specs/069-reveal-spec-folder"
+}
+```
+
+### Fields used by this feature
+
+| Field      | Type     | Source                              | Used for                                                    |
+|------------|----------|-------------------------------------|-------------------------------------------------------------|
+| `label`    | `string` | `SpecExplorerProvider`              | Error-message text when folder is missing / unreadable       |
+| `specPath` | `string?`| `SpecExplorerProvider`              | Workspace-relative folder path → resolved to absolute `Uri` |
+
+### Relationships
+
+- A `SpecTreeItem` corresponds 1:1 to a directory under the workspace's
+  `specs/` or `.claude/specs/` root (resolved per `specDirectoryResolver`).
+- No new references, parents, or children are introduced.
+
+### Validation rules
+
+1. `specPath` **MAY** be `undefined` on legacy items; the reveal handler
+   **MUST** fall back to `specs/${label}` (same fallback already used by
+   `speckit.delete` in `specCommands.ts:114`).
+2. After resolving to an absolute path, the handler **MUST** verify the
+   directory exists via `vscode.workspace.fs.stat(uri)` before invoking
+   `revealFileInOS` (FR-005, SC-004).
+
+### State transitions
+
+None. The reveal action is stateless and idempotent: invoking it does not
+change any spec's lifecycle, status, `.spec-context.json`, or tree state.
+
+## Non-entities (explicitly not added)
+
+- **No new command registry entity**: the command id
+  `speckit.specs.reveal` is registered alongside existing ones in
+  `specCommands.ts` and (optionally) declared in `core/constants.ts`
+  `Commands` enum if that pattern is used there.
+- **No new context-key**: the menu gate reuses the existing
+  `viewItem == spec` mechanism.
+- **No new setting**: behavior is invariant across users.

--- a/specs/069-reveal-spec-folder/plan.md
+++ b/specs/069-reveal-spec-folder/plan.md
@@ -1,0 +1,89 @@
+# Implementation Plan: Reveal Spec Folder in OS File Browser
+
+**Branch**: `069-reveal-spec-folder` | **Date**: 2026-04-20 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/069-reveal-spec-folder/spec.md`
+
+## Summary
+
+Add a right-click action on spec tree items that opens the spec's folder in the OS
+file browser (Finder / File Explorer / default Linux file manager). The tree already
+tracks each spec's workspace-relative path (`SpecTreeItem.specPath`), so the command
+just resolves it to an absolute path and delegates to VS Code's built-in
+`revealFileInOS` command. Gated to `viewItem == spec` so it does not appear on
+steering docs, workflow entries, or sub-document rows.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.3+ (ES2022 target, strict mode)
+**Primary Dependencies**: VS Code Extension API (`@types/vscode ^1.84.0`)
+**Storage**: N/A (filesystem reveal only; no persisted state)
+**Testing**: Jest + `ts-jest` via `tests/__mocks__/vscode.ts` extension mock
+**Target Platform**: VS Code desktop on macOS, Windows, Linux
+**Project Type**: Single-project VS Code extension
+**Performance Goals**: Reveal action completes within 1s of click (SC-004)
+**Constraints**: Must ship inside the packaged `.vsix`; no `.claude/**` or
+`.specify/**` edits (extension isolation rule in CLAUDE.md)
+**Scale/Scope**: One new command, one new context-menu entry, one handler
+(~20 LOC + tests)
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- **I. Extensibility and Configuration**: PASS — feature is a built-in action on
+  the existing specs tree, reuses `SpecTreeItem.specPath`, and requires no new
+  provider abstraction or setting.
+- **II. Spec-Driven Workflow**: PASS — the action surfaces existing filesystem
+  artifacts (spec.md / plan.md / tasks.md / `.spec-context.json`) without
+  altering the Specify → Plan → Tasks → Implement pipeline or lifecycle states.
+- **III. Visual and Interactive**: PASS — the action is exposed via the
+  right-click context menu (GUI-first, not a bare command).
+- **IV. Modular Architecture**: PASS — the feature is one handler in the
+  existing `src/features/specs/specCommands.ts`; no new module split needed
+  (well under the 3–4-file threshold).
+
+No violations → no Complexity Tracking entries required.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/069-reveal-spec-folder/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+└── tasks.md             # Phase 2 output (produced by /speckit.tasks)
+```
+
+No `contracts/` directory: the feature exposes no external API, CLI schema, or
+network interface — it is a VS Code-internal command invoked from a context
+menu. Per the plan template: "Skip if project is purely internal."
+
+### Source Code (repository root)
+
+```text
+src/
+├── features/
+│   └── specs/
+│       ├── specCommands.ts          # ADD: speckit.specs.reveal handler (~20 LOC)
+│       └── specCommands.test.ts     # ADD: reveal-command tests
+└── core/
+    └── constants.ts                 # (inspect) — add command id if Commands enum is used
+
+package.json                         # ADD: command contribution + view/item/context entry
+```
+
+**Structure Decision**: Single-project VS Code extension layout (existing).
+All changes live inside `src/features/specs/` and `package.json`. No webview,
+no new module, no new directory — matches the "Option 1: Single project" branch
+of the template.
+
+## Complexity Tracking
+
+> No Constitution Check violations. Table intentionally empty.
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| —         | —          | —                                   |

--- a/specs/069-reveal-spec-folder/quickstart.md
+++ b/specs/069-reveal-spec-folder/quickstart.md
@@ -1,0 +1,74 @@
+# Quickstart: Reveal Spec Folder in OS File Browser
+
+**Feature**: 069-reveal-spec-folder
+**Audience**: Reviewers, QA, and anyone verifying the shipped feature.
+
+## Prerequisites
+
+- VS Code 1.84+ with the SpecKit Companion extension installed from the built
+  `.vsix` on this branch.
+- A workspace containing at least one spec directory (e.g.
+  `specs/069-reveal-spec-folder`).
+
+## Happy-path verification (SC-001, SC-002)
+
+1. Open the SpecKit activity bar panel → **Specs** view.
+2. Locate any spec in the tree (e.g. `069-reveal-spec-folder`).
+3. Right-click the spec node.
+4. In the context menu, click **Reveal in File Explorer**.
+5. **Expected**:
+   - macOS: Finder opens with the spec's folder selected/focused.
+   - Windows: File Explorer opens with the spec's folder focused.
+   - Linux: The default file manager opens at the spec's folder.
+   - `spec.md`, `plan.md` (if present), `tasks.md` (if present), and
+     `.spec-context.json` are visible inside that folder.
+6. Total interaction: **2 clicks** (right-click + menu item) → SC-001.
+
+## Menu-scoping verification (FR-004, SC-003)
+
+1. Expand a spec node so its sub-documents (e.g. `spec.md`, `plan.md`) appear.
+2. Right-click a sub-document row.
+   - **Expected**: the "Reveal in File Explorer" item does **not** appear.
+3. Switch to the **Steering** view, right-click any steering document.
+   - **Expected**: the action does **not** appear.
+4. Right-click a lifecycle group header (Active / Completed / Archived).
+   - **Expected**: the action does **not** appear.
+
+## Error-path verification (FR-005, SC-004)
+
+1. In a terminal, rename the spec's directory out from under the extension:
+   ```bash
+   mv specs/069-reveal-spec-folder specs/069-reveal-spec-folder.bak
+   ```
+   (Do **not** refresh the tree — the stale tree item is the test fixture.)
+2. Right-click the now-stale spec node → **Reveal in File Explorer**.
+3. **Expected**: within ~1 second, an error notification appears, e.g.
+   `Cannot reveal: /abs/path/to/specs/069-reveal-spec-folder does not exist`.
+   No silent failure.
+4. Restore the folder:
+   ```bash
+   mv specs/069-reveal-spec-folder.bak specs/069-reveal-spec-folder
+   ```
+
+## Automated test checklist
+
+Expected to exist in `src/features/specs/specCommands.test.ts`:
+
+- [ ] Registers `speckit.specs.reveal` when `registerSpecKitCommands` runs.
+- [ ] On invocation with a valid `SpecTreeItem`, calls
+      `vscode.commands.executeCommand('revealFileInOS', <Uri>)` with the
+      absolute folder URI resolved from `specPath`.
+- [ ] Falls back to `specs/<label>` when `specPath` is undefined.
+- [ ] On a missing folder (stat rejects), calls
+      `vscode.window.showErrorMessage` and does **not** call `revealFileInOS`.
+- [ ] Does nothing when no workspace folder is open.
+
+## Smoke-build
+
+```bash
+npm install
+npm run compile
+npm test -- specCommands
+```
+
+All three commands must succeed on `main`'s CI environment.

--- a/specs/069-reveal-spec-folder/research.md
+++ b/specs/069-reveal-spec-folder/research.md
@@ -1,0 +1,115 @@
+# Phase 0 Research: Reveal Spec Folder in OS File Browser
+
+**Feature**: 069-reveal-spec-folder
+**Date**: 2026-04-20
+
+## Unknowns extracted from Technical Context
+
+None. Every field in the plan's Technical Context resolves to a concrete value
+from existing project conventions (CLAUDE.md, constitution, existing specs
+feature code). No `NEEDS CLARIFICATION` markers.
+
+## Research Items
+
+### R1 — Cross-platform "reveal folder in OS" primitive
+
+**Decision**: Use VS Code's built-in command `revealFileInOS`.
+
+**Rationale**:
+- Ships with VS Code core on all three OSes — no native dependency, no child
+  process, no platform branching in our code.
+- Accepts a `vscode.Uri` argument; opens Finder on macOS, Explorer on Windows,
+  the default file manager on Linux.
+- Handles folder targets as well as file targets (a directory URI causes the
+  folder itself to be opened/focused).
+- Matches the default VS Code UX users already know from the File Explorer
+  ("Reveal in Finder" / "Reveal in File Explorer" / "Open Containing Folder").
+
+**Alternatives considered**:
+- **`child_process.exec` with `open` / `explorer` / `xdg-open`**: Requires
+  per-platform branching, pulls in shell-escaping concerns, and duplicates what
+  `revealFileInOS` already does. Rejected.
+- **`vscode.env.openExternal(Uri.file(...))`**: Opens the URI in the system
+  handler — for folders this behavior is inconsistent across OSes (on macOS it
+  may open in Finder, on Linux it may open a terminal or nothing). Rejected —
+  `revealFileInOS` is the purpose-built primitive.
+- **`workbench.action.files.revealActiveFileInWindows`**: VS Code-internal
+  workbench command scoped to the active editor — not usable for an arbitrary
+  tree item. Rejected.
+
+### R2 — Command title per platform
+
+**Decision**: Use a single static title, "Reveal in File Explorer".
+
+**Rationale**:
+- VS Code itself uses platform-specific titles for its own "Reveal in ..."
+  entry, but those are implemented via localization, not runtime branching.
+- Our `package.json` command contribution is static; adding `osx`/`linux`/
+  `windows` key overrides is possible but adds surface area for a cosmetic
+  difference.
+- "Reveal in File Explorer" is the Windows phrasing and is understandable on
+  all platforms; it matches what several popular VS Code extensions do.
+
+**Alternatives considered**:
+- **Per-OS title overrides via `osx` / `linux` / `windows` in `contributes.commands`**:
+  Possible (`osx: "Reveal in Finder"`, etc.) and more polished. Kept as a
+  future improvement — not required by the spec's Acceptance Scenarios, which
+  only assert that the correct OS tool opens, not what the menu label says.
+
+### R3 — Error handling for missing / inaccessible folders (FR-005, SC-004)
+
+**Decision**: Stat the resolved absolute path before delegating. If the folder
+does not exist, show `vscode.window.showErrorMessage(...)` with the path and
+abort. For permission or other I/O errors from the reveal itself, wrap the
+`executeCommand` call in a try/catch and surface `err.message`.
+
+**Rationale**:
+- `revealFileInOS` on a nonexistent path can silently no-op on some Linux
+  desktops — a pre-stat gives us a deterministic, user-visible failure path
+  (meets SC-004: error within 1s, no silent failures).
+- Matches the defensive style already used in `speckit.delete` and
+  `speckit.openSpecSource` in `specCommands.ts`.
+
+**Alternatives considered**:
+- **Rely solely on `revealFileInOS` errors**: Rejected — Linux silent-no-op
+  edge case would violate SC-004.
+- **Refresh the tree on failure to auto-heal**: Out of scope; a missing
+  folder is rare and best surfaced to the user rather than hidden.
+
+### R4 — Selecting the correct `viewItem` gate
+
+**Decision**: `view == speckit.views.explorer && viewItem == spec`.
+
+**Rationale**:
+- `SpecExplorerProvider` already sets `contextValue = 'spec'` on spec nodes
+  (seen via existing menu gates in `package.json` for `speckit.delete`,
+  `speckit.archive`, etc., all using the same `viewItem == spec` condition).
+- Sub-documents use `viewItem =~ /spec-document-/` and are correctly excluded
+  by the strict `== spec` match.
+- Steering docs live on a different view (`speckit.views.steering`) and are
+  excluded by the `view ==` part of the gate.
+- Satisfies FR-004 and SC-003 (100% of spec items show the action, 0% of
+  non-spec items do).
+
+**Alternatives considered**: none — this is the established pattern in the
+codebase.
+
+### R5 — Accepting an argument from a single-click vs. multi-select
+
+**Decision**: Accept only the single `SpecTreeItem` passed by VS Code as the
+first argument; do not support multi-select reveal.
+
+**Rationale**:
+- Revealing many folders simultaneously spawns multiple OS file-browser
+  windows — noisy and rarely intended.
+- The spec's Acceptance Scenarios and SC-001 describe a single right-click →
+  single reveal interaction.
+- Existing bulk commands (`markCompleted`, `archive`, `reactivate`) accept a
+  second `items?: SpecTreeItem[]` argument; reveal intentionally does not.
+
+**Alternatives considered**: Multi-reveal via `items?: SpecTreeItem[]` —
+rejected as out of scope and likely annoying.
+
+## Outcome
+
+All open questions resolved. Ready for Phase 1 design.

--- a/specs/069-reveal-spec-folder/spec.md
+++ b/specs/069-reveal-spec-folder/spec.md
@@ -1,0 +1,60 @@
+# Feature Specification: Reveal Spec Folder in OS File Browser
+
+**Feature Branch**: `069-reveal-spec-folder`
+**Created**: 2026-04-20
+**Status**: Draft
+**Input**: User description: "Reveal spec folder in Finder/Explorer — right-click a spec → open its folder in the OS file browser."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Reveal Spec Folder via Context Menu (Priority: P1)
+
+A developer working in the SpecKit Companion specs tree view wants to inspect, copy, or share the raw files for a spec (spec.md, plan.md, tasks.md, `.spec-context.json`, checklists, etc.). They right-click the spec in the tree, choose "Reveal in Finder" (macOS) / "Reveal in File Explorer" (Windows) / "Open Containing Folder" (Linux), and the OS file browser opens at that spec's folder.
+
+**Why this priority**: This is the entire feature. Without it, users must manually navigate `.claude/specs/<feature>/` every time they need to access files outside the extension's UI — a common friction point when debugging, sharing, or comparing specs.
+
+**Independent Test**: Can be fully tested by right-clicking any spec in the tree and verifying the OS file browser opens at that spec's directory with the spec files visible.
+
+**Acceptance Scenarios**:
+
+1. **Given** a spec exists in the tree view, **When** the user right-clicks the spec and chooses the reveal action, **Then** the OS file browser opens showing that spec's folder contents.
+2. **Given** the user is on macOS, **When** they trigger the reveal action, **Then** Finder opens with the spec's folder focused.
+3. **Given** the user is on Windows, **When** they trigger the reveal action, **Then** File Explorer opens with the spec's folder focused.
+4. **Given** the user is on Linux, **When** they trigger the reveal action, **Then** the default file manager opens at the spec's folder.
+
+---
+
+### Edge Cases
+
+- **Folder was deleted externally**: If the spec's directory no longer exists on disk when the action fires, the extension surfaces a clear error message instead of silently failing.
+- **Permission denied**: If the OS denies access to the folder, the underlying error is shown to the user.
+- **Non-spec tree items**: The reveal action only appears on spec nodes, not on steering documents, workflow items, or group/section headers.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The specs tree view MUST expose a right-click context-menu action that reveals a spec's folder in the OS file browser.
+- **FR-002**: The action MUST open the spec's root folder (the directory containing `spec.md`, `plan.md`, `tasks.md`, and `.spec-context.json`).
+- **FR-003**: The action MUST use the platform-appropriate reveal behavior so the folder is shown in Finder on macOS, File Explorer on Windows, and the default file manager on Linux.
+- **FR-004**: The action MUST only appear on spec tree items; it MUST NOT appear on steering docs, workflow entries, groupings, or other non-spec nodes.
+- **FR-005**: If the spec folder cannot be opened (missing, permission error, etc.), the extension MUST display a user-visible error message describing the failure.
+
+### Key Entities
+
+- **Spec Tree Item**: Represents one spec in the tree view; exposes the absolute path of the spec's folder so the reveal action can act on it.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A user can open a spec's folder in the OS file browser in a single right-click interaction (two clicks total: right-click + menu item).
+- **SC-002**: The reveal action works correctly on all three supported platforms (macOS, Windows, Linux) without platform-specific branching beyond the standard platform-aware reveal primitive.
+- **SC-003**: 100% of spec tree items show the reveal action in their context menu; 0% of non-spec tree items show it.
+- **SC-004**: When the target folder is missing, users see a clear error message within 1 second of triggering the action (no silent failures).
+
+## Assumptions
+
+- The extension already tracks each spec's absolute folder path via its existing tree data provider — no new filesystem scanning is required to implement this.
+- VS Code's built-in reveal-in-OS command is acceptable as the reveal mechanism, so cross-platform behavior is delegated to the editor/host.
+- The feature applies only to the specs tree; a parallel action for steering documents is out of scope for this spec.

--- a/specs/069-reveal-spec-folder/tasks.md
+++ b/specs/069-reveal-spec-folder/tasks.md
@@ -1,0 +1,152 @@
+# Tasks: Reveal Spec Folder in OS File Browser
+
+**Input**: Design documents from `/specs/069-reveal-spec-folder/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, quickstart.md
+
+**Tests**: Test tasks are included — `quickstart.md` ships an explicit automated-test checklist and the project convention (`specCommands.test.ts` already exists) is to cover new command handlers with Jest.
+
+**Organization**: Only one user story exists (P1). Phases 1–2 are empty because this feature plugs into an existing VS Code extension — no new project, no new foundational layer.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Maps to user stories from spec.md (US1 = Reveal Spec Folder via Context Menu)
+- File paths below are absolute to the repository root.
+
+## Path Conventions
+
+Single-project VS Code extension. All source lives under `src/`, webview under `webview/`, and package metadata in `package.json` at the repo root.
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Nothing to set up — the extension project, Jest config, `tests/__mocks__/vscode.ts`, and `specCommands.ts` / `specCommands.test.ts` files already exist. Skip.
+
+*(No tasks in this phase.)*
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: No foundational changes required. The reveal handler reuses the existing `SpecTreeItem.specPath` field, the existing `viewItem == spec` menu gate, and VS Code's built-in `revealFileInOS` command. Skip.
+
+*(No tasks in this phase.)*
+
+---
+
+## Phase 3: User Story 1 - Reveal Spec Folder via Context Menu (Priority: P1) 🎯 MVP
+
+**Goal**: A developer right-clicks a spec in the Specs tree and picks "Reveal in File Explorer"; the OS file browser opens focused on that spec's folder. Missing folders surface a clear error within ~1s instead of silently failing.
+
+**Independent Test**: Follow `specs/069-reveal-spec-folder/quickstart.md` — happy path (SC-001/SC-002), menu-scoping (FR-004/SC-003), and error path (FR-005/SC-004). Feature ships as a standalone increment.
+
+### Tests for User Story 1 ⚠️
+
+> Write these tests FIRST and confirm they FAIL before implementing T004.
+
+- [X] T001 [P] [US1] Add test "registers speckit.specs.reveal when registerSpecKitCommands runs" in `src/features/specs/specCommands.test.ts` — assert the command id is registered via the existing `vscode.commands.registerCommand` mock.
+- [X] T002 [P] [US1] Add test "calls revealFileInOS with absolute folder URI resolved from specPath" in `src/features/specs/specCommands.test.ts` — invoke the registered handler with a `SpecTreeItem { label, specPath }`, stub `vscode.workspace.fs.stat` to resolve, and assert `vscode.commands.executeCommand('revealFileInOS', <Uri>)` was called with the workspace-joined absolute Uri.
+- [X] T003 [P] [US1] Add test "falls back to specs/<label> when specPath is undefined" in `src/features/specs/specCommands.test.ts` — invoke with `SpecTreeItem { label: 'foo' }` (no specPath) and assert the Uri passed to `revealFileInOS` ends in `specs/foo`.
+- [X] T004 [P] [US1] Add test "shows error and does not call revealFileInOS when folder is missing" in `src/features/specs/specCommands.test.ts` — stub `vscode.workspace.fs.stat` to reject, assert `vscode.window.showErrorMessage` is called with a message containing the absolute path, and assert `executeCommand('revealFileInOS', ...)` is **not** called.
+- [X] T005 [P] [US1] Add test "no-op when no workspace folder is open" in `src/features/specs/specCommands.test.ts` — set `vscode.workspace.workspaceFolders = undefined`, invoke handler, assert neither `stat` nor `executeCommand('revealFileInOS', ...)` runs.
+
+### Implementation for User Story 1
+
+- [X] T006 [US1] (Optional) If `src/core/constants.ts` exports a `Commands` enum containing spec-action ids, add `SpecsReveal = 'speckit.specs.reveal'` there so the handler and `package.json` share a single source of truth. If the enum isn't used for these ids, skip and hard-code the string.
+- [X] T007 [US1] Register the reveal handler in `src/features/specs/specCommands.ts` inside `registerSpecKitCommands`, next to the existing `speckit.delete` registration (around line 103). Signature: `vscode.commands.registerCommand('speckit.specs.reveal', async (item: SpecTreeItem) => { ... })`.
+- [X] T008 [US1] Inside the handler in `src/features/specs/specCommands.ts`: (a) read `vscode.workspace.workspaceFolders?.[0]` and return silently if absent; (b) resolve `relativePath = item.specPath ?? \`specs/${item.label}\`` (same fallback as `speckit.delete` at line 114); (c) build absolute Uri via `vscode.Uri.file(path.join(workspaceFolder.uri.fsPath, relativePath))`.
+- [X] T009 [US1] Pre-stat the folder in `src/features/specs/specCommands.ts`: wrap `await vscode.workspace.fs.stat(uri)` in try/catch; on failure call `vscode.window.showErrorMessage(\`Cannot reveal: ${uri.fsPath} does not exist\`)` and return before invoking `revealFileInOS` (satisfies FR-005 and SC-004).
+- [X] T010 [US1] On stat success in `src/features/specs/specCommands.ts`: wrap `await vscode.commands.executeCommand('revealFileInOS', uri)` in try/catch and surface `vscode.window.showErrorMessage(err.message)` on failure, matching the defensive style used elsewhere in this file.
+- [X] T011 [US1] Add the command contribution in `package.json` under `contributes.commands`: `{ "command": "speckit.specs.reveal", "title": "Reveal in File Explorer", "category": "SpecKit" }`.
+- [X] T012 [US1] Add the context-menu entry in `package.json` under `contributes.menus["view/item/context"]`: `{ "command": "speckit.specs.reveal", "when": "view == speckit.views.explorer && viewItem == spec", "group": "navigation@99" }` (or the next available `navigation` order after existing spec-level entries — confirm ordering while editing so the entry sits near the bottom of the group, not above destructive actions like delete).
+- [X] T013 [US1] Run `npm run compile` from the repo root and fix any TypeScript errors introduced by T007–T010.
+- [X] T014 [US1] Run `npm test -- specCommands` from the repo root and confirm the new tests from T001–T005 pass alongside the existing suite.
+- [ ] T015 [US1] Manually validate by launching the Extension Development Host (F5) and walking through all three verification blocks in `specs/069-reveal-spec-folder/quickstart.md` (happy path, menu-scoping, error path). If on macOS only, note that Windows/Linux happy paths are covered by the platform-agnostic `revealFileInOS` delegation — no platform branching to re-test.
+
+**Checkpoint**: User Story 1 is the entire feature. After T015 the spec is shippable.
+
+---
+
+## Phase 4: Polish & Cross-Cutting Concerns
+
+- [X] T016 [P] Update `README.md` to mention the new right-click "Reveal in File Explorer" action under the specs tree section (project rule: update README whenever a user-facing feature changes).
+- [ ] T017 [P] If `docs/viewer-states.md` or `docs/architecture.md` document the specs tree context menu, add the new entry there as well; if neither mentions context-menu actions today, skip.
+- [ ] T018 Bump the extension patch version in `package.json` (but do NOT commit the bump into the feature PR — per project convention version bumps land separately; install-local will re-bump locally).
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: empty — nothing to wait on.
+- **Foundational (Phase 2)**: empty — nothing to wait on.
+- **User Story 1 (Phase 3)**: the whole feature. Tests (T001–T005) run in parallel and MUST be written (and failing) before T007–T010. T006 is independent and can happen any time. T011/T012 (`package.json`) are independent of the TypeScript edits and can be done in parallel with them, but compile (T013) and test (T014) must come after all code/config changes. T015 is last.
+- **Polish (Phase 4)**: T016/T017 depend only on Phase 3 landing; T018 is a mechanical bump.
+
+### User Story Dependencies
+
+- Only one user story (US1). No inter-story dependencies.
+
+### Within User Story 1
+
+- Tests (T001–T005) FIRST → verify they fail → then implementation (T006–T012).
+- T007 must precede T008/T009/T010 (they edit the same handler body).
+- T011 must precede T012 (the menu entry references the command id contributed in T011).
+- T013 (compile) before T014 (test).
+- T015 (manual) last.
+
+### Parallel Opportunities
+
+- T001–T005 all edit the same test file but cover independent cases; they can be authored in parallel by different contributors but must merge into one file — treat as "conceptually parallel, physically sequential." Marked [P] for clarity.
+- T011 and T012 both edit `package.json` and are sequential with each other, but both can run in parallel with T007–T010 (different file).
+- T016 and T017 edit different docs files → truly parallel.
+
+---
+
+## Parallel Example: User Story 1
+
+```bash
+# While one contributor writes the Jest cases (same file, coordinate via diff):
+Task: "T001 register-command test in src/features/specs/specCommands.test.ts"
+Task: "T002 revealFileInOS call test in src/features/specs/specCommands.test.ts"
+Task: "T003 specPath-fallback test in src/features/specs/specCommands.test.ts"
+Task: "T004 missing-folder error test in src/features/specs/specCommands.test.ts"
+Task: "T005 no-workspace no-op test in src/features/specs/specCommands.test.ts"
+
+# Another contributor can simultaneously land the package.json contribution:
+Task: "T011 command contribution in package.json"
+Task: "T012 view/item/context menu entry in package.json"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 only)
+
+1. Phase 1 and Phase 2 are empty — nothing to do.
+2. Write tests T001–T005, confirm they fail.
+3. Land handler edits T007–T010 (+ optional T006).
+4. Land `package.json` entries T011–T012.
+5. Compile (T013), run tests (T014), manually validate via quickstart (T015).
+6. **STOP and VALIDATE**: the feature is complete and shippable.
+
+### Incremental Delivery
+
+Only one increment exists. After User Story 1 passes, run the Polish phase (README / docs / version bump) and open the PR.
+
+### Parallel Team Strategy
+
+This feature is too small to split across a team — realistically one contributor lands everything in under an hour. Parallelism is noted above only to preserve template structure.
+
+---
+
+## Notes
+
+- `[P]` marks tasks that touch different files OR different test cases; respect the same-file caveat in Phase 3.
+- No new modules, directories, settings, or schemas. No `.claude/**` or `.specify/**` edits (extension isolation rule).
+- Total task count: 18 (5 tests + 10 implementation + 3 polish).
+- Suggested MVP scope: T001–T015 (everything in Phase 3).
+- Commit after each logical group (tests, handler, package.json, docs). Do not commit the T018 version bump into the feature PR.

--- a/src/features/specs/specCommands.test.ts
+++ b/src/features/specs/specCommands.test.ts
@@ -224,6 +224,91 @@ describe('bulk status command handlers', () => {
     });
 });
 
+describe('speckit.specs.reveal command handler', () => {
+    const originalWorkspaceFolders = (vscode.workspace as any).workspaceFolders;
+    const mockWindow = vscode.window as jest.Mocked<typeof vscode.window>;
+
+    beforeEach(() => {
+        (vscode.workspace as any).workspaceFolders = [{ uri: { fsPath: '/ws' } }];
+    });
+
+    afterEach(() => {
+        (vscode.workspace as any).workspaceFolders = originalWorkspaceFolders;
+    });
+
+    it('registers speckit.specs.reveal when registerSpecKitCommands runs', () => {
+        const context = createMockContext();
+        const handlers = captureCommandHandlers(context);
+
+        expect(handlers.has('speckit.specs.reveal')).toBe(true);
+    });
+
+    it('calls revealFileInOS with absolute folder URI resolved from specPath', async () => {
+        const context = createMockContext();
+        const handlers = captureCommandHandlers(context);
+        const handler = handlers.get('speckit.specs.reveal')!;
+
+        (vscode.workspace.fs.stat as jest.Mock).mockResolvedValueOnce({ type: 2 });
+
+        await handler({ label: 'my-spec', specPath: 'specs/my-spec' });
+
+        const calls = (mockCommands.executeCommand as jest.Mock).mock.calls;
+        const revealCall = calls.find(c => c[0] === 'revealFileInOS');
+        expect(revealCall).toBeDefined();
+        expect(revealCall![1].fsPath).toBe('/ws/specs/my-spec');
+    });
+
+    it('falls back to specs/<label> when specPath is undefined', async () => {
+        const context = createMockContext();
+        const handlers = captureCommandHandlers(context);
+        const handler = handlers.get('speckit.specs.reveal')!;
+
+        (vscode.workspace.fs.stat as jest.Mock).mockResolvedValueOnce({ type: 2 });
+
+        await handler({ label: 'foo' });
+
+        const revealCall = (mockCommands.executeCommand as jest.Mock).mock.calls
+            .find(c => c[0] === 'revealFileInOS');
+        expect(revealCall).toBeDefined();
+        expect(revealCall![1].fsPath).toBe('/ws/specs/foo');
+    });
+
+    it('shows error and does not call revealFileInOS when folder is missing', async () => {
+        const context = createMockContext();
+        const handlers = captureCommandHandlers(context);
+        const handler = handlers.get('speckit.specs.reveal')!;
+
+        (vscode.workspace.fs.stat as jest.Mock).mockRejectedValueOnce(new Error('ENOENT'));
+
+        await handler({ label: 'gone', specPath: 'specs/gone' });
+
+        expect(mockWindow.showErrorMessage).toHaveBeenCalledTimes(1);
+        expect((mockWindow.showErrorMessage as jest.Mock).mock.calls[0][0])
+            .toContain('/ws/specs/gone');
+        expect(mockCommands.executeCommand).not.toHaveBeenCalledWith(
+            'revealFileInOS',
+            expect.anything()
+        );
+    });
+
+    it('no-op when no workspace folder is open', async () => {
+        const context = createMockContext();
+        const handlers = captureCommandHandlers(context);
+        const handler = handlers.get('speckit.specs.reveal')!;
+
+        (vscode.workspace as any).workspaceFolders = undefined;
+        (vscode.workspace.fs.stat as jest.Mock).mockClear();
+
+        await handler({ label: 'anything', specPath: 'specs/anything' });
+
+        expect(vscode.workspace.fs.stat).not.toHaveBeenCalled();
+        expect(mockCommands.executeCommand).not.toHaveBeenCalledWith(
+            'revealFileInOS',
+            expect.anything()
+        );
+    });
+});
+
 describe('speckit.create command handler', () => {
     it('always opens the spec editor without any initialization check', async () => {
         const context = createMockContext();

--- a/src/features/specs/specCommands.ts
+++ b/src/features/specs/specCommands.ts
@@ -121,6 +121,29 @@ export function registerSpecKitCommands(
         })
     );
 
+    // Reveal a spec's folder in the OS file browser (Finder / Explorer / default FM).
+    // Pre-stats the path so missing folders surface a visible error instead of the
+    // silent no-op `revealFileInOS` produces on some Linux desktops.
+    context.subscriptions.push(
+        vscode.commands.registerCommand('speckit.specs.reveal', async (item: SpecTreeItem) => {
+            const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
+            if (!workspaceFolder) return;
+            const relativePath = (item as SpecTreeItem).specPath || `specs/${item.label}`;
+            const uri = vscode.Uri.file(path.join(workspaceFolder.uri.fsPath, relativePath));
+            try {
+                await vscode.workspace.fs.stat(uri);
+            } catch {
+                vscode.window.showErrorMessage(`Cannot reveal: ${uri.fsPath} does not exist`);
+                return;
+            }
+            try {
+                await vscode.commands.executeCommand('revealFileInOS', uri);
+            } catch (err: any) {
+                vscode.window.showErrorMessage(err?.message ?? String(err));
+            }
+        })
+    );
+
     // Open source file from sidebar inline action
     context.subscriptions.push(
         vscode.commands.registerCommand('speckit.openSpecSource', async (item: vscode.TreeItem & { fileUri?: vscode.Uri }) => {


### PR DESCRIPTION
## Summary

- New right-click action **Reveal in File Explorer** on spec tree items — opens the spec's folder in Finder (macOS) / File Explorer (Windows) / the default file manager (Linux) via VS Code's built-in `revealFileInOS`.
- Pre-stats the resolved path so a deleted or renamed folder surfaces a clear `Cannot reveal: <path> does not exist` error within ~1s instead of the silent no-op `revealFileInOS` produces on some Linux desktops.
- Menu gated to `view == speckit.views.explorer && viewItem == spec`, so the action never appears on sub-documents, steering docs, or group headers.

Spec: [`specs/069-reveal-spec-folder/`](specs/069-reveal-spec-folder/) (spec / plan / tasks / research / data-model / quickstart).

## Test plan

- [x] `npm run compile` passes
- [x] `npm test` — full suite green (282/282); adds 5 new cases in `specCommands.test.ts` (register / happy path / label fallback / missing-folder error / no-workspace no-op)
- [ ] Manually: right-click a spec → **Reveal in File Explorer** → Finder/Explorer/FM opens on the folder (quickstart happy path)
- [ ] Manually: right-click a sub-document row, steering doc, and lifecycle group header → action is absent
- [ ] Manually: rename a spec folder externally, right-click the stale node → error toast shows the missing path, no silent failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)