### PR TITLE
feat(spec-viewer): polish related-tab styles to match step-tab chip language

### DIFF
--- a/specs/079-polish-subnav-tabs/.spec-context.json
+++ b/specs/079-polish-subnav-tabs/.spec-context.json
@@ -5,7 +5,9 @@
   "progress": null,
   "next": "done",
   "status": "completed",
-  "checkpointStatus": { "commit": false, "pr": false },
+  "checkpointStatus": { "commit": true, "pr": true },
+  "prUrl": "https://github.com/alfredoperez/speckit-companion/pull/133",
+  "prNumber": 133,
   "updated": "2026-04-25",
   "selectedAt": "2026-04-24T23:44:05Z",
   "specName": "Polish Subnav Tabs",
@@ -16,7 +18,7 @@
   "auto": true,
   "approach": "Update the Related Documents Tabs CSS rules in _navigation.css so the active state mirrors the .step-tab.current accent-pill recipe (color-mix at 18% tint + accent underline + bold --text-primary), and the inactive state uses --text-secondary with --bg-hover on hover. Pure CSS — no markup change.",
   "files_modified": ["webview/styles/spec-viewer/_navigation.css"],
-  "last_action": "Resumed after viewer-fixes (#131) and reveal (#132) merged — proceeding to commit + PR",
+  "last_action": "PR #133 opened — feat(spec-viewer): polish related-tab styles",
   "task_summaries": {
     "T001": {
       "status": "DONE",

--- a/specs/079-polish-subnav-tabs/.spec-context.json
+++ b/specs/079-polish-subnav-tabs/.spec-context.json
@@ -1,0 +1,47 @@
+{
+  "workflow": "sdd",
+  "currentStep": "done",
+  "currentTask": null,
+  "progress": null,
+  "next": "done",
+  "status": "completed",
+  "checkpointStatus": { "commit": false, "pr": false },
+  "updated": "2026-04-25",
+  "selectedAt": "2026-04-24T23:44:05Z",
+  "specName": "Polish Subnav Tabs",
+  "branch": "main",
+  "workingBranch": "feat/polish-subnav-tabs",
+  "type": "feat",
+  "createdAt": "2026-04-24T23:44:05Z",
+  "auto": true,
+  "approach": "Update the Related Documents Tabs CSS rules in _navigation.css so the active state mirrors the .step-tab.current accent-pill recipe (color-mix at 18% tint + accent underline + bold --text-primary), and the inactive state uses --text-secondary with --bg-hover on hover. Pure CSS — no markup change.",
+  "files_modified": ["webview/styles/spec-viewer/_navigation.css"],
+  "last_action": "Resumed after viewer-fixes (#131) and reveal (#132) merged — proceeding to commit + PR",
+  "task_summaries": {
+    "T001": {
+      "status": "DONE",
+      "did": "Rewrote .related-tab, .related-tab:hover, .related-tab.active in _navigation.css — base now uses --text-secondary with radius-sm; active uses 18% accent color-mix pill + bold + accent underline.",
+      "files": ["webview/styles/spec-viewer/_navigation.css"],
+      "concerns": []
+    }
+  },
+  "step_summaries": {
+    "specify": {
+      "complexity": "minimal",
+      "requirements": 4,
+      "scenarios": 3,
+      "key_finding": ".step-tab.current uses a color-mix accent pill (22%) + inset accent ring + radius-sm — the related-tab active state mirrors this recipe at a quieter 18% tint to read as one coherent system."
+    }
+  },
+  "transitions": [
+    { "step": "specify", "substep": "parsing", "from": null, "by": "sdd", "at": "2026-04-24T23:44:05Z" },
+    { "step": "specify", "substep": "exploring", "from": { "step": "specify", "substep": "parsing" }, "by": "sdd", "at": "2026-04-24T23:44:10Z" },
+    { "step": "specify", "substep": "detecting", "from": { "step": "specify", "substep": "exploring" }, "by": "sdd", "at": "2026-04-24T23:44:15Z" },
+    { "step": "specify", "substep": "writing-spec", "from": { "step": "specify", "substep": "detecting" }, "by": "sdd", "at": "2026-04-24T23:44:20Z" },
+    { "step": "tasks", "substep": null, "from": { "step": "specify", "substep": "writing-spec" }, "by": "sdd", "at": "2026-04-24T23:44:30Z" },
+    { "step": "implement", "substep": "phase1", "from": { "step": "tasks", "substep": null }, "by": "sdd", "at": "2026-04-24T23:45:00Z" },
+    { "step": "implement", "substep": "code-review", "from": { "step": "implement", "substep": "phase1" }, "by": "sdd", "at": "2026-04-24T23:47:00Z" },
+    { "step": "implement", "substep": "code-review", "from": { "step": "implement", "substep": "code-review" }, "by": "sdd", "at": "2026-04-24T23:50:00Z", "note": "paused — pivoting to viewer-fixes spec" },
+    { "step": "done", "substep": null, "from": { "step": "implement", "substep": "code-review" }, "by": "sdd", "at": "2026-04-25T02:00:00Z", "note": "resumed after #131 + #132 merged" }
+  ]
+}

--- a/specs/079-polish-subnav-tabs/plan.md
+++ b/specs/079-polish-subnav-tabs/plan.md
@@ -1,0 +1,16 @@
+# Plan: Polish Subnav Tabs
+
+**Spec**: [spec.md](./spec.md) | **Date**: 2026-04-24
+
+## Approach
+
+Update the "Related Documents Tabs" rules in `webview/styles/spec-viewer/_navigation.css` so the active state uses an accent-tinted pill fill (mirroring `.step-tab.current`'s `color-mix` recipe) plus an accent underline flush to the pill bottom, and the inactive state uses `--text-secondary` with `--bg-hover` on hover. Pure CSS — no markup or component changes.
+
+## Files to Change
+
+### Modify
+
+- `webview/styles/spec-viewer/_navigation.css` — replace the `.related-tab`, `.related-tab:hover`, and `.related-tab.active` rule blocks (lines ~183–205) to:
+  - `.related-tab`: change color from `--text-muted` to `--text-secondary`, keep transparent background and 2px transparent bottom border for layout stability, add `border-radius: var(--radius-sm)` so hover/active fill renders as a pill.
+  - `.related-tab:hover`: keep current behavior (`--text-primary` + `--bg-hover`).
+  - `.related-tab.active`: add `background: color-mix(in srgb, var(--accent, #4a9eff) 18%, transparent)` for the pill tint, set `color: var(--text-primary)`, set `font-weight: 600` (bold), and keep `border-bottom: 2px solid var(--accent)` flush to the pill bottom.

--- a/specs/079-polish-subnav-tabs/spec.md
+++ b/specs/079-polish-subnav-tabs/spec.md
@@ -1,0 +1,37 @@
+# Spec: Polish Subnav Tabs
+
+**Slug**: 079-polish-subnav-tabs | **Date**: 2026-04-24
+
+## Summary
+
+The right-aligned related-document subnav tabs in the spec viewer (Data Model / Quickstart / Research / Requirements) currently use muted text and a thin underline for the active state, which reads as visual noise rather than clear navigation. This polishes the active and inactive states so they share visual language with the primary step-tab chip — making the two navigation levels feel like one coherent system.
+
+## Requirements
+
+- **R001** (MUST): The active `.related-tab` must be clearly distinguishable from inactive tabs at arm's length. It uses a subtle accent-tinted pill fill, `--text-primary` text in bold weight, and an accent-colored underline flush to the pill's bottom edge.
+- **R002** (MUST): Inactive `.related-tab` text uses `--text-secondary` (not `--text-muted`), and the hover state applies `--bg-hover` background while shifting text to `--text-primary`.
+- **R003** (MUST): Active and inactive subnav styling reads as visually coherent with the primary `.step-tab.current` chip — same accent-tint family, same border-radius scale, same hover-feedback pattern — so the two navigation levels feel like one system.
+- **R004** (SHOULD): No layout shift between active and inactive tabs (the underline/pill must not cause the tab to jump in height or width when toggled).
+
+## Scenarios
+
+### Viewing Plan with related sub-docs
+
+**When** the user opens a Plan that has Data Model, Quickstart, and Research sub-docs and selects "Quickstart"
+**Then** the Quickstart tab shows an accent-tinted pill background with bold `--text-primary` text and an accent underline at its bottom; Data Model and Research show `--text-secondary` text with no fill.
+
+### Hovering an inactive subnav tab
+
+**When** the user hovers an inactive `.related-tab`
+**Then** the tab's background becomes `--bg-hover` and text shifts to `--text-primary`, mirroring the inactive `.step-tab` hover behavior.
+
+### Switching active subnav tab
+
+**When** the user clicks a different related-tab
+**Then** the previously active tab returns to the inactive style and the newly clicked tab gains the accent-tinted pill + bold + underline — with no vertical or horizontal layout shift in the row.
+
+## Out of Scope
+
+- Changes to `.step-tab` styling (the primary nav chips already have the target visual language).
+- Changes to tab order, labels, or visibility logic in `NavigationBar.tsx`.
+- Theme-token changes; this uses existing `--accent`, `--text-primary`, `--text-secondary`, `--bg-hover` variables.

--- a/specs/079-polish-subnav-tabs/tasks.md
+++ b/specs/079-polish-subnav-tabs/tasks.md
@@ -1,0 +1,22 @@
+# Tasks: Polish Subnav Tabs
+
+**Plan**: [plan.md](./plan.md) | **Date**: 2026-04-24
+
+## Format
+
+- `[P]` marks tasks that can run in parallel with adjacent `[P]` tasks.
+- Consecutive `[P]` tasks form a **parallel group** — `/sdd:implement` spawns them as concurrent subagents.
+- Tasks without `[P]` are **gates**: they start only after all prior tasks complete.
+- Two tasks that touch the same file are never both `[P]`.
+
+---
+
+## Phase 1: Core Implementation
+
+- [x] **T001** Update related-tab base, hover, and active styles — `webview/styles/spec-viewer/_navigation.css` | R001, R002, R003, R004
+  - **Do**: In the "Related Documents Tabs" section (lines ~183–205), rewrite the three rule blocks:
+    - `.related-tab`: change `color: var(--text-muted)` → `color: var(--text-secondary)`; add `border-radius: var(--radius-sm)`; keep `border-bottom: 2px solid transparent` so the underline slot reserves space and prevents layout shift.
+    - `.related-tab:hover`: leave as-is (`color: var(--text-primary)` + `background: var(--bg-hover)`).
+    - `.related-tab.active`: add `background: color-mix(in srgb, var(--accent, #4a9eff) 18%, transparent)`; set `color: var(--text-primary)`; change `font-weight: 500` → `font-weight: 600`; keep `border-bottom-color: var(--accent)` so the underline sits flush to the pill bottom.
+  - **Verify**: `npm run compile` passes. Open the spec viewer on a Plan with related sub-docs (Data Model / Quickstart / Research) — the active tab shows an accent-tinted pill with bold text and accent underline; inactives are `--text-secondary` and gain `--bg-hover` on hover; switching tabs causes no layout shift.
+  - **Leverage**: `.step-tab.current` rule in the same file (lines ~97–103) — uses `color-mix(in srgb, var(--accent, #4a9eff) 22%, transparent)` for its pill fill; this task uses 18% to keep the secondary nav level visually quieter than the primary step chips.

--- a/webview/styles/spec-viewer/_navigation.css
+++ b/webview/styles/spec-viewer/_navigation.css
@@ -185,11 +185,11 @@
     border: none;
     border-bottom: 2px solid transparent;
     background: transparent;
-    color: var(--text-muted);
+    color: var(--text-secondary);
     cursor: pointer;
     font-size: 12px;
     font-family: inherit;
-    border-radius: 0;
+    border-radius: var(--radius-sm);
     transition: all var(--transition-fast);
 }
 
@@ -199,7 +199,8 @@
 }
 
 .related-tab.active {
+    background: color-mix(in srgb, var(--accent, #4a9eff) 18%, transparent);
     color: var(--text-primary);
     border-bottom-color: var(--accent);
-    font-weight: 500;
+    font-weight: 600;
 }


### PR DESCRIPTION
## What

- `.related-tab.active` — accent-tinted pill fill (`color-mix` at 18%) + bold `--text-primary` + accent underline flush to pill bottom.
- `.related-tab` (inactive) — text uses `--text-secondary` (was `--text-muted`); hover stays as `--text-primary` + `--bg-hover`.
- Border-radius added to base so hover/active fill renders as a pill instead of a sharp rectangle.

## Why

Right-aligned subnav tabs (Data Model / Quickstart / Research / Requirements) were too muted to read as active/inactive at arm's length — they looked like noise rather than navigation. This polish mirrors the primary `.step-tab.current` recipe at a quieter 18% tint so the two navigation levels feel like one coherent system.

Closes #127

## Testing

- `npm run compile` passes.
- Manual smoke: open a Plan with related sub-docs (Data Model / Quickstart / Research) — the active tab is clearly distinguished at arm's length; switching tabs has no layout shift; hover on inactive tabs shows `--bg-hover` background.