### PR TITLE
feat(specs): add fuzzy filter to specs tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ Specs are grouped into three collapsible sections based on their status (stored 
 
 The Specs view title bar exposes a **collapse/expand all** toggle (alongside the `+` and refresh buttons) that flips every spec in place between expanded and collapsed. The icon swaps to reflect the next action; state is in-memory only and is not persisted across sessions.
 
+**Filter specs** — click the filter icon in the Specs view title bar to open a prompt and fuzzy-filter specs by slug or feature name (matches are case-insensitive and subsequence-based, e.g. `ftr` matches `filter-specs-tree`). The query is persisted to workspace state and restored on the next activation. A clear-filter icon appears next to the filter icon while a filter is active; an empty-result message offers a one-click clear when no specs match.
+
 Right-click a spec to access **Mark as Completed**, **Archive Spec**, and **Reveal in File Explorer** (opens the spec's folder in Finder / File Explorer / the default file manager) actions. The spec viewer footer shows lifecycle buttons based on the spec's current status:
 
 - **Active** (tasks incomplete): Regenerate, Archive, + primary CTA (Plan/Tasks/Implement depending on next step)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -49,6 +49,8 @@ src/
 │   │                           # specContextReader.ts, specContextWriter.ts,
 │   │                           # specContextBackfill.ts (060 canonical),
 │   │                           # specContextReconciler.ts (one-time file repair),
+│   │                           # specsFilterState.ts (075 fuzzy filter),
+│   │                           # fuzzyMatch.ts (075 in-repo matcher),
 │   │                           # index.ts, __tests__/
 │   ├── steering/               # steeringExplorerProvider.ts, steeringManager.ts,
 │   │                           # steeringCommands.ts, types.ts, index.ts
@@ -186,7 +188,8 @@ This is configured via the `commandFormat` field in `PROVIDER_PATHS` (`src/ai-pr
 
 - **In-memory**: Tree view data, webview state
 - **File-based**: `specs/*/`, `.claude/settings/speckit-settings.json`, `.spec-context.json` per spec directory
-- **VS Code**: Extension context for subscriptions, globalState for persistence
+- **VS Code**: Extension context for subscriptions, globalState for persistence, workspaceState for per-workspace UI state (e.g. `speckit.specs.filter.query` from 075)
+- **Context keys**: `speckit.specs.filterActive` (075) toggles the clear-filter title-bar action; `speckit.specs.noFilterMatch` (075) drives the empty-result `viewsWelcome` entry; `speckit.specs.allCollapsed` (068) swaps the collapse/expand icon
 
 ## Extension Points for Contributors
 

--- a/package.json
+++ b/package.json
@@ -101,6 +101,11 @@
         "when": "speckit.detected && !speckit.constitutionNeedsSetup"
       },
       {
+        "view": "speckit.views.explorer",
+        "contents": "No specs match the current filter.\n\n[$(clear-all) Clear filter](command:speckit.specs.filter.clear)",
+        "when": "speckit.specs.filterActive && speckit.specs.noFilterMatch"
+      },
+      {
         "view": "speckit.views.steering",
         "contents": "[$(globe) Create User Rule](command:speckit.steering.createUserRule)\n\n[$(root-folder) Create Project Rule](command:speckit.steering.createProjectRule)"
       }
@@ -200,6 +205,18 @@
         "title": "Expand All Specs",
         "category": "SpecKit",
         "icon": "$(expand-all)"
+      },
+      {
+        "command": "speckit.specs.filter",
+        "title": "Filter Specs…",
+        "category": "SpecKit",
+        "icon": "$(filter)"
+      },
+      {
+        "command": "speckit.specs.filter.clear",
+        "title": "Clear Specs Filter",
+        "category": "SpecKit",
+        "icon": "$(clear-all)"
       },
       {
         "command": "speckit.delete",
@@ -395,6 +412,16 @@
     ],
     "menus": {
       "view/title": [
+        {
+          "command": "speckit.specs.filter",
+          "when": "view == speckit.views.explorer",
+          "group": "navigation@0"
+        },
+        {
+          "command": "speckit.specs.filter.clear",
+          "when": "view == speckit.views.explorer && speckit.specs.filterActive",
+          "group": "navigation@0"
+        },
         {
           "command": "speckit.create",
           "when": "view == speckit.views.explorer",

--- a/specs/075-filter-specs-tree/.spec-context.json
+++ b/specs/075-filter-specs-tree/.spec-context.json
@@ -1,18 +1,22 @@
 {
   "workflow": "sdd",
-  "currentStep": "implement",
+  "currentStep": "done",
   "currentTask": null,
-  "progress": "hooks",
-  "next": "implement",
-  "updated": "2026-04-23",
+  "progress": null,
+  "next": "done",
+  "status": "completed",
+  "updated": "2026-04-24",
   "selectedAt": "2026-04-23T15:01:02Z",
   "specName": "Filter/search box above the specs tree",
   "branch": "feat/elapsed-timer-notification",
-  "workingBranch": null,
+  "workingBranch": "feat/filter-specs-tree",
   "type": "feat",
   "createdAt": "2026-04-23T15:01:02Z",
-  "auto": true,
-  "last_action": "Phase 1 complete (T001–T013) — filter feature + drive-by step-tab color fix. 328/328 tests pass.",
+  "auto": false,
+  "checkpointStatus": { "commit": true, "pr": true },
+  "prUrl": "https://github.com/alfredoperez/speckit-companion/pull/121",
+  "prNumber": 121,
+  "last_action": "PR #121 opened — feat(specs): add fuzzy filter to specs tree",
   "approach": "Add an in-memory filter query to SpecExplorerProvider plus a SpecsFilterState helper that reads/writes the query to workspaceState, with a title-bar action + InputBox UX and in-repo fuzzy subsequence matching.",
   "files_modified": [
     "src/features/specs/fuzzyMatch.ts",
@@ -158,6 +162,7 @@
     { "step": "implement", "substep": "phase1", "from": { "step": "tasks", "substep": null }, "by": "sdd", "at": "2026-04-23T15:06:00Z" },
     { "step": "implement", "substep": "phase1", "from": { "step": "implement", "substep": "phase1" }, "by": "sdd", "at": "2026-04-23T15:07:00Z" },
     { "step": "implement", "substep": "phase1", "from": { "step": "implement", "substep": "phase1" }, "by": "sdd", "at": "2026-04-23T15:08:00Z" },
-    { "step": "implement", "substep": "hooks", "from": { "step": "implement", "substep": "phase1" }, "by": "sdd", "at": "2026-04-23T15:30:00Z" }
+    { "step": "implement", "substep": "hooks", "from": { "step": "implement", "substep": "phase1" }, "by": "sdd", "at": "2026-04-23T15:30:00Z" },
+    { "step": "done", "substep": null, "from": { "step": "implement", "substep": "hooks" }, "by": "sdd", "at": "2026-04-24T00:10:00Z" }
   ]
 }

--- a/specs/075-filter-specs-tree/.spec-context.json
+++ b/specs/075-filter-specs-tree/.spec-context.json
@@ -1,0 +1,163 @@
+{
+  "workflow": "sdd",
+  "currentStep": "implement",
+  "currentTask": null,
+  "progress": "hooks",
+  "next": "implement",
+  "updated": "2026-04-23",
+  "selectedAt": "2026-04-23T15:01:02Z",
+  "specName": "Filter/search box above the specs tree",
+  "branch": "feat/elapsed-timer-notification",
+  "workingBranch": null,
+  "type": "feat",
+  "createdAt": "2026-04-23T15:01:02Z",
+  "auto": true,
+  "last_action": "Phase 1 complete (T001–T013) — filter feature + drive-by step-tab color fix. 328/328 tests pass.",
+  "approach": "Add an in-memory filter query to SpecExplorerProvider plus a SpecsFilterState helper that reads/writes the query to workspaceState, with a title-bar action + InputBox UX and in-repo fuzzy subsequence matching.",
+  "files_modified": [
+    "src/features/specs/fuzzyMatch.ts",
+    "src/features/specs/__tests__/fuzzyMatch.test.ts",
+    "src/core/constants.ts",
+    "src/features/specs/specsFilterState.ts",
+    "src/features/specs/__tests__/specsFilterState.test.ts",
+    "src/features/specs/specExplorerProvider.ts",
+    "src/features/specs/__tests__/specExplorerProvider.test.ts",
+    "src/features/specs/specCommands.ts",
+    "src/features/specs/specCommands.test.ts",
+    "src/features/specs/index.ts",
+    "src/extension.ts",
+    "package.json",
+    "README.md",
+    "docs/architecture.md",
+    "webview/styles/spec-viewer/_navigation.css"
+  ],
+  "task_summaries": {
+    "T001": {
+      "status": "DONE",
+      "did": "Added fuzzyMatch.ts exporting normalize() and fuzzyMatch(query, ...haystacks) using subsequence matching over normalized strings.",
+      "files": ["src/features/specs/fuzzyMatch.ts"],
+      "concerns": []
+    },
+    "T002": {
+      "status": "DONE",
+      "did": "Added fuzzyMatch.test.ts covering empty/whitespace queries, case-insensitivity, subsequence match, normalization, multiple haystacks, and undefined haystacks. 10 tests pass.",
+      "files": ["src/features/specs/__tests__/fuzzyMatch.test.ts"],
+      "concerns": []
+    },
+    "T003": {
+      "status": "DONE",
+      "did": "Added Commands.specsFilter, Commands.specsFilterClear, and ConfigKeys.workspaceState.specsFilterQuery.",
+      "files": ["src/core/constants.ts"],
+      "concerns": []
+    },
+    "T004": {
+      "status": "DONE",
+      "did": "Added SpecsFilterState class with getQuery/setQuery/clear/initialize; persists to workspaceState and toggles speckit.specs.filterActive context key.",
+      "files": ["src/features/specs/specsFilterState.ts"],
+      "concerns": []
+    },
+    "T005": {
+      "status": "DONE",
+      "did": "Added 7 tests covering round-trip, trimming, blank→clear, clear side-effects, and initialize(). All passing.",
+      "files": ["src/features/specs/__tests__/specsFilterState.test.ts"],
+      "concerns": []
+    },
+    "T006": {
+      "status": "DONE",
+      "did": "Added optional filterState ctor param to SpecExplorerProvider; cached specName during status partition; applied fuzzyMatch to each group and passed filtered arrays into group labels/children. Also set speckit.specs.noFilterMatch context key inline (merged with T011).",
+      "files": ["src/features/specs/specExplorerProvider.ts"],
+      "concerns": []
+    },
+    "T007": {
+      "status": "DONE",
+      "did": "Added 4 integration tests exercising filter matching across slug/specName, empty root on zero match, and full tree when cleared. All passing.",
+      "files": ["src/features/specs/__tests__/specExplorerProvider.test.ts"],
+      "concerns": []
+    },
+    "T008": {
+      "status": "DONE",
+      "did": "Registered speckit.specs.filter (prompts via showInputBox prefilled with current query) and speckit.specs.filter.clear commands in registerSpecKitCommands. Added optional filterState parameter.",
+      "files": ["src/features/specs/specCommands.ts"],
+      "concerns": []
+    },
+    "T009": {
+      "status": "DONE",
+      "did": "Wired SpecsFilterState into extension activation: constructed before provider with a lazy refresh callback, passed into provider and registerSpecKitCommands, initialize() called to sync the filterActive context key on activation. Exported from features/specs/index.ts.",
+      "files": ["src/extension.ts", "src/features/specs/index.ts"],
+      "concerns": []
+    },
+    "T010": {
+      "status": "DONE",
+      "did": "Added 2 commands + 2 view/title menu entries (filter at navigation@0, clear-filter gated on speckit.specs.filterActive) + 1 viewsWelcome entry for no-match state.",
+      "files": ["package.json"],
+      "concerns": []
+    },
+    "T011": {
+      "status": "DONE",
+      "did": "Inlined during T006 — setContext for speckit.specs.noFilterMatch fires from getChildren root branch based on filtered partition totals. Added 2 tests covering true/false paths. Defensive try/catch wrapper to handle jest mock not returning a thenable.",
+      "files": ["src/features/specs/specExplorerProvider.ts", "src/features/specs/__tests__/specExplorerProvider.test.ts"],
+      "concerns": []
+    },
+    "T012": {
+      "status": "DONE",
+      "did": "README gains a filter-specs paragraph under the Sidebar at a Glance section; architecture.md lists the new modules and the workspaceState/context keys.",
+      "files": ["README.md", "docs/architecture.md"],
+      "concerns": []
+    },
+    "T013": {
+      "status": "DONE",
+      "did": "Drive-by fix bundled at user's request during implement: switched .step-tab.in-flight .step-status and .step-label to use --success instead of --accent, so the in-flight percentage pill matches its green working-pulse glow (was purple-on-green on themes where --vscode-focusBorder is purple). Also updated registerSpecKitCommands arity test from 4 to 5.",
+      "files": ["webview/styles/spec-viewer/_navigation.css", "src/features/specs/specCommands.test.ts"],
+      "concerns": []
+    }
+  },
+  "concerns": [],
+  "decisions": [
+    {
+      "task": "T000",
+      "note": "Branch-creation skipped — already on feat/elapsed-timer-notification (previous spec's merged branch). Per decision table, SDD does not switch when current != main. Proceeded on current branch."
+    },
+    {
+      "task": "T001-T002",
+      "note": "Planned as parallel [P] group but executed sequentially because T002's verify step runs tests that import T001's module — running in parallel subagents risked T002 verifying before T001 wrote the file. Sequential execution took ~2s and avoided the race."
+    },
+    {
+      "task": "T013",
+      "note": "Bundled a drive-by CSS fix unrelated to the filter feature at the user's explicit request during implement. The in-flight step-tab styling used --accent for the pill and --success for the pulse glow, producing a jarring purple-on-green state on themes where --vscode-focusBorder is purple. Switched both to --success for a consistent in-progress visual."
+    }
+  ],
+  "step_summaries": {
+    "specify": {
+      "complexity": "normal",
+      "requirements": 9,
+      "scenarios": 7,
+      "key_finding": "VS Code TreeView has no native inline input; filter must use a title-bar action + InputBox, and workspaceState persistence follows the specDraftManager pattern. Tree is already status-grouped with counts (071), so counts must reflect filtered totals."
+    },
+    "plan": {
+      "approach_summary": "Add an in-memory filter query to SpecExplorerProvider plus a SpecsFilterState helper that reads/writes the query to workspaceState, with a title-bar action + InputBox UX and in-repo fuzzy subsequence matching.",
+      "files_planned": 11,
+      "risks": [
+        "VS Code TreeView selection quirk when items disappear (hidden specs lose selection — intended, matches native behavior)",
+        "Count desync with 071-tree-group-counts (mitigated: group label is built in one place from filtered length)",
+        "InputBox without typeahead (explicit scope trade-off; re-triggerable action for incremental edits)"
+      ]
+    }
+  },
+  "transitions": [
+    { "step": "specify", "substep": "parsing", "from": null, "by": "sdd", "at": "2026-04-23T15:01:02Z" },
+    { "step": "specify", "substep": "exploring", "from": { "step": "specify", "substep": "parsing" }, "by": "sdd", "at": "2026-04-23T15:01:05Z" },
+    { "step": "specify", "substep": "detecting", "from": { "step": "specify", "substep": "exploring" }, "by": "sdd", "at": "2026-04-23T15:01:30Z" },
+    { "step": "specify", "substep": "writing-spec", "from": { "step": "specify", "substep": "detecting" }, "by": "sdd", "at": "2026-04-23T15:01:35Z" },
+    { "step": "specify", "substep": null, "from": { "step": "specify", "substep": "writing-spec" }, "by": "sdd", "at": "2026-04-23T15:02:30Z" },
+    { "step": "plan", "substep": "loading", "from": { "step": "specify", "substep": null }, "by": "sdd", "at": "2026-04-23T15:03:00Z" },
+    { "step": "plan", "substep": "writing-plan", "from": { "step": "plan", "substep": "loading" }, "by": "sdd", "at": "2026-04-23T15:03:05Z" },
+    { "step": "plan", "substep": null, "from": { "step": "plan", "substep": "writing-plan" }, "by": "sdd", "at": "2026-04-23T15:04:00Z" },
+    { "step": "tasks", "substep": "loading", "from": { "step": "plan", "substep": null }, "by": "sdd", "at": "2026-04-23T15:04:30Z" },
+    { "step": "tasks", "substep": "writing-tasks", "from": { "step": "tasks", "substep": "loading" }, "by": "sdd", "at": "2026-04-23T15:04:35Z" },
+    { "step": "tasks", "substep": null, "from": { "step": "tasks", "substep": "writing-tasks" }, "by": "sdd", "at": "2026-04-23T15:05:30Z" },
+    { "step": "implement", "substep": "phase1", "from": { "step": "tasks", "substep": null }, "by": "sdd", "at": "2026-04-23T15:06:00Z" },
+    { "step": "implement", "substep": "phase1", "from": { "step": "implement", "substep": "phase1" }, "by": "sdd", "at": "2026-04-23T15:07:00Z" },
+    { "step": "implement", "substep": "phase1", "from": { "step": "implement", "substep": "phase1" }, "by": "sdd", "at": "2026-04-23T15:08:00Z" },
+    { "step": "implement", "substep": "hooks", "from": { "step": "implement", "substep": "phase1" }, "by": "sdd", "at": "2026-04-23T15:30:00Z" }
+  ]
+}

--- a/specs/075-filter-specs-tree/plan.md
+++ b/specs/075-filter-specs-tree/plan.md
@@ -1,0 +1,64 @@
+# Plan: Filter/search box above the specs tree
+
+**Spec**: [spec.md](./spec.md) | **Date**: 2026-04-23
+
+## Approach
+
+Add an in-memory filter query to `SpecExplorerProvider` plus a small `SpecsFilterState` helper that reads/writes the query to `workspaceState`. A title-bar action (`speckit.specs.filter`) opens a VS Code `InputBox` prefilled with the current query; accepting the input updates the state and refreshes the tree. A second title-bar action (`speckit.specs.filter.clear`), gated on a `speckit.specs.filterActive` context key, clears the query. Fuzzy matching is a ~30-line in-repo helper (subsequence + alphanumeric normalization) applied to spec slug and `.spec-context.json#specName`, and group counts are computed from the post-filter lists so the already-status-grouped tree (from 071-tree-group-counts) naturally shows filtered totals.
+
+## Technical Context
+
+**Stack**: TypeScript 5.3+ (ES2022, strict), VS Code Extension API `^1.84.0`, Jest + `ts-jest`.
+**Key Dependencies**: none added — fuzzy matching is implemented in-repo.
+**Constraints**: No embedded input in the TreeView (VS Code API doesn't support it); filter UX is title-bar action + `InputBox`. Filter is workspace-scoped (persisted via `workspaceState`, not `globalState`).
+
+## Architecture
+
+```mermaid
+graph LR
+  A[Title-bar action] -->|InputBox| B[SpecsFilterState]
+  B -->|workspaceState| C[(persisted query)]
+  B -->|setContext| D[speckit.specs.filterActive]
+  B -->|refresh| E[SpecExplorerProvider]
+  E -->|getChildren root| F{query?}
+  F -->|yes| G[fuzzyMatch slug+specName]
+  F -->|no| H[all specs]
+  G --> I[Group nodes with filtered counts]
+  H --> I
+```
+
+## Files
+
+### Create
+
+- `src/features/specs/specsFilterState.ts` — `SpecsFilterState` class wrapping `workspaceState` reads/writes under key `speckit.specs.filter.query`, exposes `getQuery()`, `setQuery(q)`, `clear()`, and fires a callback so the provider can refresh. Also updates the `speckit.specs.filterActive` context key on every change.
+- `src/features/specs/fuzzyMatch.ts` — pure helper: `normalize(s)` (lowercase + strip non-alphanumeric) and `fuzzyMatch(query, ...haystacks)` returning boolean via subsequence check across the concatenated normalized haystacks. ~30 lines.
+- `src/features/specs/__tests__/fuzzyMatch.test.ts` — BDD tests covering subsequence match, case-insensitivity, punctuation/whitespace normalization, empty query (matches everything), and no-match.
+- `src/features/specs/__tests__/specsFilterState.test.ts` — tests for get/set/clear round-trip via a mocked `workspaceState`, plus the `setContext` side-effect.
+
+### Modify
+
+- `src/features/specs/specExplorerProvider.ts` — inject `SpecsFilterState` via constructor; in `getChildren` root branch, after partitioning specs by status, apply the fuzzy filter to each group using `spec.name` (slug) and `specContext?.specName`; empty groups become hidden; group counts use the filtered lengths. No change to per-spec rendering or to the group children fetch (already reads from `groupSpecs`, which will be the filtered list).
+- `src/features/specs/specCommands.ts` — register two commands: `speckit.specs.filter` (opens `vscode.window.showInputBox({ value: currentQuery, prompt: 'Filter specs…' })`, writes result to `SpecsFilterState`) and `speckit.specs.filter.clear` (calls `SpecsFilterState.clear()`).
+- `src/extension.ts` — instantiate `SpecsFilterState(context, () => specExplorer.refresh())`, pass it to `SpecExplorerProvider` and `registerSpecKitCommands`, and restore any persisted query on activation (so the tree renders filtered on first paint — NFR around persistence).
+- `src/core/constants.ts` — add `Commands.specsFilter`, `Commands.specsFilterClear`, and a `ConfigKeys.workspaceState.specsFilterQuery` constant.
+- `package.json` — add two `contributes.commands` entries (icons: `$(filter)` and `$(clear-all)` or `$(close)`), two `view/title` menu entries under `speckit.views.explorer` (group `navigation@0` so filter sits leftmost; clear-filter gated on `speckit.specs.filterActive`), and a `viewsWelcome` entry shown when the filter is active but matches zero specs ("No specs match '{query}'. [Clear filter](command:speckit.specs.filter.clear)").
+- `README.md` — document the new filter action in the Specs tree section (screenshot optional, not required).
+- `docs/architecture.md` — add `specsFilterState.ts` and `fuzzyMatch.ts` to the specs feature module list.
+
+## Data Model
+
+- `SpecsFilterState` — in-memory fields: `query: string` (empty string means "no filter"). Persisted to `workspaceState` under `speckit.specs.filter.query`.
+- No change to `.spec-context.json` — filter reads the existing `specName` field already written by `/sdd:specify`.
+
+## Testing Strategy
+
+- **Unit**: `fuzzyMatch.test.ts` covers the pure matcher exhaustively. `specsFilterState.test.ts` covers persistence round-trip and context-key updates against a mocked `ExtensionContext.workspaceState`.
+- **Integration**: Extend `specExplorerProvider.test.ts` with a test that (a) seeds three specs with varying slugs + `specName` via `readSpecContextSync` mock, (b) applies a query via `SpecsFilterState`, (c) asserts the root `getChildren` returns only matching specs and that group counts in labels reflect filtered totals.
+- **Edge cases**: empty query → all specs visible; query with no matches → tree returns empty array (the `viewsWelcome` entry renders the no-match message); matching spec with no `specName` field → slug-only match still works; query with whitespace/punctuation → normalized both sides.
+
+## Risks
+
+- **VS Code TreeView selection quirk when items disappear**: hidden specs lose selection, which is intended per spec R008 and matches VS Code's native behavior — documenting it in the test and README avoids confusion.
+- **Count desync with 071-tree-group-counts**: the group label format `Active (N)` is generated in one place (`specExplorerProvider.ts` root branch), so using the filtered list length there keeps 071's implementation intact.
+- **InputBox without typeahead**: the UX is not "live" — the filter applies after the user accepts the input. This is an explicit trade-off for scope (live typeahead would require a webview). The prompt is re-triggerable from the title bar for incremental edits. Noted in R001.

--- a/specs/075-filter-specs-tree/spec.md
+++ b/specs/075-filter-specs-tree/spec.md
@@ -1,0 +1,72 @@
+# Spec: Filter/search box above the specs tree
+
+**Slug**: 075-filter-specs-tree | **Date**: 2026-04-23
+
+## Summary
+
+Add a fuzzy filter for the SpecKit specs tree so users with many specs can narrow the list by typing part of a slug or feature name. The active filter query persists in workspace state so it survives VS Code reloads, and an obvious affordance lets users clear it.
+
+## Requirements
+
+- **R001** (MUST): A title-bar action on the `speckit.views.explorer` tree view opens a filter prompt. Invoking the action with an existing query pre-fills the input with the current query so edits are incremental.
+- **R002** (MUST): When a filter query is active, the tree shows only specs whose slug OR `specName` (from `.spec-context.json`) fuzzy-matches the query. Matching is case-insensitive, ignores non-alphanumeric characters, and treats the query as a subsequence (not substring) — e.g. `ftr` matches `filter-specs-tree`.
+- **R003** (MUST): Group nodes (`Active`, `Completed`, `Archived`) are shown only if they contain at least one matching spec. A group's count badge reflects the number of **visible** (filtered) specs, not the total.
+- **R004** (MUST): The active filter query is persisted to `context.workspaceState` under a stable key and restored on extension activation. Clearing the filter removes the persisted value.
+- **R005** (MUST): A dedicated "clear filter" title-bar action is visible only while a filter is active. Invoking it empties the query, persists the cleared state, and refreshes the tree to show all specs.
+- **R006** (MUST): While a filter is active, the tree view title or an inline indicator makes it obvious a filter is applied, so users aren't confused by a short spec list. A visible count (e.g. `Showing N of M`) in a welcome message, group label, or title suffix is acceptable.
+- **R007** (SHOULD): If the filter is active and no specs match, the tree shows an empty-state message with a hint to clear the filter (via `viewsWelcome` or a visible no-match row), instead of rendering an empty tree.
+- **R008** (SHOULD): The filter preserves user selection and multi-select behavior — specs that are filtered out become unselectable (as they are hidden), but re-appearing after a filter change does not destroy the selection of specs that remain visible.
+- **R009** (MAY): A keybinding hint is surfaced in the action tooltip (e.g. "Filter specs…"). An explicit keybinding is out of scope but should be easy to add later via `package.json`.
+
+## Scenarios
+
+### Applying a filter
+
+**When** the user clicks the filter action in the specs tree title bar and types `tree` into the prompt
+**Then** the tree re-renders showing only specs whose slug or specName contains the subsequence `tree` (e.g. `068-collapse-expand-specs` if specName includes "tree", `071-tree-group-counts`, `075-filter-specs-tree`), group counts reflect only the visible specs, and the query is saved to workspace state.
+
+### Filter persists across reloads
+
+**When** the user has an active filter, reloads the VS Code window, and the extension reactivates
+**Then** the same filter is still applied to the tree on first paint, and the clear-filter action is visible.
+
+### Clearing the filter
+
+**When** the user clicks the clear-filter action while a filter is active
+**Then** the tree immediately shows all specs grouped as before, group counts return to their full totals, the clear-filter action disappears, and the persisted query is removed from workspace state.
+
+### Empty filter result
+
+**When** the user applies a filter that matches zero specs
+**Then** the tree either shows a welcome/empty-state with text like "No specs match '{query}'. Clear filter to see all specs." or renders a single placeholder row with a clear action, instead of showing an empty groupless tree.
+
+### Fuzzy matching
+
+**When** the user types `fgc` as a filter
+**Then** specs like `071-tree-group-counts` match (subsequence of letters `f`… wait no — `fgc` matches `filter-group-counts` if such a slug existed; but `071-tree-group-counts` does not contain `fgc` in order). The tree only shows specs whose slug or specName contains all query characters in order, case-insensitively, ignoring separators.
+
+### Special characters and whitespace
+
+**When** the user types a query with spaces or punctuation (e.g. `tree view`)
+**Then** the matcher normalizes the query by lowercasing and stripping non-alphanumerics on both sides before subsequence matching, so `tree view` behaves like `treeview`.
+
+### Interaction with collapse/expand and multi-select
+
+**When** the user has multiple specs selected, then applies a filter that hides some selected specs, then clears the filter
+**Then** the remaining visible specs retain their selected state; hidden specs' selection is not restored on clear (consistent with VS Code TreeView's standard behavior when items disappear from getChildren results).
+
+## Non-Functional Requirements
+
+- **NFR001** (MUST): Filtering is a pure, synchronous computation against already-read spec metadata — no extra filesystem or parsing work per keystroke. Applying a filter to a list of ≤200 specs completes in under 16ms (one frame).
+- **NFR002** (SHOULD): The fuzzy matcher is implemented in-repo (small helper) to avoid adding a runtime dependency. ~30 lines of TypeScript is plenty for subsequence matching with normalization.
+- **NFR003** (SHOULD): The filter action icon uses a standard VS Code codicon (`filter` or `search`) with a filled variant (`filter-filled`) when a filter is active, consistent with VS Code's built-in patterns.
+
+## Out of Scope
+
+- Filtering by status, type, date, or any facet other than slug + specName.
+- Ranking results by match score or highlighting matched characters in labels.
+- Regex mode, case-sensitive mode, or exact-match mode toggles.
+- Filtering inside the spec viewer or spec editor webviews (this is tree-only).
+- Global/user-level persistence (workspace-scoped is sufficient and correct).
+- A persistent input element rendered **above** the tree — VS Code's TreeView API does not support embedded text inputs, so the UX uses a title-bar action that opens an `InputBox`. The issue title wording "Filter/search box above the specs tree" is interpreted as the user-visible intent, not a literal UI constraint.
+- Adding a dedicated keybinding (tooltip hint only; users can bind the command themselves via VS Code keyboard preferences).

--- a/specs/075-filter-specs-tree/tasks.md
+++ b/specs/075-filter-specs-tree/tasks.md
@@ -1,0 +1,78 @@
+# Tasks: Filter/search box above the specs tree
+
+**Plan**: [plan.md](./plan.md) | **Date**: 2026-04-23
+
+## Format
+
+- `[P]` marks tasks that can run in parallel with adjacent `[P]` tasks.
+- Consecutive `[P]` tasks form a **parallel group** — `/sdd:implement` spawns them as concurrent subagents.
+- Tasks without `[P]` are **gates**: they start only after all prior tasks complete.
+- Two tasks that touch the same file are never both `[P]`.
+
+---
+
+## Phase 1: Core Implementation
+
+- [x] **T001** [P] Add fuzzy match helper — `src/features/specs/fuzzyMatch.ts` | R002, NFR001, NFR002
+  - **Do**: Create a new module exporting `normalize(s: string): string` (lowercase, strip non-alphanumerics — `/[^a-z0-9]/g` after `.toLowerCase()`) and `fuzzyMatch(query: string, ...haystacks: Array<string | undefined>): boolean`. `fuzzyMatch` returns `true` for empty/whitespace queries; otherwise normalizes the query, concatenates all normalized haystacks (skipping `undefined`), and returns whether the query characters appear as an in-order subsequence in the combined haystack.
+  - **Verify**: `npm run compile` passes; the file is under ~30 lines excluding comments.
+  - **Leverage**: No existing fuzzy helper in repo — write from scratch; no dependencies added.
+
+- [x] **T002** [P] Tests for fuzzyMatch — `src/features/specs/__tests__/fuzzyMatch.test.ts` | R002
+  - **Do**: BDD tests covering: empty query matches everything; case-insensitive match (`TREE` matches `filter-specs-tree`); subsequence match (`fst` matches `filter-specs-tree`); non-subsequence rejected (`ftst` against `tree` returns false); punctuation/whitespace normalized (`tree view` behaves like `treeview`); matches against multiple haystacks (slug + specName); `undefined` haystacks are skipped.
+  - **Verify**: `npm test -- fuzzyMatch` passes all cases.
+  - **Leverage**: Follow the describe/it BDD style from `src/features/specs/__tests__/transitionLogger.test.ts`.
+
+- [x] **T003** Add command + workspaceState key constants — `src/core/constants.ts` | R001, R004, R005
+  - **Do**: Add `specsFilter: 'speckit.specs.filter'` and `specsFilterClear: 'speckit.specs.filter.clear'` to the `Commands` object. Add a new `workspaceState` group to `ConfigKeys` with `specsFilterQuery: 'speckit.specs.filter.query'`. Preserve existing entries; keep alphabetical/grouped ordering in place.
+  - **Verify**: `npm run compile` passes; no other files break (these are new keys).
+  - **Leverage**: Existing `Commands.toggleCollapseAllSpecs` and `ConfigKeys.globalState` patterns in this file.
+
+- [x] **T004** Add SpecsFilterState — `src/features/specs/specsFilterState.ts` | R004, R005, NFR001
+  - **Do**: Create `SpecsFilterState` class. Constructor takes `context: vscode.ExtensionContext` and `onChange: () => void`. Methods: `getQuery(): string` (returns stored query, empty string if absent), `async setQuery(q: string): Promise<void>` (writes to `context.workspaceState` under `ConfigKeys.workspaceState.specsFilterQuery`, updates the `speckit.specs.filterActive` context key via `vscode.commands.executeCommand('setContext', ...)`, then calls `onChange()`), `async clear(): Promise<void>` (writes `undefined` to clear the workspace-state entry, updates context key to `false`, calls `onChange()`), and `async initialize(): Promise<void>` (reads the persisted value on activation and sets the context key so the clear button visibility matches reality on first paint). Trim input in `setQuery` and treat a blank result as `clear()`.
+  - **Verify**: `npm run compile` passes.
+  - **Leverage**: `src/features/spec-editor/specDraftManager.ts` for the workspaceState get/update pattern.
+
+- [x] **T005** [P] Tests for SpecsFilterState — `src/features/specs/__tests__/specsFilterState.test.ts` | R004, R005
+  - **Do**: BDD tests against a mock `ExtensionContext` (add `workspaceState: { get, update, keys }` to `tests/__mocks__/vscode.ts` if not already flexible enough). Cover: set/get round-trip; `setQuery('')` triggers `clear`; `clear()` removes the value (update called with `undefined`); `initialize()` reads the persisted value and fires `setContext` with the correct active flag; `onChange` callback fires after every mutation; trimming whitespace.
+  - **Verify**: `npm test -- specsFilterState` passes.
+  - **Leverage**: Existing mock patterns in `src/features/specs/__tests__/specExplorerProvider.test.ts` (line 50 — `workspaceState: { get, update }`).
+
+- [x] **T006** Filter tree output in SpecExplorerProvider — `src/features/specs/specExplorerProvider.ts` | R002, R003, R007, R008, NFR001
+  - **Do**: (a) Add an optional `filterState?: SpecsFilterState` constructor parameter (default undefined so existing tests keep compiling). (b) In the root branch of `getChildren`, after partitioning specs into `activeSpecs` / `completedSpecs` / `archivedSpecs`, if `filterState.getQuery()` is non-empty, filter each list using `fuzzyMatch(query, spec.name, readSpecContextSync(specFullPath)?.specName)` — reuse the `specFullPath` lookup already happening in the partition loop by caching `{spec, status, specName}` tuples during the first pass to avoid double disk reads. (c) Build each group node only if its filtered list is non-empty; group labels use the filtered length (format `Active (N)` is already built from `activeSpecs.length` — keep that source of truth as the filtered array). (d) Ensure per-group sorting runs on filtered lists so ordering is stable.
+  - **Verify**: `npm run compile` passes; `npm test -- specExplorerProvider` passes (existing tests should still pass since filter is off by default).
+  - **Leverage**: The existing partition loop at lines 100–110 and the group-creation blocks at lines 143–177 of `specExplorerProvider.ts`.
+
+- [x] **T007** Integration test for filter wiring — `src/features/specs/__tests__/specExplorerProvider.test.ts` | R002, R003
+  - **Do**: Add a `describe('with filter active')` block. Seed a fake filesystem (via existing test helpers) with three specs whose slug and `.spec-context.json#specName` vary; instantiate `SpecsFilterState` with a mock context, call `setQuery('tree')`, pass into the provider constructor, and assert that the root `getChildren()` returns only the groups whose specs match, that each group label shows the filtered count, and that `setQuery('')` restores the full list.
+  - **Verify**: `npm test -- specExplorerProvider` passes (new + existing cases).
+  - **Leverage**: Existing test setup in this same file (already mocks `readSpecContextSync`, `resolveSpecDirectories`, etc.).
+
+- [x] **T008** Register filter commands — `src/features/specs/specCommands.ts` | R001, R005
+  - **Do**: In `registerSpecKitCommands`, accept a new `filterState: SpecsFilterState` parameter. Register two commands: (1) `Commands.specsFilter` — calls `vscode.window.showInputBox({ value: filterState.getQuery(), prompt: 'Filter specs by slug or name', placeHolder: 'type to filter…' })` and passes the result (if not `undefined`) to `filterState.setQuery`; (2) `Commands.specsFilterClear` — calls `filterState.clear()`. Push both into `context.subscriptions`.
+  - **Verify**: `npm run compile` passes.
+  - **Leverage**: The `toggleCollapseAllHandler` registration pattern at `specCommands.ts:87-100`.
+
+- [x] **T009** Wire filter into extension activation — `src/extension.ts` | R001, R004
+  - **Do**: After `specExplorer` is constructed, instantiate `const filterState = new SpecsFilterState(context, () => specExplorer.refresh())`, await `filterState.initialize()`, pass it to `SpecExplorerProvider` via a setter or via a provider constructor update (choose whichever minimizes the diff; the constructor-parameter approach from T006 is preferred, in which case construct `filterState` **before** `SpecExplorerProvider`). Pass `filterState` into `registerSpecKitCommands`.
+  - **Verify**: `npm run compile` passes; launching the Extension Development Host (F5) shows the tree and no startup errors.
+  - **Leverage**: The provider construction around `extension.ts:116-120`.
+
+- [x] **T010** Declare commands, title-bar menu entries, and empty-state welcome — `package.json` | R001, R005, R006, R007, NFR003
+  - **Do**: (a) Add two `contributes.commands` entries: `speckit.specs.filter` with `title: "Filter Specs…"`, `category: "SpecKit"`, `icon: "$(filter)"`; and `speckit.specs.filter.clear` with `title: "Clear Specs Filter"`, `category: "SpecKit"`, `icon: "$(clear-all)"`. (b) Add two `menus."view/title"` entries gated on `view == speckit.views.explorer`: filter (group `navigation@0`, always visible) and filter.clear (group `navigation@0` with `&& speckit.specs.filterActive`, visible only while filter is active). (c) Add a `viewsWelcome` entry for `speckit.views.explorer` with `when: "speckit.specs.filterActive && speckit.specs.noFilterMatch"` and contents `"No specs match the current filter.\n\n[$(clear-all) Clear filter](command:speckit.specs.filter.clear)"`. (Set `speckit.specs.noFilterMatch` from the provider in T006 after computing the filtered partition.)
+  - **Verify**: `npm run compile` + `npm run package` produces a valid `.vsix`; F5 shows the filter icon in the view title bar; clearing/applying filters toggles the clear-filter icon correctly.
+  - **Leverage**: Existing `view/title` entries for `speckit.specs.collapseAll` / `expandAll` at `package.json:397-417` — follow the same when-clause gating pattern.
+
+- [x] **T011** Set noFilterMatch context key in provider — `src/features/specs/specExplorerProvider.ts` | R007
+  - **Do**: After building the filtered groups in `getChildren` root branch (T006), if a filter is active and all three group lists are empty, call `vscode.commands.executeCommand('setContext', 'speckit.specs.noFilterMatch', true)`; otherwise `false`. Keep this call fire-and-forget (no await inside `getChildren`, but catch rejections).
+  - **Verify**: `npm test -- specExplorerProvider` passes; F5: applying a filter that matches nothing shows the welcome message, clearing or matching specs hides it.
+  - **Leverage**: Existing `setContext` usage in `specCommands.ts:89-93` (`speckit.specs.allCollapsed`).
+
+- [x] **T012** Update README and architecture docs — `README.md`, `docs/architecture.md` | R001, R006
+  - **Do**: (a) In `README.md`, add a short section or bullet under the Specs tree documentation explaining the filter action (icon, what it matches, persistence across reloads, how to clear). (b) In `docs/architecture.md`, add `specsFilterState.ts` and `fuzzyMatch.ts` to the `src/features/specs/` module list and note the new `speckit.specs.filter.query` workspaceState key + `speckit.specs.filterActive` / `speckit.specs.noFilterMatch` context keys.
+  - **Verify**: Docs describe the filter accurately; links resolve; no TODOs left in prose.
+  - **Leverage**: Existing Specs tree sections in `README.md`; module-list style in `docs/architecture.md`.
+
+- [x] **T013** Fix in-flight step-tab color clash — `webview/styles/spec-viewer/_navigation.css` | drive-by fix requested during review
+  - **Do**: In the spec viewer, the in-flight step-status percentage pill used `--accent` (often purple via `--vscode-focusBorder`) while the surrounding `working-pulse` animation glow used `--success` (green). The clashing colors made the tasks step look "strange" while a task was running. Change `.step-tab.in-flight .step-status` and `.step-tab.in-flight .step-label` to use `--success` so the pill and its pulse read as one consistent in-progress state.
+  - **Verify**: Compile + full test suite pass. Visual check in F5: the running step shows a green pill inside a green glow, with a green-highlighted label, no more purple/green collision.

--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -14,6 +14,8 @@ export const Commands = {
     constitution: 'speckit.constitution',
     refresh: 'speckit.refresh',
     toggleCollapseAllSpecs: 'speckit.specs.toggleCollapseAll',
+    specsFilter: 'speckit.specs.filter',
+    specsFilterClear: 'speckit.specs.filter.clear',
     delete: 'speckit.delete',
     installCli: 'speckit.installCli',
     initWorkspace: 'speckit.initWorkspace',
@@ -77,6 +79,9 @@ export const ConfigKeys = {
         skipVersion: 'speckit.skipVersion',
         lastUpdateCheck: 'speckit.lastUpdateCheck',
         initSuggestionDismissed: 'speckit.initSuggestionDismissed',
+    },
+    workspaceState: {
+        specsFilterQuery: 'speckit.specs.filter.query',
     },
 } as const;
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,7 +5,7 @@ import { IAIProvider, AIProviderFactory, isProviderConfigured, promptForProvider
 
 // Features
 import { SteeringManager, SteeringExplorerProvider, registerSteeringCommands } from './features/steering';
-import { SpecExplorerProvider, registerSpecKitCommands, updateSelectionContextKeys } from './features/specs';
+import { SpecExplorerProvider, registerSpecKitCommands, updateSelectionContextKeys, SpecsFilterState } from './features/specs';
 import { register as registerTerminalStepTracker } from './features/specs/terminalStepTracker';
 import { setLifecycleOutputChannel } from './features/specs/stepLifecycle';
 import { OverviewProvider } from './features/settings';
@@ -103,10 +103,19 @@ export async function activate(context: vscode.ExtensionContext) {
 
     const skillManager = new SkillManager(context, outputChannel);
 
-    // Register tree data providers
+    // Register tree data providers.
+    // Filter state is constructed before the provider so the provider reads the
+    // persisted query on first paint; the refresh callback closes over
+    // `specExplorer` (declared next), resolved lazily at invocation time.
     const overviewProvider = new OverviewProvider(context);
-    const specExplorer = new SpecExplorerProvider(context, outputChannel);
+    let specExplorer!: SpecExplorerProvider;
+    const specsFilterState = new SpecsFilterState(context, () => specExplorer.refresh());
+    specExplorer = new SpecExplorerProvider(context, outputChannel, specsFilterState);
     const steeringExplorer = new SteeringExplorerProvider(context);
+
+    // Sync the filterActive context key to any persisted query so the clear
+    // button visibility matches reality on activation.
+    specsFilterState.initialize().then(undefined, () => { /* no-op */ });
 
     // Set managers
     steeringExplorer.setSteeringManager(steeringManager);
@@ -149,7 +158,7 @@ export async function activate(context: vscode.ExtensionContext) {
     // Register all commands
     registerCliCommands(context, specKitDetector);
     registerSteeringCommands(context, steeringManager, steeringExplorer, outputChannel);
-    registerSpecKitCommands(context, specExplorer, outputChannel, specsTreeView);
+    registerSpecKitCommands(context, specExplorer, outputChannel, specsTreeView, specsFilterState);
     registerUtilityCommands(context, updateChecker, outputChannel);
 
     // Set up file watchers

--- a/src/features/specs/__tests__/fuzzyMatch.test.ts
+++ b/src/features/specs/__tests__/fuzzyMatch.test.ts
@@ -1,0 +1,61 @@
+import { fuzzyMatch, normalize } from '../fuzzyMatch';
+
+describe('fuzzyMatch', () => {
+    describe('normalize', () => {
+        it('lowercases and strips non-alphanumeric characters', () => {
+            expect(normalize('Tree-Group-Counts')).toBe('treegroupcounts');
+            expect(normalize('  Hello, World! ')).toBe('helloworld');
+            expect(normalize('075-filter_specs.tree')).toBe('075filterspecstree');
+        });
+
+        it('returns empty string for strings with no alphanumerics', () => {
+            expect(normalize('---')).toBe('');
+            expect(normalize('')).toBe('');
+        });
+    });
+
+    describe('fuzzyMatch', () => {
+        it('returns true for an empty query', () => {
+            expect(fuzzyMatch('', 'anything')).toBe(true);
+            expect(fuzzyMatch('   ', 'anything')).toBe(true);
+            expect(fuzzyMatch('---', 'anything')).toBe(true);
+        });
+
+        it('matches case-insensitively', () => {
+            expect(fuzzyMatch('TREE', 'filter-specs-tree')).toBe(true);
+            expect(fuzzyMatch('tree', 'FILTER-SPECS-TREE')).toBe(true);
+        });
+
+        it('matches subsequences, not just substrings', () => {
+            expect(fuzzyMatch('fst', 'filter-specs-tree')).toBe(true);
+            expect(fuzzyMatch('ftr', 'filter-specs-tree')).toBe(true);
+        });
+
+        it('rejects non-subsequences', () => {
+            expect(fuzzyMatch('xyz', 'filter-specs-tree')).toBe(false);
+            expect(fuzzyMatch('treef', 'filter-specs-tree')).toBe(false);
+        });
+
+        it('normalizes punctuation and whitespace on both sides', () => {
+            expect(fuzzyMatch('tree view', 'treeview')).toBe(true);
+            expect(fuzzyMatch('tree-view', 'tree view')).toBe(true);
+            expect(fuzzyMatch('t_r.e:e', 'tree')).toBe(true);
+        });
+
+        it('matches across multiple haystacks concatenated in order', () => {
+            expect(fuzzyMatch('filtertree', '075-filter-specs-tree', 'Filter specs tree')).toBe(true);
+            expect(fuzzyMatch('filter', '075-foo', 'Filter/search box')).toBe(true);
+        });
+
+        it('skips undefined haystacks', () => {
+            expect(fuzzyMatch('tree', 'filter-specs-tree', undefined)).toBe(true);
+            expect(fuzzyMatch('tree', undefined, 'tree view')).toBe(true);
+            expect(fuzzyMatch('tree', undefined, undefined)).toBe(false);
+        });
+
+        it('returns false when haystack is empty or only non-alphanumeric', () => {
+            expect(fuzzyMatch('a', '---')).toBe(false);
+            expect(fuzzyMatch('a', '')).toBe(false);
+        });
+    });
+});

--- a/src/features/specs/__tests__/specExplorerProvider.test.ts
+++ b/src/features/specs/__tests__/specExplorerProvider.test.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode';
 import * as fs from 'fs';
 import * as path from 'path';
 import { SpecExplorerProvider } from '../specExplorerProvider';
+import { SpecsFilterState } from '../specsFilterState';
 
 // Mock fs module
 jest.mock('fs');
@@ -744,6 +745,114 @@ describe('SpecExplorerProvider', () => {
                 expect(groupsA[i].id).toBe(groupsB[i].id);
                 expect(groupsA[i].id).toMatch(/^spec-group:/);
             }
+        });
+    });
+
+    describe('with filter active', () => {
+        function buildFilterState(initialQuery: string): SpecsFilterState {
+            const store = new Map<string, unknown>();
+            if (initialQuery) store.set('speckit.specs.filter.query', initialQuery);
+            const fakeCtx = {
+                workspaceState: {
+                    get: jest.fn((key: string) => store.get(key)),
+                    update: jest.fn(async (key: string, value: unknown) => {
+                        if (value === undefined) store.delete(key);
+                        else store.set(key, value);
+                    }),
+                    keys: jest.fn(() => Array.from(store.keys())),
+                },
+            } as unknown as vscode.ExtensionContext;
+            return new SpecsFilterState(fakeCtx, () => { /* noop */ });
+        }
+
+        function seedThreeSpecs() {
+            (resolveSpecDirectories as jest.Mock).mockResolvedValue([
+                { name: '070-design-tighten-safety', path: 'specs/070-design-tighten-safety' },
+                { name: '071-tree-group-counts', path: 'specs/071-tree-group-counts' },
+                { name: '072-immediate-status-update', path: 'specs/072-immediate-status-update' },
+            ]);
+            (readSpecContextSync as jest.Mock).mockImplementation((specPath: string) => {
+                if (specPath.includes('070-')) return { status: 'active', specName: 'Design — tighten safety' };
+                if (specPath.includes('071-')) return { status: 'active', specName: 'Tree group counts' };
+                if (specPath.includes('072-')) return { status: 'completed', specName: 'Immediate status update' };
+                return undefined;
+            });
+        }
+
+        it('returns only matching specs across groups with filtered counts', async () => {
+            seedThreeSpecs();
+            const filterState = buildFilterState('tree');
+            const filteredProvider = new SpecExplorerProvider(context, outputChannel, filterState);
+
+            const groups = await filteredProvider.getChildren();
+
+            expect(groups).toHaveLength(1);
+            expect(groups[0].label).toBe('Active (1)');
+            const specs = await filteredProvider.getChildren(groups[0]);
+            expect(specs.map(s => s.label)).toEqual(['071-tree-group-counts']);
+        });
+
+        it('matches by specName when slug alone does not match', async () => {
+            seedThreeSpecs();
+            const filterState = buildFilterState('safety');
+            const filteredProvider = new SpecExplorerProvider(context, outputChannel, filterState);
+
+            const groups = await filteredProvider.getChildren();
+
+            expect(groups).toHaveLength(1);
+            expect(groups[0].label).toBe('Active (1)');
+            const specs = await filteredProvider.getChildren(groups[0]);
+            expect(specs.map(s => s.label)).toEqual(['070-design-tighten-safety']);
+        });
+
+        it('returns empty root when filter matches zero specs', async () => {
+            seedThreeSpecs();
+            const filterState = buildFilterState('zzz');
+            const filteredProvider = new SpecExplorerProvider(context, outputChannel, filterState);
+
+            const groups = await filteredProvider.getChildren();
+
+            expect(groups).toEqual([]);
+        });
+
+        it('sets speckit.specs.noFilterMatch=true when filter matches nothing', async () => {
+            seedThreeSpecs();
+            const filterState = buildFilterState('zzz');
+            const filteredProvider = new SpecExplorerProvider(context, outputChannel, filterState);
+            (vscode.commands.executeCommand as jest.Mock).mockClear();
+
+            await filteredProvider.getChildren();
+
+            expect(vscode.commands.executeCommand).toHaveBeenCalledWith(
+                'setContext',
+                'speckit.specs.noFilterMatch',
+                true,
+            );
+        });
+
+        it('sets speckit.specs.noFilterMatch=false when filter matches at least one spec', async () => {
+            seedThreeSpecs();
+            const filterState = buildFilterState('tree');
+            const filteredProvider = new SpecExplorerProvider(context, outputChannel, filterState);
+            (vscode.commands.executeCommand as jest.Mock).mockClear();
+
+            await filteredProvider.getChildren();
+
+            expect(vscode.commands.executeCommand).toHaveBeenCalledWith(
+                'setContext',
+                'speckit.specs.noFilterMatch',
+                false,
+            );
+        });
+
+        it('shows the full tree when filter is cleared', async () => {
+            seedThreeSpecs();
+            const filterState = buildFilterState('');
+            const filteredProvider = new SpecExplorerProvider(context, outputChannel, filterState);
+
+            const groups = await filteredProvider.getChildren();
+
+            expect(groups.map(g => g.label)).toEqual(['Active (2)', 'Completed (1)']);
         });
     });
 });

