### PR TITLE
fix(spec-viewer): branch chip, in-flight % pill, and substep label

### DIFF
--- a/specs/080-fix-viewer-state-display/.spec-context.json
+++ b/specs/080-fix-viewer-state-display/.spec-context.json
@@ -5,7 +5,9 @@
   "progress": null,
   "next": "done",
   "status": "completed",
-  "checkpointStatus": { "commit": false, "pr": false },
+  "checkpointStatus": { "commit": true, "pr": true },
+  "prUrl": "https://github.com/alfredoperez/speckit-companion/pull/131",
+  "prNumber": 131,
   "updated": "2026-04-25",
   "selectedAt": "2026-04-25T00:01:29Z",
   "specName": "Fix Viewer State Display",
@@ -31,7 +33,7 @@
   "concerns": [
     { "task": "T002", "note": "Silent fix: also added workingBranch to FeatureWorkflowContext at src/features/workflows/types.ts:147 — the viewer reads featureCtx via that type, not SpecContext directly. Without this addition, the build failed with TS2339. Plan only listed SpecContext (T001 scope)." }
   ],
-  "last_action": "CP1 approved — proceeding to commit + PR",
+  "last_action": "PR #131 opened — fix(spec-viewer): branch chip, in-flight % pill, and substep label",
   "task_summaries": {
     "T001": { "status": "DONE", "did": "Added workingBranch?: string|null to SpecContext interface and preserved it in normalizeSpecContext.", "files": ["src/core/types/specContext.ts", "src/features/specs/specContextReader.ts"], "concerns": [] },
     "T002": { "status": "DONE_WITH_CONCERNS", "did": "Branch chip in specViewerProvider falls back to workingBranch ?? branch ?? null at both writes. Silent fix: added workingBranch to FeatureWorkflowContext.", "files": ["src/features/spec-viewer/specViewerProvider.ts", "src/features/workflows/types.ts"], "concerns": ["FeatureWorkflowContext is a parallel type to SpecContext — both needed the new field. Plan missed this."] },
@@ -52,6 +54,7 @@
     { "step": "implement", "substep": "phase1", "from": { "step": "tasks", "substep": null }, "by": "sdd", "at": "2026-04-25T00:03:00Z" },
     { "step": "implement", "substep": "hooks", "from": { "step": "implement", "substep": "phase1" }, "by": "sdd", "at": "2026-04-25T00:08:00Z" },
     { "step": "implement", "substep": "code-review", "from": { "step": "implement", "substep": "hooks" }, "by": "sdd", "at": "2026-04-25T00:09:00Z" },
-    { "step": "done", "substep": null, "from": { "step": "implement", "substep": "code-review" }, "by": "sdd", "at": "2026-04-25T00:15:00Z" }
+    { "step": "done", "substep": null, "from": { "step": "implement", "substep": "code-review" }, "by": "sdd", "at": "2026-04-25T00:15:00Z" },
+    { "step": "done", "substep": null, "from": { "step": "done", "substep": null }, "by": "sdd", "at": "2026-04-25T00:18:00Z", "note": "PR #131 opened" }
   ]
 }

