### PR TITLE
feat(specs): show count on tree group headers

### DIFF
--- a/.sdd.json
+++ b/.sdd.json
@@ -1,5 +1,12 @@
 {
+  "branchStage": "implement",
+  "branchNameFormat": "{type}/{slug}",
+  "buildCommand": "npm run compile",
+  "testCommand": "npm test",
   "hooks": {
-    "pre:code-review": ["/install-local"]
+    "pre:code-review": ["/install-local"],
+    "pre:commit": [
+      { "shell": "npm run compile", "blocking": true }
+    ]
   }
 }

--- a/.sdd.json
+++ b/.sdd.json
@@ -4,8 +4,11 @@
   "buildCommand": "npm run compile",
   "testCommand": "npm test",
   "hooks": {
-    "pre:code-review": ["/install-local"],
+    "pre:code-review": [
+      { "skill": "/install-local" }
+    ],
     "pre:commit": [
+      { "shell": "git reset HEAD -- package.json package-lock.json 2>/dev/null || true", "blocking": false },
       { "shell": "npm run compile", "blocking": true }
     ]
   }

--- a/specs/071-tree-group-counts/.spec-context.json
+++ b/specs/071-tree-group-counts/.spec-context.json
@@ -1,0 +1,64 @@
+{
+  "workflow": "sdd",
+  "currentStep": "implement",
+  "currentTask": null,
+  "progress": "commit-review",
+  "next": "implement",
+  "updated": "2026-04-21",
+  "selectedAt": "2026-04-21T23:03:55Z",
+  "specName": "Tree Group Counts",
+  "branch": "chore/expand-sdd-config",
+  "workingBranch": null,
+  "type": "feat",
+  "createdAt": "2026-04-21T23:03:55Z",
+  "approach": "Append ` (N)` to the label passed to each SpecItem group header in specExplorerProvider.ts using the array lengths already computed. In the SpecItem constructor, strip the count suffix before looking up the group icon and tooltip so the existing maps keep working.",
+  "last_action": "CP3 approved — splitting into chore(sdd) + feat(specs) commits",
+  "files_modified": [
+    "src/features/specs/specExplorerProvider.ts",
+    "src/features/specs/__tests__/specExplorerProvider.test.ts"
+  ],
+  "task_summaries": {
+    "T001": {
+      "status": "DONE",
+      "did": "Changed the three `new SpecItem('Active'|'Completed'|'Archived', ...)` calls in getChildren to include ` (N)` suffixes using the already-computed array lengths.",
+      "files": ["src/features/specs/specExplorerProvider.ts"],
+      "concerns": []
+    },
+    "T002": {
+      "status": "DONE",
+      "did": "Added `const baseLabel = label.split(' (')[0];` in the SpecItem `spec-group` branch and keyed groupIcons/groupTooltips off baseLabel so icon + tooltip lookups still match after the label suffix was added.",
+      "files": ["src/features/specs/specExplorerProvider.ts"],
+      "concerns": []
+    },
+    "T003": {
+      "status": "DONE",
+      "did": "Updated 8 group-label assertions across getChildren, sorting, and spec-group tests to expect `Active (N)` / `Completed (N)` / `Archived (N)` formats matching each fixture's spec count. All 289 tests pass.",
+      "files": ["src/features/specs/__tests__/specExplorerProvider.test.ts"],
+      "concerns": []
+    }
+  },
+  "decisions": [
+    { "at": "2026-04-21T23:03:55Z", "note": "Fixed .sdd.json pre:code-review hook to use `{ skill: \"/install-local\" }` payload instead of plain string (plain strings go to Agent, not Skill). Added pre:commit shell to unstage package.json/package-lock.json as belt-and-suspenders against install-local version bumps leaking into commits." }
+  ],
+  "step_summaries": {
+    "specify": {
+      "complexity": "minimal",
+      "requirements": 5,
+      "scenarios": 3,
+      "key_finding": "Group label is also used as the lookup key for icon and tooltip in the SpecItem constructor — appending ' (N)' requires stripping the suffix before lookup."
+    }
+  },
+  "transitions": [
+    { "step": "specify", "substep": "parsing", "from": null, "by": "sdd", "at": "2026-04-21T23:03:55Z" },
+    { "step": "specify", "substep": "exploring", "from": { "step": "specify", "substep": "parsing" }, "by": "sdd", "at": "2026-04-21T23:03:55Z" },
+    { "step": "specify", "substep": "detecting", "from": { "step": "specify", "substep": "exploring" }, "by": "sdd", "at": "2026-04-21T23:03:55Z" },
+    { "step": "specify", "substep": "writing-spec", "from": { "step": "specify", "substep": "detecting" }, "by": "sdd", "at": "2026-04-21T23:03:55Z" },
+    { "step": "tasks", "substep": null, "from": { "step": "specify", "substep": "writing-spec" }, "by": "sdd", "at": "2026-04-21T23:03:55Z" },
+    { "step": "implement", "substep": "phase1", "from": { "step": "tasks", "substep": null }, "by": "sdd", "at": "2026-04-21T23:03:55Z" },
+    { "step": "implement", "substep": "phase1", "from": { "step": "implement", "substep": "phase1" }, "by": "sdd", "at": "2026-04-21T23:03:55Z" },
+    { "step": "implement", "substep": "hooks", "from": { "step": "implement", "substep": "phase1" }, "by": "sdd", "at": "2026-04-21T23:03:55Z" },
+    { "step": "implement", "substep": "code-review", "from": { "step": "implement", "substep": "hooks" }, "by": "sdd", "at": "2026-04-21T23:03:55Z" },
+    { "step": "implement", "substep": "test-results", "from": { "step": "implement", "substep": "code-review" }, "by": "sdd", "at": "2026-04-21T23:03:55Z" },
+    { "step": "implement", "substep": "commit-review", "from": { "step": "implement", "substep": "test-results" }, "by": "sdd", "at": "2026-04-21T23:03:55Z" }
+  ]
+}

