### PR TITLE
feat(spec-viewer): split header rows, hide file pill, restore current-step outline

### DIFF
--- a/specs/073-viewer-header-layout/.spec-context.json
+++ b/specs/073-viewer-header-layout/.spec-context.json
@@ -1,0 +1,61 @@
+{
+  "workflow": "sdd",
+  "currentStep": "done",
+  "currentTask": null,
+  "progress": null,
+  "next": "done",
+  "updated": "2026-04-22",
+  "selectedAt": "2026-04-22T18:32:27Z",
+  "specName": "Viewer Header Layout",
+  "branch": "main",
+  "workingBranch": "feat/viewer-header-layout",
+  "status": "completed",
+  "checkpointStatus": { "commit": true, "pr": true },
+  "type": "feat",
+  "createdAt": "2026-04-22T18:32:27Z",
+  "approach": "Two-row header: wrap badges + title in sibling divs; switch .spec-header to flex column. Suppress file-name pill by dropping Plan/Spec capture in preprocessors.ts. Also restore step-tab current outline and keep the done ✓ when a completed step is being viewed (bundled fix for pre-existing regression from PR #118).",
+  "step_summaries": {
+    "specify": {
+      "complexity": "minimal",
+      "requirements": 8,
+      "scenarios": 5,
+      "key_finding": "spec-viewer header is a single flex-wrap row in _content.css:197 and SpecHeader.tsx, and the `spec.md` pill comes from preprocessSpecMetadata capturing **Plan**/**Spec** links in preprocessors.ts. StepTab.tsx had current override done precedence and PR #118 removed the .current outline."
+    }
+  },
+  "task_summaries": {
+    "T001": { "status": "DONE", "did": "Wrapped spec-badge + spec-header-branch in .spec-header-badges and spec-header-title + spec-date in .spec-header-main; preserved outer .spec-header div, data-has-context, and empty-state return.", "files": ["webview/src/spec-viewer/components/SpecHeader.tsx"], "concerns": [] },
+    "T002": { "status": "DONE", "did": "Switched .spec-header to flex-direction column with gap var(--space-2); added .spec-header-badges and .spec-header-main rules.", "files": ["webview/styles/spec-viewer/_content.css"], "concerns": [] },
+    "T003": { "status": "DONE", "did": "Removed fileLinks/fileLinkHtml from preprocessSpecMetadata so the file-name pill no longer renders. 289 tests pass.", "files": ["webview/src/spec-viewer/markdown/preprocessors.ts"], "concerns": [] },
+    "T004": { "status": "DONE", "did": "User approved header layout at CP1.", "files": [], "concerns": [] },
+    "T005": { "status": "DONE", "did": "Reordered canonicalState precedence to locked > in-flight > done > current and added orthogonal current class when viewing. 289 tests pass.", "files": ["webview/src/spec-viewer/components/StepTab.tsx"], "concerns": [] },
+    "T006": { "status": "DONE", "did": "Restored .step-tab.current outline rule removed in PR #118.", "files": ["webview/styles/spec-viewer/_navigation.css"], "concerns": [] }
+  },
+  "files_modified": [
+    "webview/src/spec-viewer/components/SpecHeader.tsx",
+    "webview/styles/spec-viewer/_content.css",
+    "webview/src/spec-viewer/markdown/preprocessors.ts",
+    "webview/src/spec-viewer/components/StepTab.tsx",
+    "webview/styles/spec-viewer/_navigation.css"
+  ],
+  "decisions": [
+    { "note": "Bundled stepper current-indicator fix (R007, R008) into 073 after user flagged regression at CP3. Kept current class as orthogonal viewing marker rather than introducing a new `.viewing` class — minimal diff.", "at": "2026-04-22T18:40:00Z" }
+  ],
+  "concerns": [],
+  "last_action": "CP3 approved — commit staged",
+  "transitions": [
+    { "step": "specify", "substep": "parsing", "from": null, "by": "sdd", "at": "2026-04-22T18:32:27Z" },
+    { "step": "specify", "substep": "exploring", "from": { "step": "specify", "substep": "parsing" }, "by": "sdd", "at": "2026-04-22T18:32:30Z" },
+    { "step": "specify", "substep": "detecting", "from": { "step": "specify", "substep": "exploring" }, "by": "sdd", "at": "2026-04-22T18:32:33Z" },
+    { "step": "specify", "substep": "writing-spec", "from": { "step": "specify", "substep": "detecting" }, "by": "sdd", "at": "2026-04-22T18:32:36Z" },
+    { "step": "tasks", "substep": null, "from": { "step": "specify", "substep": "writing-spec" }, "by": "sdd", "at": "2026-04-22T18:32:42Z" },
+    { "step": "implement", "substep": "phase1", "from": { "step": "tasks", "substep": null }, "by": "sdd", "at": "2026-04-22T18:33:10Z" },
+    { "step": "implement", "substep": "phase1", "from": { "step": "implement", "substep": "phase1" }, "by": "sdd", "at": "2026-04-22T18:34:20Z", "note": "T001-T003 parallel group complete" },
+    { "step": "implement", "substep": "hooks", "from": { "step": "implement", "substep": "phase1" }, "by": "sdd", "at": "2026-04-22T18:34:50Z" },
+    { "step": "implement", "substep": "code-review", "from": { "step": "implement", "substep": "hooks" }, "by": "sdd", "at": "2026-04-22T18:35:30Z" },
+    { "step": "implement", "substep": "commit-review", "from": { "step": "implement", "substep": "code-review" }, "by": "sdd", "at": "2026-04-22T18:36:00Z" },
+    { "step": "implement", "substep": "phase1", "from": { "step": "implement", "substep": "commit-review" }, "by": "sdd", "at": "2026-04-22T18:40:30Z", "note": "Reopened for T005-T006 bundled fix" },
+    { "step": "implement", "substep": "code-review", "from": { "step": "implement", "substep": "phase1" }, "by": "sdd", "at": "2026-04-22T18:41:00Z" },
+    { "step": "implement", "substep": "commit-review", "from": { "step": "implement", "substep": "code-review" }, "by": "sdd", "at": "2026-04-22T18:42:00Z" },
+    { "step": "done", "substep": null, "from": { "step": "implement", "substep": "commit-review" }, "by": "sdd", "at": "2026-04-22T18:43:00Z" }
+  ]
+}

