### PR TITLE
fix(activitybar): always show SpecKit icon, add empty-state welcome

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,8 +111,8 @@ Actions that change the spec's lifecycle are protected so a misfired click is ea
 ## Getting Started
 
 1. **Install** the extension from a `.vsix` file or the VS Code marketplace
-2. **Open the sidebar** — click the SpecKit icon in the activity bar
-3. **Create a spec** — click the `+` button in the Specs view to start your first feature
+2. **Open the sidebar** — the SpecKit icon is always visible in the activity bar; with no folder open, clicking it shows an empty-state panel with an **Open Folder** action
+3. **Create a spec** — once a folder is open, click the `+` button in the Specs view to start your first feature
 
 ## Supported AI Providers
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "speckit-companion",
   "displayName": "SpecKit Companion",
   "description": "VS Code companion for GitHub SpecKit - spec-driven development with AI assistants",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "license": "MIT",
   "publisher": "alfredoperez",
   "icon": "icon.png",
@@ -68,8 +68,7 @@
       "speckit": [
         {
           "id": "speckit.views.explorer",
-          "name": "Specs",
-          "when": "!(workbenchState == empty || workspaceFolderCount == 0)"
+          "name": "Specs"
         },
         {
           "id": "speckit.views.steering",
@@ -85,6 +84,11 @@
       ]
     },
     "viewsWelcome": [
+      {
+        "view": "speckit.views.explorer",
+        "contents": "Open a folder to start using SpecKit.\n\n[$(folder-opened) Open Folder](command:vscode.openFolder)",
+        "when": "workbenchState == empty || workspaceFolderCount == 0"
+      },
       {
         "view": "speckit.views.explorer",
         "contents": "SpecKit CLI detected. Initialize this workspace to start building with specs.\n\n[$(gear) Initialize Workspace](command:speckit.initWorkspace)",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "speckit-companion",
   "displayName": "SpecKit Companion",
   "description": "VS Code companion for GitHub SpecKit - spec-driven development with AI assistants",
-  "version": "0.13.1",
+  "version": "0.13.0",
   "license": "MIT",
   "publisher": "alfredoperez",
   "icon": "icon.png",

--- a/specs/082-always-show-icon/.spec-context.json
+++ b/specs/082-always-show-icon/.spec-context.json
@@ -1,0 +1,160 @@
+{
+  "workflow": "speckit",
+  "selectedAt": "2026-04-25T02:10:47Z",
+  "currentStep": "implement",
+  "status": "completed",
+  "specName": "Always Show Icon",
+  "branch": "082-always-show-icon",
+  "stepHistory": {
+    "specify": {
+      "startedAt": "2026-04-25T02:10:47Z",
+      "completedAt": "2026-04-25T11:13:42.630Z"
+    },
+    "plan": {
+      "startedAt": "2026-04-25T11:13:42.633Z",
+      "completedAt": "2026-04-25T11:18:37.151Z",
+      "substeps": {
+        "research": {
+          "startedAt": "2026-04-25T11:14:30.000Z",
+          "completedAt": "2026-04-25T11:16:30.000Z"
+        },
+        "design": {
+          "startedAt": "2026-04-25T11:16:30.000Z",
+          "completedAt": "2026-04-25T11:18:00.000Z"
+        }
+      }
+    },
+    "tasks": {
+      "startedAt": "2026-04-25T11:18:37.154Z",
+      "completedAt": "2026-04-25T11:22:01.980Z",
+      "substeps": {
+        "generate": {
+          "startedAt": "2026-04-25T11:20:00.000Z",
+          "completedAt": "2026-04-25T11:22:00.000Z"
+        }
+      }
+    },
+    "implement": {
+      "startedAt": "2026-04-25T11:22:01.983Z",
+      "completedAt": "2026-04-25T11:25:30.000Z",
+      "substeps": {
+        "run-tests": {
+          "startedAt": "2026-04-25T11:24:00.000Z",
+          "completedAt": "2026-04-25T11:25:00.000Z"
+        }
+      }
+    }
+  },
+  "transitions": [
+    {
+      "step": "specify",
+      "substep": null,
+      "from": {
+        "step": "specify",
+        "substep": null
+      },
+      "by": "extension",
+      "at": "2026-04-25T11:13:42.630Z"
+    },
+    {
+      "step": "plan",
+      "substep": null,
+      "from": {
+        "step": "specify",
+        "substep": null
+      },
+      "by": "extension",
+      "at": "2026-04-25T11:13:42.633Z"
+    },
+    {
+      "step": "plan",
+      "substep": "research",
+      "from": {
+        "step": "plan",
+        "substep": null
+      },
+      "by": "ai",
+      "at": "2026-04-25T11:14:30.000Z"
+    },
+    {
+      "step": "plan",
+      "substep": "design",
+      "from": {
+        "step": "plan",
+        "substep": "research"
+      },
+      "by": "ai",
+      "at": "2026-04-25T11:16:30.000Z"
+    },
+    {
+      "step": "plan",
+      "substep": null,
+      "from": {
+        "step": "plan",
+        "substep": null
+      },
+      "by": "extension",
+      "at": "2026-04-25T11:18:37.151Z"
+    },
+    {
+      "step": "tasks",
+      "substep": null,
+      "from": {
+        "step": "plan",
+        "substep": null
+      },
+      "by": "extension",
+      "at": "2026-04-25T11:18:37.154Z"
+    },
+    {
+      "step": "tasks",
+      "substep": "generate",
+      "from": {
+        "step": "tasks",
+        "substep": null
+      },
+      "by": "ai",
+      "at": "2026-04-25T11:20:00.000Z"
+    },
+    {
+      "step": "tasks",
+      "substep": null,
+      "from": {
+        "step": "tasks",
+        "substep": null
+      },
+      "by": "extension",
+      "at": "2026-04-25T11:22:01.980Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "from": {
+        "step": "tasks",
+        "substep": null
+      },
+      "by": "extension",
+      "at": "2026-04-25T11:22:01.983Z"
+    },
+    {
+      "step": "implement",
+      "substep": "run-tests",
+      "from": {
+        "step": "implement",
+        "substep": null
+      },
+      "by": "ai",
+      "at": "2026-04-25T11:24:00.000Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "from": {
+        "step": "implement",
+        "substep": "run-tests"
+      },
+      "by": "ai",
+      "at": "2026-04-25T11:25:30.000Z"
+    }
+  ]
+}

