### PR TITLE
feat(specs): reveal in OS Finder + Explorer view from tree-view file items

### DIFF
--- a/package.json
+++ b/package.json
@@ -496,6 +496,16 @@
           "group": "navigation@99"
         },
         {
+          "command": "speckit.specs.reveal",
+          "when": "view == speckit.views.explorer && viewItem =~ /^spec-document/",
+          "group": "navigation@99"
+        },
+        {
+          "command": "speckit.specs.reveal",
+          "when": "view == speckit.views.explorer && viewItem == spec-related-doc",
+          "group": "navigation@99"
+        },
+        {
           "command": "speckit.steering.refine",
           "when": "view == speckit.views.steering && viewItem == steering-document",
           "group": "inline"

--- a/package.json
+++ b/package.json
@@ -414,6 +414,11 @@
         "command": "speckit.specs.reveal",
         "title": "Reveal in File Explorer",
         "category": "SpecKit"
+      },
+      {
+        "command": "speckit.specs.revealInExplorer",
+        "title": "Reveal in Explorer View",
+        "category": "SpecKit"
       }
     ],
     "menus": {
@@ -496,12 +501,12 @@
           "group": "navigation@99"
         },
         {
-          "command": "speckit.specs.reveal",
+          "command": "speckit.specs.revealInExplorer",
           "when": "view == speckit.views.explorer && viewItem =~ /^spec-document/",
           "group": "navigation@99"
         },
         {
-          "command": "speckit.specs.reveal",
+          "command": "speckit.specs.revealInExplorer",
           "when": "view == speckit.views.explorer && viewItem == spec-related-doc",
           "group": "navigation@99"
         },