--- a/specs/071-tree-group-counts/.spec-context.json
+++ b/specs/071-tree-group-counts/.spec-context.json
@@ -2,8 +2,8 @@
   "workflow": "sdd",
   "currentStep": "implement",
   "currentTask": null,
-  "progress": "commit-review",
-  "next": "implement",
+  "progress": null,
+  "next": "done",
   "updated": "2026-04-21",
   "selectedAt": "2026-04-21T23:03:55Z",
   "specName": "Tree Group Counts",
@@ -12,11 +12,13 @@
   "type": "feat",
   "createdAt": "2026-04-21T23:03:55Z",
   "approach": "Append ` (N)` to the label passed to each SpecItem group header in specExplorerProvider.ts using the array lengths already computed. In the SpecItem constructor, strip the count suffix before looking up the group icon and tooltip so the existing maps keep working.",
-  "last_action": "CP3 approved — splitting into chore(sdd) + feat(specs) commits",
+  "last_action": "Pushed chore/expand-sdd-config and opened PR #101",
+  "checkpointStatus": { "commit": true, "pr": true },
   "files_modified": [
     "src/features/specs/specExplorerProvider.ts",
     "src/features/specs/__tests__/specExplorerProvider.test.ts"
   ],
+  "prUrl": "https://github.com/alfredoperez/speckit-companion/pull/101",
   "task_summaries": {
     "T001": {
       "status": "DONE",
@@ -38,7 +40,8 @@
     }
   },
   "decisions": [
-    { "at": "2026-04-21T23:03:55Z", "note": "Fixed .sdd.json pre:code-review hook to use `{ skill: \"/install-local\" }` payload instead of plain string (plain strings go to Agent, not Skill). Added pre:commit shell to unstage package.json/package-lock.json as belt-and-suspenders against install-local version bumps leaking into commits." }
+    { "at": "2026-04-21T23:03:55Z", "note": "Fixed .sdd.json pre:code-review hook to use `{ skill: \"/install-local\" }` payload instead of plain string (plain strings go to Agent, not Skill). Added pre:commit shell to unstage package.json/package-lock.json as belt-and-suspenders against install-local version bumps leaking into commits." },
+    { "at": "2026-04-21T23:03:55Z", "note": "Shipped as two commits on existing chore/expand-sdd-config branch: chore(sdd) for .sdd.json fix + feat(specs) for the tree group counts feature. Branch was not main, SDD did not auto-switch." }
   ],
   "step_summaries": {
     "specify": {
@@ -59,6 +62,7 @@
     { "step": "implement", "substep": "hooks", "from": { "step": "implement", "substep": "phase1" }, "by": "sdd", "at": "2026-04-21T23:03:55Z" },
     { "step": "implement", "substep": "code-review", "from": { "step": "implement", "substep": "hooks" }, "by": "sdd", "at": "2026-04-21T23:03:55Z" },
     { "step": "implement", "substep": "test-results", "from": { "step": "implement", "substep": "code-review" }, "by": "sdd", "at": "2026-04-21T23:03:55Z" },
-    { "step": "implement", "substep": "commit-review", "from": { "step": "implement", "substep": "test-results" }, "by": "sdd", "at": "2026-04-21T23:03:55Z" }
+    { "step": "implement", "substep": "commit-review", "from": { "step": "implement", "substep": "test-results" }, "by": "sdd", "at": "2026-04-21T23:03:55Z" },
+    { "step": "implement", "substep": null, "from": { "step": "implement", "substep": "commit-review" }, "by": "sdd", "at": "2026-04-21T23:03:55Z" }
   ]
 }