--- a/specs/080-fix-viewer-state-display/.spec-context.json
+++ b/specs/080-fix-viewer-state-display/.spec-context.json
@@ -1,0 +1,57 @@
+{
+  "workflow": "sdd",
+  "currentStep": "done",
+  "currentTask": null,
+  "progress": null,
+  "next": "done",
+  "status": "completed",
+  "checkpointStatus": { "commit": false, "pr": false },
+  "updated": "2026-04-25",
+  "selectedAt": "2026-04-25T00:01:29Z",
+  "specName": "Fix Viewer State Display",
+  "branch": "main",
+  "workingBranch": "fix/fix-viewer-state-display",
+  "type": "fix",
+  "createdAt": "2026-04-25T00:01:29Z",
+  "auto": true,
+  "approach": "Three independent viewer-side derivation fixes plumbed through .spec-context.json → SpecContext → NavState/ViewerState → Preact components. No SDD pipeline writes added; pure read-side typing + fallbacks.",
+  "files_modified": [
+    "src/core/types/specContext.ts",
+    "src/features/specs/specContextReader.ts",
+    "src/features/spec-viewer/specViewerProvider.ts",
+    "src/features/spec-viewer/types.ts",
+    "src/features/spec-viewer/html/generator.ts",
+    "src/features/spec-viewer/stateDerivation.ts",
+    "src/features/spec-viewer/__tests__/stateDerivation.test.ts",
+    "src/features/workflows/types.ts",
+    "webview/src/spec-viewer/types.ts",
+    "webview/src/spec-viewer/components/StepTab.tsx",
+    "webview/src/spec-viewer/components/NavigationBar.tsx"
+  ],
+  "concerns": [
+    { "task": "T002", "note": "Silent fix: also added workingBranch to FeatureWorkflowContext at src/features/workflows/types.ts:147 — the viewer reads featureCtx via that type, not SpecContext directly. Without this addition, the build failed with TS2339. Plan only listed SpecContext (T001 scope)." }
+  ],
+  "last_action": "CP1 approved — proceeding to commit + PR",
+  "task_summaries": {
+    "T001": { "status": "DONE", "did": "Added workingBranch?: string|null to SpecContext interface and preserved it in normalizeSpecContext.", "files": ["src/core/types/specContext.ts", "src/features/specs/specContextReader.ts"], "concerns": [] },
+    "T002": { "status": "DONE_WITH_CONCERNS", "did": "Branch chip in specViewerProvider falls back to workingBranch ?? branch ?? null at both writes. Silent fix: added workingBranch to FeatureWorkflowContext.", "files": ["src/features/spec-viewer/specViewerProvider.ts", "src/features/workflows/types.ts"], "concerns": ["FeatureWorkflowContext is a parallel type to SpecContext — both needed the new field. Plan missed this."] },
+    "T003": { "status": "DONE", "did": "Added currentStep?: string|null to NavState (extension types.ts), populated in initialNavState (generator.ts) and navState literal.", "files": ["src/features/spec-viewer/types.ts", "src/features/spec-viewer/html/generator.ts", "src/features/spec-viewer/specViewerProvider.ts"], "concerns": [] },
+    "T004": { "status": "DONE", "did": "Added currentStep to webview NavState + StepTabProps; rewrote inProgress predicate; NavigationBar forwards currentStep to StepTab.", "files": ["webview/src/spec-viewer/types.ts", "webview/src/spec-viewer/components/StepTab.tsx", "webview/src/spec-viewer/components/NavigationBar.tsx"], "concerns": [] },
+    "T005": { "status": "DONE", "did": "deriveActiveSubstep falls back to top-level progress when stepHistory.substeps is empty.", "files": ["src/features/spec-viewer/stateDerivation.ts"], "concerns": [] },
+    "T006": { "status": "DONE", "did": "Added 3 new test cases under describe('deriveActiveSubstep'). All 38 tests pass.", "files": ["src/features/spec-viewer/__tests__/stateDerivation.test.ts"], "concerns": [] }
+  },
+  "step_summaries": {
+    "specify": { "complexity": "minimal", "requirements": 4, "scenarios": 5, "key_finding": "html/navigation.ts is dead code — Preact NavigationBar.tsx is the live nav renderer." }
+  },
+  "transitions": [
+    { "step": "specify", "substep": "parsing", "from": null, "by": "sdd", "at": "2026-04-25T00:01:29Z" },
+    { "step": "specify", "substep": "exploring", "from": { "step": "specify", "substep": "parsing" }, "by": "sdd", "at": "2026-04-25T00:01:34Z" },
+    { "step": "specify", "substep": "detecting", "from": { "step": "specify", "substep": "exploring" }, "by": "sdd", "at": "2026-04-25T00:01:39Z" },
+    { "step": "specify", "substep": "writing-spec", "from": { "step": "specify", "substep": "detecting" }, "by": "sdd", "at": "2026-04-25T00:01:44Z" },
+    { "step": "tasks", "substep": null, "from": { "step": "specify", "substep": "writing-spec" }, "by": "sdd", "at": "2026-04-25T00:02:00Z" },
+    { "step": "implement", "substep": "phase1", "from": { "step": "tasks", "substep": null }, "by": "sdd", "at": "2026-04-25T00:03:00Z" },
+    { "step": "implement", "substep": "hooks", "from": { "step": "implement", "substep": "phase1" }, "by": "sdd", "at": "2026-04-25T00:08:00Z" },
+    { "step": "implement", "substep": "code-review", "from": { "step": "implement", "substep": "hooks" }, "by": "sdd", "at": "2026-04-25T00:09:00Z" },
+    { "step": "done", "substep": null, "from": { "step": "implement", "substep": "code-review" }, "by": "sdd", "at": "2026-04-25T00:15:00Z" }
+  ]
+}

