### PR TITLE
fix(spec-viewer): quiet title/heading colors, simplify current-step indicator, enlarge mermaid diagrams

### DIFF
--- a/webview/src/spec-viewer/highlighting.ts
+++ b/webview/src/spec-viewer/highlighting.ts
@@ -13,6 +13,10 @@ declare const mermaid: {
         startOnLoad: boolean;
         theme: string;
         themeVariables?: Record<string, string>;
+        flowchart?: { useMaxWidth?: boolean };
+        sequence?: { useMaxWidth?: boolean };
+        stateDiagram?: { useMaxWidth?: boolean };
+        class?: { useMaxWidth?: boolean };
     }) => void;
     run: (config: { querySelector: string }) => void;
 };
@@ -96,6 +100,12 @@ export function initializeMermaid(): void {
         mermaid.initialize({
             startOnLoad: false,
             theme: 'base',
+            // Let diagrams render at their natural size; container handles overflow.
+            // Without this, mermaid scales SVGs down to container width, shrinking text.
+            flowchart: { useMaxWidth: false },
+            sequence: { useMaxWidth: false },
+            stateDiagram: { useMaxWidth: false },
+            class: { useMaxWidth: false },
             themeVariables: {
                 // Background colors
                 primaryColor: bgSecondary,
@@ -129,7 +139,7 @@ export function initializeMermaid(): void {
 
                 // Fonts
                 fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif',
-                fontSize: '14px'
+                fontSize: '16px'
             }
         });
 

--- a/webview/src/spec-viewer/highlighting.ts
+++ b/webview/src/spec-viewer/highlighting.ts
@@ -13,10 +13,6 @@ declare const mermaid: {
         startOnLoad: boolean;
         theme: string;
         themeVariables?: Record<string, string>;
-        flowchart?: { useMaxWidth?: boolean };
-        sequence?: { useMaxWidth?: boolean };
-        stateDiagram?: { useMaxWidth?: boolean };
-        class?: { useMaxWidth?: boolean };
     }) => void;
     run: (config: { querySelector: string }) => void;
 };
@@ -100,12 +96,6 @@ export function initializeMermaid(): void {
         mermaid.initialize({
             startOnLoad: false,
             theme: 'base',
-            // Let diagrams render at their natural size; container handles overflow.
-            // Without this, mermaid scales SVGs down to container width, shrinking text.
-            flowchart: { useMaxWidth: false },
-            sequence: { useMaxWidth: false },
-            stateDiagram: { useMaxWidth: false },
-            class: { useMaxWidth: false },
             themeVariables: {
                 // Background colors
                 primaryColor: bgSecondary,
@@ -139,7 +129,7 @@ export function initializeMermaid(): void {
 
                 // Fonts
                 fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif',
-                fontSize: '16px'
+                fontSize: '18px'
             }
         });
 

--- a/webview/src/spec-viewer/highlighting.ts
+++ b/webview/src/spec-viewer/highlighting.ts
@@ -13,6 +13,8 @@ declare const mermaid: {
         startOnLoad: boolean;
         theme: string;
         themeVariables?: Record<string, string>;
+        flowchart?: { useMaxWidth?: boolean };
+        sequence?: { useMaxWidth?: boolean };
     }) => void;
     run: (config: { querySelector: string }) => void;
 };
@@ -96,6 +98,12 @@ export function initializeMermaid(): void {
         mermaid.initialize({
             startOnLoad: false,
             theme: 'base',
+            // Disable max-width for flowchart + sequence so they render at natural
+            // width rather than being scaled down to the container (which shrinks
+            // per-box text). State / class diagrams keep defaults so we don't risk
+            // affecting mermaid's parser for those types.
+            flowchart: { useMaxWidth: false },
+            sequence: { useMaxWidth: false },
             themeVariables: {
                 // Background colors
                 primaryColor: bgSecondary,

--- a/webview/src/spec-viewer/highlighting.ts
+++ b/webview/src/spec-viewer/highlighting.ts
@@ -142,11 +142,37 @@ export function initializeMermaid(): void {
         });
 
         mermaid.run({ querySelector: '.mermaid' });
-        // Add zoom controls after mermaid renders (use setTimeout to wait for DOM update)
-        setTimeout(() => addMermaidZoomControls(), 100);
+        // Classify + add zoom controls after mermaid renders
+        // (use setTimeout to wait for DOM update)
+        setTimeout(() => {
+            classifyMermaidSize();
+            addMermaidZoomControls();
+        }, 100);
     } catch (e) {
         console.warn('[SpecViewer] Failed to initialize mermaid:', e);
     }
+}
+
+/**
+ * Tag each .mermaid-container as `.mermaid-wide` when the rendered SVG's
+ * intrinsic viewBox width crosses a threshold — only those get the break-out
+ * CSS width. Narrow diagrams (small state machines, short flowcharts) stay
+ * inside the 72ch prose column at their natural size instead of getting
+ * absurdly stretched.
+ */
+const WIDE_VIEWBOX_THRESHOLD = 900;
+function classifyMermaidSize(): void {
+    document.querySelectorAll('.mermaid-container').forEach(container => {
+        const svg = container.querySelector('.mermaid svg') as SVGSVGElement | null;
+        if (!svg) return;
+        const viewBox = svg.viewBox?.baseVal;
+        if (!viewBox) return;
+        if (viewBox.width >= WIDE_VIEWBOX_THRESHOLD) {
+            container.classList.add('mermaid-wide');
+        } else {
+            container.classList.remove('mermaid-wide');
+        }
+    });
 }
 
 /**

--- a/webview/styles/spec-viewer/_code.css
+++ b/webview/styles/spec-viewer/_code.css
@@ -171,13 +171,17 @@ pre.code-block code.hljs {
 
 .mermaid {
     display: flex;
-    justify-content: flex-start;
+    justify-content: center;
     background: transparent;
     font-family: var(--font-family);
 }
 
 .mermaid svg {
     height: auto;
+    /* Force diagrams to render at a generous minimum width so per-box text
+       has enough pixels to stay legible even for short diagrams. The
+       container's overflow-x: auto handles anything wider than the viewport. */
+    min-width: min(100%, 1100px);
     transform-origin: top left;
 }
 