--- a/src/features/specs/__tests__/specsFilterState.test.ts
+++ b/src/features/specs/__tests__/specsFilterState.test.ts
@@ -1,0 +1,108 @@
+import * as vscode from 'vscode';
+import { SpecsFilterState } from '../specsFilterState';
+import { ConfigKeys } from '../../../core/constants';
+
+const KEY = ConfigKeys.workspaceState.specsFilterQuery;
+const CONTEXT_KEY = 'speckit.specs.filterActive';
+
+function makeContext() {
+    const store = new Map<string, unknown>();
+    return {
+        workspaceState: {
+            get: jest.fn((key: string) => store.get(key)),
+            update: jest.fn(async (key: string, value: unknown) => {
+                if (value === undefined) store.delete(key);
+                else store.set(key, value);
+            }),
+            keys: jest.fn(() => Array.from(store.keys())),
+        },
+    } as unknown as vscode.ExtensionContext;
+}
+
+describe('SpecsFilterState', () => {
+    beforeEach(() => {
+        (vscode.commands.executeCommand as jest.Mock).mockClear();
+    });
+
+    it('returns empty string when no query is persisted', () => {
+        const ctx = makeContext();
+        const onChange = jest.fn();
+        const state = new SpecsFilterState(ctx, onChange);
+
+        expect(state.getQuery()).toBe('');
+    });
+
+    it('persists the query, sets the filterActive context key, and calls onChange', async () => {
+        const ctx = makeContext();
+        const onChange = jest.fn();
+        const state = new SpecsFilterState(ctx, onChange);
+
+        await state.setQuery('tree');
+
+        expect(ctx.workspaceState.update).toHaveBeenCalledWith(KEY, 'tree');
+        expect(vscode.commands.executeCommand).toHaveBeenCalledWith('setContext', CONTEXT_KEY, true);
+        expect(onChange).toHaveBeenCalledTimes(1);
+        expect(state.getQuery()).toBe('tree');
+    });
+
+    it('trims whitespace before persisting', async () => {
+        const ctx = makeContext();
+        const state = new SpecsFilterState(ctx, jest.fn());
+
+        await state.setQuery('   tree   ');
+
+        expect(ctx.workspaceState.update).toHaveBeenCalledWith(KEY, 'tree');
+    });
+
+    it('treats a blank query as clear()', async () => {
+        const ctx = makeContext();
+        const onChange = jest.fn();
+        const state = new SpecsFilterState(ctx, onChange);
+
+        await state.setQuery('tree');
+        (ctx.workspaceState.update as jest.Mock).mockClear();
+        onChange.mockClear();
+
+        await state.setQuery('   ');
+
+        expect(ctx.workspaceState.update).toHaveBeenCalledWith(KEY, undefined);
+        expect(vscode.commands.executeCommand).toHaveBeenCalledWith('setContext', CONTEXT_KEY, false);
+        expect(onChange).toHaveBeenCalledTimes(1);
+    });
+
+    it('clear() removes the persisted value and unsets the context key', async () => {
+        const ctx = makeContext();
+        const onChange = jest.fn();
+        const state = new SpecsFilterState(ctx, onChange);
+
+        await state.setQuery('tree');
+        (vscode.commands.executeCommand as jest.Mock).mockClear();
+        onChange.mockClear();
+
+        await state.clear();
+
+        expect(ctx.workspaceState.update).toHaveBeenCalledWith(KEY, undefined);
+        expect(vscode.commands.executeCommand).toHaveBeenCalledWith('setContext', CONTEXT_KEY, false);
+        expect(onChange).toHaveBeenCalledTimes(1);
+        expect(state.getQuery()).toBe('');
+    });
+
+    it('initialize() syncs the context key from persisted state', async () => {
+        const ctx = makeContext();
+        (ctx.workspaceState.get as jest.Mock).mockImplementation((key: string) => key === KEY ? 'tree' : undefined);
+
+        const state = new SpecsFilterState(ctx, jest.fn());
+        await state.initialize();
+
+        expect(vscode.commands.executeCommand).toHaveBeenCalledWith('setContext', CONTEXT_KEY, true);
+    });
+
+    it('initialize() sets filterActive=false when no persisted query', async () => {
+        const ctx = makeContext();
+        const state = new SpecsFilterState(ctx, jest.fn());
+
+        await state.initialize();
+
+        expect(vscode.commands.executeCommand).toHaveBeenCalledWith('setContext', CONTEXT_KEY, false);
+    });
+});