--- a/specs/080-fix-viewer-state-display/plan.md
+++ b/specs/080-fix-viewer-state-display/plan.md
@@ -1,0 +1,38 @@
+# Plan: Fix Viewer State Display
+
+**Spec**: [spec.md](./spec.md) | **Date**: 2026-04-25
+
+## Approach
+
+Three independent, viewer-side derivation fixes wired through the existing `.spec-context.json` → `SpecContext` → `NavState` / `ViewerState` → Preact components pipeline. All changes are read-only at the schema layer (no SDD pipeline writes added) and add no new components — just one new typed field (`workingBranch`), one prop plumbed through (`currentStep`), and a fallback branch in `deriveActiveSubstep`.
+
+## Files to Change
+
+### Modify
+
+- `src/core/types/specContext.ts` — add `workingBranch?: string | null` to the `SpecContext` interface (~line 84) so downstream consumers get a typed field instead of relying on the index signature.
+- `src/features/specs/specContextReader.ts` — in `normalizeSpecContext` (~line 67), explicitly preserve `workingBranch` when present (`workingBranch: typeof raw.workingBranch === 'string' ? raw.workingBranch : (raw.workingBranch === null ? null : undefined)`), so legacy and current shapes both flow through cleanly.
+- `src/features/spec-viewer/specViewerProvider.ts` —
+  - Two branch-chip writes: line ~568 and ~833. Change `featureCtx?.branch ?? null` → `(featureCtx?.workingBranch as string | null | undefined) ?? featureCtx?.branch ?? null`.
+  - Two `navState`/`generateHtml` argument lists need a new `currentStep` value derived from `featureCtx?.currentStep ?? doc?.type ?? null`. Already passed at line 570 to `generateHtml`; needs to be added to the `NavState` literal at line ~810.
+- `src/features/spec-viewer/types.ts` — add `currentStep?: string | null` to the `NavState` interface (after line 264) so it can be plumbed to webview components.
+- `src/features/spec-viewer/html/generator.ts` — in the `initialNavState` literal (~line 97), include `currentStep: currentStep ?? null` so the initial render (pre-Preact-hydrate) carries the field.
+- `webview/src/spec-viewer/components/NavigationBar.tsx` — destructure `currentStep` from `navState`; pass it as a prop to `<StepTab currentStep={currentStep} ... />`.
+- `webview/src/spec-viewer/components/StepTab.tsx` —
+  - Add `currentStep?: string | null` to `StepTabProps`.
+  - Rewrite the `inProgress` predicate (line 45):
+    ```ts
+    const inProgress = isLastStep && currentStep === 'implement' && taskCompletionPercent < 100;
+    ```
+  - Update `statusIcon` (line 81) so the pill text shows `${taskCompletionPercent}%` whenever `canonicalState === 'in-flight' && inProgress` (existing condition is already correct once `inProgress` is fixed; no separate change needed).
+- `src/features/spec-viewer/stateDerivation.ts` — in `deriveActiveSubstep` (~line 78), after the existing `stepHistory.substeps` scan finds no active substep, fall back to:
+  ```ts
+  const progress = (ctx as { progress?: string | null }).progress;
+  if (progress) return { step: ctx.currentStep, name: progress };
+  return null;
+  ```
+  This surfaces the SDD pipeline's top-level `progress` field as the active substep without requiring SDD to populate `stepHistory.substeps`.
+
+### Tests to Add
+
+- `src/features/spec-viewer/__tests__/stateDerivation.test.ts` — extend the `deriveViewerState` describe block with three cases covering R002, R003, and R005 (workingBranch fallback is not exercised here — it lives in specViewerProvider, hard to unit-test without VSCode mocks; covered by manual smoke).

