### PR TITLE
feat(activitybar): replace zero-spec welcome with onboarding card

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
       },
       {
         "view": "speckit.views.explorer",
-        "contents": "Build features with specs\n\n[$(plus) Create New Spec](command:speckit.create)",
+        "contents": "Welcome to SpecKit\n\nA spec turns an idea into a plan and tasks your AI assistant can implement, step by step.\n\n[$(plus) Create your first spec](command:speckit.create)\n\n[$(book) Read the docs](https://github.com/alfredoperez/speckit-companion#readme)",
         "when": "speckit.detected && !speckit.constitutionNeedsSetup"
       },
       {

--- a/specs/084-empty-state-onboarding/.spec-context.json
+++ b/specs/084-empty-state-onboarding/.spec-context.json
@@ -1,0 +1,64 @@
+{
+  "workflow": "sdd",
+  "currentStep": "done",
+  "currentTask": null,
+  "progress": null,
+  "next": "done",
+  "updated": "2026-04-25",
+  "selectedAt": "2026-04-25T13:28:01Z",
+  "specName": "Empty-State Onboarding Card",
+  "branch": "main",
+  "workingBranch": "feat/empty-state-onboarding",
+  "type": "feat",
+  "auto": true,
+  "status": "completed",
+  "checkpointStatus": { "commit": false, "pr": false },
+  "createdAt": "2026-04-25T13:28:01Z",
+  "approach": "Rewrite the zero-spec viewsWelcome contents string in package.json to a richer onboarding card (headline + description + create button + docs link). No new commands or context keys.",
+  "last_action": "CP3 approved — preparing to commit + push + PR",
+  "files_modified": [
+    "package.json"
+  ],
+  "concerns": [
+    {
+      "task": "T001",
+      "note": "Visual verification (F5 Extension Development Host) is a manual step — automated build only confirms the JSON parses and tsc passes; the user will need to confirm the welcome view renders as intended at CP1."
+    }
+  ],
+  "decisions": [
+    "Used two stacked buttons (Create + Read the docs) separated by `\\n\\n`, mirroring the existing constitution-needs-setup welcome entry's two-action pattern.",
+    "Docs link points to the repo README (`https://github.com/alfredoperez/speckit-companion#readme`) — same URL the package.json `homepage` field already uses, so no new docs surface introduced."
+  ],
+  "task_summaries": {
+    "T001": {
+      "status": "DONE",
+      "did": "Rewrote the zero-spec viewsWelcome entry in package.json: headline (Welcome to SpecKit), one-sentence description of what a spec is, primary `Create your first spec` button, and `Read the docs` link to the README.",
+      "files": ["package.json"],
+      "concerns": [
+        "Visual confirmation requires manual F5 launch — surfaced for CP1."
+      ]
+    }
+  },
+  "step_summaries": {
+    "specify": {
+      "complexity": "minimal",
+      "requirements": 6,
+      "scenarios": 5,
+      "key_finding": "viewsWelcome already has a zero-spec entry at package.json:102 guarded by `speckit.detected && !speckit.constitutionNeedsSetup` — the change is purely a contents-string rewrite, no new commands or context keys"
+    }
+  },
+  "transitions": [
+    { "step": "specify", "substep": "parsing", "from": null, "by": "sdd", "at": "2026-04-25T13:28:01Z" },
+    { "step": "specify", "substep": "exploring", "from": { "step": "specify", "substep": "parsing" }, "by": "sdd", "at": "2026-04-25T13:28:01Z" },
+    { "step": "specify", "substep": "detecting", "from": { "step": "specify", "substep": "exploring" }, "by": "sdd", "at": "2026-04-25T13:28:01Z" },
+    { "step": "specify", "substep": "writing-spec", "from": { "step": "specify", "substep": "detecting" }, "by": "sdd", "at": "2026-04-25T13:28:01Z" },
+    { "step": "tasks", "substep": null, "from": { "step": "specify", "substep": "writing-spec" }, "by": "sdd", "at": "2026-04-25T13:28:01Z" },
+    { "step": "implement", "substep": "phase1", "from": { "step": "tasks", "substep": null }, "by": "sdd", "at": "2026-04-25T13:28:01Z" },
+    { "step": "implement", "substep": "phase1", "from": { "step": "implement", "substep": "phase1" }, "by": "sdd", "at": "2026-04-25T13:28:01Z" },
+    { "step": "implement", "substep": "phase1", "from": { "step": "implement", "substep": "phase1" }, "by": "sdd", "at": "2026-04-25T13:28:01Z" },
+    { "step": "implement", "substep": "hooks", "from": { "step": "implement", "substep": "phase1" }, "by": "sdd", "at": "2026-04-25T13:28:01Z" },
+    { "step": "implement", "substep": "code-review", "from": { "step": "implement", "substep": "hooks" }, "by": "sdd", "at": "2026-04-25T13:28:01Z" },
+    { "step": "implement", "substep": "commit-review", "from": { "step": "implement", "substep": "code-review" }, "by": "sdd", "at": "2026-04-25T13:28:01Z" },
+    { "step": "done", "substep": null, "from": { "step": "implement", "substep": "commit-review" }, "by": "sdd", "at": "2026-04-25T13:28:01Z" }
+  ]
+}

--- a/specs/084-empty-state-onboarding/.spec-context.json
+++ b/specs/084-empty-state-onboarding/.spec-context.json
@@ -12,10 +12,12 @@
   "type": "feat",
   "auto": true,
   "status": "completed",
-  "checkpointStatus": { "commit": false, "pr": false },
+  "checkpointStatus": { "commit": true, "pr": true },
+  "prUrl": "https://github.com/alfredoperez/speckit-companion/pull/137",
+  "prNumber": 137,
   "createdAt": "2026-04-25T13:28:01Z",
   "approach": "Rewrite the zero-spec viewsWelcome contents string in package.json to a richer onboarding card (headline + description + create button + docs link). No new commands or context keys.",
-  "last_action": "CP3 approved — preparing to commit + push + PR",
+  "last_action": "PR #137 opened — feat(activitybar): replace zero-spec welcome with onboarding card",
   "files_modified": [
     "package.json"
   ],
@@ -59,6 +61,7 @@
     { "step": "implement", "substep": "hooks", "from": { "step": "implement", "substep": "phase1" }, "by": "sdd", "at": "2026-04-25T13:28:01Z" },
     { "step": "implement", "substep": "code-review", "from": { "step": "implement", "substep": "hooks" }, "by": "sdd", "at": "2026-04-25T13:28:01Z" },
     { "step": "implement", "substep": "commit-review", "from": { "step": "implement", "substep": "code-review" }, "by": "sdd", "at": "2026-04-25T13:28:01Z" },
-    { "step": "done", "substep": null, "from": { "step": "implement", "substep": "commit-review" }, "by": "sdd", "at": "2026-04-25T13:28:01Z" }
+    { "step": "done", "substep": null, "from": { "step": "implement", "substep": "commit-review" }, "by": "sdd", "at": "2026-04-25T13:28:01Z" },
+    { "step": "done", "substep": null, "from": { "step": "done", "substep": null }, "by": "sdd", "at": "2026-04-25T13:28:01Z" }
   ]
 }

