### PR TITLE
Polish spec-viewer: step tabs, badge status colors, header layout

### DIFF
--- a/docs/viewer-states.md
+++ b/docs/viewer-states.md
@@ -251,8 +251,8 @@ stateDiagram-v2
 
 | Class | Meaning | Visual |
 |-------|---------|--------|
-| `exists` | File exists on disk | Green checkmark dot |
-| `viewing` | Currently displayed in viewer | White bold label |
+| `exists` | File exists on disk | Green checkmark dot + bright label (normal weight) |
+| `viewing` | Currently displayed in viewer | Accent-tinted fill + inset accent ring wrapping the whole tab + bold bright label |
 | `working` | Step being worked on (from `spec-context.step`, only if not completed) | Pulsing green glow on dot + live elapsed timer (e.g. `3m 22s`) rendered via `.step-tab__elapsed` |
 | `tasks-active` | Viewing tasks with 0-100% progress | Percentage badge in dot |
 | `in-progress` | Tasks have progress but not viewing | Percentage in dot (subtle) |

--- a/webview/src/shared/components/Badge.stories.tsx
+++ b/webview/src/shared/components/Badge.stories.tsx
@@ -9,18 +9,85 @@ export default meta;
 
 type Story = StoryObj<typeof Badge>;
 
-export const Draft: Story = { args: { text: 'DRAFT', variant: 'status' } };
-export const Completed: Story = { args: { text: 'COMPLETED', variant: 'status' } };
-export const Active: Story = { args: { text: 'ACTIVE', variant: 'status' } };
+// Canonical status labels mirrored from src/features/spec-viewer/phaseCalculation.ts
+// (stories can't import from src/, so duplicated here).
+const LABELS = {
+    draft: 'DRAFT',
+    active: 'ACTIVE',
+    specifying: 'SPECIFYING...',
+    specified: 'SPECIFY COMPLETE',
+    planning: 'PLANNING...',
+    planned: 'PLAN COMPLETE',
+    tasking: 'CREATING TASKS...',
+    readyToImplement: 'READY TO IMPLEMENT',
+    implementing: 'IMPLEMENTING...',
+    tasksDone: 'TASKS DONE',
+    completed: 'COMPLETED',
+    archived: 'ARCHIVED',
+};
+
+// ── Neutral / pre-work ──────────────────────────────────
+
+export const Default: Story = { args: { text: LABELS.active, variant: 'status' } };
+export const Active: Story = { args: { text: LABELS.active, variant: 'status', status: 'active' } };
+export const Draft: Story = { args: { text: LABELS.draft, variant: 'status', status: 'draft' } };
+
+// ── In-progress (accent tier) ───────────────────────────
+
+export const Specifying: Story = { args: { text: LABELS.specifying, variant: 'status', status: 'specifying' } };
+export const Planning: Story = { args: { text: LABELS.planning, variant: 'status', status: 'planning' } };
+export const Tasking: Story = { args: { text: LABELS.tasking, variant: 'status', status: 'tasking' } };
+export const Implementing: Story = { args: { text: LABELS.implementing, variant: 'status', status: 'implementing' } };
+
+// ── Intermediate done (success-subtle tier) ─────────────
+
+export const Specified: Story = { args: { text: LABELS.specified, variant: 'status', status: 'specified' } };
+export const Planned: Story = { args: { text: LABELS.planned, variant: 'status', status: 'planned' } };
+export const ReadyToImplement: Story = { args: { text: LABELS.readyToImplement, variant: 'status', status: 'ready-to-implement' } };
+export const TasksDone: Story = { args: { text: LABELS.tasksDone, variant: 'status', status: 'tasks-done' } };
+
+// ── Terminal ────────────────────────────────────────────
+
+export const Completed: Story = { args: { text: LABELS.completed, variant: 'status', status: 'completed' } };
+export const Archived: Story = { args: { text: LABELS.archived, variant: 'status', status: 'archived' } };
+
+// ── Stale indicator (circle, distinct from pill) ────────
+
 export const Stale: Story = { args: { text: '!', variant: 'stale' } };
 