--- a/specs/080-fix-viewer-state-display/spec.md
+++ b/specs/080-fix-viewer-state-display/spec.md
@@ -1,0 +1,47 @@
+# Spec: Fix Viewer State Display
+
+**Slug**: 080-fix-viewer-state-display | **Date**: 2026-04-25
+
+## Summary
+
+The spec viewer header and step-stepper drift from the canonical `.spec-context.json` state in three ways: the branch chip shows the wrong field, the Tasks tab doesn't enter in-flight (% pill) until the first task ticks off, and `progress` substeps are never surfaced visually. This is a viewer-only fix — pure read-side derivation; no SDD pipeline changes.
+
+## Requirements
+
+- **R001** (MUST): The branch chip in `SpecHeader` displays `workingBranch` when present in `.spec-context.json`, falling back to the audit-trail `branch` field only when `workingBranch` is null/missing.
+- **R002** (MUST): The last step tab (Tasks) renders the in-flight % pill from `0%` through `99%` whenever `currentStep === "implement"` and `taskCompletionPercent < 100`. At `100%` it switches to the `done` ✓ check.
+- **R003** (MUST): When `.spec-context.json` has a non-null top-level `progress` field but `stepHistory[currentStep].substeps` is empty, the viewer treats `{ step: currentStep, name: progress }` as the active substep so the substep label renders on the active step tab.
+- **R004** (MUST): The `SpecContext` TypeScript type explicitly declares `workingBranch?: string | null`, and the `specContextReader.normalizeSpecContext` function preserves the field through the read pipeline.
+
+## Scenarios
+
+### Branch chip during implement
+
+**When** `.spec-context.json` has `branch: "main"` and `workingBranch: "feat/foo-bar"`
+**Then** the spec-viewer header chip displays `feat/foo-bar` (with the existing `git-branch` codicon and `Branch: feat/foo-bar` tooltip).
+
+### Tasks tab at 0% during implement
+
+**When** the viewer renders for a spec with `currentStep: "implement"`, `taskCompletionPercent: 0`, and no `stepHistory.implement.startedAt`
+**Then** the Tasks step tab renders with `canonicalState === "in-flight"` and the status pill shows `0%`.
+
+### Tasks tab transitions to done at 100%
+
+**When** the viewer renders for a spec with `currentStep: "implement"` and `taskCompletionPercent: 100`
+**Then** the Tasks step tab renders with `canonicalState === "done"` and the status pill shows `✓` (not `100%`).
+
+### Substep label from top-level progress
+
+**When** `.spec-context.json` has `currentStep: "specify"`, `progress: "exploring"`, and `stepHistory.specify.substeps` is empty/missing
+**Then** the Specify step tab renders a `step-tab__substep` element with text `exploring` (driven by `viewerState.activeSubstep`).
+
+### Backward compatibility — old contexts
+
+**When** `.spec-context.json` has no `workingBranch` field and no top-level `progress` field (older specs)
+**Then** the branch chip falls back to `branch`, no substep is shown, and existing behavior is preserved.
+
+## Out of Scope
+
+- Changes to the SDD pipeline skills (no writes to `stepHistory.substeps[]` introduced in this PR).
+- The dead-code path `src/features/spec-viewer/html/navigation.ts` (server-side mirror of StepTab) — it's only barrel-exported, never called. Leave as-is.
+- Re-rendering on `.spec-context.json` file changes (separate viewer-refresh issue not covered here).