--- a/specs/084-empty-state-onboarding/plan.md
+++ b/specs/084-empty-state-onboarding/plan.md
@@ -1,0 +1,17 @@
+# Plan: Empty-State Onboarding Card
+
+**Spec**: [spec.md](./spec.md) | **Date**: 2026-04-25
+
+## Approach
+
+Replace the `contents` string of the existing zero-spec welcome view in `package.json` (the entry guarded by `speckit.detected && !speckit.constitutionNeedsSetup`) with a richer markdown payload — headline, one-sentence description, a `[$(plus) Create your first spec](command:speckit.create)` button, and a `[$(book) Read the docs](https://github.com/alfredoperez/speckit-companion#readme)` link. No new commands, no new TypeScript code, no context-key changes — VS Code already hides the welcome view when the tree has children, so spec-presence handling is automatic.
+
+## Files to Change
+
+### Modify
+
+- `package.json` — the third `viewsWelcome` entry (line ~102), `when: "speckit.detected && !speckit.constitutionNeedsSetup"`: rewrite its `contents` string to include the headline, description, primary button, and docs link.
+
+### No new files
+
+No code, types, or commands are introduced. The existing `speckit.create` command and the upstream `homepage` URL (already declared in `package.json`) are reused.

--- a/specs/084-empty-state-onboarding/spec.md
+++ b/specs/084-empty-state-onboarding/spec.md
@@ -1,0 +1,50 @@
+# Spec: Empty-State Onboarding Card
+
+**Slug**: 084-empty-state-onboarding | **Date**: 2026-04-25
+
+## Summary
+
+When a user opens an initialized SpecKit workspace with zero specs, the Specs tree shows a polished onboarding "card" — a short headline, one-sentence value prop, a primary "Create your first spec" button, and a secondary "Read the docs" link. Today the same state shows only the line "Build features with specs" with a single button, which reads as a placeholder rather than a deliberate first-run experience.
+
+## Requirements
+
+- **R001** (MUST): When `speckit.detected` is true, `speckit.constitutionNeedsSetup` is false, and the workspace contains zero specs, the Specs tree welcome view renders the onboarding content (headline, description, primary button, docs link) instead of the current single-line message.
+- **R002** (MUST): The primary button invokes the existing `speckit.create` command (no new command is introduced).
+- **R003** (MUST): The docs link opens `https://github.com/alfredoperez/speckit-companion#readme` in the user's external browser via VS Code's standard markdown-link command (no custom command needed).
+- **R004** (MUST): When at least one spec exists, the onboarding view is hidden and the normal Specs tree is shown — the new copy must not display alongside spec rows.
+- **R005** (MUST): The other welcome states (no workspace, CLI not detected, constitution-needs-setup, filter-no-match) are not regressed — each still appears under its existing `when` clause and only one welcome view shows at a time.
+- **R006** (SHOULD): The onboarding copy is friendly and concrete (e.g., describes what a spec is in one sentence) so a first-run user understands the value before clicking.
+
+## Scenarios
+
+### First-run user with no specs
+
+**When** the user installs the extension, opens an initialized SpecKit workspace, and the `specs/` directory is empty
+**Then** the Specs view shows the onboarding card: headline, one-line description, "Create your first spec" button, and "Read the docs" link
+
+### User clicks the primary button
+
+**When** the user clicks "Create your first spec" in the onboarding card
+**Then** the existing `speckit.create` flow runs exactly as it does today from the command palette
+
+### User clicks the docs link
+
+**When** the user clicks "Read the docs"
+**Then** VS Code opens `https://github.com/alfredoperez/speckit-companion#readme` in the user's default browser
+
+### Existing specs hide the onboarding card
+
+**When** the workspace contains one or more specs under `specs/`
+**Then** the onboarding card does not render — the normal spec tree is shown
+
+### Other empty states still work
+
+**When** any of the existing `when` clauses match (no workspace open, CLI installed but workspace not initialized, constitution needs setup, active filter with no match)
+**Then** the corresponding welcome view shows and the new onboarding view does not
+
+## Out of Scope
+
+- Adding a new `speckit.openDocs` command or any custom command — the docs link uses a standard URL.
+- Changing the constitution-needs-setup, no-workspace, CLI-not-detected, or filter-no-match welcome views.
+- Adding analytics or telemetry around the onboarding view.
+- Changing the activity-bar icon or the welcome view in the Steering panel.