--- a/specs/073-viewer-header-layout/.spec-context.json
+++ b/specs/073-viewer-header-layout/.spec-context.json
@@ -11,6 +11,8 @@
   "workingBranch": "feat/viewer-header-layout",
   "status": "completed",
   "checkpointStatus": { "commit": true, "pr": true },
+  "prUrl": "https://github.com/alfredoperez/speckit-companion/pull/119",
+  "prNumber": 119,
   "type": "feat",
   "createdAt": "2026-04-22T18:32:27Z",
   "approach": "Two-row header: wrap badges + title in sibling divs; switch .spec-header to flex column. Suppress file-name pill by dropping Plan/Spec capture in preprocessors.ts. Also restore step-tab current outline and keep the done ✓ when a completed step is being viewed (bundled fix for pre-existing regression from PR #118).",
@@ -41,7 +43,7 @@
     { "note": "Bundled stepper current-indicator fix (R007, R008) into 073 after user flagged regression at CP3. Kept current class as orthogonal viewing marker rather than introducing a new `.viewing` class — minimal diff.", "at": "2026-04-22T18:40:00Z" }
   ],
   "concerns": [],
-  "last_action": "CP3 approved — commit staged",
+  "last_action": "PR #119 opened — feat(spec-viewer): split header rows, hide file pill, restore current-step outline",
   "transitions": [
     { "step": "specify", "substep": "parsing", "from": null, "by": "sdd", "at": "2026-04-22T18:32:27Z" },
     { "step": "specify", "substep": "exploring", "from": { "step": "specify", "substep": "parsing" }, "by": "sdd", "at": "2026-04-22T18:32:30Z" },
@@ -56,6 +58,7 @@
     { "step": "implement", "substep": "phase1", "from": { "step": "implement", "substep": "commit-review" }, "by": "sdd", "at": "2026-04-22T18:40:30Z", "note": "Reopened for T005-T006 bundled fix" },
     { "step": "implement", "substep": "code-review", "from": { "step": "implement", "substep": "phase1" }, "by": "sdd", "at": "2026-04-22T18:41:00Z" },
     { "step": "implement", "substep": "commit-review", "from": { "step": "implement", "substep": "code-review" }, "by": "sdd", "at": "2026-04-22T18:42:00Z" },
-    { "step": "done", "substep": null, "from": { "step": "implement", "substep": "commit-review" }, "by": "sdd", "at": "2026-04-22T18:43:00Z" }
+    { "step": "done", "substep": null, "from": { "step": "implement", "substep": "commit-review" }, "by": "sdd", "at": "2026-04-22T18:43:00Z" },
+    { "step": "done", "substep": null, "from": { "step": "done", "substep": null }, "by": "sdd", "at": "2026-04-22T18:45:00Z", "note": "PR #119 opened" }
   ]
 }