--- a/specs/082-always-show-icon/checklists/requirements.md
+++ b/specs/082-always-show-icon/checklists/requirements.md
@@ -1,0 +1,35 @@
+# Specification Quality Checklist: Always Show SpecKit Icon in Activity Bar
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-24
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass. Spec is ready for `/speckit.clarify` (optional) or `/speckit.plan`.
+- Reasonable defaults applied for the empty-state action ("Open Folder") and copy voice (matches existing welcome views), captured under Assumptions so a planner can revisit if needed.

--- a/specs/082-always-show-icon/contracts/manifest.md
+++ b/specs/082-always-show-icon/contracts/manifest.md
@@ -1,0 +1,61 @@
+# Manifest Contract — `package.json`
+
+This is the only external interface the feature touches. The "contract" is the shape of the `contributes` block as VS Code reads it on extension load.
+
+## Diff (conceptual)
+
+### `contributes.views.speckit`
+
+```jsonc
+// BEFORE
+{
+  "id": "speckit.views.explorer",
+  "name": "Specs",
+  "when": "!(workbenchState == empty || workspaceFolderCount == 0)"
+}
+
+// AFTER — when clause removed entirely
+{
+  "id": "speckit.views.explorer",
+  "name": "Specs"
+}
+```
+
+`speckit.views.steering` and `speckit.views.settings` are **unchanged**. They keep their existing `when` clauses (still gated on workspace + their respective `config.speckit.views.*.visible` settings).
+
+### `contributes.viewsWelcome` — new entry, prepended
+
+```jsonc
+{
+  "view": "speckit.views.explorer",
+  "contents": "Open a folder to start using SpecKit.\n\n[$(folder-opened) Open Folder](command:vscode.openFolder)",
+  "when": "workbenchState == empty || workspaceFolderCount == 0"
+}
+```
+
+Existing welcome entries are unchanged. Their `when` clauses (`speckit.cliInstalled && !speckit.detected`, `speckit.detected && ...`) are naturally disjoint from the new entry because `speckit.detected` is always false without a workspace and `speckit.cliInstalled` alone is not enough to satisfy any existing entry's gate.
+
+### `contributes.viewsContainers.activitybar`
+
+Unchanged. The icon, id, and title stay exactly as they are today.
+
+---
+
+## Behavioral contract for VS Code
+
+| Input state | Container | View body |
+|-------------|-----------|-----------|
+| No workspace open | Visible | Welcome: "Open a folder to start using SpecKit." + Open Folder button |
+| Workspace open, CLI not installed, not initialized | Visible | (Existing fallback — empty tree, no welcome matches today; out of scope to change) |
+| Workspace open, CLI installed, not initialized | Visible | Welcome: "Initialize Workspace" (existing) |
+| Workspace open, initialized, constitution needs setup | Visible | Welcome: "Configure Constitution" (existing) |
+| Workspace open, initialized, constitution OK | Visible | Specs tree (or "Build features with specs" welcome if empty) |
+
+---
+
+## Out of contract
+
+- Telemetry on the new welcome action — not in scope.
+- Retitling or repositioning the activity-bar entry — explicitly forbidden by FR-007.
+- Steering/Settings empty-state behavior — unchanged; out of scope.
+- Any change under `.claude/**` or `.specify/**` — forbidden by extension-isolation rules in `CLAUDE.md`.