--- a/specs/071-tree-group-counts/.spec-context.json
+++ b/specs/071-tree-group-counts/.spec-context.json
@@ -1,6 +1,7 @@
 {
   "workflow": "sdd",
-  "currentStep": "implement",
+  "currentStep": "done",
+  "status": "completed",
   "currentTask": null,
   "progress": null,
   "next": "done",
@@ -63,6 +64,7 @@
     { "step": "implement", "substep": "code-review", "from": { "step": "implement", "substep": "hooks" }, "by": "sdd", "at": "2026-04-21T23:03:55Z" },
     { "step": "implement", "substep": "test-results", "from": { "step": "implement", "substep": "code-review" }, "by": "sdd", "at": "2026-04-21T23:03:55Z" },
     { "step": "implement", "substep": "commit-review", "from": { "step": "implement", "substep": "test-results" }, "by": "sdd", "at": "2026-04-21T23:03:55Z" },
-    { "step": "implement", "substep": null, "from": { "step": "implement", "substep": "commit-review" }, "by": "sdd", "at": "2026-04-21T23:03:55Z" }
+    { "step": "implement", "substep": null, "from": { "step": "implement", "substep": "commit-review" }, "by": "sdd", "at": "2026-04-21T23:03:55Z" },
+    { "step": "done", "substep": null, "from": { "step": "implement", "substep": null }, "by": "sdd", "at": "2026-04-21T23:03:55Z" }
   ]
 }