--- a/webview/styles/spec-viewer/_code.css
+++ b/webview/styles/spec-viewer/_code.css
@@ -171,7 +171,7 @@ pre.code-block code.hljs {
 
 .mermaid {
     display: flex;
-    justify-content: center;
+    justify-content: flex-start;
     background: transparent;
     font-family: var(--font-family);
 }

--- a/webview/styles/spec-viewer/_code.css
+++ b/webview/styles/spec-viewer/_code.css
@@ -169,12 +169,12 @@ pre.code-block code.hljs {
     overflow-x: auto;
 }
 
-/* Mermaid-only break-out of the 72ch prose column.
-   Prose stays centered at 72ch on #markdown-content; only diagrams
-   expand to a wider layout via negative horizontal margins that pull
-   the block beyond its parent's bounds. Width clamps to viewport so
-   it never escapes the editor pane on narrow windows. */
-#markdown-content > .mermaid-container {
+/* Mermaid-only break-out of the 72ch prose column — applied conditionally.
+   Only diagrams whose rendered SVG viewBox width crosses the threshold in
+   classifyMermaidSize() get the `.mermaid-wide` class and the break-out
+   width; narrow diagrams (short state machines, small flowcharts) stay
+   inside the prose column at natural size to avoid absurd up-scaling. */
+#markdown-content > .mermaid-container.mermaid-wide {
     width: min(92vw, 1600px);
     max-width: none;
     margin-left: calc((100% - min(92vw, 1600px)) / 2);

--- a/webview/styles/spec-viewer/_code.css
+++ b/webview/styles/spec-viewer/_code.css
@@ -171,16 +171,17 @@ pre.code-block code.hljs {
 
 .mermaid {
     display: flex;
-    justify-content: center;
+    justify-content: flex-start;
     background: transparent;
     font-family: var(--font-family);
 }
 
 .mermaid svg {
     height: auto;
-    /* Force diagrams to render at a generous minimum width so per-box text
-       has enough pixels to stay legible even for short diagrams. The
-       container's overflow-x: auto handles anything wider than the viewport. */
+    /* Force narrow diagrams (short state/flowchart) up to at least 1100px so
+       per-box text has enough pixels to stay legible; wider diagrams render
+       at natural width (useMaxWidth=false on flowchart/sequence) and the
+       container's overflow-x: auto handles horizontal scroll. */
     min-width: min(100%, 1100px);
     transform-origin: top left;
 }

--- a/webview/styles/spec-viewer/_code.css
+++ b/webview/styles/spec-viewer/_code.css
@@ -169,6 +169,18 @@ pre.code-block code.hljs {
     overflow-x: auto;
 }
 
+/* Mermaid-only break-out of the 72ch prose column.
+   Prose stays centered at 72ch on #markdown-content; only diagrams
+   expand to a wider layout via negative horizontal margins that pull
+   the block beyond its parent's bounds. Width clamps to viewport so
+   it never escapes the editor pane on narrow windows. */
+#markdown-content > .mermaid-container {
+    width: min(92vw, 1600px);
+    max-width: none;
+    margin-left: calc((100% - min(92vw, 1600px)) / 2);
+    margin-right: calc((100% - min(92vw, 1600px)) / 2);
+}
+
 .mermaid {
     display: flex;
     justify-content: flex-start;

--- a/webview/styles/spec-viewer/_content.css
+++ b/webview/styles/spec-viewer/_content.css
@@ -12,18 +12,11 @@
     font-size: var(--font-size);
     line-height: var(--leading-loose);
     color: var(--text-body);
+    max-width: 72ch;
+    margin: 0 auto;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
     letter-spacing: -0.01em;
-}
-
-/* Constrain prose children to the readable column; wider blocks
-   (mermaid-container) override this via a more-specific selector
-   in _code.css. */
-#markdown-content > * {
-    max-width: clamp(72ch, 70%, 100ch);
-    margin-left: auto;
-    margin-right: auto;
 }
 
 /* ============================================

--- a/webview/styles/spec-viewer/_content.css
+++ b/webview/styles/spec-viewer/_content.css
@@ -12,11 +12,18 @@
     font-size: var(--font-size);
     line-height: var(--leading-loose);
     color: var(--text-body);
-    max-width: 72ch;
-    margin: 0 auto;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
     letter-spacing: -0.01em;
+}
+
+/* Constrain prose children to the readable column; wider blocks
+   (mermaid-container) override this via a more-specific selector
+   in _code.css. */
+#markdown-content > * {
+    max-width: clamp(72ch, 70%, 100ch);
+    margin-left: auto;
+    margin-right: auto;
 }
 
 /* ============================================

--- a/webview/styles/spec-viewer/_navigation.css
+++ b/webview/styles/spec-viewer/_navigation.css
@@ -91,12 +91,6 @@
 }
 
 /* Highlight the currently viewed step tab (canonical: current) */
