### PR TITLE
fix(spec-viewer): improve current-step chip contrast on purple themes

### DIFF
--- a/specs/078-fix-step-chip-contrast/.spec-context.json
+++ b/specs/078-fix-step-chip-contrast/.spec-context.json
@@ -6,7 +6,9 @@
   "next": "done",
   "updated": "2026-04-24",
   "checkpointStatus": { "commit": true, "pr": true },
-  "last_action": "CP3 approved — staging commit",
+  "last_action": "PR #130 opened — fix(spec-viewer): improve current-step chip contrast on purple themes",
+  "prUrl": "https://github.com/alfredoperez/speckit-companion/pull/130",
+  "prNumber": 130,
   "selectedAt": "2026-04-24T23:26:02Z",
   "specName": "Fix Step Chip Contrast",
   "branch": "main",
@@ -153,6 +155,16 @@
       },
       "by": "sdd",
       "at": "2026-04-24T23:38:30Z"
+    },
+    {
+      "step": "done",
+      "substep": null,
+      "from": {
+        "step": "done",
+        "substep": null
+      },
+      "by": "sdd",
+      "at": "2026-04-24T23:40:00Z"
     }
   ],
   "status": "completed",

--- a/specs/078-fix-step-chip-contrast/.spec-context.json
+++ b/specs/078-fix-step-chip-contrast/.spec-context.json
@@ -1,0 +1,160 @@
+{
+  "workflow": "sdd",
+  "currentStep": "done",
+  "currentTask": null,
+  "progress": null,
+  "next": "done",
+  "updated": "2026-04-24",
+  "checkpointStatus": { "commit": true, "pr": true },
+  "last_action": "CP3 approved — staging commit",
+  "selectedAt": "2026-04-24T23:26:02Z",
+  "specName": "Fix Step Chip Contrast",
+  "branch": "main",
+  "workingBranch": "fix/fix-step-chip-contrast",
+  "type": "fix",
+  "createdAt": "2026-04-24T23:26:02Z",
+  "auto": true,
+  "approach": "Modify .step-tab.current rule in webview/styles/spec-viewer/_navigation.css: bump color-mix from 15% to 22% and add an outer box-shadow glow at 25% accent.",
+  "files_modified": [
+    "webview/styles/spec-viewer/_navigation.css"
+  ],
+  "task_summaries": {
+    "T001": {
+      "status": "DONE",
+      "did": "In .step-tab.current: changed color-mix from 15% to 22%; added second box-shadow layer at 25% accent for outer glow.",
+      "files": [
+        "webview/styles/spec-viewer/_navigation.css"
+      ],
+      "concerns": []
+    }
+  },
+  "step_summaries": {
+    "specify": {
+      "complexity": "minimal",
+      "requirements": 4,
+      "scenarios": 3,
+      "key_finding": ".step-tab.current already uses color-mix(var(--accent, …)) on a single rule — bump the mix and add an outer box-shadow for depth"
+    }
+  },
+  "transitions": [
+    {
+      "step": "specify",
+      "substep": "parsing",
+      "from": null,
+      "by": "sdd",
+      "at": "2026-04-24T23:26:02Z"
+    },
+    {
+      "step": "specify",
+      "substep": "exploring",
+      "from": {
+        "step": "specify",
+        "substep": "parsing"
+      },
+      "by": "sdd",
+      "at": "2026-04-24T23:26:10Z"
+    },
+    {
+      "step": "specify",
+      "substep": "detecting",
+      "from": {
+        "step": "specify",
+        "substep": "exploring"
+      },
+      "by": "sdd",
+      "at": "2026-04-24T23:26:20Z"
+    },
+    {
+      "step": "specify",
+      "substep": "writing-spec",
+      "from": {
+        "step": "specify",
+        "substep": "detecting"
+      },
+      "by": "sdd",
+      "at": "2026-04-24T23:26:30Z"
+    },
+    {
+      "step": "tasks",
+      "substep": null,
+      "from": {
+        "step": "specify",
+        "substep": "writing-spec"
+      },
+      "by": "sdd",
+      "at": "2026-04-24T23:26:45Z"
+    },
+    {
+      "step": "implement",
+      "substep": "phase1",
+      "from": {
+        "step": "tasks",
+        "substep": null
+      },
+      "by": "sdd",
+      "at": "2026-04-24T23:27:30Z"
+    },
+    {
+      "step": "implement",
+      "substep": "phase1",
+      "from": {
+        "step": "implement",
+        "substep": "phase1"
+      },
+      "by": "sdd",
+      "at": "2026-04-24T23:28:00Z"
+    },
+    {
+      "step": "implement",
+      "substep": "hooks",
+      "from": {
+        "step": "implement",
+        "substep": "phase1"
+      },
+      "by": "sdd",
+      "at": "2026-04-24T23:28:30Z"
+    },
+    {
+      "step": "implement",
+      "substep": "code-review",
+      "from": {
+        "step": "implement",
+        "substep": "hooks"
+      },
+      "by": "sdd",
+      "at": "2026-04-24T23:30:00Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "from": {
+        "step": "implement",
+        "substep": null
+      },
+      "by": "extension",
+      "at": "2026-04-24T23:37:40.734Z"
+    },
+    {
+      "step": "implement",
+      "substep": "commit-review",
+      "from": {
+        "step": "implement",
+        "substep": "code-review"
+      },
+      "by": "sdd",
+      "at": "2026-04-24T23:38:00Z"
+    },
+    {
+      "step": "done",
+      "substep": null,
+      "from": {
+        "step": "implement",
+        "substep": "commit-review"
+      },
+      "by": "sdd",
+      "at": "2026-04-24T23:38:30Z"
+    }
+  ],
+  "status": "completed",
+  "stepHistory": {}
+}