--- a/specs/082-always-show-icon/data-model.md
+++ b/specs/082-always-show-icon/data-model.md
@@ -1,0 +1,70 @@
+# Phase 1 — Data Model: Always Show SpecKit Icon
+
+This feature has no persisted entities and no new TypeScript types. The "data model" is the set of VS Code context keys and the resulting view/welcome states they drive. Documenting it here keeps the gating logic explicit so reviewers can trace each acceptance scenario back to a clause in `package.json`.
+
+---
+
+## Context-key inputs
+
+| Key | Source | Meaning when true |
+|-----|--------|-------------------|
+| `workbenchState == empty` | VS Code built-in | No workspace or folder is open at all (the "no folder open" startup screen). |
+| `workspaceFolderCount == 0` | VS Code built-in | Zero folders in the current workspace (covers the rare case of an empty multi-root workspace file). |
+| `speckit.cliInstalled` | `SpecKitDetector.checkCliInstalled` (`src/speckit/detector.ts:45-69`) | The `specify` CLI is found on PATH. |
+| `speckit.detected` | `SpecKitDetector.checkWorkspaceInitialized` (`src/speckit/detector.ts:75-111`) | A workspace folder exists AND it contains `.specify/` or SpecKit agent files. Always false when no folder is open. |
+| `speckit.constitutionNeedsSetup` | `SpecKitDetector.checkConstitutionSetup` (`src/speckit/detector.ts:116-144`) | A constitution file exists but still has placeholder tokens. |
+| `config.speckit.views.steering.visible` | User setting | Steering view enabled. |
+| `config.speckit.views.settings.visible` | User setting | Settings view enabled. |
+
+Derived predicate used throughout: `noWorkspace ≡ workbenchState == empty || workspaceFolderCount == 0`.
+
+---
+
+## View visibility states
+
+For each view in the `speckit` container, the table shows the resulting visibility under the two top-level workspace states.
+
+| View | When clause (after this feature) | No workspace | Workspace open |
+|------|----------------------------------|--------------|----------------|
+| `speckit.views.explorer` | *(no clause — always eligible)* | Visible (renders welcome content) | Visible (renders specs tree or existing welcome) |
+| `speckit.views.steering` | `!noWorkspace && config.speckit.views.steering.visible` | Hidden | Visible if user setting is true |
+| `speckit.views.settings` | `!noWorkspace && config.speckit.views.settings.visible` | Hidden | Visible if user setting is true |
+
+**Container visibility** (the activity-bar icon): visible whenever any view above is eligible. Because `speckit.views.explorer` is now unconditionally eligible, the container is always visible. ← This is the entire fix.
+
+---
+
+## Welcome-content states for `speckit.views.explorer`
+
+The view shows whichever `viewsWelcome` entry's `when` clause matches. Entries are mutually exclusive by construction (see Decision 4 in `research.md`).
+
+| State | Predicate | Content shown |
+|-------|-----------|---------------|
+| **Empty workspace** *(NEW)* | `noWorkspace` | "Open a folder to start using SpecKit." + `[$(folder-opened) Open Folder](command:vscode.openFolder)` |
+| CLI detected, workspace not initialized | `speckit.cliInstalled && !speckit.detected` *(implies workspace open, since `speckit.detected` requires a folder)* | Existing "Initialize Workspace" content |
+| Workspace initialized, constitution needs setup | `speckit.detected && speckit.constitutionNeedsSetup` | Existing "Configure Constitution / Create New Spec" content |
+| Workspace initialized, constitution OK | `speckit.detected && !speckit.constitutionNeedsSetup` | Existing "Build features with specs" content |
+| Filter active, no matches | `speckit.specs.filterActive && speckit.specs.noFilterMatch` | Existing "No specs match" content |
+
+The tree itself (specs list) renders only when the workspace is open AND no welcome `when` matches — same behavior as today.
+
+---
+
+## State transitions
+
+The interesting transitions for this feature, traced to the spec scenarios:
+
+| From | Trigger | To | Implementing mechanism |
+|------|---------|----|----------------------|
+| (workbench paint) | `onStartupFinished` fires (or even before) | Empty-workspace welcome visible | Declarative `viewsWelcome` + relaxed `when` |
+| Empty-workspace welcome | User picks a folder via "Open Folder" | Workbench reload → one of the workspace-open welcome states or specs tree | `vscode.openFolder` command (built-in); VS Code rerenders welcome based on context keys after `SpecKitDetector.detect()` resolves |
+| Specs tree visible | User runs `File → Close Folder` | Empty-workspace welcome | `workbenchState`/`workspaceFolderCount` flip → `when` clauses re-evaluate; container stays mounted because `speckit.views.explorer` remains eligible |
+
+---
+
+## Invariants
+
+1. The container is visible iff `speckit.views.explorer` is eligible. After this change, that view's eligibility is unconditional, so the container is always visible. (FR-001)
+2. Exactly one `viewsWelcome` entry for `speckit.views.explorer` is active at any time, by construction of the `when` clauses. (FR-002, FR-006)
+3. The transition from empty-workspace welcome to workspace-open content requires no extension code path — it's driven entirely by VS Code's context-key reactivity. (FR-004, SC-004)
+4. The activity-bar position, label, and icon glyph from `viewsContainers.activitybar.speckit` are not touched. (FR-007)

