### PR TITLE
chore: expand SDD config with branch auto-creation

### DIFF
--- a/.sdd.json
+++ b/.sdd.json
@@ -1,5 +1,12 @@
 {
+  "branchStage": "implement",
+  "branchNameFormat": "{type}/{slug}",
+  "buildCommand": "npm run compile",
+  "testCommand": "npm test",
   "hooks": {
-    "pre:code-review": ["/install-local"]
+    "pre:code-review": ["/install-local"],
+    "pre:commit": [
+      { "shell": "npm run compile", "blocking": true }
+    ]
   }
 }


### PR DESCRIPTION
## Summary
- Expands `.sdd.json` for SDD plugin v1.10.0: auto-creates the feature branch at the start of `/sdd:implement` using `feat/{slug}` / `fix/{slug}` naming.
- Adds `buildCommand` / `testCommand` and a blocking `pre:commit` hook (`npm run compile` — typecheck).
- Preserves the existing `pre:code-review` → `/install-local` hook.

## Test plan
- [ ] Install SDD v1.10.0+ and run `/sdd:auto "fix something"` — verify a `fix/...` branch is created at implement.
- [ ] Run `/sdd:implement` with a TypeScript error — verify `pre:commit` halts before commit.
- [ ] Confirm the `/install-local` subagent still runs at `pre:code-review`.