--- a/specs/078-fix-step-chip-contrast/plan.md
+++ b/specs/078-fix-step-chip-contrast/plan.md
@@ -1,0 +1,13 @@
+# Plan: Fix Step Chip Contrast
+
+**Spec**: [spec.md](./spec.md) | **Date**: 2026-04-24
+
+## Approach
+
+Modify the `.step-tab.current` rule in `webview/styles/spec-viewer/_navigation.css`: bump the `color-mix` fill from 15% to ~22% accent and add an outer `box-shadow` glow at ~25% accent for depth. Pure CSS change to one rule — no JS, no template, no theme detection.
+
+## Files to Change
+
+### Modify
+
+- `webview/styles/spec-viewer/_navigation.css` — update `.step-tab.current` rule (lines 97–101): increase the `color-mix` percentage and add an outer `box-shadow` glow alongside the existing inset ring.

--- a/specs/078-fix-step-chip-contrast/spec.md
+++ b/specs/078-fix-step-chip-contrast/spec.md
@@ -1,0 +1,36 @@
+# Spec: Fix Step Chip Contrast
+
+**Slug**: 078-fix-step-chip-contrast | **Date**: 2026-04-24
+
+## Summary
+
+The current-step chip in the spec viewer's step tabs reads faded on VS Code themes where `--vscode-focusBorder` resolves to purple (Dracula, Monokai Pro). Bump the accent-tinted fill and add an outer accent glow so the chip reads as clearly elevated across all themes.
+
+## Requirements
+
+- **R001** (MUST): The `.step-tab.current` chip's label appears visibly contrasted against the accent-tinted fill on Dracula and Monokai Pro themes.
+- **R002** (MUST): The chip reads as clearly elevated (distinct from neighboring step tabs) on all five reference themes.
+- **R003** (MUST): No visual regression on Default Dark Modern, Default Light Modern, or Default High Contrast.
+- **R004** (SHOULD): The fix uses only `var(--accent, …)` and CSS color functions — no theme-specific overrides.
+
+## Scenarios
+
+### Viewing on a purple-accent theme
+
+**When** a user opens the spec viewer using Dracula or Monokai Pro
+**Then** the current-step chip's accent-tinted fill and outer glow make the chip and its label visibly stand out from neighboring tabs
+
+### Viewing on a blue-accent theme
+
+**When** a user opens the spec viewer using Default Dark Modern
+**Then** the current-step chip renders with at least parity to the v0.13.0 appearance (no regression)
+
+### Viewing on a high-contrast theme
+
+**When** a user opens the spec viewer using Default High Contrast
+**Then** the chip's inset ring and label remain readable; the new outer glow does not muddy the existing high-contrast outline
+
+## Out of Scope
+
+- Changes to `.step-tab.in-flight`, `.step-tab.done`, or `.step-tab.locked` styles.
+- Theme-specific CSS overrides or detection logic.