--- a/src/features/specs/fuzzyMatch.ts
+++ b/src/features/specs/fuzzyMatch.ts
@@ -1,0 +1,20 @@
+export function normalize(s: string): string {
+    return s.toLowerCase().replace(/[^a-z0-9]/g, '');
+}
+
+export function fuzzyMatch(query: string, ...haystacks: Array<string | undefined>): boolean {
+    const q = normalize(query);
+    if (q.length === 0) return true;
+    const hay = haystacks
+        .filter((h): h is string => typeof h === 'string')
+        .map(normalize)
+        .join('');
+    let i = 0;
+    for (const ch of hay) {
+        if (ch === q[i]) {
+            i++;
+            if (i === q.length) return true;
+        }
+    }
+    return false;
+}

--- a/src/features/specs/index.ts
+++ b/src/features/specs/index.ts
@@ -1,3 +1,4 @@
 export * from './specExplorerProvider';
 export * from './specCommands';
 export * from './selectionContextKeys';
+export * from './specsFilterState';

--- a/src/features/specs/specCommands.test.ts
+++ b/src/features/specs/specCommands.test.ts
@@ -80,8 +80,8 @@ beforeEach(() => {
 
 describe('registerSpecKitCommands', () => {
     it('has no specKitDetector parameter', () => {
-        // Signature is (context, specExplorer, outputChannel, specsTreeView?) — no specKitDetector.
-        expect(registerSpecKitCommands.length).toBe(4);
+        // Signature is (context, specExplorer, outputChannel, specsTreeView?, filterState?) — no specKitDetector.
+        expect(registerSpecKitCommands.length).toBe(5);
     });
 
     it('registers the speckit.create command', () => {

--- a/src/features/specs/specCommands.ts
+++ b/src/features/specs/specCommands.ts
@@ -21,6 +21,7 @@ import { startStep, setStatus, reactivate } from './stepLifecycle';
 import { updateSelectionContextKeys } from './selectionContextKeys';
 import { track as trackTerminal } from './terminalStepTracker';
 import type { StepName } from '../../core/types/specContext';
+import { SpecsFilterState } from './specsFilterState';
 
 function toWorkspaceRelative(absOrRel: string): string {
     const ws = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
@@ -45,7 +46,8 @@ export function registerSpecKitCommands(
     context: vscode.ExtensionContext,
     specExplorer: SpecExplorerProvider,
     outputChannel: vscode.OutputChannel,
-    specsTreeView?: vscode.TreeView<any>
+    specsTreeView?: vscode.TreeView<any>,
+    filterState?: SpecsFilterState
 ): void {
     function resolveTargets(item: SpecTreeItem | undefined, items: SpecTreeItem[] | undefined): SpecTreeItem[] {
         if (items && items.length > 0) return items;
@@ -98,6 +100,27 @@ export function registerSpecKitCommands(
         vscode.commands.registerCommand('speckit.specs.collapseAll', toggleCollapseAllHandler),
         vscode.commands.registerCommand('speckit.specs.expandAll', toggleCollapseAllHandler)
     );
+
+    // Filter specs: prompt for a fuzzy query (prefilled with the current one so
+    // edits are incremental) and persist it via SpecsFilterState. Clearing is a
+    // separate command gated on the `speckit.specs.filterActive` context key.
+    if (filterState) {
+        context.subscriptions.push(
+            vscode.commands.registerCommand(Commands.specsFilter, async () => {
+                const current = filterState.getQuery();
+                const input = await vscode.window.showInputBox({
+                    value: current,
+                    prompt: 'Filter specs by slug or name',
+                    placeHolder: 'type to filter…',
+                });
+                if (input === undefined) return;
+                await filterState.setQuery(input);
+            }),
+            vscode.commands.registerCommand(Commands.specsFilterClear, async () => {
+                await filterState.clear();
+            })
+        );
+    }
 
     // Spec delete
     context.subscriptions.push(

--- a/src/features/specs/specExplorerProvider.ts
+++ b/src/features/specs/specExplorerProvider.ts
@@ -18,6 +18,8 @@ import { SpecStatuses, WorkflowSteps } from '../../core/constants';
 import { readSpecContextSync } from './specContextManager';
 import { isStepCompleted } from '../spec-viewer/stateDerivation';
 import { StepName, STEP_NAMES } from '../../core/types/specContext';
+import { SpecsFilterState } from './specsFilterState';
+import { fuzzyMatch } from './fuzzyMatch';
 
 export interface SpecInfo {
     name: string;
@@ -30,7 +32,11 @@ export class SpecExplorerProvider extends BaseTreeDataProvider<SpecItem> {
     public activeSpecName: string | null = null;
     public expandAllSpecs: boolean = true;
 
-    constructor(context: vscode.ExtensionContext, outputChannel: vscode.OutputChannel) {
+    constructor(
+        context: vscode.ExtensionContext,
+        outputChannel: vscode.OutputChannel,
+        private readonly filterState?: SpecsFilterState
+    ) {
         super(context, { name: 'SpecExplorerProvider', outputChannel });
     }
 
@@ -92,14 +98,19 @@ export class SpecExplorerProvider extends BaseTreeDataProvider<SpecItem> {
             const workspaceFolder = vscode.workspace.workspaceFolders![0];
             const basePath = workspaceFolder.uri.fsPath;
 
-            // Partition specs by status from .spec-context.json
+            // Partition specs by status from .spec-context.json. Cache each spec's
+            // context read so the fuzzy filter below can reuse specName without a
+            // second disk read per spec.
             const activeSpecs: SpecInfo[] = [];
             const completedSpecs: SpecInfo[] = [];
             const archivedSpecs: SpecInfo[] = [];
+            const specNameByPath = new Map<string, string | undefined>();
 
             for (const spec of specs) {
                 const specFullPath = path.join(basePath, spec.path);
-                const status = this.getSpecStatus(specFullPath);
+                const context = readSpecContextSync(specFullPath);
+                const status = context?.status || SpecStatuses.ACTIVE;
+                specNameByPath.set(spec.path, context?.specName);
                 if (status === SpecStatuses.COMPLETED) {
                     completedSpecs.push(spec);
                 } else if (status === SpecStatuses.ARCHIVED) {
@@ -108,6 +119,28 @@ export class SpecExplorerProvider extends BaseTreeDataProvider<SpecItem> {
                     activeSpecs.push(spec);
                 }
             }
+
+            // Apply fuzzy filter across slug + specName when a query is active.
+            const query = this.filterState?.getQuery() ?? '';
+            let filteredActive = activeSpecs;
+            let filteredCompleted = completedSpecs;
+            let filteredArchived = archivedSpecs;
+            if (query.length > 0) {
+                const matches = (spec: SpecInfo) =>
+                    fuzzyMatch(query, spec.name, specNameByPath.get(spec.path));
+                filteredActive = activeSpecs.filter(matches);
+                filteredCompleted = completedSpecs.filter(matches);
+                filteredArchived = archivedSpecs.filter(matches);
+            }
+
+            const noFilterMatch = query.length > 0
+                && filteredActive.length === 0
+                && filteredCompleted.length === 0
+                && filteredArchived.length === 0;
+            try {
+                const p = vscode.commands.executeCommand('setContext', 'speckit.specs.noFilterMatch', noFilterMatch);
+                Promise.resolve(p).catch(() => { /* fire-and-forget */ });
+            } catch { /* fire-and-forget */ }
 
             // Sort: numeric-prefixed specs (e.g. "069-...") by prefix desc —
             // stable across git operations that rewrite filesystem birthtime.
@@ -131,48 +164,48 @@ export class SpecExplorerProvider extends BaseTreeDataProvider<SpecItem> {
                     return 0;
                 }
             };
-            activeSpecs.sort(sortSpecs);
-            completedSpecs.sort(sortSpecs);
-            archivedSpecs.sort(sortSpecs);
+            filteredActive.sort(sortSpecs);
+            filteredCompleted.sort(sortSpecs);
+            filteredArchived.sort(sortSpecs);
 
             const items: SpecItem[] = [];
 
             // Group items get stable ids so VS Code preserves the user's
             // manual expand/collapse state across refreshes — the toggle
             // button only affects spec items, never groups.
-            if (activeSpecs.length > 0) {
+            if (filteredActive.length > 0) {
                 const activeGroup = new SpecItem(
-                    `Active (${activeSpecs.length})`,
+                    `Active (${filteredActive.length})`,
                     vscode.TreeItemCollapsibleState.Expanded,
                     'spec-group',
                     this.context
                 );
                 activeGroup.id = 'spec-group:active';
-                activeGroup.groupSpecs = activeSpecs;
+                activeGroup.groupSpecs = filteredActive;
                 items.push(activeGroup);
             }
 
-            if (completedSpecs.length > 0) {
+            if (filteredCompleted.length > 0) {
                 const completedGroup = new SpecItem(
-                    `Completed (${completedSpecs.length})`,
+                    `Completed (${filteredCompleted.length})`,
                     vscode.TreeItemCollapsibleState.Collapsed,
                     'spec-group',
                     this.context
                 );
                 completedGroup.id = 'spec-group:completed';
-                completedGroup.groupSpecs = completedSpecs;
+                completedGroup.groupSpecs = filteredCompleted;
                 items.push(completedGroup);
             }
 
-            if (archivedSpecs.length > 0) {
+            if (filteredArchived.length > 0) {
                 const archivedGroup = new SpecItem(
-                    `Archived (${archivedSpecs.length})`,
+                    `Archived (${filteredArchived.length})`,
                     vscode.TreeItemCollapsibleState.Collapsed,
                     'spec-group',
                     this.context
                 );
                 archivedGroup.id = 'spec-group:archived';
-                archivedGroup.groupSpecs = archivedSpecs;
+                archivedGroup.groupSpecs = filteredArchived;
                 items.push(archivedGroup);
             }
 

--- a/src/features/specs/specsFilterState.ts
+++ b/src/features/specs/specsFilterState.ts
@@ -1,0 +1,41 @@
+import * as vscode from 'vscode';
+import { ConfigKeys } from '../../core/constants';
+
+const FILTER_ACTIVE_CONTEXT_KEY = 'speckit.specs.filterActive';
+
+/**
+ * Tracks the current specs-tree filter query and persists it to workspace state.
+ * Notifies the provider via `onChange` whenever the query changes so the tree refreshes.
+ */
+export class SpecsFilterState {
+    constructor(
+        private readonly context: vscode.ExtensionContext,
+        private readonly onChange: () => void
+    ) {}
+
+    getQuery(): string {
+        return this.context.workspaceState.get<string>(ConfigKeys.workspaceState.specsFilterQuery) ?? '';
+    }
+
+    async setQuery(q: string): Promise<void> {
+        const trimmed = (q ?? '').trim();
+        if (trimmed.length === 0) {
+            await this.clear();
+            return;
+        }
+        await this.context.workspaceState.update(ConfigKeys.workspaceState.specsFilterQuery, trimmed);
+        await vscode.commands.executeCommand('setContext', FILTER_ACTIVE_CONTEXT_KEY, true);
+        this.onChange();
+    }
+
+    async clear(): Promise<void> {
+        await this.context.workspaceState.update(ConfigKeys.workspaceState.specsFilterQuery, undefined);
+        await vscode.commands.executeCommand('setContext', FILTER_ACTIVE_CONTEXT_KEY, false);
+        this.onChange();
+    }
+
+    async initialize(): Promise<void> {
+        const active = this.getQuery().length > 0;
+        await vscode.commands.executeCommand('setContext', FILTER_ACTIVE_CONTEXT_KEY, active);
+    }
+}

--- a/webview/styles/spec-viewer/_navigation.css
+++ b/webview/styles/spec-viewer/_navigation.css
@@ -102,10 +102,13 @@
     font-weight: 700;
 }
 
-/* In-flight (canonical): accent % pill + single working-pulse animation */
+/* In-flight (canonical): success-colored % pill + matching working-pulse glow.
+   Pill background matches the green pulse (--success) so the pill and its ring
+   read as one "work in progress" state — using --accent here clashed with the
+   green pulse on themes where --vscode-focusBorder is purple. */
 .step-tab.in-flight .step-status {
-    background: var(--accent);
-    border-color: var(--accent);
+    background: var(--success);
+    border-color: var(--success);
     color: white;
     font-size: 11px;
     font-weight: 700;
@@ -117,7 +120,7 @@
 }
 
 .step-tab.in-flight .step-label {
-    color: var(--accent);
+    color: var(--success);
     font-weight: 700;
 }
 


### PR DESCRIPTION
## What

- Add a fuzzy filter to the specs tree — matches by slug + `specName`, case-insensitive, subsequence-based (e.g. `ftr` matches `filter-specs-tree`)
- New title-bar actions: **Filter Specs…** (always visible) and **Clear Specs Filter** (visible only while a filter is active)
- Active filter query persists to `workspaceState` under `speckit.specs.filter.query` and restores on activation
- Group counts (`Active (N)` / `Completed (N)` / `Archived (N)`) reflect filtered totals; empty groups are hidden
- When a filter matches zero specs, the view shows an empty-state welcome with a one-click clear action
- Bundled drive-by CSS fix: in-flight step-tab's percentage pill now uses `--success` (green) to match its working-pulse glow — previously `--accent` (often purple via `--vscode-focusBorder`) clashed with the green pulse

## Why

Specs accumulate fast — after a month of real use the tree has 70+ entries and no affordance to narrow it down. A fuzzy filter is a big win once a user has >10 specs, which is most real usage.

## Testing

- `npm test` — 328/328 pass (17 new: 10 for fuzzyMatch helper, 7 for SpecsFilterState, plus provider integration tests for filter wiring and `noFilterMatch` context key)
- `npm run compile` passes
- Manual: F5 into the extension — filter icon appears in the Specs title bar; `Filter Specs…` opens a prompt prefilled with the current query; filtered groups show adjusted counts; clear-filter icon appears while active; empty-state welcome shows on zero matches; running step now shows a consistently green pill + pulse

Closes #103