--- a/specs/080-fix-viewer-state-display/tasks.md
+++ b/specs/080-fix-viewer-state-display/tasks.md
@@ -1,0 +1,70 @@
+# Tasks: Fix Viewer State Display
+
+**Plan**: [plan.md](./plan.md) | **Date**: 2026-04-25
+
+## Format
+
+- `[P]` marks tasks that can run in parallel with adjacent `[P]` tasks.
+- Consecutive `[P]` tasks form a **parallel group** — `/sdd:implement` spawns them as concurrent subagents.
+- Tasks without `[P]` are **gates**: they start only after all prior tasks complete.
+- Two tasks that touch the same file are never both `[P]`.
+
+---
+
+## Phase 1: Core Implementation
+
+- [x] **T001** Type `workingBranch` in SpecContext + preserve in reader — `src/core/types/specContext.ts`, `src/features/specs/specContextReader.ts` | R004
+  - **Do**:
+    - In `src/core/types/specContext.ts`, after the `branch: string;` line in the `SpecContext` interface, add: `workingBranch?: string | null;`
+    - In `src/features/specs/specContextReader.ts` `normalizeSpecContext` (the `out` literal), add: `workingBranch: typeof raw.workingBranch === 'string' ? (raw.workingBranch as string) : (raw.workingBranch === null ? null : undefined),`
+  - **Verify**: `npm run compile` passes with no type errors. The index signature `[key: string]: unknown` already preserved this field; the change is purely additive typing.
+
+- [x] **T002** Branch chip falls back to workingBranch — `src/features/spec-viewer/specViewerProvider.ts` | R001
+  - **Do**: At lines ~568 (call to `generateHtml`) and ~833 (`navState` literal), replace `featureCtx?.branch ?? null` with:
+    ```ts
+    (featureCtx?.workingBranch as string | null | undefined) ??
+      featureCtx?.branch ??
+      null;
+    ```
+  - **Verify**: `npm run compile` passes. Manually confirm in extension host that the branch chip shows `feat/foo-bar` when `.spec-context.json` has `workingBranch` set.
+  - **Leverage**: `branch-creation.md` semantics — `workingBranch` is set by `/sdd:implement` when `branchStage` matches; `branch` is the immutable audit field.
+
+- [x] **T003** Plumb currentStep through navState/types/initial-render — `src/features/spec-viewer/types.ts`, `src/features/spec-viewer/html/generator.ts`, `src/features/spec-viewer/specViewerProvider.ts` | R002
+  - **Do**:
+    - In `src/features/spec-viewer/types.ts` `NavState` (after `branch?:`), add: `/** SDD currentStep from spec-context (drives implement-phase pill) */ currentStep?: string | null;`
+    - In `src/features/spec-viewer/html/generator.ts` `initialNavState` literal, add: `currentStep: currentStep ?? null,` next to the existing `branch:` field.
+    - In `src/features/spec-viewer/specViewerProvider.ts` `navState` literal at line ~810, add: `currentStep: featureCtx?.currentStep ?? documentType ?? null,`
+  - **Verify**: `npm run compile` passes. The `currentStep` argument was already passed to `generateHtml` (line 570); this task only widens NavState and the literals.
+
+- [x] **T004** StepTab uses currentStep for in-flight predicate _(depends on T003)_ — `webview/src/spec-viewer/components/StepTab.tsx`, `webview/src/spec-viewer/components/NavigationBar.tsx` | R002
+  - **Do**:
+    - In `webview/src/spec-viewer/components/StepTab.tsx`:
+      - Add `currentStep?: string | null;` to `StepTabProps` (after `runningStepIndex`).
+      - Destructure `currentStep` in the function body alongside the other props.
+      - Rewrite the `inProgress` predicate (line 45) to: `const inProgress = isLastStep && currentStep === 'implement' && taskCompletionPercent < 100;`
+    - In `webview/src/spec-viewer/components/NavigationBar.tsx`:
+      - Destructure `currentStep` from `navState`.
+      - Pass `currentStep={currentStep}` to `<StepTab ... />`.
+  - **Verify**: `npm run compile` passes. With a spec at `currentStep: "implement"` and 0/1 tasks done, the Tasks tab shows a `0%` pill (not a green check). At 1/1, it shows `✓`.
+
+- [x] **T005** Substep fallback to top-level progress — `src/features/spec-viewer/stateDerivation.ts` | R003
+  - **Do**: In `deriveActiveSubstep` (~line 78), replace the function body with:
+    ```ts
+    for (const step of STEP_NAMES) {
+      const entry = ctx.stepHistory[step];
+      const active = entry?.substeps?.find((s) => !s.completedAt);
+      if (active) return { step, name: active.name };
+    }
+    const progress = (ctx as { progress?: string | null }).progress;
+    if (progress) return { step: ctx.currentStep, name: progress };
+    return null;
+    ```
+  - **Verify**: `npm test -- stateDerivation` passes (after T006 adds tests). With a context that has `currentStep: "specify"`, `progress: "exploring"`, and no `stepHistory.specify.substeps`, the active step tab shows `exploring` as a `step-tab__substep`.
+
+- [x] **T006** Add unit tests for the three derivations _(depends on T005)_ — `src/features/spec-viewer/__tests__/stateDerivation.test.ts` | R002, R003
+  - **Do**: In the existing `describe('deriveViewerState', ...)` block, add three `it` cases:
+    - "falls back to top-level `progress` when stepHistory.substeps is empty" — input ctx with `currentStep: "specify"`, `progress: "exploring"`, empty stepHistory → expect `activeSubstep: { step: "specify", name: "exploring" }`.
+    - "returns null activeSubstep when neither stepHistory.substeps nor progress is present" — confirms backward compat.
+    - "prefers stepHistory.substeps over top-level progress" — both populated → uses substeps entry.
+  - **Verify**: `npm test -- stateDerivation` passes; all new cases green.
+  - **Leverage**: existing `it('returns activeSubstep when an entry has substeps with no completedAt'` test as the structural template.