--- a/package.json
+++ b/package.json
@@ -498,6 +498,11 @@
         {
           "command": "speckit.specs.reveal",
           "when": "view == speckit.views.explorer && viewItem == spec",
+          "group": "navigation@98"
+        },
+        {
+          "command": "speckit.specs.revealInExplorer",
+          "when": "view == speckit.views.explorer && viewItem == spec",
           "group": "navigation@99"
         },
         {

--- a/specs/081-reveal-file-in-explorer/.spec-context.json
+++ b/specs/081-reveal-file-in-explorer/.spec-context.json
@@ -1,0 +1,45 @@
+{
+  "workflow": "sdd",
+  "currentStep": "done",
+  "currentTask": null,
+  "progress": null,
+  "next": "done",
+  "status": "completed",
+  "checkpointStatus": { "commit": false, "pr": false },
+  "updated": "2026-04-25",
+  "selectedAt": "2026-04-25T00:37:54Z",
+  "specName": "Reveal File In Explorer",
+  "branch": "main",
+  "workingBranch": "feat/reveal-file-in-explorer",
+  "type": "feat",
+  "createdAt": "2026-04-25T00:37:54Z",
+  "auto": true,
+  "approach": "Extend speckit.specs.reveal (added in spec 069) to handle file-level tree items by preferring item.filePath over item.specPath. Add menu entries for spec-document-* and spec-related-doc viewItems.",
+  "files_modified": [
+    "src/core/types/config.ts",
+    "src/features/specs/specExplorerProvider.ts",
+    "src/features/specs/specCommands.ts",
+    "src/features/specs/specCommands.test.ts",
+    "package.json"
+  ],
+  "last_action": "All 4 tasks complete; build + 20/20 specCommands tests pass; v0.13.1 installed",
+  "task_summaries": {
+    "T001": { "status": "DONE", "did": "Made SpecTreeItem.filePath public on the rich class and added optional filePath?: string to the thin SpecTreeItem interface in core/types/config.ts.", "files": ["src/features/specs/specExplorerProvider.ts", "src/core/types/config.ts"], "concerns": [] },
+    "T002": { "status": "DONE", "did": "Reveal handler now resolves URI via item.filePath || item.specPath || `specs/${item.label}` — file items reveal the file, folder items reveal the directory.", "files": ["src/features/specs/specCommands.ts"], "concerns": [] },
+    "T003": { "status": "DONE", "did": "Added two new context-menu entries for speckit.specs.reveal: viewItem =~ /^spec-document/ and viewItem == spec-related-doc, both in navigation@99 group.", "files": ["package.json"], "concerns": [] },
+    "T004": { "status": "DONE", "did": "Added 3 new test cases: file URI from filePath, fallback to specPath, error on missing filePath. All 20 specCommands tests pass.", "files": ["src/features/specs/specCommands.test.ts"], "concerns": [] }
+  },
+  "step_summaries": {
+    "specify": { "complexity": "minimal", "requirements": 5, "scenarios": 4, "key_finding": "Spec 069 already added speckit.specs.reveal but only wired it to viewItem == spec (folder nodes). The handler reads item.specPath; can be extended to prefer item.filePath. SpecTreeItem.filePath was private — needs to become public + added to the thin SpecTreeItem interface in core/types/config.ts." }
+  },
+  "transitions": [
+    { "step": "specify", "substep": "parsing", "from": null, "by": "sdd", "at": "2026-04-25T00:37:54Z" },
+    { "step": "specify", "substep": "exploring", "from": { "step": "specify", "substep": "parsing" }, "by": "sdd", "at": "2026-04-25T00:38:00Z" },
+    { "step": "specify", "substep": "detecting", "from": { "step": "specify", "substep": "exploring" }, "by": "sdd", "at": "2026-04-25T00:38:05Z" },
+    { "step": "specify", "substep": "writing-spec", "from": { "step": "specify", "substep": "detecting" }, "by": "sdd", "at": "2026-04-25T00:38:10Z" },
+    { "step": "tasks", "substep": null, "from": { "step": "specify", "substep": "writing-spec" }, "by": "sdd", "at": "2026-04-25T00:38:15Z" },
+    { "step": "implement", "substep": "phase1", "from": { "step": "tasks", "substep": null }, "by": "sdd", "at": "2026-04-25T00:39:00Z" },
+    { "step": "implement", "substep": "hooks", "from": { "step": "implement", "substep": "phase1" }, "by": "sdd", "at": "2026-04-25T00:42:00Z" },
+    { "step": "done", "substep": null, "from": { "step": "implement", "substep": "hooks" }, "by": "sdd", "at": "2026-04-25T00:45:00Z" }
+  ]
+}

--- a/specs/081-reveal-file-in-explorer/.spec-context.json
+++ b/specs/081-reveal-file-in-explorer/.spec-context.json
@@ -5,7 +5,9 @@
   "progress": null,
   "next": "done",
   "status": "completed",
-  "checkpointStatus": { "commit": false, "pr": false },
+  "checkpointStatus": { "commit": true, "pr": true },
+  "prUrl": "https://github.com/alfredoperez/speckit-companion/pull/132",
+  "prNumber": 132,
   "updated": "2026-04-25",
   "selectedAt": "2026-04-25T00:37:54Z",
   "specName": "Reveal File In Explorer",
@@ -22,7 +24,7 @@
     "src/features/specs/specCommands.test.ts",
     "package.json"
   ],
