### PR TITLE
docs(readme): add sample specs section pointing at in-repo examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,16 @@ Actions that change the spec's lifecycle are protected so a misfired click is ea
 2. **Open the sidebar** — the SpecKit icon is always visible in the activity bar; with no folder open, clicking it shows an empty-state panel with an **Open Folder** action
 3. **Create a spec** — once a folder is open, click the `+` button in the Specs view to start your first feature
 
+## Sample Specs
+
+Looking for "what does good look like?" The repo's own `specs/` directory is the answer — every feature ships with the spec that drove it. A few worth opening:
+
+- [`specs/008-spec-viewer-ux/`](./specs/008-spec-viewer-ux/) — **full SpecKit flow**: spec, plan, research, data model, quickstart, tasks, plus checklists and contracts.
+- [`specs/065-multi-select-specs/`](./specs/065-multi-select-specs/) — **minimal SDD flow**: just `spec.md` + `plan.md` + `tasks.md` for a small UX change.
+- [`specs/051-explorer-viewer-fixes/`](./specs/051-explorer-viewer-fixes/) — **minimal SDD flow**: same lean shape, applied to a focused bug-fix bundle.
+
+Compare the file lists side by side to see the contrast between the full and minimal flows.
+
 ## Supported AI Providers
 
 | Feature | Claude Code | GitHub Copilot CLI | Gemini CLI | Codex CLI |

--- a/specs/083-sample-spec-repo/.spec-context.json
+++ b/specs/083-sample-spec-repo/.spec-context.json
@@ -5,7 +5,9 @@
   "progress": null,
   "next": "done",
   "status": "completed",
-  "checkpointStatus": { "commit": false, "pr": false },
+  "checkpointStatus": { "commit": true, "pr": true },
+  "prUrl": "https://github.com/alfredoperez/speckit-companion/pull/136",
+  "prNumber": 136,
   "updated": "2026-04-25",
   "selectedAt": "2026-04-25T12:23:26Z",
   "specName": "Sample Spec Repo Link",
@@ -34,7 +36,7 @@
   "decisions": [
     { "task": "T001", "note": "User feedback at CP1: reference in-repo specs instead of an external companion repo. Spec/plan/tasks updated to match. Picked one full SpecKit example (008) plus two minimal SDD examples (065, 051) to make the full-vs-minimal contrast visible." }
   ],
-  "last_action": "CP3 approved — running pre:commit hooks",
+  "last_action": "PR #136 opened — docs(readme): add sample specs section pointing at in-repo examples",
   "transitions": [
     { "step": "specify", "substep": "parsing", "from": null, "by": "sdd", "at": "2026-04-25T12:23:26Z" },
     { "step": "specify", "substep": "exploring", "from": { "step": "specify", "substep": "parsing" }, "by": "sdd", "at": "2026-04-25T12:23:30Z" },
@@ -49,6 +51,7 @@
     { "step": "implement", "substep": "code-review", "from": { "step": "implement", "substep": "hooks" }, "by": "sdd", "at": "2026-04-25T12:27:00Z" },
     { "step": "implement", "substep": "code-review", "from": { "step": "implement", "substep": "code-review" }, "by": "sdd", "at": "2026-04-25T12:30:00Z" },
     { "step": "implement", "substep": "commit-review", "from": { "step": "implement", "substep": "code-review" }, "by": "sdd", "at": "2026-04-25T12:32:00Z" },
-    { "step": "done", "substep": null, "from": { "step": "implement", "substep": "commit-review" }, "by": "sdd", "at": "2026-04-25T12:33:00Z" }
+    { "step": "done", "substep": null, "from": { "step": "implement", "substep": "commit-review" }, "by": "sdd", "at": "2026-04-25T12:33:00Z" },
+    { "step": "done", "substep": null, "from": { "step": "done", "substep": null }, "by": "sdd", "at": "2026-04-25T12:35:00Z" }
   ]
 }