--- a/src/core/types/specContext.ts
+++ b/src/core/types/specContext.ts
@@ -82,6 +82,7 @@ export interface SpecContext {
     workflow: string;
     specName: string;
     branch: string;
+    workingBranch?: string | null;
     selectedAt?: string;
     currentStep: StepName;
     status: Status;

--- a/src/features/spec-viewer/__tests__/stateDerivation.test.ts
+++ b/src/features/spec-viewer/__tests__/stateDerivation.test.ts
@@ -3,6 +3,7 @@ import {
     deriveStepBadges,
     derivePulse,
     deriveHighlights,
+    deriveActiveSubstep,
     deriveViewerState,
 } from '../stateDerivation';
 import type { SpecContext, StepName } from '../../../core/types/specContext';
@@ -117,6 +118,38 @@ describe('deriveHighlights', () => {
         expect(highlights).toContain('specify');
         expect(highlights).toContain('plan');
         expect(highlights).not.toContain('tasks');
+    });
+});
+
+describe('deriveActiveSubstep', () => {
+    it('falls back to top-level `progress` when stepHistory.substeps is empty', () => {
+        const ctx = makeContext({
+            currentStep: 'specify',
+            stepHistory: {},
+            // top-level `progress` is a tolerated extra field on .spec-context.json
+            progress: 'exploring',
+        } as Partial<SpecContext> as SpecContext);
+        expect(deriveActiveSubstep(ctx)).toEqual({ step: 'specify', name: 'exploring' });
+    });
+
+    it('returns null when neither stepHistory.substeps nor progress is present', () => {
+        const ctx = makeContext({ currentStep: 'plan', stepHistory: {} });
+        expect(deriveActiveSubstep(ctx)).toBeNull();
+    });
+
+    it('prefers stepHistory.substeps over top-level progress', () => {
+        const ctx = makeContext({
+            currentStep: 'specify',
+            stepHistory: {
+                specify: {
+                    startedAt: '2026-01-01',
+                    completedAt: null,
+                    substeps: [{ name: 'writing-spec', startedAt: '2026-01-01', completedAt: null }],
+                },
+            },
+            progress: 'exploring',
+        } as Partial<SpecContext> as SpecContext);
+        expect(deriveActiveSubstep(ctx)).toEqual({ step: 'specify', name: 'writing-spec' });
     });
 });
 

--- a/src/features/spec-viewer/html/generator.ts
+++ b/src/features/spec-viewer/html/generator.ts
@@ -117,6 +117,7 @@ export function generateHtml(
         lastUpdatedDate: lastUpdatedDate ?? null,
         specContextName: contextSpecName ?? null,
         branch: contextBranch ?? null,
+        currentStep: currentStep ?? null,
         filePath: currentFilePath ?? null,
         docTypeLabel: getDocTypeLabel(currentStep ?? currentDocType),
     };