--- a/specs/073-viewer-header-layout/plan.md
+++ b/specs/073-viewer-header-layout/plan.md
@@ -1,0 +1,15 @@
+# Plan: Viewer Header Layout
+
+**Spec**: [spec.md](./spec.md) | **Date**: 2026-04-22
+
+## Approach
+
+Restructure `SpecHeader.tsx` to render two explicit rows (badges row + title row) by wrapping the badge cluster and the title in their own containers, and switch `.spec-header` from a single `flex-wrap` row to `flex-direction: column` with a nested inline row for badges. Suppress the file-name pill by removing the `Plan`/`Spec` capture branch in `preprocessors.ts` so `fileLinks` is never populated — the `.spec-file-link` / `.spec-file-ref` CSS is left in place but goes unused (no callers remain in shipped code).
+
+## Files to Change
+
+- `webview/src/spec-viewer/components/SpecHeader.tsx` — wrap `spec-badge` + `spec-header-branch` in a `.spec-header-badges` row; move `spec-header-title` (and optional `spec-date`) into a `.spec-header-main` row.
+- `webview/styles/spec-viewer/_content.css` — change `.spec-header` to `flex-direction: column` with `align-items: stretch`; add `.spec-header-badges { display: flex; gap: var(--space-3); align-items: center; }` and `.spec-header-main { display: flex; gap: var(--space-3); align-items: baseline; }`.
+- `webview/src/spec-viewer/markdown/preprocessors.ts` — stop emitting the `.spec-file-link` block (drop the `Plan`/`Spec` push into `fileLinks`, and the `fileLinkHtml` construction/concatenation).
+- `webview/src/spec-viewer/components/StepTab.tsx` — reorder canonical-state precedence so `done` wins over `current`; always apply `current` as an **additional** class when `isViewing`, so a completed-and-viewed tab gets both `.done` and `.current` classes.
+- `webview/styles/spec-viewer/_navigation.css` — restore the outline rule on `.step-tab.current` (removed in PR #118) so the currently viewed tab has a clearly visible frame.

--- a/specs/073-viewer-header-layout/spec.md
+++ b/specs/073-viewer-header-layout/spec.md
@@ -1,0 +1,51 @@
+# Spec: Viewer Header Layout
+
+**Slug**: 073-viewer-header-layout | **Date**: 2026-04-22
+
+## Summary
+
+Restructure the spec viewer header into two visual rows — a badges row (status + branch) and a title row — and hide the file-name pill (e.g. `spec.md`) that currently renders below the divider. The current single flex-wrap row puts the status badge, title, and branch badge side-by-side, which makes long titles cramped and surfaces redundant filename chrome.
+
+## Requirements
+
+- **R001** (MUST): The structured header renders in two visual rows: row 1 contains the status badge and branch badge; row 2 contains the document title (`{DocType}: {Name}`).
+- **R002** (MUST): The file-name pill generated from `**Spec**:` / `**Plan**:` metadata links (`.spec-file-link` / `.spec-file-ref`) is not rendered in the viewer.
+- **R003** (MUST): When neither a badge nor a specContextName nor a createdDate is present, the header still renders nothing (preserve the existing empty-state behavior at `SpecHeader.tsx:18`).
+- **R004** (MUST): The existing rule that hides the first `#` heading when the structured header is active continues to work (`.spec-header[data-has-context="true"] ~ #markdown-content h1:first-of-type { display: none }`).
+- **R005** (SHOULD): The Created-date element remains visible and legible; placement may sit with the title row or as an inline meta element, but must not reintroduce a third dominant row.
+- **R006** (SHOULD): Visual styling of the status badge and branch badge (colors, border, typography) is preserved; only their layout placement changes.
+- **R007** (MUST): The step tab that is currently being viewed shows a clear visual marker (restored outline + accent label) so users can identify which step the viewer is on at a glance.
+- **R008** (MUST): The green ✓ completion indicator on a step tab is **not** removed when that tab is the one being viewed — a step that has both completed and is being viewed displays the ✓ and the "current" marker together.
+
+## Scenarios
+
+### Header with status badge, title, and branch
+
+**When** a spec is open and `.spec-context.json` provides status, specName, and branch
+**Then** the viewer renders row 1 with the status badge on the left and the branch badge after it, and row 2 with `{DocType}: {Name}` as the title — the file-name pill below the divider is not shown
+
+### Header with only title (no status)
+
+**When** a spec has no derivable status badge but has a specName
+**Then** row 1 is empty (or collapses) and the title still renders on its own row; the branch badge, if present, appears in row 1
+
+### Completed / archived spec
+
+**When** `body[data-spec-status]` is `completed`, `archived`, or `tasks-done`
+**Then** the status badge uses its existing colored style and sits in row 1 as usual — the two-row layout does not regress badge coloring
+
+### File-name pill suppression
+
+**When** the underlying markdown contains `**Spec**: [spec.md](./spec.md)` or `**Plan**: [plan.md](./plan.md)` metadata lines
+**Then** the preprocessor no longer emits the `.spec-file-link` pill block in the rendered HTML
+
+### Viewed step retains completion indicator
+
+**When** a user clicks a completed step tab (`stepDocExists === true`) and it becomes the viewed tab
+**Then** the tab shows both the green ✓ (done state) and a visible "currently viewed" outline/accent — neither marker hides the other
+
+## Out of Scope
+
+- Changes to the stepper, footer action buttons, or non-header viewer regions
+- Changes to how `.spec-context.json` is populated or read
+- Reworking the markdown metadata preprocessor beyond suppressing the file-name pill output

--- a/specs/073-viewer-header-layout/tasks.md
+++ b/specs/073-viewer-header-layout/tasks.md
@@ -1,0 +1,50 @@
+# Tasks: Viewer Header Layout
+
+**Plan**: [plan.md](./plan.md) | **Date**: 2026-04-22
+
+## Format
+
+- `[P]` marks tasks that can run in parallel with adjacent `[P]` tasks.
+- Consecutive `[P]` tasks form a **parallel group** — `/sdd:implement` spawns them as concurrent subagents.
+- Tasks without `[P]` are **gates**: they start only after all prior tasks complete.
+- Two tasks that touch the same file are never both `[P]`.
+
+---
+
+## Phase 1: Core Implementation
+
+- [x] **T001** [P] Split header JSX into badges row + title row — `webview/src/spec-viewer/components/SpecHeader.tsx` | R001, R003, R006
+  - **Do**: Wrap `spec-badge` and `spec-header-branch` inside a new `<div class="spec-header-badges">` row, and `spec-header-title` (plus `spec-date`) inside `<div class="spec-header-main">`. Keep the existing `data-has-context` attribute and empty-state return at line 18.
+  - **Verify**: `npm run compile` passes; open a spec — row 1 shows status + branch pills, row 2 shows the title.
+  - **Leverage**: current structure at `webview/src/spec-viewer/components/SpecHeader.tsx:22-43`.
+
+- [x] **T002** [P] Stack `.spec-header` vertically with inline badge row — `webview/styles/spec-viewer/_content.css` | R001, R004, R006
+  - **Do**: Change `.spec-header` to `flex-direction: column; align-items: stretch; gap: var(--space-2)`. Add `.spec-header-badges { display: flex; flex-wrap: wrap; align-items: center; gap: var(--space-3); }` and `.spec-header-main { display: flex; flex-wrap: wrap; align-items: baseline; gap: var(--space-3); }`. Leave `.spec-header[data-has-context="true"] ~ #markdown-content h1:first-of-type` rule untouched.
+  - **Verify**: `npm run compile` passes; badges sit above title with no extra divider; completed/archived status colors still apply.
+  - **Leverage**: existing `.spec-header` rules at `webview/styles/spec-viewer/_content.css:197-206`.
+
+- [x] **T003** [P] Stop emitting the `.spec-file-link` pill — `webview/src/spec-viewer/markdown/preprocessors.ts` | R002
+  - **Do**: In `preprocessSpecMetadata`, remove the `if (label === 'Plan' || label === 'Spec') { fileLinks.push(value); continue; }` branch and drop the `fileLinkHtml` construction. Reduce `replacement` to `${metaBar}${title}\n`. Remove the now-unused `fileLinks` array.
+  - **Verify**: `npm run compile` passes; `npm test` passes; opening a `plan.md` or `tasks.md` shows no pill between the divider and the first heading.
+  - **Leverage**: `webview/src/spec-viewer/markdown/preprocessors.ts:30, 48-52, 75-82, 86`.
+
+- [x] **T004** Manual viewer smoke check *(depends on T001, T002, T003)* — n/a | R001, R002, R004, R005
+  - **Do**: Run `/install-local`, reload VS Code, open an in-progress spec (e.g. `specs/072-immediate-status-update/tasks.md`) and a completed spec. Confirm two-row header, hidden file pill, no duplicated H1, and intact status-color variants.
+  - **Verify**: Visual layout matches spec R001–R006; no console errors in the webview devtools.
+
+- [x] **T005** [P] Decouple viewed state from done state in StepTab — `webview/src/spec-viewer/components/StepTab.tsx` | R007, R008
+  - **Do**: Reorder the `canonicalState` precedence block so `done` (stepDocExists || vsCompleted) is checked before `current` (isViewing), and append `isViewing && 'current'` as an additional class in the `classes` array so a completed tab keeps its `done` canonical state while also getting the `current` viewing marker.
+  - **Verify**: `npm run compile` + `npm test` pass; a completed step tab that is being viewed renders with classes `step-tab done current` (✓ + outline).
+  - **Leverage**: existing canonical-state block at `webview/src/spec-viewer/components/StepTab.tsx:60-76`.
+
+- [x] **T006** [P] Restore `.step-tab.current` outline — `webview/styles/spec-viewer/_navigation.css` | R007
+  - **Do**: Add back the outline rule for the currently viewed tab (removed in PR #118) next to the existing `.step-tab.current .step-label` rule:
+    ```css
+    .step-tab.current {
+        outline: 1px solid var(--accent, #4a9eff);
+        outline-offset: 2px;
+        border-radius: 4px;
+    }
+    ```
+  - **Verify**: `npm run compile` passes; currently viewed step shows a visible accent frame that coexists with the `.done` ✓ styling.
+  - **Leverage**: prior version of `_navigation.css` (pre-PR #118) — the same outline rule lived here.

--- a/webview/src/spec-viewer/components/SpecHeader.tsx
+++ b/webview/src/spec-viewer/components/SpecHeader.tsx
@@ -21,23 +21,31 @@ export function SpecHeader() {
 
     return (
         <div class="spec-header" data-has-context={String(hasContext)}>
-            {badgeText && <span class="spec-badge">{badgeText}</span>}
-            {ns.specContextName && (
-                <span class="spec-header-title">
-                    <span class="spec-header-doctype">{docTypeLabel}:</span>{' '}
-                    {ns.specContextName}
-                </span>
+            {(badgeText || ns.branch) && (
+                <div class="spec-header-badges">
+                    {badgeText && <span class="spec-badge">{badgeText}</span>}
+                    {ns.branch && (
+                        <span class="spec-header-branch">
+                            <span class="branch-icon">{''}</span> {ns.branch}
+                        </span>
+                    )}
+                </div>
             )}
-            {ns.branch && (
-                <span class="spec-header-branch">
-                    <span class="branch-icon">{''}</span> {ns.branch}
-                </span>
-            )}
-            {ns.createdDate && (
-                <span class="spec-date">
-                    <span class="meta-label">Created:</span>{' '}
-                    <span class="meta-date">{ns.createdDate}</span>
-                </span>
+            {(ns.specContextName || ns.createdDate) && (
+                <div class="spec-header-main">
+                    {ns.specContextName && (
+                        <span class="spec-header-title">
+                            <span class="spec-header-doctype">{docTypeLabel}:</span>{' '}
+                            {ns.specContextName}
+                        </span>
+                    )}
+                    {ns.createdDate && (
+                        <span class="spec-date">
+                            <span class="meta-label">Created:</span>{' '}
+                            <span class="meta-date">{ns.createdDate}</span>
+                        </span>
+                    )}
+                </div>
             )}
         </div>
     );

--- a/webview/src/spec-viewer/components/StepTab.tsx
+++ b/webview/src/spec-viewer/components/StepTab.tsx
@@ -57,21 +57,22 @@ export function StepTab(props: StepTabProps) {
     const vsSubstep = vs?.activeSubstep?.step === stepName ? vs.activeSubstep.name : null;
 
     // Collapse to four canonical states (R007, R008).
-    // Precedence: locked > in-flight > current > done; default = untouched.
+    // Precedence: locked > in-flight > done > current; default = untouched.
     let canonicalState: 'current' | 'done' | 'in-flight' | 'locked' | null = null;
     if (isLocked) {
         canonicalState = 'locked';
     } else if (isWorking || inProgress) {
         canonicalState = 'in-flight';
-    } else if (isViewing) {
-        canonicalState = 'current';
     } else if (stepDocExists || vsCompleted) {
         canonicalState = 'done';
+    } else if (isViewing) {
+        canonicalState = 'current';
     }
 
     const classes = [
         'step-tab',
         canonicalState,
+        canonicalState !== 'current' && isViewing && 'current',
         isStale && 'stale',
     ].filter(Boolean).join(' ');
 

--- a/webview/src/spec-viewer/markdown/preprocessors.ts
+++ b/webview/src/spec-viewer/markdown/preprocessors.ts
@@ -27,7 +27,6 @@ export function preprocessSpecMetadata(markdown: string, stripForContext = false
     // Parse individual metadata items - captures **Label** or **Label:** then the value
     // Also handles pipe-separated fields like: **Plan**: value | **Date**: value
     const items: { label: string; value: string }[] = [];
-    const fileLinks: string[] = [];
     const itemPattern = /\*\*([^*]+)\*\*:?\s*(.+?)(?=\s*\|\s*\*\*|\n\*\*|\n\n|$)/g;
     let itemMatch;
 
@@ -42,20 +41,15 @@ export function preprocessSpecMetadata(markdown: string, stripForContext = false
         value = value.replace(/`([^`]+)`/g, '$1');
 
         // Only include recognized metadata fields
-        const recognizedFields = ['Feature Branch', 'Status', 'Input', 'Version', 'Author', 'Plan', 'Spec', 'Slug'];
+        const recognizedFields = ['Feature Branch', 'Status', 'Input', 'Version', 'Author', 'Slug'];
         if (!recognizedFields.includes(label)) continue;
 
-        // Collect Plan/Spec links for file link below title
-        if (label === 'Plan' || label === 'Spec') {
-            fileLinks.push(value);
-            continue;
-        }
         if (label === 'Slug') continue;
 
         items.push({ label, value });
     }
 
-    if (items.length === 0 && fileLinks.length === 0) return markdown;
+    if (items.length === 0) return markdown;
 
     // Build compact metadata HTML
     const metadataHtml = items.map(item => {
@@ -72,18 +66,9 @@ export function preprocessSpecMetadata(markdown: string, stripForContext = false
         return `<span class="meta-item"><span class="meta-label">${item.label}:</span> ${item.value}</span>`;
     }).join('');
 
-    // Build file link HTML (shown below title)
-    const fileLinkHtml = fileLinks.length > 0
-        ? `<div class="spec-file-link">${fileLinks.map(link => {
-            const mdLink = link.match(/\[([^\]]+)\]\(([^)]+)\)/);
-            if (mdLink) return `<a href="${mdLink[2]}" class="spec-file-ref" data-file-ref="${mdLink[1]}">${mdLink[1]}</a>`;
-            return `<span class="spec-file-ref">${link}</span>`;
-        }).join(' · ')}</div>\n`
-        : '';
-
-    // Place metadata ABOVE the title, file link BELOW
+    // Place metadata ABOVE the title
     const metaBar = items.length > 0 ? `<div class="spec-meta">${metadataHtml}</div>\n\n` : '';
-    const replacement = `${metaBar}${title}${fileLinkHtml}\n`;
+    const replacement = `${metaBar}${title}\n`;
 
     return markdown.replace(metadataPattern, replacement);
 }

--- a/webview/styles/spec-viewer/_content.css
+++ b/webview/styles/spec-viewer/_content.css
@@ -198,11 +198,25 @@ body[data-spec-status="archived"] .meta-status-draft {
     max-width: 72ch;
     margin: 0 auto var(--space-4);
     display: flex;
+    flex-direction: column;
+    align-items: stretch;
+    gap: var(--space-2);
+    padding-bottom: var(--space-3);
+    border-bottom: 1px solid var(--border);
+}
+
+.spec-header-badges {
+    display: flex;
     flex-wrap: wrap;
     align-items: center;
     gap: var(--space-3);
-    padding-bottom: var(--space-3);
-    border-bottom: 1px solid var(--border);
+}
+
+.spec-header-main {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    gap: var(--space-3);
 }
 
 .spec-header-title {

--- a/webview/styles/spec-viewer/_navigation.css
+++ b/webview/styles/spec-viewer/_navigation.css
@@ -91,6 +91,12 @@
 }
 
 /* Highlight the currently viewed step tab (canonical: current) */
+.step-tab.current {
+    outline: 1px solid var(--accent, #4a9eff);
+    outline-offset: 2px;
+    border-radius: 4px;
+}
+
 .step-tab.current .step-label {
     color: var(--accent);
     font-weight: 700;


### PR DESCRIPTION
## What

- Restructure the structured header into two rows — status/branch badges above, title below — instead of a single flex-wrap row
- Drop the `spec.md` / `plan.md` / `tasks.md` pill rendered under the divider
- Keep the green ✓ on a completed step tab when it is the viewed tab, and restore the accent outline that marks the current step (regression from PR #118)

## Why

The single flex-wrap row cramped long titles next to badges and surfaced redundant filename chrome. PR #118 simplified the current-step indicator too aggressively — users couldn't tell which step was active, and clicking a completed step hid its ✓.

## Testing

- [x] `npm run compile` passes
- [x] `npm test` — 289/289 passing
- [x] Verified in VS Code (0.12.2 install): two-row header, no file pill, viewed step shows outline + ✓