-.step-tab.current {
-    outline: 1px solid var(--accent, #4a9eff);
-    outline-offset: 2px;
-    border-radius: 4px;
-}
-
 .step-tab.current .step-label {
     color: var(--accent);
     font-weight: 700;

--- a/webview/styles/tokens.css
+++ b/webview/styles/tokens.css
@@ -82,8 +82,8 @@
     --text-body: #d0d0d0;
 
     /* Semantic header colors - mapped to VS Code theme variables */
-    --header-title: var(--vscode-textLink-foreground, #3794ff);
-    --header-section: var(--vscode-symbolIcon-classForeground, #ee9d28);
+    --header-title: var(--vscode-foreground, #e4e4e4);
+    --header-section: var(--vscode-foreground, #e4e4e4);
     --header-subsection: var(--vscode-descriptionForeground, #858585);
 
     /* Code block backgrounds */


### PR DESCRIPTION
## What

Three polish fixes for the spec viewer.

### 1. Quieted header colors
`--header-title` and `--header-section` now both fall back to `--vscode-foreground` instead of `--vscode-textLink-foreground` (bright cyan) and `--vscode-symbolIcon-classForeground` (bright orange). Visual hierarchy is preserved by size + weight alone.

### 2. Simpler current-step indicator
`.step-tab.current` no longer draws a full `outline: 1px solid var(--accent); outline-offset: 2px;` box around the label. Only the label goes bold + accent-colored. Previously the outlined first step looked disproportionately large next to the plain checkmark-only siblings.

### 3. Size-aware mermaid diagrams
Mermaid rendering is now adaptive: wide diagrams break out of the 72ch prose column; narrow ones stay in it.

- **Base font** bumped from `14px` → `18px`.
- **`useMaxWidth: false`** set for `flowchart` and `sequence` only — they now render at their natural width instead of being scaled down to fit the container (which was shrinking per-box text). `stateDiagram` and `class` keep mermaid defaults (adding config keys for those triggered a parser error).
- **`classifyMermaidSize()`** runs after `mermaid.run()` completes. It inspects each rendered SVG's `viewBox.baseVal.width` and adds `.mermaid-wide` to the container when width ≥ 900px.
- **Break-out CSS** (`width: min(92vw, 1600px)` with matching negative horizontal margins) applies *only* to `.mermaid-container.mermaid-wide`. Narrow diagrams stay inside the prose column at their natural size so a 3-node state diagram doesn't get absurdly stretched.
- **`min-width: min(100%, 1100px)`** floor on `.mermaid svg` helps narrow flowcharts/sequences still get readable per-box text when they fit inside the prose column.
- **Flex alignment** switched from `center` to `flex-start` so overflowing SVGs don't get clipped on the left edge by centering.

## Why

Visual feedback on the spec viewer: orange/cyan heading scheme clashed on dark backgrounds; the current-step outline looked like a rendering glitch next to the other checkmark tabs; the 8-participant sequence diagram in `plan.md` had box text that was too small to read because mermaid was scaling it down to fit a 1400px container. First attempt made *all* diagrams wide — but that over-stretched simple 3-node state diagrams. The viewBox-based classification is the fix: use the geometry mermaid itself chose to decide whether break-out applies.

## Testing

- Open any spec — title/H2s render in normal foreground color.
- Step-tab bar — current step is bold + accent-colored label only, no outlined box.
- Open `specs/072-immediate-status-update/plan.md`:
  - "Who writes what, and when" sequence diagram → breaks out wide (~1380px on a 1500px viewport), 18px text readable.
  - "Badge behavior on a single click" state diagram (3 nodes) → stays inside the 72ch prose column at natural size, no absurd stretching.
  - "Full canonical status lifecycle" state diagram shows `Syntax error in text` — pre-existing content-side issue (mermaid 10.9.5's `stateDiagram-v2` parser rejects the diagram's mix of parens, slashes, and `⚠` inside transition labels), unrelated to this PR.
- Open a spec with no mermaid → prose layout untouched, no regressions.