--- a/specs/084-empty-state-onboarding/tasks.md
+++ b/specs/084-empty-state-onboarding/tasks.md
@@ -1,0 +1,19 @@
+# Tasks: Empty-State Onboarding Card
+
+**Plan**: [plan.md](./plan.md) | **Date**: 2026-04-25
+
+## Format
+
+- `[P]` marks tasks that can run in parallel with adjacent `[P]` tasks.
+- Consecutive `[P]` tasks form a **parallel group** — `/sdd:implement` spawns them as concurrent subagents.
+- Tasks without `[P]` are **gates**: they start only after all prior tasks complete.
+- Two tasks that touch the same file are never both `[P]`.
+
+---
+
+## Phase 1: Core Implementation
+
+- [x] **T001** Rewrite the zero-spec welcome view contents — `package.json` | R001, R002, R003, R006
+  - **Do**: In `package.json`, locate the `viewsWelcome` entry whose `when` is `"speckit.detected && !speckit.constitutionNeedsSetup"` (currently `"Build features with specs\n\n[$(plus) Create New Spec](command:speckit.create)"`). Replace its `contents` value with a multi-paragraph markdown string containing: a headline ("Welcome to SpecKit"), a one-sentence description of what specs do, a primary button `[$(plus) Create your first spec](command:speckit.create)`, and a docs link `[$(book) Read the docs](https://github.com/alfredoperez/speckit-companion#readme)`. Use `\n\n` between paragraphs/buttons (matching the pattern already used in the constitution-needs-setup entry on the line above).
+  - **Verify**: `npm run compile` passes. Press F5 to launch the Extension Development Host, open an initialized SpecKit workspace with no specs, and confirm: headline + description show, both buttons render, "Create your first spec" launches the create flow, "Read the docs" opens the README in the browser, and once a spec exists the welcome view disappears.
+  - **Leverage**: `package.json` line ~99 — the existing `constitutionNeedsSetup` welcome entry already uses `\n\n` between two action links; mirror that pattern.


### PR DESCRIPTION
## What

- Rewrite the `speckit.detected && !speckit.constitutionNeedsSetup` viewsWelcome entry into a richer onboarding card: headline, one-sentence value prop, "Create your first spec" button, and "Read the docs" link.

## Why

The previous zero-spec view was a single line of text — first-run users had no clear next step. The new card makes the primary action obvious and points new users at the README.

## Testing

- `npm run compile` passes
- Install the packaged extension in an initialized SpecKit workspace with no specs and confirm: headline + description render, both buttons appear, "Create your first spec" launches the create flow, "Read the docs" opens the README in the default browser, and the card disappears once a spec exists.

Closes #111