--- a/src/features/spec-viewer/specViewerProvider.ts
+++ b/src/features/spec-viewer/specViewerProvider.ts
@@ -565,7 +565,7 @@ export class SpecViewerProvider {
         createdDate,
         lastUpdatedDate,
         featureCtx?.specName ?? deriveSpecName(specDirectory),
-        featureCtx?.branch ?? null,
+        featureCtx?.workingBranch ?? featureCtx?.branch ?? null,
         doc?.filePath ?? null,
         featureCtx?.currentStep ?? doc?.type ?? null,
         mapStepHistoryKeys(featureCtx?.stepHistory),
@@ -830,7 +830,8 @@ export class SpecViewerProvider {
         createdDate: computeCreatedDate(featureCtx?.stepHistory),
         lastUpdatedDate: computeLastUpdatedDate(featureCtx?.stepHistory),
         specContextName: featureCtx?.specName ?? deriveSpecName(specDirectory),
-        branch: featureCtx?.branch ?? null,
+        branch: featureCtx?.workingBranch ?? featureCtx?.branch ?? null,
+        currentStep: featureCtx?.currentStep ?? documentType ?? null,
         filePath: doc?.filePath ?? null,
         docTypeLabel: getDocTypeLabel(featureCtx?.currentStep ?? documentType),
       };

--- a/src/features/spec-viewer/stateDerivation.ts
+++ b/src/features/spec-viewer/stateDerivation.ts
@@ -83,6 +83,8 @@ export function deriveActiveSubstep(
         const active = entry?.substeps?.find(s => !s.completedAt);
         if (active) return { step, name: active.name };
     }
+    const progress = (ctx as { progress?: string | null }).progress;
+    if (progress) return { step: ctx.currentStep, name: progress };
     return null;
 }
 