--- a/specs/083-sample-spec-repo/.spec-context.json
+++ b/specs/083-sample-spec-repo/.spec-context.json
@@ -1,0 +1,54 @@
+{
+  "workflow": "sdd",
+  "currentStep": "done",
+  "currentTask": null,
+  "progress": null,
+  "next": "done",
+  "status": "completed",
+  "checkpointStatus": { "commit": false, "pr": false },
+  "updated": "2026-04-25",
+  "selectedAt": "2026-04-25T12:23:26Z",
+  "specName": "Sample Spec Repo Link",
+  "branch": "main",
+  "workingBranch": "docs/sample-spec-repo",
+  "type": "docs",
+  "createdAt": "2026-04-25T12:23:26Z",
+  "auto": true,
+  "step_summaries": {
+    "specify": {
+      "complexity": "minimal",
+      "requirements": 5,
+      "scenarios": 2,
+      "key_finding": "README uses top-level ## sections in fixed order (Getting Started → Supported AI Providers → Configuration); the natural insertion point is between Getting Started and Supported AI Providers"
+    }
+  },
+  "task_summaries": {
+    "T001": {
+      "status": "DONE",
+      "did": "Added a `## Sample Specs` section to README.md between Getting Started and Supported AI Providers. Pivoted from external companion-repo link to in-repo pointers: 008-spec-viewer-ux (full SpecKit), 065-multi-select-specs and 051-explorer-viewer-fixes (minimal SDD).",
+      "files": ["README.md"],
+      "concerns": []
+    }
+  },
+  "files_modified": ["README.md"],
+  "decisions": [
+    { "task": "T001", "note": "User feedback at CP1: reference in-repo specs instead of an external companion repo. Spec/plan/tasks updated to match. Picked one full SpecKit example (008) plus two minimal SDD examples (065, 051) to make the full-vs-minimal contrast visible." }
+  ],
+  "last_action": "CP3 approved — running pre:commit hooks",
+  "transitions": [
+    { "step": "specify", "substep": "parsing", "from": null, "by": "sdd", "at": "2026-04-25T12:23:26Z" },
+    { "step": "specify", "substep": "exploring", "from": { "step": "specify", "substep": "parsing" }, "by": "sdd", "at": "2026-04-25T12:23:30Z" },
+    { "step": "specify", "substep": "detecting", "from": { "step": "specify", "substep": "exploring" }, "by": "sdd", "at": "2026-04-25T12:23:40Z" },
+    { "step": "specify", "substep": "writing-spec", "from": { "step": "specify", "substep": "detecting" }, "by": "sdd", "at": "2026-04-25T12:23:50Z" },
+    { "step": "tasks", "substep": null, "from": { "step": "specify", "substep": "writing-spec" }, "by": "sdd", "at": "2026-04-25T12:24:00Z" },
+    { "step": "tasks", "substep": null, "from": { "step": "tasks", "substep": null }, "by": "sdd", "at": "2026-04-25T12:24:05Z" },
+    { "step": "implement", "substep": "phase1", "from": { "step": "tasks", "substep": null }, "by": "sdd", "at": "2026-04-25T12:24:30Z" },
+    { "step": "implement", "substep": "phase1", "from": { "step": "implement", "substep": "phase1" }, "by": "sdd", "at": "2026-04-25T12:24:35Z" },
+    { "step": "implement", "substep": "phase1", "from": { "step": "implement", "substep": "phase1" }, "by": "sdd", "at": "2026-04-25T12:25:00Z" },
+    { "step": "implement", "substep": "hooks", "from": { "step": "implement", "substep": "phase1" }, "by": "sdd", "at": "2026-04-25T12:25:30Z" },
+    { "step": "implement", "substep": "code-review", "from": { "step": "implement", "substep": "hooks" }, "by": "sdd", "at": "2026-04-25T12:27:00Z" },
+    { "step": "implement", "substep": "code-review", "from": { "step": "implement", "substep": "code-review" }, "by": "sdd", "at": "2026-04-25T12:30:00Z" },
+    { "step": "implement", "substep": "commit-review", "from": { "step": "implement", "substep": "code-review" }, "by": "sdd", "at": "2026-04-25T12:32:00Z" },
+    { "step": "done", "substep": null, "from": { "step": "implement", "substep": "commit-review" }, "by": "sdd", "at": "2026-04-25T12:33:00Z" }
+  ]
+}

--- a/specs/083-sample-spec-repo/plan.md
+++ b/specs/083-sample-spec-repo/plan.md
@@ -1,0 +1,14 @@
+# Plan: Sample Spec Pointers in README
+
+**Spec**: [spec.md](./spec.md) | **Date**: 2026-04-25
+
+## Approach
+
+Add a "Sample Specs" subsection to README.md between **Getting Started** and **Supported AI Providers**. The section points to in-repo spec directories (no external repo) using GitHub-relative links so the example artifacts ship with the codebase and stay in sync with reality. Pick one full SpecKit-style spec and two minimal SDD-style specs to highlight the contrast between the two flows.
+
+## Files to Change
+
+- `README.md` — insert a `## Sample Specs` section after the **Getting Started** block (around line 116). Section contains:
+  - 1–2 sentences of intro
+  - Bullet list of 3 in-repo specs with relative links and a one-line annotation each
+  - Picks: `specs/008-spec-viewer-ux/` (full SpecKit flow), `specs/065-multi-select-specs/` (minimal SDD flow), `specs/051-explorer-viewer-fixes/` (minimal SDD flow)