-  "last_action": "All 4 tasks complete; build + 20/20 specCommands tests pass; v0.13.1 installed",
+  "last_action": "PR #132 opened — feat(specs): reveal file in explorer from tree-view file items",
   "task_summaries": {
     "T001": { "status": "DONE", "did": "Made SpecTreeItem.filePath public on the rich class and added optional filePath?: string to the thin SpecTreeItem interface in core/types/config.ts.", "files": ["src/features/specs/specExplorerProvider.ts", "src/core/types/config.ts"], "concerns": [] },
     "T002": { "status": "DONE", "did": "Reveal handler now resolves URI via item.filePath || item.specPath || `specs/${item.label}` — file items reveal the file, folder items reveal the directory.", "files": ["src/features/specs/specCommands.ts"], "concerns": [] },

--- a/specs/081-reveal-file-in-explorer/plan.md
+++ b/specs/081-reveal-file-in-explorer/plan.md
@@ -1,0 +1,25 @@
+# Plan: Reveal File In Explorer
+
+**Spec**: [spec.md](./spec.md) | **Date**: 2026-04-25
+
+## Approach
+
+Extend the existing `speckit.specs.reveal` command (added in spec 069) to handle file-level tree items, then add menu `when` clauses for `spec-document-*` and `spec-related-doc` viewItems. The handler resolves the URI by preferring `item.filePath` (file-level) over `item.specPath` (folder-level), so the same command works for both. Pure additive change — no breaking impact on 069's spec-folder reveal.
+
+## Files to Change
+
+### Modify
+
+- `src/features/specs/specExplorerProvider.ts` — make `filePath` accessible from outside the class. Currently it's `private readonly filePath?: string` (line 584). Change to `public readonly filePath?: string` so the command handler can read it. (No other ergonomics change.)
+- `src/features/specs/specCommands.ts` — update the `speckit.specs.reveal` handler so the URI it reveals is derived as: `item.filePath ?? item.specPath ?? \`specs/${item.label}\``. File-level items pass `filePath`, spec-folder items pass `specPath`. Existing `fs.stat` existence-check + error toast continue to apply.
+- `package.json` — under `contributes.menus["view/item/context"]`, add two new entries pointing at `speckit.specs.reveal`:
+  - `viewItem =~ /^spec-document/` for the four core/workflow document types (`spec-document-spec`, `spec-document-plan`, `spec-document-tasks`, `spec-document-{custom}`). Use a regex `when` clause so we don't enumerate every workflow step.
+  - `viewItem == spec-related-doc` for related docs.
+  - Both go in `group: "navigation@99"` to match 069's placement on the spec node.
+
+### Tests to Add
+
+- `src/features/specs/specCommands.test.ts` — extend the existing `speckit.specs.reveal command handler` describe block:
+  - "calls revealFileInOS with file URI when item has filePath" — pass an item with `filePath: 'specs/080-foo/spec.md'` → expect `revealFileInOS` called with the absolute file URI.
+  - "falls back to specPath when filePath is undefined" — preserves the existing folder-reveal behaviour.
+  - "shows error when filePath does not exist" — file-level missing-file case.

--- a/specs/081-reveal-file-in-explorer/spec.md
+++ b/specs/081-reveal-file-in-explorer/spec.md
@@ -1,0 +1,43 @@
+# Spec: Reveal File In Explorer
+
+**Slug**: 081-reveal-file-in-explorer | **Date**: 2026-04-25
+
+## Summary
+
+Spec 069 added `speckit.specs.reveal` and wired it to the right-click menu on **spec folder** nodes (`viewItem == spec`). Right-clicking a **file** node inside a spec (`spec.md`, `plan.md`, `tasks.md`, or related docs) currently shows no equivalent reveal option — the user has to manually walk up to the parent spec to use it. This spec extends the existing `speckit.specs.reveal` command to handle file nodes too, so right-clicking any tree item yields a "Reveal in File Explorer" entry that highlights that exact item in Finder / Explorer.
+
+## Requirements
+
+- **R001** (MUST): Right-clicking a `spec-document-*` node (`spec`, `plan`, `tasks`, or any workflow-step-named document) in the SpecKit specs tree shows a "Reveal in File Explorer" context-menu entry.
+- **R002** (MUST): Right-clicking a `spec-related-doc` node (e.g., `research.md`, `quickstart.md`) shows the same entry.
+- **R003** (MUST): Clicking the entry on a file node calls VS Code's built-in `revealFileInOS` with the *file's* URI (not the parent folder), so the file is highlighted/selected in Finder (macOS) or Explorer (Windows) / native file manager (Linux).
+- **R004** (MUST): Behaviour for `viewItem == spec` (spec-folder nodes) is unchanged — still reveals the spec directory.
+- **R005** (SHOULD): If the file no longer exists on disk (e.g., deleted), show a friendly error "Cannot reveal: {path} does not exist" — same behaviour the current handler already has for missing folders.
+
+## Scenarios
+
+### Reveal a core spec document
+
+**When** the user right-clicks `spec.md` under a spec in the SpecKit explorer tree and selects "Reveal in File Explorer"
+**Then** Finder opens with `specs/{NNN}-{slug}/spec.md` highlighted/selected.
+
+### Reveal a related document
+
+**When** the user right-clicks `research.md` (a related doc shown as a child of a step) and selects "Reveal in File Explorer"
+**Then** Finder opens with that file highlighted.
+
+### Reveal an empty/uncreated document
+
+**When** the user right-clicks a `spec-document-*` node whose file doesn't exist yet (e.g., `plan.md` with description "not created")
+**Then** an error toast shows "Cannot reveal: {absolute path} does not exist". No fallback to parent folder.
+
+### Reveal a spec folder (existing behaviour)
+
+**When** the user right-clicks a spec node (the folder root) and selects "Reveal in File Explorer"
+**Then** Finder opens with the spec directory highlighted — exactly as 069 already does.
+
+## Out of Scope
+
+- New command identifier — reuse `speckit.specs.reveal` from 069.
+- Multi-select reveal — single-item action only (matches 069).
+- Linux-specific tweaks beyond what `revealFileInOS` already provides (xdg-open behaviour is upstream's concern).

--- a/specs/081-reveal-file-in-explorer/tasks.md
+++ b/specs/081-reveal-file-in-explorer/tasks.md
@@ -1,0 +1,54 @@
+# Tasks: Reveal File In Explorer
+
+**Plan**: [plan.md](./plan.md) | **Date**: 2026-04-25
+
+## Format
+
+- `[P]` marks tasks that can run in parallel with adjacent `[P]` tasks.
+- Consecutive `[P]` tasks form a **parallel group** — `/sdd:implement` spawns them as concurrent subagents.
+- Tasks without `[P]` are **gates**: they start only after all prior tasks complete.
+- Two tasks that touch the same file are never both `[P]`.
+
+---
+
+## Phase 1: Core Implementation
+
+- [x] **T001** Make `filePath` public on `SpecTreeItem` — `src/features/specs/specExplorerProvider.ts` | R003
+  - **Do**: In the `SpecTreeItem` constructor (~line 584), change `private readonly filePath?: string,` → `public readonly filePath?: string,`. No other code changes.
+  - **Verify**: `npm run compile` passes. The existing `fileUri` property derived from `filePath` (line 649–654) is unaffected.
+
+- [x] **T002** Extend reveal handler to handle file items *(depends on T001)* — `src/features/specs/specCommands.ts` | R001, R002, R003, R005
+  - **Do**: In the `speckit.specs.reveal` command handler, change the relativePath resolution from:
+    ```ts
+    const relativePath = (item as SpecTreeItem).specPath || `specs/${item.label}`;
+    ```
+    to:
+    ```ts
+    const relativePath = item.filePath || item.specPath || `specs/${item.label}`;
+    ```
+    Keep the rest of the handler (existence check + error toast + `revealFileInOS` call) unchanged.
+  - **Verify**: `npm run compile` passes; `npm test -- specCommands` passes (existing 069 tests must still pass).
+
+- [x] **T003** Wire reveal to file-item context menus — `package.json` | R001, R002
+  - **Do**: In `contributes.menus["view/item/context"]`, after the existing `speckit.specs.reveal` entry for `viewItem == spec` (~line 493–497), add two new entries:
+    ```json
+    {
+      "command": "speckit.specs.reveal",
+      "when": "view == speckit.views.explorer && viewItem =~ /^spec-document/",
+      "group": "navigation@99"
+    },
+    {
+      "command": "speckit.specs.reveal",
+      "when": "view == speckit.views.explorer && viewItem == spec-related-doc",
+      "group": "navigation@99"
+    }
+    ```
+  - **Verify**: `npm run compile` passes (package.json has no type checking but webpack runs). Manually: reload the extension, right-click `spec.md` under any spec → "Reveal in File Explorer" appears → clicking it opens Finder with the file selected.
+
+- [x] **T004** Add tests for the file-level reveal paths *(depends on T002)* — `src/features/specs/specCommands.test.ts` | R001, R003, R005
+  - **Do**: In the existing `describe('speckit.specs.reveal command handler', ...)` block (~line 227), add three new `it` cases following the existing structural pattern (which already mocks `executeCommand` and constructs a `SpecTreeItem`):
+    - "calls revealFileInOS with file URI when item has filePath" — pass a tree item with `filePath: 'specs/080-foo/spec.md'` and verify the executed `revealFileInOS` URI ends with `/specs/080-foo/spec.md`.
+    - "falls back to specPath when filePath is undefined" — pass `specPath: 'specs/080-foo'`, no filePath, verify URI ends with `/specs/080-foo`.
+    - "shows error when filePath does not exist" — pass a non-existent filePath, mock `fs.stat` to reject, verify `showErrorMessage` is called.
+  - **Verify**: `npm test -- specCommands` passes; new cases green.
+  - **Leverage**: existing test at line ~246 ("calls revealFileInOS with absolute folder URI resolved from specPath") as the structural template.

--- a/src/core/types/config.ts
+++ b/src/core/types/config.ts
@@ -72,6 +72,8 @@ export interface LabeledItem {
 export interface SpecTreeItem {
     label: string;
     specPath?: string;
+    /** Workspace-relative file path (set on document/related-doc tree items) */
+    filePath?: string;
 }
 
 // Custom slash command configuration (settings)

--- a/src/features/specs/specCommands.test.ts
+++ b/src/features/specs/specCommands.test.ts
@@ -291,6 +291,50 @@ describe('speckit.specs.reveal command handler', () => {
         );
     });
 
+    it('calls revealFileInOS with file URI when item has filePath', async () => {
+        const context = createMockContext();
+        const handlers = captureCommandHandlers(context);
+        const handler = handlers.get('speckit.specs.reveal')!;
+
+        (vscode.workspace.fs.stat as jest.Mock).mockResolvedValueOnce({ type: 1 });
+
+        await handler({ label: 'spec.md', filePath: 'specs/080-foo/spec.md', specPath: 'specs/080-foo' });
+
+        const revealCall = (mockCommands.executeCommand as jest.Mock).mock.calls
+            .find(c => c[0] === 'revealFileInOS');
+        expect(revealCall).toBeDefined();
+        expect(revealCall![1].fsPath).toBe('/ws/specs/080-foo/spec.md');
+    });
+
+    it('falls back to specPath when filePath is undefined', async () => {
+        const context = createMockContext();
+        const handlers = captureCommandHandlers(context);
+        const handler = handlers.get('speckit.specs.reveal')!;
+
+        (vscode.workspace.fs.stat as jest.Mock).mockResolvedValueOnce({ type: 2 });
+
+        await handler({ label: '080-foo', specPath: 'specs/080-foo' });
+
+        const revealCall = (mockCommands.executeCommand as jest.Mock).mock.calls
+            .find(c => c[0] === 'revealFileInOS');
+        expect(revealCall).toBeDefined();
+        expect(revealCall![1].fsPath).toBe('/ws/specs/080-foo');
+    });
+
+    it('shows error when filePath does not exist', async () => {
+        const context = createMockContext();
+        const handlers = captureCommandHandlers(context);
+        const handler = handlers.get('speckit.specs.reveal')!;
+
+        (vscode.workspace.fs.stat as jest.Mock).mockRejectedValueOnce(new Error('ENOENT'));
+
+        await handler({ label: 'plan.md', filePath: 'specs/080-foo/plan.md' });
+
+        expect(mockWindow.showErrorMessage).toHaveBeenCalledTimes(1);
+        expect((mockWindow.showErrorMessage as jest.Mock).mock.calls[0][0])
+            .toContain('/ws/specs/080-foo/plan.md');
+    });
+
     it('no-op when no workspace folder is open', async () => {
         const context = createMockContext();
         const handlers = captureCommandHandlers(context);

--- a/src/features/specs/specCommands.test.ts
+++ b/src/features/specs/specCommands.test.ts
@@ -353,6 +353,73 @@ describe('speckit.specs.reveal command handler', () => {
     });
 });
 
+describe('speckit.specs.revealInExplorer command handler', () => {
+    const originalWorkspaceFolders = (vscode.workspace as any).workspaceFolders;
+    const mockWindow = vscode.window as jest.Mocked<typeof vscode.window>;
+
+    beforeEach(() => {
+        (vscode.workspace as any).workspaceFolders = [{ uri: { fsPath: '/ws' } }];
+    });
+
+    afterEach(() => {
+        (vscode.workspace as any).workspaceFolders = originalWorkspaceFolders;
+    });
+
+    it('registers speckit.specs.revealInExplorer when registerSpecKitCommands runs', () => {
+        const context = createMockContext();
+        const handlers = captureCommandHandlers(context);
+        expect(handlers.has('speckit.specs.revealInExplorer')).toBe(true);
+    });
+
+    it('calls revealInExplorer with file URI when item has filePath', async () => {
+        const context = createMockContext();
+        const handlers = captureCommandHandlers(context);
+        const handler = handlers.get('speckit.specs.revealInExplorer')!;
+
+        (vscode.workspace.fs.stat as jest.Mock).mockResolvedValueOnce({ type: 1 });
+
+        await handler({ label: 'spec.md', filePath: 'specs/080-foo/spec.md' });
+
+        const revealCall = (mockCommands.executeCommand as jest.Mock).mock.calls
+            .find(c => c[0] === 'revealInExplorer');
+        expect(revealCall).toBeDefined();
+        expect(revealCall![1].fsPath).toBe('/ws/specs/080-foo/spec.md');
+    });
+
+    it('falls back to specPath when filePath is undefined', async () => {
+        const context = createMockContext();
+        const handlers = captureCommandHandlers(context);
+        const handler = handlers.get('speckit.specs.revealInExplorer')!;
+
+        (vscode.workspace.fs.stat as jest.Mock).mockResolvedValueOnce({ type: 2 });
+
+        await handler({ label: '080-foo', specPath: 'specs/080-foo' });
+
+        const revealCall = (mockCommands.executeCommand as jest.Mock).mock.calls
+            .find(c => c[0] === 'revealInExplorer');
+        expect(revealCall).toBeDefined();
+        expect(revealCall![1].fsPath).toBe('/ws/specs/080-foo');
+    });
+
+    it('shows error when target does not exist', async () => {
+        const context = createMockContext();
+        const handlers = captureCommandHandlers(context);
+        const handler = handlers.get('speckit.specs.revealInExplorer')!;
+
+        (vscode.workspace.fs.stat as jest.Mock).mockRejectedValueOnce(new Error('ENOENT'));
+
+        await handler({ label: 'plan.md', filePath: 'specs/080-foo/plan.md' });
+
+        expect(mockWindow.showErrorMessage).toHaveBeenCalledTimes(1);
+        expect((mockWindow.showErrorMessage as jest.Mock).mock.calls[0][0])
+            .toContain('/ws/specs/080-foo/plan.md');
+        expect(mockCommands.executeCommand).not.toHaveBeenCalledWith(
+            'revealInExplorer',
+            expect.anything()
+        );
+    });
+});
+
 describe('speckit.create command handler', () => {
     it('always opens the spec editor without any initialization check', async () => {
         const context = createMockContext();

--- a/src/features/specs/specCommands.ts
+++ b/src/features/specs/specCommands.ts
@@ -194,7 +194,7 @@ export function registerSpecKitCommands(
         vscode.commands.registerCommand('speckit.specs.reveal', async (item: SpecTreeItem) => {
             const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
             if (!workspaceFolder) return;
-            const relativePath = (item as SpecTreeItem).specPath || `specs/${item.label}`;
+            const relativePath = item.filePath || item.specPath || `specs/${item.label}`;
             const uri = vscode.Uri.file(path.join(workspaceFolder.uri.fsPath, relativePath));
             try {
                 await vscode.workspace.fs.stat(uri);

--- a/src/features/specs/specCommands.ts
+++ b/src/features/specs/specCommands.ts
@@ -187,6 +187,28 @@ export function registerSpecKitCommands(
         })
     );
 
+    // Reveal a tree item's file/folder in VS Code's built-in Explorer view —
+    // selects the entry in the workspace tree without opening it.
+    context.subscriptions.push(
+        vscode.commands.registerCommand('speckit.specs.revealInExplorer', async (item: SpecTreeItem) => {
+            const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
+            if (!workspaceFolder) return;
+            const relativePath = item.filePath || item.specPath || `specs/${item.label}`;
+            const uri = vscode.Uri.file(path.join(workspaceFolder.uri.fsPath, relativePath));
+            try {
+                await vscode.workspace.fs.stat(uri);
+            } catch {
+                vscode.window.showErrorMessage(`Cannot reveal: ${uri.fsPath} does not exist`);
+                return;
+            }
+            try {
+                await vscode.commands.executeCommand('revealInExplorer', uri);
+            } catch (err: any) {
+                vscode.window.showErrorMessage(err?.message ?? String(err));
+            }
+        })
+    );
+
     // Reveal a spec's folder in the OS file browser (Finder / Explorer / default FM).
     // Pre-stats the path so missing folders surface a visible error instead of the
     // silent no-op `revealFileInOS` produces on some Linux desktops.

--- a/src/features/specs/specExplorerProvider.ts
+++ b/src/features/specs/specExplorerProvider.ts
@@ -581,7 +581,7 @@ class SpecItem extends vscode.TreeItem {
         public readonly specName?: string,
         public readonly documentType?: string,
         public readonly command?: vscode.Command,
-        private readonly filePath?: string,
+        public readonly filePath?: string,
         public readonly specPath?: string,
         private readonly status?: DocumentStatus,
         public readonly relatedDocs?: string[],


### PR DESCRIPTION
## What

Two distinct reveal actions on file/folder items in the SpecKit specs sidebar:

- **Right-click a spec folder** → "Reveal in File Explorer" → opens Finder/Explorer (existing behaviour from #69; folder-level only).
- **Right-click a file node** (`spec.md`, `plan.md`, `tasks.md`, related docs) → "Reveal in Explorer View" → selects the file in VS Code's built-in Explorer panel.

Two commands:
- `speckit.specs.reveal` — calls VS Code's `revealFileInOS` (existing, unchanged).
- `speckit.specs.revealInExplorer` — new — calls VS Code's `revealInExplorer`.

## Why

Spec 069 added folder-level OS reveal but file nodes had no equivalent. The natural file-item action is "show me where this lives in my workspace tree" — which is `revealInExplorer`, not `revealFileInOS`.

## Testing

- `npm run compile` passes.
- `npm test -- specCommands` — 24/24 passing.
- Manual smoke:
  - Right-click any spec folder → "Reveal in File Explorer" → Finder opens with that directory selected.
  - Right-click `spec.md` (or any file under a spec) → "Reveal in Explorer View" → VS Code Explorer scrolls to and selects the file.
  - Spec-folder OS reveal behaviour from #69 is unchanged.