-export const AllBadges: Story = {
+// ── All at once, grouped by tier ────────────────────────
+
+export const AllStatuses: Story = {
     render: () => (
-        <div style="display: flex; gap: 12px; align-items: center;">
-            <Badge text="DRAFT" variant="status" />
-            <Badge text="COMPLETED" variant="status" />
-            <Badge text="ACTIVE" variant="status" />
-            <Badge text="!" variant="stale" />
+        <div style="display: flex; flex-direction: column; gap: 16px; align-items: flex-start;">
+            <div style="display: flex; gap: 10px; align-items: center; flex-wrap: wrap;">
+                <span style="font-size: 11px; color: var(--text-secondary); min-width: 120px;">Pre-work / neutral</span>
+                <Badge text={LABELS.draft} status="draft" />
+                <Badge text={LABELS.active} status="active" />
+            </div>
+            <div style="display: flex; gap: 10px; align-items: center; flex-wrap: wrap;">
+                <span style="font-size: 11px; color: var(--text-secondary); min-width: 120px;">In-progress</span>
+                <Badge text={LABELS.specifying} status="specifying" />
+                <Badge text={LABELS.planning} status="planning" />
+                <Badge text={LABELS.tasking} status="tasking" />
+                <Badge text={LABELS.implementing} status="implementing" />
+            </div>
+            <div style="display: flex; gap: 10px; align-items: center; flex-wrap: wrap;">
+                <span style="font-size: 11px; color: var(--text-secondary); min-width: 120px;">Intermediate done</span>
+                <Badge text={LABELS.specified} status="specified" />
+                <Badge text={LABELS.planned} status="planned" />
+                <Badge text={LABELS.readyToImplement} status="ready-to-implement" />
+                <Badge text={LABELS.tasksDone} status="tasks-done" />
+            </div>
+            <div style="display: flex; gap: 10px; align-items: center; flex-wrap: wrap;">
+                <span style="font-size: 11px; color: var(--text-secondary); min-width: 120px;">Terminal</span>
+                <Badge text={LABELS.completed} status="completed" />
+                <Badge text={LABELS.archived} status="archived" />
+            </div>
+            <div style="display: flex; gap: 10px; align-items: center; flex-wrap: wrap;">
+                <span style="font-size: 11px; color: var(--text-secondary); min-width: 120px;">Stale indicator</span>
+                <Badge text="!" variant="stale" />
+            </div>
         </div>
     ),
 };

--- a/webview/src/shared/components/Badge.tsx
+++ b/webview/src/shared/components/Badge.tsx
@@ -3,11 +3,13 @@ export type BadgeVariant = 'status' | 'stale';
 export interface BadgeProps {
     text: string;
     variant?: BadgeVariant;
+    status?: string;
     class?: string;
 }
 
-export function Badge({ text, variant = 'status', class: cls }: BadgeProps) {
+export function Badge({ text, variant = 'status', status, class: cls }: BadgeProps) {
     const base = variant === 'stale' ? 'stale-badge' : 'spec-badge';
-    const className = [base, cls].filter(Boolean).join(' ');
+    const statusClass = variant === 'status' && status ? `spec-badge--${status}` : '';
+    const className = [base, statusClass, cls].filter(Boolean).join(' ');
     return <span class={className}>{text}</span>;
 }

--- a/webview/src/spec-viewer/components/SpecHeader.stories.tsx
+++ b/webview/src/spec-viewer/components/SpecHeader.stories.tsx
@@ -6,10 +6,25 @@ import { mockNavState } from './__stories__/mockData';
 const meta: Meta<typeof SpecHeader> = {
     title: 'Viewer/SpecHeader',
     component: SpecHeader,
+    // Reset body[data-spec-status] before every story so a previous status
+    // variant doesn't leak into the next one. Status stories below re-apply
+    // the attribute via their own decorator.
+    decorators: [
+        (Story) => {
+            document.body.removeAttribute('data-spec-status');
+            return <Story />;
+        },
+    ],
 };
 export default meta;
 
 type Story = StoryObj<typeof SpecHeader>;
+
+/** Per-story decorator that sets body[data-spec-status] for the duration of the story. */
+const withStatus = (status: string) => (Story: any) => {
+    document.body.setAttribute('data-spec-status', status);
+    return <Story />;
+};
 
 export const Full: Story = {
     render: () => {
@@ -57,6 +72,58 @@ export const Empty: Story = {
             createdDate: null,
             specContextName: null,
             branch: null,
+        });
+        return <SpecHeader />;
+    },
+};
+
+// ── Spec-badge variants driven by body[data-spec-status] ─────
+// Each sets the attribute via the `withStatus` decorator so the
+// .spec-badge overrides in _content.css (lines 275–297) render.
+
+export const StatusActive: Story = {
+    decorators: [withStatus('active')],
+    render: () => {
+        navState.value = mockNavState({
+            badgeText: 'ACTIVE',
+            specContextName: 'Active Feature',
+            docTypeLabel: 'Spec',
+        });
+        return <SpecHeader />;
+    },
+};
+
+export const StatusCompleted: Story = {
+    decorators: [withStatus('completed')],
+    render: () => {
+        navState.value = mockNavState({
+            badgeText: 'COMPLETED',
+            specContextName: 'Completed Feature',
+            docTypeLabel: 'Tasks',
+        });
+        return <SpecHeader />;
+    },
+};
+
+export const StatusArchived: Story = {
+    decorators: [withStatus('archived')],
+    render: () => {
+        navState.value = mockNavState({
+            badgeText: 'ARCHIVED',
+            specContextName: 'Archived Feature',
+            docTypeLabel: 'Spec',
+        });
+        return <SpecHeader />;
+    },
+};
+
+export const StatusTasksDone: Story = {
+    decorators: [withStatus('tasks-done')],
+    render: () => {
+        navState.value = mockNavState({
+            badgeText: 'TASKS DONE',
+            specContextName: 'All Tasks Complete',
+            docTypeLabel: 'Tasks',
         });
         return <SpecHeader />;
     },

--- a/webview/src/spec-viewer/components/SpecHeader.tsx
+++ b/webview/src/spec-viewer/components/SpecHeader.tsx
@@ -22,7 +22,7 @@ export function SpecHeader() {
 
     return (
         <div class="spec-header" data-has-context={String(hasContext)}>
-            {(badgeText || ns.branch) && (
+            {(badgeText || ns.branch || ns.createdDate) && (
                 <div class="spec-header-badges">
                     {badgeText && (
                         <span class={`spec-badge${statusClass ? ` spec-badge--${statusClass}` : ''}`}>
@@ -30,26 +30,22 @@ export function SpecHeader() {
                         </span>
                     )}
                     {ns.branch && (
-                        <span class="spec-header-branch">
-                            <span class="branch-icon">{''}</span> {ns.branch}
-                        </span>
-                    )}
-                </div>
-            )}
-            {(ns.specContextName || ns.createdDate) && (
-                <div class="spec-header-main">
-                    {ns.specContextName && (
-                        <span class="spec-header-title">
-                            <span class="spec-header-doctype">{docTypeLabel}:</span>{' '}
-                            {ns.specContextName}
+                        <span class="spec-header-branch" title={`Branch: ${ns.branch}`}>
+                            <span class="codicon codicon-git-branch" aria-hidden="true"></span>
+                            {ns.branch}
                         </span>
                     )}
                     {ns.createdDate && (
-                        <span class="spec-date">
-                            <span class="meta-label">Created:</span>{' '}
-                            <span class="meta-date">{ns.createdDate}</span>
-                        </span>
+                        <span class="spec-header-date">{ns.createdDate}</span>
                     )}
+                </div>
+            )}
+            {ns.specContextName && (
+                <div class="spec-header-main">
+                    <span class="spec-header-title">
+                        <span class="spec-header-doctype">{docTypeLabel}:</span>{' '}
+                        {ns.specContextName}
+                    </span>
                 </div>
             )}
         </div>

--- a/webview/src/spec-viewer/components/StepTab.stories.tsx
+++ b/webview/src/spec-viewer/components/StepTab.stories.tsx
@@ -73,16 +73,128 @@ export const LockedStale: Story = {
     },
 };
 
+// ── Current + in-flight (the image 3/4 bug case) ─────────
+
+export const CurrentInFlight: Story = {
+    args: {
+        ...base,
+        doc: mockDoc('tasks', true, 'Tasks'),
+        index: 2,
+        currentDoc: 'tasks',
+        taskCompletionPercent: 33,
+    },
+};
+
+export const CurrentInFlightStale: Story = {
+    args: {
+        ...base,
+        doc: mockDoc('tasks', true, 'Tasks'),
+        index: 2,
+        currentDoc: 'tasks',
+        taskCompletionPercent: 33,
+        stalenessMap: staleMap('tasks'),
+    },
+};
+
+// ── Elapsed-timer bands (non-last step, activeStep + stepHistory) ─
+// Frozen at module load — open a story and it ticks forward. If the
+// Storybook tab sits idle, elapsed will drift past the labeled band;
+// reload to reset.
+const STARTED_12S_AGO = new Date(Date.now() - 12_000).toISOString();
+const STARTED_3M_22S_AGO = new Date(Date.now() - (3 * 60_000 + 22_000)).toISOString();
+const STARTED_2H_15M_AGO = new Date(Date.now() - (2 * 60 * 60_000 + 15 * 60_000)).toISOString();
+
+export const InFlightElapsedSeconds: Story = {
+    args: {
+        ...base,
+        doc: mockDoc('plan', true, 'Plan'),
+        index: 1,
+        activeStep: 'plan',
+        stepHistory: { plan: { startedAt: STARTED_12S_AGO } },
+    },
+};
+
+export const InFlightElapsedMinutes: Story = {
+    args: {
+        ...base,
+        doc: mockDoc('plan', true, 'Plan'),
+        index: 1,
+        activeStep: 'plan',
+        stepHistory: { plan: { startedAt: STARTED_3M_22S_AGO } },
+    },
+};
+
+export const InFlightElapsedHours: Story = {
+    args: {
+        ...base,
+        doc: mockDoc('plan', true, 'Plan'),
+        index: 1,
+        activeStep: 'plan',
+        stepHistory: { plan: { startedAt: STARTED_2H_15M_AGO } },
+    },
+};
+
+export const CurrentInFlightElapsed: Story = {
+    args: {
+        ...base,
+        doc: mockDoc('plan', true, 'Plan'),
+        index: 1,
+        currentDoc: 'plan',
+        activeStep: 'plan',
+        stepHistory: { plan: { startedAt: STARTED_3M_22S_AGO } },
+    },
+};
+
 // ── Full row ─────────────────────────────────────────────
 
 export const AllStates: Story = {
     render: () => (
         <div style="display: flex; gap: 0; align-items: center;">
-            <StepTab {...base} doc={mockDoc('spec', true, 'Specification')} currentDoc="spec" workflowPhase="plan" />
+            <StepTab
+                {...base}
+                doc={mockDoc('spec', true, 'Specification')}
+                currentDoc="_"
+                totalSteps={4}
+            />
             <span class="step-connector filled" />
-            <StepTab {...base} doc={mockDoc('plan', true, 'Plan')} index={1} activeStep="plan" />
+            <StepTab
+                {...base}
+                doc={mockDoc('plan', true, 'Plan')}
+                index={1}
+                currentDoc="plan"
+                totalSteps={4}
+            />
+            <span class="step-connector filled" />
+            <StepTab
+                {...base}
+                doc={mockDoc('tasks', true, 'Tasks')}
+                index={2}
+                currentDoc="_"
+                activeStep="tasks"
+                stepHistory={{ tasks: { startedAt: STARTED_3M_22S_AGO } }}
+                totalSteps={4}
+            />
             <span class="step-connector" />
-            <StepTab {...base} doc={mockDoc('tasks', true, 'Tasks')} index={2} taskCompletionPercent={45} currentDoc="tasks" />
+            <StepTab
+                {...base}
+                doc={mockDoc('done', false, 'Implement')}
+                index={3}
+                currentDoc="_"
+                totalSteps={4}
+                runningStepIndex={2}
+            />
+        </div>
+    ),
+};
+
+export const AllStatesWithPercent: Story = {
+    render: () => (
+        <div style="display: flex; gap: 0; align-items: center;">
+            <StepTab {...base} doc={mockDoc('spec', true, 'Specification')} currentDoc="spec" />
+            <span class="step-connector filled" />
+            <StepTab {...base} doc={mockDoc('plan', true, 'Plan')} index={1} currentDoc="_" />
+            <span class="step-connector filled" />
+            <StepTab {...base} doc={mockDoc('tasks', true, 'Tasks')} index={2} currentDoc="_" taskCompletionPercent={45} />
         </div>
     ),
 };

--- a/webview/styles/spec-viewer/_animations.css
+++ b/webview/styles/spec-viewer/_animations.css
@@ -73,6 +73,18 @@
     }
 }
 
+/* Gentle border breath for in-progress spec badges (specifying / planning /
+   tasking / implementing). Subtle enough to coexist with multiple badges in
+   a list view — border only, no glow. */
+@keyframes spec-badge-working {
+    0%, 100% {
+        border-color: color-mix(in srgb, var(--accent) 40%, transparent);
+    }
+    50% {
+        border-color: color-mix(in srgb, var(--accent) 75%, transparent);
+    }
+}
+
 /* Pulsing glow for active working step (green = active progress) */
 @keyframes working-pulse {
     0%, 100% {

--- a/webview/styles/spec-viewer/_content.css
+++ b/webview/styles/spec-viewer/_content.css
@@ -241,18 +241,26 @@ body[data-spec-status="archived"] .meta-status-draft {
     font-family: var(--font-mono);
     font-size: var(--text-xs);
     padding: 2px 8px;
-    background: var(--bg-secondary);
-    border: 1px solid var(--border);
+    background: color-mix(in srgb, var(--purple, #9a6dd7) 10%, transparent);
+    border: 1px solid color-mix(in srgb, var(--purple, #9a6dd7) 35%, transparent);
     border-radius: var(--radius-sm);
-    color: var(--text-muted);
+    color: var(--purple, #9a6dd7);
     display: inline-flex;
     align-items: center;
     gap: 4px;
 }
 
-.spec-header-branch .branch-icon {
-    font-family: 'codicon';
+.spec-header-branch .codicon {
     font-size: 12px;
+}
+
+/* Created-date tucked right in the top row — glance metadata, not a heading. */
+.spec-header-date {
+    margin-left: auto;
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    color: var(--text-muted);
+    white-space: nowrap;
 }
 
 /* ============================================
@@ -277,21 +285,58 @@ body[data-spec-status="completed"] .spec-badge {
     background: var(--vscode-charts-green, var(--success));
     color: var(--bg-primary);
     border-color: var(--vscode-charts-green, var(--success));
-    padding: 4px 12px;
-    font-size: var(--text-sm, 13px);
-    letter-spacing: 0.08em;
     box-shadow: 0 0 0 3px color-mix(in srgb, var(--vscode-charts-green, var(--success)) 22%, transparent);
     font-weight: 800;
 }
 
+/* Active — subtle accent hint so a live working spec reads distinct from
+   the unstyled default / DRAFT / ARCHIVED neutrals, without competing with
+   the in-progress tier. */
+.spec-badge--active {
+    background: color-mix(in srgb, var(--accent) 6%, transparent);
+    color: var(--text-primary);
+    border-color: color-mix(in srgb, var(--accent) 30%, transparent);
+}
+
+.spec-badge--archived,
 body[data-spec-status="archived"] .spec-badge {
     background: var(--bg-secondary);
     color: var(--text-muted);
     border-color: var(--border);
 }
 
+.spec-badge--tasks-done,
 body[data-spec-status="tasks-done"] .spec-badge {
     background: var(--success-subtle);
     color: var(--success);
     border-color: color-mix(in srgb, var(--success) 30%, transparent);
+}
+
+/* In-progress statuses — specifying / planning / tasking / implementing.
+   Accent-tinted fill so "work in progress" reads distinct from completed-green.
+   Gentle border breath via spec-badge-working keyframe signals live work. */
+.spec-badge--specifying,
+.spec-badge--planning,
+.spec-badge--tasking,
+.spec-badge--implementing {
+    background: color-mix(in srgb, var(--accent) 15%, transparent);
+    color: var(--accent);
+    border-color: color-mix(in srgb, var(--accent) 40%, transparent);
+    animation: spec-badge-working 2.5s ease-in-out infinite;
+}
+
+/* Intermediate-done statuses — a phase finished, workflow continues. */
+.spec-badge--specified,
+.spec-badge--planned,
+.spec-badge--ready-to-implement {
+    background: var(--success-subtle);
+    color: var(--success);
+    border-color: color-mix(in srgb, var(--success) 30%, transparent);
+}
+
+/* Draft / pre-work — muted, not as dim as archived. */
+.spec-badge--draft {
+    background: color-mix(in srgb, var(--text-secondary) 10%, transparent);
+    color: var(--text-secondary);
+    border-color: color-mix(in srgb, var(--text-secondary) 30%, transparent);
 }

--- a/webview/styles/spec-viewer/_navigation.css
+++ b/webview/styles/spec-viewer/_navigation.css
@@ -45,7 +45,7 @@
     padding: 8px 14px;
     border: none;
     background: transparent;
-    color: var(--text-muted);
+    color: var(--text-secondary);
     cursor: pointer;
     font-size: 13px;
     font-weight: 500;
@@ -55,7 +55,7 @@
     border-radius: var(--radius-sm);
 }
 
-.step-tab:hover:not(:disabled) {
+.step-tab:hover:not(:disabled):not(.current) {
     color: var(--text-primary);
     background: var(--bg-hover);
 }
@@ -87,18 +87,21 @@
 }
 
 .step-tab.done .step-label {
-    color: var(--text-secondary);
+    color: var(--text-primary);
 }
 
-/* Highlight the currently viewed step tab (canonical: current) */
+/* Highlight the currently viewed step tab (canonical: current).
+   Inset ring + accent-tinted fill so the highlight wraps the whole tab as one
+   contiguous chip — including when the step is also in-flight (the pulse stays
+   inside the ring instead of visually overflowing an outer outline). */
 .step-tab.current {
-    outline: 1px solid var(--accent, #4a9eff);
-    outline-offset: 2px;
-    border-radius: 4px;
+    background: color-mix(in srgb, var(--accent, #4a9eff) 15%, transparent);
+    box-shadow: inset 0 0 0 2px var(--accent, #4a9eff);
+    border-radius: 6px;
 }
 
 .step-tab.current .step-label {
-    color: var(--accent);
+    color: var(--text-primary);
     font-weight: 700;
 }
 
@@ -119,8 +122,14 @@
     animation: working-pulse 2s ease-in-out infinite;
 }
 
+/* Extra left padding so the pill's ~16px working-pulse glow doesn't crash
+   into the preceding connector line. */
+.step-tab.in-flight {
+    padding-left: 20px;
+}
+
 .step-tab.in-flight .step-label {
-    color: var(--success);
+    color: var(--text-primary);
     font-weight: 700;
 }
 


### PR DESCRIPTION
## Summary

- **Step tabs**: bright completed labels, inset accent ring + tinted fill for the current step (wraps the whole tab even when in-flight), white labels with icons/rings carrying state color, extra left padding on in-flight tabs so the working-pulse has room.
- **Badges**: `Badge` primitive now accepts a `status` prop (matches the modifier class `SpecHeader` emits in prod). New CSS tiers color-code every canonical status — accent in-progress (with gentle border-breath), success-subtle intermediate-done, muted draft. Completed rule simplified to align vertical rhythm.
- **Header**: created-date moved to top-right of row 1 (smaller, muted, no "Created:" prefix); title gets its own line; branch tag now rendered with a `codicon-git-branch` glyph on a purple-tinted pill (`--purple` → `--vscode-symbolIcon-classForeground`) so it reads as a distinct identity signal.
- **Storybook**: one story per canonical status for `Primitives/Badge` (+ `AllStatuses` aggregate), `Viewer/SpecHeader` status variants using a `body[data-spec-status]` decorator, and `Viewer/StepTab` stories for current+in-flight, elapsed-timer bands, and a 4-step `AllStates` row.
- **Docs**: `docs/viewer-states.md` Visual column updated for `exists`/`viewing`.

Zero prod-behavior change — CSS + one additive component prop + new stories. `SpecHeader` prod render path already emits `spec-badge--${statusClass}` matching the new CSS selectors, so real specs in statuses like `specifying` / `planning` will pick up the new colors automatically on reload.

## Test plan

- [ ] `npm run compile` passes
- [ ] `npm test` — 368 tests green
- [ ] `npm run storybook` → walk `Primitives/Badge` (all 15 stories, verify in-progress tier pulses and terminal statuses pop)
- [ ] Storybook → `Viewer/SpecHeader` → check Status Active/Completed/Archived/TasksDone render the right badge colors
- [ ] Storybook → `Viewer/StepTab` → confirm `CurrentInFlight`/`CurrentInFlightElapsed` show ring + pulse without clipping
- [ ] `/install-local` + reload, open a real spec, confirm: header date is small + right-aligned, branch is purple, step tabs read cleanly
- [ ] Toggle a dark + a light VS Code theme, verify colors still read

🤖 Generated with [Claude Code](https://claude.com/claude-code)