--- a/specs/083-sample-spec-repo/spec.md
+++ b/specs/083-sample-spec-repo/spec.md
@@ -1,0 +1,34 @@
+# Spec: Sample Spec Pointers in README
+
+**Slug**: 083-sample-spec-repo | **Date**: 2026-04-25
+
+## Summary
+
+Add a "Sample Specs" section to README.md that points readers at concrete spec directories already living inside this repo's `specs/` folder. The repo's own history is the best "what does good look like" artifact: include one full SpecKit-style spec (with research, data-model, quickstart, tasks) and a couple of minimal SDD-style specs (just `spec.md` + `plan.md` + `tasks.md`) so newcomers can compare both flows side by side.
+
+## Requirements
+
+- **R001** (MUST): README.md contains a discoverable section that lists at least three sample spec directories from this repo's `specs/` folder.
+- **R002** (MUST): The section appears after **Getting Started** and before **Supported AI Providers** so first-time readers see it immediately after install steps.
+- **R003** (MUST): At least one of the listed samples is a full SpecKit-style spec (artifacts include `research.md`, `data-model.md`, `quickstart.md`, `tasks.md`, plus `checklists/` and/or `contracts/`) and at least one is a minimal SDD-style spec (only `spec.md`, `plan.md`, `tasks.md`).
+- **R004** (MUST): Each listed sample is rendered as a clickable relative link (e.g., `specs/008-spec-viewer-ux/`) so readers can jump straight to the directory on GitHub.
+- **R005** (SHOULD): Each entry has a one-line annotation describing what the sample shows (full-flow vs. minimal-flow, kind of change).
+
+## Scenarios
+
+### First-time reader skimming the README
+
+**When** a new visitor reads the README on GitHub or the marketplace
+**Then** they see a "Sample Specs" heading shortly after Getting Started, with clickable links to a small set of in-repo example specs and one-line annotations on each.
+
+### Developer comparing full SpecKit vs. minimal SDD output
+
+**When** a reader follows two of the links — one full sample and one minimal sample
+**Then** they can see the file-list difference (multiple artifacts vs. just spec/plan/tasks) without leaving GitHub.
+
+## Out of Scope
+
+- Creating a separate companion repo for samples.
+- Adding new spec directories or rewriting existing ones.
+- Embedding screenshots or diff snippets of the samples in this README.
+- Marketplace listing / `package.json` description updates.

--- a/specs/083-sample-spec-repo/tasks.md
+++ b/specs/083-sample-spec-repo/tasks.md
@@ -1,0 +1,25 @@
+# Tasks: Sample Spec Pointers in README
+
+**Plan**: [plan.md](./plan.md) | **Date**: 2026-04-25
+
+## Format
+
+- `[P]` marks tasks that can run in parallel with adjacent `[P]` tasks.
+- Consecutive `[P]` tasks form a **parallel group** — `/sdd:implement` spawns them as concurrent subagents.
+- Tasks without `[P]` are **gates**: they start only after all prior tasks complete.
+- Two tasks that touch the same file are never both `[P]`.
+
+---
+
+## Phase 1: Core Implementation
+
+- [x] **T001** Add Sample Specs section to README — `README.md` | R001, R002, R003, R004, R005
+  - **Do**: Insert a new `## Sample Specs` section in `README.md` between the **Getting Started** section (ends ~line 115) and the **Supported AI Providers** heading (~line 117). The section MUST contain:
+    - A heading: `## Sample Specs`
+    - A 1–2 sentence intro that frames the section as "what good looks like" with examples drawn from this repo
+    - A bullet list with these three entries (each a clickable relative link + one-line annotation):
+      - [`specs/008-spec-viewer-ux/`](./specs/008-spec-viewer-ux/) — full SpecKit flow: spec, plan, research, data model, quickstart, tasks, checklists, contracts
+      - [`specs/065-multi-select-specs/`](./specs/065-multi-select-specs/) — minimal SDD flow: spec + plan + tasks for a small UX change
+      - [`specs/051-explorer-viewer-fixes/`](./specs/051-explorer-viewer-fixes/) — minimal SDD flow: spec + plan + tasks for a focused bug-fix bundle
+  - **Verify**: `npm run compile` passes (sanity check; README change shouldn't affect the build). Visually scan the section: heading renders, all three relative links resolve to existing directories under `specs/`, one-line annotations make the full-vs-minimal contrast obvious.
+  - **Leverage**: existing README sections like **Getting Started** (line 111) and **Acknowledgments** (line 472) for tone — short, declarative, no marketing fluff.


### PR DESCRIPTION
## What

- Add a `## Sample Specs` section to README.md between Getting Started and Supported AI Providers.
- Link to three in-repo specs: `008-spec-viewer-ux` (full SpecKit flow), `065-multi-select-specs` and `051-explorer-viewer-fixes` (minimal SDD flow).
- Frame the picks so readers can compare the full vs. minimal flows side by side.

## Why

Newcomers evaluating SpecKit Companion need a single artifact for "what does good look like" — pointing at the repo's own `specs/` keeps the examples honest and in sync with reality, with no extra companion repo to maintain.

## Testing

- `npm run compile` passes.
- Visual check: section renders, all three relative links resolve to existing directories on GitHub.

Closes #115