--- a/src/features/spec-viewer/types.ts
+++ b/src/features/spec-viewer/types.ts
@@ -260,8 +260,10 @@ export interface NavState {
     lastUpdatedDate?: string | null;
     /** Human-readable spec name from spec-context.json */
     specContextName?: string | null;
-    /** Git branch name from spec-context.json */
+    /** Git branch name from spec-context.json (workingBranch with fallback to branch) */
     branch?: string | null;
+    /** SDD currentStep from spec-context.json — drives implement-phase pill on the last step tab */
+    currentStep?: string | null;
     /** Current document file path */
     filePath?: string | null;
     /** Display label for the current doc type (e.g., "Spec", "Plan") */

--- a/src/features/specs/specContextReader.ts
+++ b/src/features/specs/specContextReader.ts
@@ -83,6 +83,9 @@ export function normalizeSpecContext(raw: Record<string, unknown>): SpecContext 
             : 'speckit',
         specName: typeof raw.specName === 'string' ? (raw.specName as string) : '',
         branch: typeof raw.branch === 'string' ? (raw.branch as string) : '',
+        workingBranch: typeof raw.workingBranch === 'string'
+            ? (raw.workingBranch as string)
+            : (raw.workingBranch === null ? null : undefined),
         currentStep,
         status,
         stepHistory,

--- a/src/features/workflows/types.ts
+++ b/src/features/workflows/types.ts
@@ -142,8 +142,10 @@ export interface FeatureWorkflowContext {
     checkpointStatus?: Record<CheckpointId, CheckpointStatus>;
     /** Human-readable spec name derived from directory slug */
     specName?: string;
-    /** Git branch name associated with this spec */
+    /** Git branch name associated with this spec (audit trail — branch when /sdd:specify ran) */
     branch?: string;
+    /** Active feature branch where implementation runs (set by /sdd:implement when branchStage matches) */
+    workingBranch?: string | null;
     /** In-progress indicator (e.g., "exploring", "phase1") */
     progress?: string | null;
     /** Current task being executed (e.g., "T001") */

--- a/webview/src/spec-viewer/components/NavigationBar.tsx
+++ b/webview/src/spec-viewer/components/NavigationBar.tsx
@@ -10,7 +10,7 @@ export function NavigationBar() {
 
     const { coreDocs, relatedDocs, currentDoc, workflowPhase,
         taskCompletionPercent, isViewingRelatedDoc, activeStep,
-        stepHistory, stalenessMap } = ns;
+        currentStep, stepHistory, stalenessMap } = ns;
 
     const viewingRelatedDoc = isViewingRelatedDoc
         ? relatedDocs.find(d => d.type === currentDoc)
@@ -70,6 +70,7 @@ export function NavigationBar() {
                                 isViewingRelatedDoc={isViewingRelatedDoc}
                                 parentPhaseForRelated={parentPhaseForRelated}
                                 activeStep={activeStep}
+                                currentStep={currentStep}
                                 stepHistory={stepHistory}
                                 stalenessMap={stalenessMap}
                                 hasRelatedChildren={hasRelatedChildren}

--- a/webview/src/spec-viewer/components/StepTab.tsx
+++ b/webview/src/spec-viewer/components/StepTab.tsx
@@ -25,6 +25,7 @@ export interface StepTabProps {
     isViewingRelatedDoc: boolean;
     parentPhaseForRelated: string;
     activeStep?: string | null;
+    currentStep?: string | null;
     stepHistory?: Record<string, { startedAt?: string; completedAt?: string | null }>;
     stalenessMap?: StalenessMap;
     hasRelatedChildren?: boolean;
@@ -35,14 +36,14 @@ export interface StepTabProps {
 export function StepTab(props: StepTabProps) {
     const { doc, index, totalSteps, currentDoc, workflowPhase,
         taskCompletionPercent, isViewingRelatedDoc, parentPhaseForRelated,
-        activeStep, stepHistory, stalenessMap, hasRelatedChildren, runningStepIndex, onClick } = props;
+        activeStep, currentStep, stepHistory, stalenessMap, hasRelatedChildren, runningStepIndex, onClick } = props;
 
     const phase = doc.type;
     const stepDocExists = doc.exists;
     const exists = stepDocExists || !!hasRelatedChildren;
     const isViewing = phase === currentDoc || (isViewingRelatedDoc && phase === parentPhaseForRelated);
     const isLastStep = index === totalSteps - 1;
-    const inProgress = isLastStep && taskCompletionPercent > 0 && taskCompletionPercent < 100;
+    const inProgress = isLastStep && currentStep === 'implement' && taskCompletionPercent < 100;
     const isStale = stalenessMap?.[phase]?.isStale ?? false;
     const isWorking = activeStep === phase && !stepHistory?.[phase]?.completedAt;
     const isLocked = runningStepIndex != null

--- a/webview/src/spec-viewer/types.ts
+++ b/webview/src/spec-viewer/types.ts
@@ -86,6 +86,7 @@ export interface NavState {
     lastUpdatedDate?: string | null;
     specContextName?: string | null;
     branch?: string | null;
+    currentStep?: string | null;
     filePath?: string | null;
     docTypeLabel?: string | null;
 }


### PR DESCRIPTION
## What

- Branch chip displays `workingBranch` (active feature branch) with fallback to `branch` (audit trail) — was showing audit field unconditionally.
- Tasks step tab enters in-flight `%` pill the moment `currentStep === "implement"`, including at `0%`; transitions to `✓` at `100%`.
- Substep names from top-level `progress` (e.g., `exploring`, `code-review`, `phase1`) now render as `step-tab__substep` on the active step tab.
- `workingBranch` is now a typed field on `SpecContext` and `FeatureWorkflowContext`; `specContextReader.normalizeSpecContext` preserves it.

## Why

The viewer was reading the wrong fields off `.spec-context.json`: the audit-trail `branch` instead of the active `workingBranch`, and `stepHistory[step].substeps[]` (which the SDD pipeline doesn't write) instead of the top-level `progress` SDD does write. The `inProgress` predicate also required `taskCompletionPercent > 0`, hiding the pill at the moment a user enters implement with 0/N tasks done.

This PR is viewer-only — no SDD pipeline changes. The substep fallback lets both schemas coexist; a future PR can decide whether to migrate SDD writes to the canonical `stepHistory.substeps` shape or simplify the schema by dropping that path.

## Testing

- `npm run compile` passes.
- `npm test -- stateDerivation` — 38/38 passing, including 3 new cases under `describe('deriveActiveSubstep')` covering progress-fallback, null-when-neither, and substeps-preferred-over-progress.
- Manual smoke: open spec 080 in the viewer — branch chip should show `fix/fix-viewer-state-display`, Tasks step should render the substep label `code-review`, Tasks step shows `✓` (6/6 done).
- Backward compat: older specs without `workingBranch` or top-level `progress` render exactly as before.