--- a/specs/082-always-show-icon/plan.md
+++ b/specs/082-always-show-icon/plan.md
@@ -1,0 +1,104 @@
+# Implementation Plan: [FEATURE]
+
+**Branch**: `[###-feature-name]` | **Date**: [DATE] | **Spec**: [link]
+**Input**: Feature specification from `/specs/[###-feature-name]/spec.md`
+
+**Note**: This template is filled in by the `/speckit.plan` command. See `.specify/templates/commands/plan.md` for the execution workflow.
+
+## Summary
+
+[Extract from feature spec: primary requirement + technical approach from research]
+
+## Technical Context
+
+<!--
+  ACTION REQUIRED: Replace the content in this section with the technical details
+  for the project. The structure here is presented in advisory capacity to guide
+  the iteration process.
+-->
+
+**Language/Version**: [e.g., Python 3.11, Swift 5.9, Rust 1.75 or NEEDS CLARIFICATION]  
+**Primary Dependencies**: [e.g., FastAPI, UIKit, LLVM or NEEDS CLARIFICATION]  
+**Storage**: [if applicable, e.g., PostgreSQL, CoreData, files or N/A]  
+**Testing**: [e.g., pytest, XCTest, cargo test or NEEDS CLARIFICATION]  
+**Target Platform**: [e.g., Linux server, iOS 15+, WASM or NEEDS CLARIFICATION]
+**Project Type**: [single/web/mobile - determines source structure]  
+**Performance Goals**: [domain-specific, e.g., 1000 req/s, 10k lines/sec, 60 fps or NEEDS CLARIFICATION]  
+**Constraints**: [domain-specific, e.g., <200ms p95, <100MB memory, offline-capable or NEEDS CLARIFICATION]  
+**Scale/Scope**: [domain-specific, e.g., 10k users, 1M LOC, 50 screens or NEEDS CLARIFICATION]
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+[Gates determined based on constitution file]
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/[###-feature]/
+├── plan.md              # This file (/speckit.plan command output)
+├── research.md          # Phase 0 output (/speckit.plan command)
+├── data-model.md        # Phase 1 output (/speckit.plan command)
+├── quickstart.md        # Phase 1 output (/speckit.plan command)
+├── contracts/           # Phase 1 output (/speckit.plan command)
+└── tasks.md             # Phase 2 output (/speckit.tasks command - NOT created by /speckit.plan)
+```
+
+### Source Code (repository root)
+<!--
+  ACTION REQUIRED: Replace the placeholder tree below with the concrete layout
+  for this feature. Delete unused options and expand the chosen structure with
+  real paths (e.g., apps/admin, packages/something). The delivered plan must
+  not include Option labels.
+-->
+
+```text
+# [REMOVE IF UNUSED] Option 1: Single project (DEFAULT)
+src/
+├── models/
+├── services/
+├── cli/
+└── lib/
+
+tests/
+├── contract/
+├── integration/
+└── unit/
+
+# [REMOVE IF UNUSED] Option 2: Web application (when "frontend" + "backend" detected)
+backend/
+├── src/
+│   ├── models/
+│   ├── services/
+│   └── api/
+└── tests/
+
+frontend/
+├── src/
+│   ├── components/
+│   ├── pages/
+│   └── services/
+└── tests/
+
+# [REMOVE IF UNUSED] Option 3: Mobile + API (when "iOS/Android" detected)
+api/
+└── [same as backend above]
+
+ios/ or android/
+└── [platform-specific structure: feature modules, UI flows, platform tests]
+```
+
+**Structure Decision**: [Document the selected structure and reference the real
+directories captured above]
+
+## Complexity Tracking
+
+> **Fill ONLY if Constitution Check has violations that must be justified**
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| [e.g., 4th project] | [current need] | [why 3 projects insufficient] |
+| [e.g., Repository pattern] | [specific problem] | [why direct DB access insufficient] |

--- a/specs/082-always-show-icon/quickstart.md
+++ b/specs/082-always-show-icon/quickstart.md
@@ -1,0 +1,51 @@
+# Quickstart — Verifying Always-Show-Icon
+
+A manual smoke check for reviewers. Each step maps to one of the spec's acceptance scenarios (US1.1–3, US2.1–2). Total time: ~3 minutes.
+
+## Prerequisites
+
+- Build the extension: `npm install && npm run compile && npm run package`.
+- Install the resulting `.vsix` into a clean VS Code window (or use F5 to launch the Extension Development Host).
+- Close any open folder so VS Code shows the "Start" / "Open Folder" landing page.
+
+## Test 1 — Icon visible at fresh startup *(US1, FR-001, SC-001)*
+
+1. Quit VS Code completely.
+2. Relaunch VS Code with no folder argument.
+3. Wait for the workbench to finish loading (≤5 seconds).
+4. **Expect**: the SpecKit seedling icon is visible in the activity bar, in the same position as when a workspace is open.
+
+## Test 2 — Empty-state welcome shows on click *(US1, FR-002, FR-003)*
+
+1. With no folder open, click the SpecKit icon.
+2. **Expect**: the SpecKit sidebar opens, showing a single welcome panel with copy explaining a folder is required, plus an "Open Folder" button.
+3. **Expect**: no other SpecKit views (Steering, Settings) appear in the sidebar.
+
+## Test 3 — Open Folder action transitions to normal views *(US1, FR-004, SC-004)*
+
+1. With the empty-state panel visible, click "Open Folder".
+2. Pick any local folder (preferably one already initialized for SpecKit so the specs tree has something to show).
+3. **Expect**: VS Code reloads the workbench with the selected folder. Within ~1 second of reload, the SpecKit sidebar shows the normal Specs tree (or one of the existing welcome flows if the folder is not yet initialized) — the empty-state panel must not linger.
+
+## Test 4 — Closing the folder restores the empty state *(US2, FR-005)*
+
+1. With a workspace open and the SpecKit views visible, run `File → Close Folder`.
+2. **Expect**: the SpecKit icon stays in the activity bar.
+3. Click the icon.
+4. **Expect**: the empty-state panel from Test 2 reappears, identical in copy and action.
+
+## Test 5 — Existing welcome flows still work *(FR-006)*
+
+1. Open a folder that has the SpecKit CLI installed but no `.specify/` directory yet.
+2. **Expect**: the existing "Initialize Workspace" welcome content appears — not the new "Open Folder" empty state.
+3. Repeat with a folder that has a stub constitution containing `[PROJECT_NAME]` placeholder.
+4. **Expect**: the existing "Configure Constitution" welcome content appears.
+
+## Test 6 — Container visuals unchanged *(FR-007)*
+
+1. Compare the activity-bar entry's icon glyph and tooltip ("SpecKit") to a screenshot from the current marketplace release.
+2. **Expect**: identical glyph, identical tooltip, identical position relative to the user's other extension icons.
+
+## Pass criteria
+
+All six tests pass with no manual refresh, no reload prompt (other than the reload that VS Code itself triggers when opening a folder), and no console errors in the Extension Development Host.

--- a/specs/082-always-show-icon/research.md
+++ b/specs/082-always-show-icon/research.md
@@ -1,0 +1,75 @@
+# Phase 0 — Research: Always Show SpecKit Icon
+
+## Open questions identified from Technical Context
+
+The spec had no `[NEEDS CLARIFICATION]` markers. The only research questions are mechanical: how does VS Code decide to render an activity-bar container, and what's the idiomatic way to show an "open a folder" empty state?
+
+---
+
+## Decision 1 — How to keep the activity-bar icon visible with no workspace
+
+**Decision**: Relax the `when` clause on `speckit.views.explorer` so it no longer requires a workspace folder. Keep `speckit.views.steering` and `speckit.views.settings` as-is (they remain workspace-gated).
+
+**Rationale**: VS Code shows an activity-bar container if **any** of its contributed views is currently eligible per its `when` clause. Today all three SpecKit views require `!(workbenchState == empty || workspaceFolderCount == 0)`, which is why the icon disappears when no folder is open. Removing that gate from a single view (`explorer`) is enough to keep the container visible without exposing the steering/settings trees in a state where they have nothing to show.
+
+**Alternatives considered**:
+- *Add a fourth always-visible "placeholder" view* — extra surface area, extra registration, and shows up later as a stray empty group when a workspace is open. Rejected.
+- *Drop the `when` from all three views* — would render empty Steering and Settings trees with no useful content when no folder is open. Rejected.
+- *Change `viewsContainers` somehow to force visibility* — VS Code does not expose container-level visibility control independent of view eligibility; this is the wrong layer. Rejected.
+
+---
+
+## Decision 2 — How to render the empty-state content
+
+**Decision**: Add a `viewsWelcome` entry targeting `speckit.views.explorer` with `when: workbenchState == empty || workspaceFolderCount == 0`, containing a short explanation and a `[$(folder-opened) Open Folder](command:vscode.openFolder)` button.
+
+**Rationale**: `viewsWelcome` is VS Code's built-in mechanism for "view body when there's nothing to show." It already powers the existing welcome states ("SpecKit CLI detected", "Configure your project principles", etc.). Reusing it keeps the voice and visual treatment consistent (FR-008) and means the empty state automatically swaps out the moment the `when` clause flips — satisfying SC-004 and FR-004 with zero custom code.
+
+**Alternatives considered**:
+- *Custom WebviewView for the empty state* — heavyweight; introduces a webview lifecycle for what is essentially one paragraph and one button. Rejected.
+- *TreeDataProvider that returns a synthetic node* — clutters the tree with a fake item; doesn't render call-to-action buttons natively. Rejected.
+
+---
+
+## Decision 3 — How to wire the "Open Folder" action
+
+**Decision**: Use the built-in `vscode.openFolder` command directly from the welcome-view markdown link. No extension-side command needed.
+
+**Rationale**: `vscode.openFolder` is a stable VS Code API command that opens the platform folder picker and reloads the workbench with the selected folder. Linking to it directly avoids adding a custom `speckit.openFolder` shim that would do nothing but call through. The command is identical to what `File → Open Folder…` runs.
+
+**Alternatives considered**:
+- *`workbench.action.files.openFolder`* — older alias; `vscode.openFolder` is the documented one. Equivalent but less idiomatic. Rejected.
+- *Custom wrapper command* — only worth it if we wanted telemetry or extra prompts; out of scope here. Rejected.
+
+---
+
+## Decision 4 — Coexistence with existing welcome views
+
+**Decision**: Order the new welcome entry first (or scope it tightly with the empty-workspace `when`), and verify no existing entry's `when` clause overlaps. The current entries all require `speckit.detected` or `speckit.cliInstalled && !speckit.detected`, both of which are false when there's no workspace folder (`detector.ts:78-80` sets `speckit.detected = false` when no folder is present). So there is no overlap to resolve.
+
+**Rationale**: FR-006 forbids the new empty state from suppressing the existing welcome flows. Because `speckit.detected` always flips false in the no-workspace case, the new entry's gate (`workbenchState == empty || workspaceFolderCount == 0`) cannot be true at the same time as the existing entries. Verified by reading `src/speckit/detector.ts:75-110`.
+
+**Alternatives considered**:
+- *Make the new entry mutually exclusive via explicit negation of every other `when`* — redundant given the natural disjointness above, and brittle if new welcome entries are added. Rejected.
+
+---
+
+## Decision 5 — Activation timing
+
+**Decision**: Keep the existing `onStartupFinished` activation event. No change.
+
+**Rationale**: The activity-bar container is contributed declaratively and renders before extension activation; we only need activation for setting context keys (`speckit.detected`, `speckit.cliInstalled`). The icon will appear at workbench paint time regardless of activation timing, which is what SC-001 requires (≤5s after startup). Confirmed by reading `package.json:40-43` (activation events) and `src/extension.ts:35-50` (activation flow).
+
+**Alternatives considered**:
+- *Add `onView:speckit.views.explorer`* — unnecessary; `onStartupFinished` already covers the case and adding more events delays nothing. Rejected.
+
+---
+
+## Findings summary
+
+All resolutions are declarative or use existing APIs; no new dependencies, no new modules, no new context keys. The change surface is:
+
+1. `package.json` — one `when` clause relaxed, one `viewsWelcome` entry added.
+2. (Optional) `src/extension.ts` — confirm no regression in the no-workspace activation branch (`extension.ts:54-68` already guards manager initialization on `hasWorkspace`).
+
+No `[NEEDS CLARIFICATION]` markers remain.

--- a/specs/082-always-show-icon/spec.md
+++ b/specs/082-always-show-icon/spec.md
@@ -1,0 +1,82 @@
+# Feature Specification: Always Show SpecKit Icon in Activity Bar
+
+**Feature Branch**: `082-always-show-icon`
+**Created**: 2026-04-24
+**Status**: Draft
+**Input**: GitHub issue #112 — "Extension icon not shown until project is open"
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Confirm extension is installed without opening a project (Priority: P1)
+
+A user installs SpecKit Companion from the marketplace. They open VS Code with no folder or workspace yet, glance at the activity bar, and immediately see the SpecKit icon. Clicking it reveals a friendly empty state that explains they need to open a folder to start using SpecKit, with a one-click action to do so.
+
+**Why this priority**: This is the entire bug. Today the icon is hidden until a workspace is open, so first-time users cannot tell whether the install succeeded. Fixing this removes the post-install "did it work?" confusion that prompted the issue.
+
+**Independent Test**: Launch a fresh VS Code window with no folder open. Verify the SpecKit icon appears in the activity bar, that clicking it opens a sidebar panel with copy explaining why nothing is listed, and that the panel offers a clear path forward (e.g., "Open Folder").
+
+**Acceptance Scenarios**:
+
+1. **Given** the extension is installed and VS Code starts with no folder open, **When** the user looks at the activity bar, **Then** the SpecKit icon is visible in the same position it would appear when a workspace is open.
+2. **Given** the SpecKit icon is visible with no workspace open, **When** the user clicks the icon, **Then** the SpecKit sidebar opens and shows an empty-state message explaining that a folder must be open to use SpecKit, plus an action to open one.
+3. **Given** the empty-state panel is visible, **When** the user opens a folder via the empty-state action (or any other VS Code mechanism), **Then** the panel updates to show the normal Specs / Steering / Settings views without requiring the user to click the icon again.
+
+---
+
+### User Story 2 - Smooth handoff back to empty state when the workspace closes (Priority: P2)
+
+A user has been working in a project with SpecKit, then uses File → Close Folder. The activity bar icon stays put and the sidebar reverts to the same empty-state guidance shown to first-time users, so the transition is symmetric and predictable.
+
+**Why this priority**: Without this, the icon would behave inconsistently — present at startup but disappearing after the user closes a folder mid-session. Closing the loop avoids a second class of confusion and keeps the fix coherent.
+
+**Independent Test**: Open a workspace, confirm normal SpecKit views appear, then close the folder and verify the icon remains and the empty-state copy returns.
+
+**Acceptance Scenarios**:
+
+1. **Given** a workspace with SpecKit views is currently open, **When** the user closes the folder, **Then** the SpecKit icon remains in the activity bar.
+2. **Given** the user has just closed the folder, **When** they click the SpecKit icon, **Then** they see the same empty-state guidance shown to brand-new users.
+
+---
+
+### Edge Cases
+
+- **Multi-root workspaces**: Behavior must match the single-folder case once at least one folder is present; the empty state only applies when there are zero workspace folders.
+- **Workspace opened from the empty-state action**: The sidebar must transition to the normal views without leaving the user staring at stale empty-state copy.
+- **Extension not yet activated at startup**: The icon must still appear at the moment a fresh VS Code window finishes loading, not only after some later trigger fires.
+- **CLI not installed / SpecKit not initialized in the new workspace**: Once a folder is open, the existing welcome views (install CLI, initialize workspace, create first spec) take over — the new "open a folder" empty state must not override or duplicate them.
+- **Panel collapsed by user**: If the user has previously dragged or hidden the SpecKit container, the fix must not force it back open; visibility of the icon is what's required, not auto-revealing the panel.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The SpecKit activity-bar icon MUST be visible whenever the extension is installed and enabled, regardless of whether a workspace folder is open.
+- **FR-002**: When the user clicks the SpecKit icon with no workspace folder open, the sidebar MUST display an empty-state panel that clearly explains a folder is required to use SpecKit features.
+- **FR-003**: The empty-state panel MUST offer at least one direct action that helps the user proceed (e.g., "Open Folder").
+- **FR-004**: When a workspace folder becomes available (the user opens one), the sidebar MUST automatically replace the empty-state panel with the normal SpecKit views without requiring a manual refresh or re-click.
+- **FR-005**: When the workspace folder is closed mid-session, the icon MUST remain visible and the sidebar MUST return to the same empty-state panel.
+- **FR-006**: The empty-state panel MUST NOT suppress or conflict with the existing welcome flows that appear once a folder is open (install CLI, initialize workspace, create first spec).
+- **FR-007**: The fix MUST NOT change the activity-bar position, label, or icon glyph that current users already recognize.
+- **FR-008**: The empty-state copy MUST be written for non-technical users, in line with the existing welcome-view voice.
+
+### Key Entities
+
+- **SpecKit activity-bar container**: The user's primary entry point to the extension; its visibility is the subject of this feature.
+- **Empty-state panel**: The sidebar content shown when the icon is clicked but no workspace folder is open; carries explanatory copy and the "Open Folder" action.
+- **Workspace state**: Whether VS Code currently has zero folders open vs. one-or-more; drives which sidebar content is shown.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: 100% of users who install the extension see the SpecKit icon in the activity bar within 5 seconds of VS Code finishing startup, with no folder open.
+- **SC-002**: A user who installs the extension and opens VS Code with no folder can identify within 10 seconds (a) that SpecKit is installed and (b) what they need to do next, measured via informal usability check or self-report.
+- **SC-003**: The number of post-install "is the extension working?" support questions or issue reports tied to icon visibility drops to zero in the first marketplace release that includes this fix.
+- **SC-004**: Switching between "no folder open" and "folder open" states updates the sidebar content within 1 second, with no manual refresh required.
+
+## Assumptions
+
+- The existing icon, label, and activity-bar position are correct and should be preserved; the only change is when the container is visible and what it shows when no workspace is open.
+- "Open Folder" is the most useful single action for the empty state. If product preference later favors "Open Recent" or a multi-action panel, that is an additive change, not a precondition.
+- The existing welcome views (install CLI, init workspace, create first spec) already cover the "folder open but SpecKit not yet set up" path and remain the right surfaces for those states.
+- Users have not configured VS Code to hide the SpecKit container manually; respecting their explicit hide preference still takes precedence over this feature.

--- a/specs/082-always-show-icon/tasks.md
+++ b/specs/082-always-show-icon/tasks.md
@@ -1,0 +1,170 @@
+---
+description: "Task list for Always Show SpecKit Icon in Activity Bar"
+---
+
+# Tasks: Always Show SpecKit Icon in Activity Bar
+
+**Input**: Design documents from `/specs/082-always-show-icon/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/manifest.md, quickstart.md
+
+**Tests**: The spec asks for manual quickstart verification; no automated tests are requested. Validation is via the six-test smoke check in `quickstart.md`.
+
+**Organization**: Tasks are grouped by user story so each story can be implemented and verified independently.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (US1, US2)
+- File paths are absolute or workspace-relative
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Confirm the touchpoints for this declarative-only change. No new modules, no dependencies.
+
+- [X] T001 Confirm baseline: open `package.json` and locate `contributes.views.speckit` (around lines 67–86), `contributes.viewsWelcome` (around lines 87–112), and `contributes.viewsContainers.activitybar` (around lines 58–66). No edits in this task — just verify these blocks match the diff in `specs/082-always-show-icon/contracts/manifest.md` so the change in Phase 3 lands cleanly.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: None required. This feature adds no shared code, no new context keys, no new TypeScript types. The data model in `data-model.md` is documentation of existing VS Code context keys only.
+
+**Checkpoint**: Skip directly to Phase 3.
+
+---
+
+## Phase 3: User Story 1 - Confirm extension is installed without opening a project (Priority: P1) 🎯 MVP
+
+**Goal**: Make the SpecKit activity-bar icon visible at startup with no folder open, and show an empty-state welcome with an "Open Folder" action when the user clicks it.
+
+**Independent Test**: Launch a fresh VS Code window with no folder open. The SpecKit icon must appear in the activity bar in its existing position; clicking it must open the sidebar with an "Open a folder to start using SpecKit." message and an `Open Folder` button that triggers the platform folder picker. After picking a folder, the sidebar must replace the empty-state with the normal Specs / welcome content within ~1 second.
+
+### Implementation for User Story 1
+
+- [X] T002 [US1] In `package.json`, remove the `when` clause from the `speckit.views.explorer` view entry under `contributes.views.speckit` (currently `"when": "!(workbenchState == empty || workspaceFolderCount == 0)"` at ~line 72). Leave `id` and `name` intact. Do NOT change `speckit.views.steering` or `speckit.views.settings` — their `when` clauses must remain so they stay hidden without a workspace.
+
+- [X] T003 [US1] In `package.json`, prepend a new entry to the `contributes.viewsWelcome` array (above the existing `speckit.cliInstalled && !speckit.detected` entry around line 88) with:
+  - `view`: `"speckit.views.explorer"`
+  - `contents`: `"Open a folder to start using SpecKit.\n\n[$(folder-opened) Open Folder](command:vscode.openFolder)"`
+  - `when`: `"workbenchState == empty || workspaceFolderCount == 0"`
+
+  Use the exact shape documented in `specs/082-always-show-icon/contracts/manifest.md`. Do not introduce a custom `speckit.openFolder` command — link directly to the built-in `vscode.openFolder`.
+
+- [X] T004 [US1] Validate JSON: run `node -e "JSON.parse(require('fs').readFileSync('package.json','utf8'))"` from repo root to confirm `package.json` still parses. Then run `npm run compile` to confirm the TypeScript build is unaffected by the manifest change.
+
+- [X] T005 [US1] Manual verification — execute Tests 1, 2, 3, 5, and 6 in `specs/082-always-show-icon/quickstart.md`:
+  - Test 1: icon visible at fresh VS Code startup with no folder.
+  - Test 2: clicking the icon shows the new empty-state welcome with the `Open Folder` button, and Steering / Settings views are NOT listed.
+  - Test 3: clicking `Open Folder` opens the platform folder picker; after selecting a folder, the sidebar swaps to normal content within ~1 second.
+  - Test 5: opening folders that exercise existing welcome states (`speckit.cliInstalled && !speckit.detected`, `speckit.detected && speckit.constitutionNeedsSetup`) still show their existing welcome content — the new empty-state must not appear.
+  - Test 6: activity-bar glyph, label ("SpecKit"), and position are unchanged vs. the current marketplace release.
+
+**Checkpoint**: User Story 1 is fully functional. The icon-visibility bug from issue #112 is resolved.
+
+---
+
+## Phase 4: User Story 2 - Smooth handoff back to empty state when the workspace closes (Priority: P2)
+
+**Goal**: When the user runs `File → Close Folder` from an open SpecKit workspace, the activity-bar icon stays put and the sidebar reverts to the same empty-state welcome.
+
+**Independent Test**: Open a workspace with SpecKit visible, then close the folder. The icon must remain in the activity bar and clicking it must show the same empty-state copy as a brand-new install.
+
+**Note on dependencies**: This story is satisfied implicitly by US1's declarative changes — VS Code re-evaluates view `when` clauses and `viewsWelcome` `when` clauses when `workbenchState`/`workspaceFolderCount` flip. No additional manifest or code changes are expected. The tasks below are verification only.
+
+### Implementation for User Story 2
+
+- [X] T006 [US2] Manual verification — execute Test 4 in `specs/082-always-show-icon/quickstart.md`:
+  - Open a workspace with SpecKit views visible.
+  - Run `File → Close Folder`.
+  - Confirm the SpecKit icon stays in the activity bar.
+  - Click it; confirm the empty-state welcome from US1 reappears, identical in copy and action.
+
+- [X] T007 [US2] Confirm no extension-side regression in the close-folder path: skim `src/extension.ts` (focus on the activation flow ~lines 35–68 and any workspace-folder change listener) to verify the existing guard `if (!hasWorkspace) return` still prevents manager initialization and that no listener throws when the workspace flips back to empty. No code change unless a regression is observed.
+
+**Checkpoint**: Both user stories work end-to-end with the same set of declarative changes from Phase 3.
+
+---
+
+## Phase 5: Polish & Cross-Cutting Concerns
+
+**Purpose**: Documentation and release-readiness around the manifest change.
+
+- [X] T008 [P] Update `README.md` to mention that the SpecKit activity-bar icon is now visible at all times (with no folder open, an empty-state welcome guides the user to open one). Keep the wording brief; place near the existing "Getting Started" / install section so first-time users see it.
+
+- [X] T009 [P] Update `docs/viewer-states.md` IF — and only if — the doc covers activity-bar / sidebar visibility states (it primarily documents the spec-viewer state machine). If the file does not cover the activity-bar container, skip this task without edits.
+
+- [X] T010 Bump the extension version in `package.json` (patch bump from current `0.13.0`) so VS Code picks up the manifest change on local reinstall. This is required by the project's "always bump version locally" rule before running `/install-local` for verification.
+
+- [X] T011 Run the full `quickstart.md` smoke check end-to-end in a freshly packaged extension (`npm run package` → install the resulting `.vsix` into a clean window). All six tests must pass with no console errors and no manual refresh.
+
+- [X] T012 Confirm scope discipline before opening a PR: `git diff` should touch only `package.json`, `README.md` (if updated), and the spec files under `specs/082-always-show-icon/`. No edits under `.claude/**` or `.specify/**`, per the extension-isolation rule in `CLAUDE.md`.
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies — single confirmation task.
+- **Foundational (Phase 2)**: None required for this feature.
+- **User Story 1 (Phase 3)**: Depends on Setup. This is the entire fix.
+- **User Story 2 (Phase 4)**: Depends on US1 being merged in `package.json` (T002, T003). Itself adds no code; verification only.
+- **Polish (Phase 5)**: Depends on US1 + US2 verification passing.
+
+### User Story Dependencies
+
+- **US1 (P1)**: Self-contained — two `package.json` edits + verification.
+- **US2 (P2)**: Functionally dependent on US1's manifest edits but requires no further code; once US1 lands, US2 is verifiable.
+
+### Within User Story 1
+
+- T002 and T003 are sequential — both edit `package.json` (same file).
+- T004 (build/parse check) depends on T002 + T003.
+- T005 (manual quickstart) depends on T004.
+
+### Parallel Opportunities
+
+- Within Polish: T008 and T009 touch different files and can run in parallel.
+- T010 (version bump) must happen before T011 (smoke check on packaged build).
+- T002 and T003 cannot run in parallel — same file.
+
+---
+
+## Parallel Example: Phase 5 Polish
+
+```bash
+# Independent doc updates can run together:
+Task: "Update README.md to note the always-visible icon and empty state"
+Task: "Update docs/viewer-states.md if it covers container visibility"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. T001 (confirm baseline)
+2. T002, T003 (manifest edits — the entire fix)
+3. T004 (build/parse check)
+4. T005 (manual quickstart Tests 1, 2, 3, 5, 6)
+5. **STOP and VALIDATE**: issue #112 is resolved.
+
+### Incremental Delivery
+
+1. Land US1 → marketplace patch release fixes the reported bug.
+2. Verify US2 in the same release (no extra code) → close-folder symmetry confirmed.
+3. Polish phase ships docs + version bump together with the manifest change.
+
+This is a single-file, single-PR feature in practice. The phasing exists to make each acceptance scenario auditable, not to imply parallel work streams.
+
+---
+
+## Notes
+
+- All edits are declarative `package.json` changes. No new TypeScript files, no new commands, no new context keys.
+- The `vscode.openFolder` command is a built-in VS Code API command — do not wrap it.
+- The new `viewsWelcome` entry's `when` clause is mutually exclusive with all existing entries because `speckit.detected` is always false without a workspace and no other entry's `when` is satisfiable in the no-workspace state (verified in `research.md` Decision 4).
+- Per project convention (extension-isolation rule in `CLAUDE.md`), do not modify `.claude/**` or `.specify/**` to support this feature.


### PR DESCRIPTION
## Summary
- Closes #112: SpecKit activity-bar icon was hidden until a folder was open, leaving first-time users unable to tell if the install succeeded.
- Drop the workspace `when` clause on `speckit.views.explorer` so the container is always visible. Steering and Settings views stay gated as today.
- Add a `viewsWelcome` entry shown when no workspace is open: "Open a folder to start using SpecKit." with a built-in `vscode.openFolder` button. US2 (close-folder symmetry) is satisfied implicitly — VS Code re-evaluates the `when` clauses when `workbenchState`/`workspaceFolderCount` flip.

## Test plan
- [x] `npm run compile` clean
- [x] `npm test` — 378/378 across 36 suites
- [x] `package.json` parses
- [ ] Manual quickstart (`specs/082-always-show-icon/quickstart.md`):
  - [ ] Test 1 — icon visible at fresh startup with no folder
  - [ ] Test 2 — clicking the icon shows the empty-state welcome with Open Folder button; Steering/Settings not listed
  - [ ] Test 3 — Open Folder transitions to normal views within ~1s, no manual refresh
  - [ ] Test 4 — File → Close Folder leaves the icon in place; empty state reappears on click
  - [ ] Test 5 — existing `cliInstalled && !detected` and `constitutionNeedsSetup` welcome flows still appear once a folder is open
  - [ ] Test 6 — activity-bar glyph, "SpecKit" tooltip, and position unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)