--- a/specs/078-fix-step-chip-contrast/tasks.md
+++ b/specs/078-fix-step-chip-contrast/tasks.md
@@ -1,0 +1,19 @@
+# Tasks: Fix Step Chip Contrast
+
+**Plan**: [plan.md](./plan.md) | **Date**: 2026-04-24
+
+## Format
+
+- `[P]` marks tasks that can run in parallel with adjacent `[P]` tasks.
+- Consecutive `[P]` tasks form a **parallel group** — `/sdd:implement` spawns them as concurrent subagents.
+- Tasks without `[P]` are **gates**: they start only after all prior tasks complete.
+- Two tasks that touch the same file are never both `[P]`.
+
+---
+
+## Phase 1: Core Implementation
+
+- [x] **T001** Bump `.step-tab.current` fill mix and add outer accent glow — `webview/styles/spec-viewer/_navigation.css` | R001, R002, R003, R004
+  - **Do**: In the `.step-tab.current` rule (currently lines 97–101), change `color-mix(in srgb, var(--accent, #4a9eff) 15%, transparent)` to `22%`, and add a second shadow layer alongside the inset ring: `box-shadow: inset 0 0 0 2px var(--accent, #4a9eff), 0 0 0 1px color-mix(in srgb, var(--accent, #4a9eff) 25%, transparent);`
+  - **Verify**: `npm run compile` passes; webpack rebuilds the bundled CSS without errors.
+  - **Leverage**: existing `color-mix(in srgb, var(--accent, …) X%, transparent)` pattern already used on line 98.

--- a/webview/styles/spec-viewer/_navigation.css
+++ b/webview/styles/spec-viewer/_navigation.css
@@ -95,8 +95,10 @@
    contiguous chip — including when the step is also in-flight (the pulse stays
    inside the ring instead of visually overflowing an outer outline). */
 .step-tab.current {
-    background: color-mix(in srgb, var(--accent, #4a9eff) 15%, transparent);
-    box-shadow: inset 0 0 0 2px var(--accent, #4a9eff);
+    background: color-mix(in srgb, var(--accent, #4a9eff) 22%, transparent);
+    box-shadow:
+        inset 0 0 0 2px var(--accent, #4a9eff),
+        0 0 0 1px color-mix(in srgb, var(--accent, #4a9eff) 25%, transparent);
     border-radius: 6px;
 }
 


### PR DESCRIPTION
## What

- Bump `.step-tab.current` accent fill from 15% → 22%
- Add outer `box-shadow` glow at 25% accent for depth, alongside the existing inset ring

## Why

The current-step chip read faded on VS Code themes where `--vscode-focusBorder` resolves to purple (Dracula, Monokai Pro). Label contrast dropped visibly compared to blue-accent themes.

## Testing

- [ ] Verify the chip is clearly elevated on Default Dark Modern, Default Light Modern, Default High Contrast, Dracula, and Monokai Pro
- [ ] Confirm the label remains readable against the accent-tinted fill on all five themes
- [ ] Confirm no regression on the in-flight pulse animation (still scoped to the inner pill)

Closes #126