--- a/specs/071-tree-group-counts/plan.md
+++ b/specs/071-tree-group-counts/plan.md
@@ -1,0 +1,18 @@
+# Plan: Tree Group Counts
+
+**Spec**: [spec.md](./spec.md) | **Date**: 2026-04-21
+
+## Approach
+
+Append ` (N)` to the label passed to each `SpecItem` group header in `specExplorerProvider.ts` using the array lengths already computed (`activeSpecs.length`, `completedSpecs.length`, `archivedSpecs.length`). In the `SpecItem` constructor, strip the count suffix before looking up the group icon and tooltip so the existing `groupIcons` / `groupTooltips` keyed-by-name maps keep working without change.
+
+## Files to Change
+
+### Modify
+
+- `src/features/specs/specExplorerProvider.ts`
+  - Change the three `new SpecItem('Active', …)`, `new SpecItem('Completed', …)`, `new SpecItem('Archived', …)` calls (~lines 144, 156, 168) to pass `` `Active (${activeSpecs.length})` ``, `` `Completed (${completedSpecs.length})` ``, and `` `Archived (${archivedSpecs.length})` `` respectively.
+  - In the `SpecItem` constructor's `spec-group` branch (~lines 574–586), derive a `baseLabel` by splitting on `' ('` and use it as the key for `groupIcons` and `groupTooltips` lookups.
+
+- `src/features/specs/__tests__/specExplorerProvider.test.ts`
+  - Update assertions that compare group labels exactly (e.g., `expect(children[0].label).toBe('Active')`) to match the new `Active (N)` / `Completed (N)` / `Archived (N)` format, using the appropriate count for each test's fixture data.

--- a/specs/071-tree-group-counts/spec.md
+++ b/specs/071-tree-group-counts/spec.md
@@ -1,0 +1,41 @@
+# Spec: Tree Group Counts
+
+**Slug**: 071-tree-group-counts | **Date**: 2026-04-21
+
+## Summary
+
+Show the spec count next to each group header in the Specs tree view — `Active (3)`, `Completed (12)`, `Archived (5)` — so users get an immediate sense of scale without expanding groups. Counts are derived from data the provider already computes, so this is a display-only change.
+
+> Note: The feature description referenced `Active (3) / In Progress (2) / Completed (12)`. The current codebase groups specs into **Active / Completed / Archived** (see `SpecStatuses` in `src/core/constants.ts` and `getChildren` in `src/features/specs/specExplorerProvider.ts`). This spec applies counts to those three actual groups and does not introduce a new "In Progress" group.
+
+## Requirements
+
+- **R001** (MUST): Each visible group header label in the Specs tree view includes the count of specs in that group in the format `{GroupName} ({N})` — e.g., `Active (3)`, `Completed (12)`, `Archived (5)`.
+- **R002** (MUST): Group headers continue to be shown only when the group is non-empty (current behavior preserved — no `Active (0)` rendered).
+- **R003** (MUST): Group icons (`pulse` for Active, `check` for Completed, `archive` for Archived) and tooltips (`Specs in progress`, `Completed specs`, …) continue to resolve correctly despite the new label suffix.
+- **R004** (MUST): Counts update reactively when specs are added, removed, or transition between groups — i.e., whenever the tree refreshes, counts reflect the current state.
+- **R005** (SHOULD): Count format uses a single space before the parenthesis (`Active (3)`, not `Active(3)` or `Active  (3)`).
+
+## Scenarios
+
+### Default workspace with mixed specs
+
+**When** the Specs tree is rendered with 3 active, 12 completed, and 5 archived specs
+**Then** the tree shows three group headers labeled exactly `Active (3)`, `Completed (12)`, `Archived (5)` (in that order), with the correct icons and tooltips unchanged
+
+### Empty group is hidden
+
+**When** no specs have status `archived`
+**Then** no "Archived" group header is rendered (no `Archived (0)`)
+
+### Count updates after refresh
+
+**When** a spec transitions from active to completed and the tree refreshes
+**Then** the Active header's count decreases by 1 and the Completed header's count increases by 1
+
+## Out of Scope
+
+- Introducing a separate "In Progress" group or changing the current 3-group model
+- Changing the sort order, icons, or colors of groups
+- Adding counts to nested items (spec documents, steps) — counts apply to top-level group headers only
+- Localization / i18n of the count format

--- a/specs/071-tree-group-counts/tasks.md
+++ b/specs/071-tree-group-counts/tasks.md
@@ -1,0 +1,25 @@
+# Tasks: Tree Group Counts
+
+**Plan**: [plan.md](./plan.md) | **Date**: 2026-04-21
+
+---
+
+## Phase 1: Core Implementation (Sequential)
+
+- [x] **T001** Append counts to group labels — `src/features/specs/specExplorerProvider.ts` | R001, R002, R004, R005
+  - **Do**: In `getChildren` (root branch), change the three `new SpecItem('Active' | 'Completed' | 'Archived', …)` calls to pass `` `Active (${activeSpecs.length})` ``, `` `Completed (${completedSpecs.length})` ``, and `` `Archived (${archivedSpecs.length})` `` respectively. Keep the existing `if (xxx.length > 0)` guards so empty groups stay hidden.
+  - **Verify**: `npm run compile` passes. Launch Extension Dev Host (F5), open a workspace with mixed specs, confirm headers read `Active (N)`, `Completed (N)`, `Archived (N)` with correct numbers.
+
+- [x] **T002** Make icon/tooltip lookup count-agnostic *(depends on T001)* — `src/features/specs/specExplorerProvider.ts` | R003
+  - **Do**: In the `SpecItem` constructor's `contextValue === 'spec-group'` branch, compute `const baseLabel = label.split(' (')[0];` and use `baseLabel` instead of `label` when indexing `groupIcons` and `groupTooltips`. Keep the final fallback behavior (`|| 'pulse'`, `|| label`) intact so the default path still renders something sensible.
+  - **Verify**: `npm run compile` passes. In the Dev Host, confirm group icons (pulse / check / archive) and tooltips (`Specs in progress`, `Completed specs`, …) render correctly on hover.
+
+- [x] **T003** Update existing group-label assertions *(depends on T001)* — `src/features/specs/__tests__/specExplorerProvider.test.ts` | R001
+  - **Do**: Update every test assertion that compares a group label exactly (e.g., `expect(children[0].label).toBe('Active')`, `'Completed'`, `'Archived'`) to include the count for that test's fixture — e.g., a test with one active spec expects `'Active (1)'`. Cover all occurrences in `describe('getChildren')` and `describe('sorting')` / `describe('spec-group icons')` blocks.
+  - **Verify**: `npm test` passes with no failures.
+
+---
+
+## Progress
+
+- Phase 1: T001–T003 [x]

--- a/src/features/specs/__tests__/specExplorerProvider.test.ts
+++ b/src/features/specs/__tests__/specExplorerProvider.test.ts
@@ -130,7 +130,7 @@ describe('SpecExplorerProvider', () => {
             const children = await provider.getChildren();
 
             expect(children).toHaveLength(1);
-            expect(children[0].label).toBe('Active');
+            expect(children[0].label).toBe('Active (1)');
             expect(children[0].collapsibleState).toBe(vscode.TreeItemCollapsibleState.Expanded);
         });
 
@@ -143,7 +143,7 @@ describe('SpecExplorerProvider', () => {
             const children = await provider.getChildren();
 
             expect(children).toHaveLength(1);
-            expect(children[0].label).toBe('Active');
+            expect(children[0].label).toBe('Active (1)');
             expect(children[0].collapsibleState).toBe(vscode.TreeItemCollapsibleState.Expanded);
         });
 
@@ -156,7 +156,7 @@ describe('SpecExplorerProvider', () => {
             const children = await provider.getChildren();
 
             expect(children).toHaveLength(1);
-            expect(children[0].label).toBe('Completed');
+            expect(children[0].label).toBe('Completed (1)');
             expect(children[0].collapsibleState).toBe(vscode.TreeItemCollapsibleState.Collapsed);
         });
 
@@ -169,7 +169,7 @@ describe('SpecExplorerProvider', () => {
             const children = await provider.getChildren();
 
             expect(children).toHaveLength(1);
-            expect(children[0].label).toBe('Archived');
+            expect(children[0].label).toBe('Archived (1)');
             expect(children[0].collapsibleState).toBe(vscode.TreeItemCollapsibleState.Collapsed);
         });
 
@@ -196,9 +196,9 @@ describe('SpecExplorerProvider', () => {
             const children = await provider.getChildren();
 
             expect(children).toHaveLength(3);
-            expect(children[0].label).toBe('Active');
-            expect(children[1].label).toBe('Completed');
-            expect(children[2].label).toBe('Archived');
+            expect(children[0].label).toBe('Active (1)');
+            expect(children[1].label).toBe('Completed (1)');
+            expect(children[2].label).toBe('Archived (1)');
         });
 
         it('should omit empty groups', async () => {
@@ -210,7 +210,7 @@ describe('SpecExplorerProvider', () => {
             const children = await provider.getChildren();
 
             expect(children).toHaveLength(1);
-            expect(children[0].label).toBe('Completed');
+            expect(children[0].label).toBe('Completed (1)');
             // No Active or Archived groups
         });
     });
@@ -618,7 +618,7 @@ describe('SpecExplorerProvider', () => {
 
             const groups = await provider.getChildren();
             expect(groups).toHaveLength(1);
-            expect(groups[0].label).toBe('Active');
+            expect(groups[0].label).toBe('Active (3)');
 
             const specs = await provider.getChildren(groups[0]);
             expect(specs).toHaveLength(3);
@@ -667,7 +667,7 @@ describe('SpecExplorerProvider', () => {
             });
 
             const groups = await provider.getChildren();
-            expect(groups[0].label).toBe('Completed');
+            expect(groups[0].label).toBe('Completed (2)');
 
             const specs = await provider.getChildren(groups[0]);
             // Completed specs sorted by creation date (newest first)

--- a/src/features/specs/specExplorerProvider.ts
+++ b/src/features/specs/specExplorerProvider.ts
@@ -142,7 +142,7 @@ export class SpecExplorerProvider extends BaseTreeDataProvider<SpecItem> {
             // button only affects spec items, never groups.
             if (activeSpecs.length > 0) {
                 const activeGroup = new SpecItem(
-                    'Active',
+                    `Active (${activeSpecs.length})`,
                     vscode.TreeItemCollapsibleState.Expanded,
                     'spec-group',
                     this.context
@@ -154,7 +154,7 @@ export class SpecExplorerProvider extends BaseTreeDataProvider<SpecItem> {
 
             if (completedSpecs.length > 0) {
                 const completedGroup = new SpecItem(
-                    'Completed',
+                    `Completed (${completedSpecs.length})`,
                     vscode.TreeItemCollapsibleState.Collapsed,
                     'spec-group',
                     this.context
@@ -166,7 +166,7 @@ export class SpecExplorerProvider extends BaseTreeDataProvider<SpecItem> {
 
             if (archivedSpecs.length > 0) {
                 const archivedGroup = new SpecItem(
-                    'Archived',
+                    `Archived (${archivedSpecs.length})`,
                     vscode.TreeItemCollapsibleState.Collapsed,
                     'spec-group',
                     this.context
@@ -582,8 +582,9 @@ class SpecItem extends vscode.TreeItem {
                 'Completed': 'Completed specs',
                 'Archived': 'Archived specs',
             };
-            this.iconPath = new vscode.ThemeIcon(groupIcons[label] || 'pulse');
-            this.tooltip = groupTooltips[label] || label;
+            const baseLabel = label.split(' (')[0];
+            this.iconPath = new vscode.ThemeIcon(groupIcons[baseLabel] || 'pulse');
+            this.tooltip = groupTooltips[baseLabel] || label;
         } else if (contextValue === 'spec') {
             if (isActive) {
                 this.iconPath = new vscode.ThemeIcon('sync~spin');


### PR DESCRIPTION
## What

- Group headers in the Specs tree now show counts: `Active (3)`, `Completed (12)`, `Archived (5)` — immediate sense of scale without expanding the group.
- Counts come from the arrays the provider already computes each refresh — no extra work, naturally reactive.
- Icon + tooltip lookups in `SpecItem` strip the ` (N)` suffix so existing lookup maps keep resolving.
- Bundled chore: `.sdd.json` `pre:code-review` hook now uses the `{ skill: "/install-local" }` payload so the skill actually invokes (plain strings went to Agent as prompts), and a new `pre:commit` shell unstages `package.json`/`package-lock.json` so install-local version bumps can't leak into commits.

## Why

Users get an immediate sense of scale of each group without expanding it.

## Testing

- `npm test` — 289 unit tests pass (8 group-label assertions updated)
- `npm run compile` — passes
- Installed locally (`speckit-companion 0.12.2`) and verified the Specs tree renders the new labels

Spec: `specs/071-tree-group-counts/`