### PR TITLE
fix(ai-providers): support powershell and force copilot auto-approve

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,8 @@ Controls whether AI CLIs run with permission prompts (safe) or bypass them (YOLO
 
 This applies to all providers that support it: Claude (`--permission-mode bypassPermissions`), Copilot (`--yolo`), and Qwen (`--yolo`). Gemini and Codex ignore this setting.
 
+> **Copilot exception**: GitHub Copilot CLI cannot surface permission prompts in `-p` mode. Even with `permissionMode: "interactive"`, the extension auto-switches Copilot to auto-approve at dispatch time — otherwise the terminal would silently hang waiting for a prompt that never appears. This is enforced at runtime; dismissing the startup warning toast does not re-enable interactive mode for Copilot.
+
 ### Command Format
 
 Controls how speckit commands are formatted when sent to AI providers:
@@ -496,7 +498,7 @@ npm run package
 | macOS        | Yes      | Fully supported                                                             |
 | Linux        | Yes      | Fully supported                                                             |
 | Windows WSL  | Yes      | Supported                                                                   |
-| Windows      | Partial  | Codex provider works in PowerShell (since v0.13.0); other providers require WSL |
+| Windows      | Yes      | All bash-only providers (Copilot, Claude, OpenCode, Qwen) auto-detect PowerShell and use the equivalent `Get-Content -Raw` substitution; cmd.exe is supported on a best-effort basis (long prompts may exceed cmd's 8191-char line limit — switch to PowerShell or Git Bash if you hit it). |
 
 ## Acknowledgments
 

--- a/package.json
+++ b/package.json
@@ -689,7 +689,7 @@
           ],
           "scope": "machine",
           "order": 3,
-          "description": "Controls how the AI CLI handles permission prompts. 'interactive' is honored only by providers whose CLI supports interactive prompting (Claude, Gemini, Codex, Qwen, OpenCode). Copilot does not support interactive prompting and will be auto-switched to auto-approve."
+          "description": "Controls how the AI CLI handles permission prompts. 'interactive' is honored only by providers whose CLI supports interactive prompting (Claude, Gemini, Codex, Qwen, OpenCode). Copilot's CLI cannot surface prompts in -p mode and is auto-switched to auto-approve at dispatch time, regardless of this setting — dismissing the startup warning will not re-enable interactive mode for Copilot."
         },
         "speckit.geminiPath": {
           "type": "string",

--- a/specs/086-fix-copilot-windows/.spec-context.json
+++ b/specs/086-fix-copilot-windows/.spec-context.json
@@ -5,7 +5,9 @@
   "progress": null,
   "next": "done",
   "status": "completed",
-  "checkpointStatus": { "commit": false, "pr": false },
+  "checkpointStatus": { "commit": true, "pr": true },
+  "prUrl": "https://github.com/alfredoperez/speckit-companion/pull/145",
+  "prNumber": 145,
   "updated": "2026-04-27",
   "selectedAt": "2026-04-27T20:01:20Z",
   "specName": "Fix Copilot Windows Shell Compatibility",
@@ -170,7 +172,7 @@
       "note": "Override notice uses console.warn (not OutputChannel/showInformationMessage) because getPermissionFlagForProvider has no VS Code context. May want to plumb a channel later."
     }
   ],
-  "last_action": "CP1 simplify pass: stripped 4 multi-line JSDocs, dropped duplicate inline comments, extracted buildSystemPromptFlag helper in claudeCodeProvider.ts (de-duped 13-line block), standardized shellDetection imports. Net -102 lines across 4 files; tests still 407/407 green.",
+  "last_action": "PR #145 opened — fix(ai-providers): support powershell and force copilot auto-approve",
   "transitions": [
     { "step": "specify", "substep": "parsing", "from": null, "by": "sdd", "at": "2026-04-27T20:01:20Z" },
     { "step": "specify", "substep": "exploring", "from": { "step": "specify", "substep": "parsing" }, "by": "sdd", "at": "2026-04-27T20:01:25Z" },
@@ -190,6 +192,7 @@
     { "step": "implement", "substep": "code-review", "from": { "step": "implement", "substep": "hooks" }, "by": "sdd", "at": "2026-04-27T21:05:00Z" },
     { "step": "implement", "substep": "code-review", "from": { "step": "implement", "substep": "code-review" }, "by": "sdd", "at": "2026-04-27T21:30:00Z" },
     { "step": "implement", "substep": "commit-review", "from": { "step": "implement", "substep": "code-review" }, "by": "sdd", "at": "2026-04-27T21:35:00Z" },
-    { "step": "done", "substep": null, "from": { "step": "implement", "substep": "commit-review" }, "by": "sdd", "at": "2026-04-27T21:40:00Z" }
+    { "step": "done", "substep": null, "from": { "step": "implement", "substep": "commit-review" }, "by": "sdd", "at": "2026-04-27T21:40:00Z" },
+    { "step": "done", "substep": null, "from": { "step": "done", "substep": null }, "by": "sdd", "at": "2026-04-27T21:45:00Z" }
   ]
 }

--- a/specs/086-fix-copilot-windows/.spec-context.json
+++ b/specs/086-fix-copilot-windows/.spec-context.json
@@ -1,0 +1,195 @@
+{
+  "workflow": "sdd",
+  "currentStep": "done",
+  "currentTask": null,
+  "progress": null,
+  "next": "done",
+  "status": "completed",
+  "checkpointStatus": { "commit": false, "pr": false },
+  "updated": "2026-04-27",
+  "selectedAt": "2026-04-27T20:01:20Z",
+  "specName": "Fix Copilot Windows Shell Compatibility",
+  "branch": "main",
+  "workingBranch": "fix/fix-copilot-windows",
+  "type": "fix",
+  "createdAt": "2026-04-27T20:01:20Z",
+  "auto": true,
+  "issueNumber": 140,
+  "approach": "Fix the two Windows-only failures with minimal-surface changes — a shell-detection helper + shared command-line builder for the bash-only `$(cat)` providers, and a hardened `getPermissionFlagForProvider` that forces auto-approve when the provider can't honor interactive prompts.",
+  "step_summaries": {
+    "specify": {
+      "complexity": "normal",
+      "requirements": 7,
+      "scenarios": 6,
+      "key_finding": "Four providers (Copilot, Claude, OpenCode, Qwen) share the bash-only `$(cat \"...\")` dispatch pattern; `validatePermissionMode` already detects bad combos but only as a dismissible warning, leaving silent-hang state reachable."
+    },
+    "plan": {
+      "approach_summary": "Fix the two Windows-only failures with minimal-surface changes — a shell-detection helper + shared command-line builder for the bash-only `$(cat)` providers, and a hardened `getPermissionFlagForProvider` that forces auto-approve when the provider can't honor interactive prompts.",
+      "files_planned": 11,
+      "risks": [
+        "PowerShell version: `Get-Content -Raw` requires PS 3.0+; PS 5.1 is the Windows default so realistic install base is fine.",
+        "cmd.exe embed-fallback path is hard to verify in CI; rare as a VS Code default — best-effort with unit tests on the escaper plus runtime error if line exceeds 8191 chars.",
+        "Forcing auto-approve when user chose interactive may surprise users; mitigated by one-time output-channel notice and keeping the existing startup toast.",
+        "Touching three additional providers for R007 increases blast radius; mitigated by mechanical helper-call change plus shared unit tests."
+      ]
+    },
+    "tasks": {
+      "total": 12,
+      "parallel_groups": 2
+    }
+  },
+  "files_modified": [
+    "src/core/utils/shellDetection.ts",
+    "src/core/utils/__tests__/shellDetection.test.ts",
+    "src/ai-providers/aiProvider.ts",
+    "src/ai-providers/copilotCliProvider.ts",
+    "src/ai-providers/claudeCodeProvider.ts",
+    "src/ai-providers/openCodeProvider.ts",
+    "src/ai-providers/qwenCliProvider.ts",
+    "src/ai-providers/permissionValidation.ts",
+    "src/ai-providers/__tests__/providerRegistry.test.ts",
+    "src/ai-providers/__tests__/promptCommand.test.ts",
+    "src/ai-providers/__tests__/permissionValidation.test.ts",
+    "tests/__mocks__/vscode.ts",
+    "package.json",
+    "README.md"
+  ],
+  "task_summaries": {
+    "T001": {
+      "status": "DONE",
+      "did": "Created shellDetection.ts exporting Shell type, detectShell() and formatPromptFileSubstitution().",
+      "files": ["src/core/utils/shellDetection.ts"],
+      "concerns": []
+    },
+    "T002": {
+      "status": "DONE",
+      "did": "Added buildPromptDispatchCommand helper in aiProvider.ts (bash/PowerShell use file substitution, cmd embeds with quote-doubling and 8000-char guard) and routed dispatchSlashCommandViaTempFile through the same shell detection.",
+      "files": ["src/ai-providers/aiProvider.ts"],
+      "concerns": []
+    },
+    "T003": {
+      "status": "DONE",
+      "did": "Wired Copilot provider's executeInTerminal and executeHeadless to buildPromptDispatchCommand.",
+      "files": ["src/ai-providers/copilotCliProvider.ts"],
+      "concerns": []
+    },
+    "T004": {
+      "status": "DONE_WITH_CONCERNS",
+      "did": "Wired Claude provider's two call sites to buildPromptDispatchCommand and made the optional --append-system-prompt segment shell-aware via formatPromptFileSubstitution.",
+      "files": ["src/ai-providers/claudeCodeProvider.ts"],
+      "concerns": [
+        "On cmd.exe, the system-prompt file is read synchronously via fs.readFileSync and embedded into the --append-system-prompt flag — combined with the user prompt this could hit cmd's ~8191-char line limit. The embed helper throws a clear error in that case, so the failure is loud, but worth flagging for CP1."
+      ]
+    },
+    "T005": {
+      "status": "DONE",
+      "did": "Wired OpenCode provider's two call sites to buildPromptDispatchCommand. No tests exist for this provider; left as-is.",
+      "files": ["src/ai-providers/openCodeProvider.ts"],
+      "concerns": []
+    },
+    "T006": {
+      "status": "DONE",
+      "did": "Wired Qwen provider's two call sites to buildPromptDispatchCommand. No tests exist for this provider; left as-is.",
+      "files": ["src/ai-providers/qwenCliProvider.ts"],
+      "concerns": []
+    },
+    "T007": {
+      "status": "DONE_WITH_CONCERNS",
+      "did": "Hardened getPermissionFlagForProvider so providers with supportsInteractivePermissions=false (Copilot) always get the auto-approve flag, with a one-time-per-provider console.warn. Pre-existing test in providerRegistry.test.ts encoded the old buggy behavior; updated the assertion as a silent fix.",
+      "files": [
+        "src/ai-providers/permissionValidation.ts",
+        "src/ai-providers/__tests__/providerRegistry.test.ts"
+      ],
+      "concerns": [
+        "Used console.warn for the one-time override notice rather than vscode.window.showInformationMessage or an OutputChannel — getPermissionFlagForProvider is a pure function with no VS Code context handle. CP1: confirm console.warn in Extension Host is acceptable; if not, plumb an OutputChannel through."
+      ]
+    },
+    "T008": {
+      "status": "DONE",
+      "did": "Added 14 unit tests for detectShell + formatPromptFileSubstitution; extended tests/__mocks__/vscode.ts with a mutable `env.shell` field.",
+      "files": [
+        "src/core/utils/__tests__/shellDetection.test.ts",
+        "tests/__mocks__/vscode.ts"
+      ],
+      "concerns": []
+    },
+    "T009": {
+      "status": "DONE",
+      "did": "Added 6 unit tests for buildPromptDispatchCommand covering bash, powershell, unknown, cmd quote-doubling, plain-text embed, and cmd over-length throw.",
+      "files": ["src/ai-providers/__tests__/promptCommand.test.ts"],
+      "concerns": []
+    },
+    "T010": {
+      "status": "DONE",
+      "did": "Added 7 unit tests for getPermissionFlagForProvider override matrix; uses jest.resetModules() per test for clean firedOverrideForProvider state.",
+      "files": ["src/ai-providers/__tests__/permissionValidation.test.ts"],
+      "concerns": []
+    },
+    "T011": {
+      "status": "DONE",
+      "did": "Updated speckit.permissionMode description in package.json to reflect dispatch-time enforcement of Copilot auto-switch.",
+      "files": ["package.json"],
+      "concerns": []
+    },
+    "T012": {
+      "status": "DONE",
+      "did": "Added Copilot exception callout under Permission Mode and updated Platform Support Windows row to reflect full support across all bash-only providers.",
+      "files": ["README.md"],
+      "concerns": []
+    }
+  },
+  "decisions": [
+    {
+      "task": "T001",
+      "note": "Used path.basename + lowercase + strip .exe for shell detection rather than substring matching, to handle Git Bash's `bash.exe` and PowerShell's `pwsh.exe` cleanly. Single-quoted the path in the PowerShell substitution to avoid `$` expansion in the file path."
+    },
+    {
+      "task": "T002",
+      "note": "Cap cmd.exe embed at 8000 chars (slightly under the 8191 hard limit) and throw with a message recommending PowerShell or Git Bash."
+    },
+    {
+      "task": "T004",
+      "note": "Read system-prompt file synchronously for cmd.exe (rather than skipping the system prompt or refusing). Keeps cmd.exe usable end-to-end for short prompts and fails loudly with the helper's existing length guard for long ones."
+    },
+    {
+      "task": "T007",
+      "note": "Updated the pre-existing test that asserted Copilot+interactive returned '' — the test had encoded the bug. New assertion expects --yolo and silences the one-time console.warn via jest.spyOn."
+    },
+    {
+      "task": "CP1-simplify",
+      "note": "User requested a simplify pass before commit. Stripped JSDocs that explained WHAT (kept only short WHY lines for the PowerShell single-quote rationale and warn-once intent). Extracted buildSystemPromptFlag helper to remove the 13-line duplicate in claudeCodeProvider's two call sites. Standardized claudeCodeProvider's shell-detection imports to come from shellDetection.ts only (single source of truth); removed the redundant re-export from aiProvider.ts. Did NOT collapse the per-provider temp-file/terminal/cleanup boilerplate — out of scope for this bug fix; flagged as a follow-up refactor candidate."
+    }
+  ],
+  "concerns": [
+    {
+      "task": "T004",
+      "note": "Claude provider's cmd.exe path embeds system prompt synchronously — long prompts may exceed line limit. Surfaces a clear error from buildPromptDispatchCommand."
+    },
+    {
+      "task": "T007",
+      "note": "Override notice uses console.warn (not OutputChannel/showInformationMessage) because getPermissionFlagForProvider has no VS Code context. May want to plumb a channel later."
+    }
+  ],
+  "last_action": "CP1 simplify pass: stripped 4 multi-line JSDocs, dropped duplicate inline comments, extracted buildSystemPromptFlag helper in claudeCodeProvider.ts (de-duped 13-line block), standardized shellDetection imports. Net -102 lines across 4 files; tests still 407/407 green.",
+  "transitions": [
+    { "step": "specify", "substep": "parsing", "from": null, "by": "sdd", "at": "2026-04-27T20:01:20Z" },
+    { "step": "specify", "substep": "exploring", "from": { "step": "specify", "substep": "parsing" }, "by": "sdd", "at": "2026-04-27T20:01:25Z" },
+    { "step": "specify", "substep": "detecting", "from": { "step": "specify", "substep": "exploring" }, "by": "sdd", "at": "2026-04-27T20:01:30Z" },
+    { "step": "specify", "substep": "writing-spec", "from": { "step": "specify", "substep": "detecting" }, "by": "sdd", "at": "2026-04-27T20:01:35Z" },
+    { "step": "specify", "substep": null, "from": { "step": "specify", "substep": "writing-spec" }, "by": "sdd", "at": "2026-04-27T20:01:40Z" },
+    { "step": "plan", "substep": "loading", "from": { "step": "specify", "substep": null }, "by": "sdd", "at": "2026-04-27T20:15:00Z" },
+    { "step": "plan", "substep": "writing-plan", "from": { "step": "plan", "substep": "loading" }, "by": "sdd", "at": "2026-04-27T20:15:05Z" },
+    { "step": "plan", "substep": null, "from": { "step": "plan", "substep": "writing-plan" }, "by": "sdd", "at": "2026-04-27T20:15:10Z" },
+    { "step": "tasks", "substep": "loading", "from": { "step": "plan", "substep": null }, "by": "sdd", "at": "2026-04-27T20:20:00Z" },
+    { "step": "tasks", "substep": "writing-tasks", "from": { "step": "tasks", "substep": "loading" }, "by": "sdd", "at": "2026-04-27T20:20:05Z" },
+    { "step": "tasks", "substep": null, "from": { "step": "tasks", "substep": "writing-tasks" }, "by": "sdd", "at": "2026-04-27T20:20:10Z" },
+    { "step": "implement", "substep": "phase1", "from": { "step": "tasks", "substep": null }, "by": "sdd", "at": "2026-04-27T20:25:00Z" },
+    { "step": "implement", "substep": "phase1", "from": { "step": "implement", "substep": "phase1" }, "by": "sdd", "at": "2026-04-27T20:30:00Z" },
+    { "step": "implement", "substep": "phase1", "from": { "step": "implement", "substep": "phase1" }, "by": "sdd", "at": "2026-04-27T20:45:00Z" },
+    { "step": "implement", "substep": "hooks", "from": { "step": "implement", "substep": "phase1" }, "by": "sdd", "at": "2026-04-27T21:00:00Z" },
+    { "step": "implement", "substep": "code-review", "from": { "step": "implement", "substep": "hooks" }, "by": "sdd", "at": "2026-04-27T21:05:00Z" },
+    { "step": "implement", "substep": "code-review", "from": { "step": "implement", "substep": "code-review" }, "by": "sdd", "at": "2026-04-27T21:30:00Z" },
+    { "step": "implement", "substep": "commit-review", "from": { "step": "implement", "substep": "code-review" }, "by": "sdd", "at": "2026-04-27T21:35:00Z" },
+    { "step": "done", "substep": null, "from": { "step": "implement", "substep": "commit-review" }, "by": "sdd", "at": "2026-04-27T21:40:00Z" }
+  ]
+}

--- a/specs/086-fix-copilot-windows/plan.md
+++ b/specs/086-fix-copilot-windows/plan.md
@@ -1,0 +1,56 @@
+# Plan: Fix Copilot Windows Shell Compatibility
+
+**Spec**: [spec.md](./spec.md) | **Date**: 2026-04-27
+
+## Approach
+
+Fix the two Windows-only failures with minimal-surface changes. For bug 1, introduce a small shell-detection helper and a shared command-line builder that emits `$(cat "...")` for bash-family shells, `$(Get-Content -Raw '...')` for PowerShell (5.1 and 7+), and an embedded-prompt fallback for cmd.exe — then route all four bash-only providers (Copilot, Claude, OpenCode, Qwen) through it. For bug 2, harden `getPermissionFlagForProvider` so it always returns the auto-approve flag when the provider's `supportsInteractivePermissions` is `false`, regardless of the configured `permissionMode`, with a one-time output-channel notice so the user understands the override.
+
+## Technical Context
+
+**Stack**: TypeScript 5.3 (ES2022, strict), VS Code Extension API `^1.84.0`, Webpack 5, Jest + ts-jest.
+**Key Dependencies**: none new.
+**Constraints**: Must run in Node 18 (VS Code's bundled runtime). Must not require new VS Code API beyond the current `engines.vscode` floor (NFR002). Must preserve prompt-scrollback hiding for shells that support file substitution (NFR001).
+
+## Files
+
+### Create
+
+- `src/core/utils/shellDetection.ts` — `detectShell(): 'bash' | 'powershell' | 'cmd' | 'unknown'` based on `vscode.env.shell` + `process.platform`. Also exports `formatPromptFileSubstitution(shell, absPath): string` returning the shell-correct inline expression that, when quoted in a command line, evaluates to the file's content.
+- `src/core/utils/__tests__/shellDetection.test.ts` — unit tests covering: pwsh.exe, powershell.exe, bash, zsh, cmd.exe, empty/undefined `vscode.env.shell`, Windows vs. macOS/Linux defaults, and the substitution-formatter output for each shell.
+- `src/ai-providers/__tests__/promptCommand.test.ts` — unit tests for the new shared `buildPromptDispatchCommand` helper covering each shell branch and the cmd.exe embed-fallback escaping.
+
+### Modify
+
+- `src/ai-providers/aiProvider.ts` — add exported `buildPromptDispatchCommand({ cliInvocation, flags, promptFilePath, promptText })` that picks the shell, returns the right command line, and uses the embed fallback when no temp-file substitution is possible. Update `dispatchSlashCommandViaTempFile` to call this helper instead of the inline `$(cat "...")` template.
+- `src/ai-providers/copilotCliProvider.ts` — replace the two `${permissionFlag}-p "$(cat "${promptFilePath}")"` lines (lines 83 and 135) with calls to `buildPromptDispatchCommand`.
+- `src/ai-providers/claudeCodeProvider.ts` — same swap for the four `$(cat "...")` occurrences (lines 87, 89, 147, 149). Per R007 — uniform application of the fix.
+- `src/ai-providers/openCodeProvider.ts` — same swap for lines 62 and 104.
+- `src/ai-providers/qwenCliProvider.ts` — same swap for lines 77 and 128.
+- `src/ai-providers/permissionValidation.ts` — update `getPermissionFlagForProvider` so it returns the provider's `autoApproveFlag` whenever (a) `permissionMode === 'auto-approve'` OR (b) `supportsInteractivePermissions === false` and `autoApproveFlag` is non-empty. Add a one-time `outputChannel`-style notice (or `vscode.window.showInformationMessage` with a "Don't show again" memento) the first time the override fires, so the user knows their `interactive` setting was bypassed for that provider.
+- `src/ai-providers/__tests__/permissionValidation.test.ts` — extend (or create) tests covering: interactive + Copilot → returns `--yolo `; auto-approve + Copilot → returns `--yolo `; interactive + Claude → returns `''`; interactive + Codex → returns `''`. (Same coverage for Qwen since it also has `supportsInteractivePermissions: true` — should NOT be force-overridden.)
+- `package.json` — update the `speckit.permissionMode` description to make the new behavior explicit: "Copilot is auto-switched to auto-approve at dispatch time because its CLI cannot surface prompts in `-p` mode." (No default change — `interactive` remains the default for providers that support it.)
+- `README.md` — update the relevant section under "Configuration" → `permissionMode` to document the Copilot override (per the project's `Update docs on feature changes` rule). Cross-reference the issue.
+
+## Data Model
+
+No persisted data changes. The only new in-memory concept is the `Shell` discriminated union (`'bash' | 'powershell' | 'cmd' | 'unknown'`) returned by `detectShell()`.
+
+## Testing Strategy
+
+- **Unit (Jest)**:
+  - `shellDetection.test.ts` — drive `vscode.env.shell` via the existing `tests/__mocks__/vscode.ts` mock; assert detection and substitution output for each shell.
+  - `promptCommand.test.ts` — assert the command string for each shell variant and that the cmd.exe fallback embeds the prompt with `"` doubled and `%` escaped to `%%`.
+  - `permissionValidation.test.ts` — assert override matrix above.
+- **Manual smoke (must do before tag)**:
+  1. macOS bash/zsh — Copilot workflow still runs (regression check, scenario "Bash / Git Bash regression").
+  2. Windows PowerShell 5.1 — Copilot workflow runs without `too many arguments` (scenario "PowerShell terminal on Windows"). User to verify since CI does not run on Windows.
+  3. Windows PowerShell + Copilot + `permissionMode: "interactive"` — workflow does not hang; output channel shows the one-time override notice (scenario "Default permission mode with Copilot").
+- **Edge cases from spec**: dismissed validation warning still produces working dispatch; headless mode behaves identically to visible-terminal mode; non-Copilot providers unchanged.
+
+## Risks
+
+- **PowerShell version**: `Get-Content -Raw` requires PS 3.0+. Windows 10 ships PS 5.1, so the realistic install base is fine; PS 2.0 is essentially extinct. No mitigation needed beyond noting it in the README.
+- **cmd.exe embed-fallback path is hard to verify in CI**: cmd.exe is rare as a VS Code default on modern Windows. Treat it as best-effort with unit tests on the escaper, and surface a clear runtime error if the embed length exceeds cmd.exe's 8191-char line limit.
+- **Forcing auto-approve when user chose interactive may surprise users**: Mitigate with the one-time output-channel notice and keep the existing `validatePermissionMode` startup toast in place. The override is bounded — it only fires for providers that truly cannot honor `interactive`.
+- **Touching three providers for R007**: increases blast radius. Mitigation — the change is mechanical (call same helper), and unit tests for the helper cover the shared behavior, so per-provider risk is low.

--- a/specs/086-fix-copilot-windows/spec.md
+++ b/specs/086-fix-copilot-windows/spec.md
@@ -1,0 +1,62 @@
+# Spec: Fix Copilot Windows Shell Compatibility
+
+**Slug**: 086-fix-copilot-windows | **Date**: 2026-04-27
+
+## Summary
+
+Fix two related Windows-only failures with the GitHub Copilot CLI provider: (1) the bash-only `$(cat "...")` prompt-dispatch syntax breaks in PowerShell (the VS Code default Windows shell), causing copilot to reject the call with `too many arguments`; and (2) the default `permissionMode: "interactive"` combined with `copilot -p` causes the terminal to hang silently because Copilot has no way to surface a permission prompt in scripted mode. Both bugs make the extension unusable on Windows out of the box without manual workarounds.
+
+## Requirements
+
+- **R001** (MUST): Copilot CLI prompt dispatch must succeed when the active VS Code integrated terminal is PowerShell (5.1 or 7+) on Windows. The full prompt content must reach `copilot -p` as a single argument, regardless of shell.
+- **R002** (MUST): Copilot CLI prompt dispatch must continue to succeed in bash, zsh, and Git Bash on macOS, Linux, and Windows. The fix for R001 must not regress non-PowerShell shells.
+- **R003** (MUST): When the configured provider's `supportsInteractivePermissions` is `false` and the resolved `permissionMode` is `"interactive"`, the extension must not dispatch a workflow that will hang silently. Either the provider's auto-approve flag is forced for that invocation, or the dispatch is blocked with a visible error explaining the mismatch and how to fix it.
+- **R004** (MUST): The fix for R003 must apply to both visible-terminal dispatch (`executeInTerminal`) and headless dispatch (`executeHeadless`).
+- **R005** (SHOULD): The existing one-time warning toast in `validatePermissionMode` should be replaced or supplemented so users cannot silently dismiss the warning into a broken state. A user who proceeds with the bad combo must either get auto-corrected behavior or a clear refusal at dispatch time — not silence.
+- **R006** (SHOULD): The default value of `speckit.permissionMode` (currently `"interactive"`) should remain valid for providers that support interactive prompts. The fix should not force all users onto auto-approve globally; it should only resolve the bad combo for affected providers.
+- **R007** (MAY): The same shell-agnostic prompt-dispatch mechanism may be applied to the other CLI providers that currently use `$(cat "...")` (Claude, OpenCode, Qwen) so the fix is uniform across the codebase, even though the bug report only names Copilot.
+
+## Scenarios
+
+### Bug 1 — PowerShell terminal on Windows
+
+**When** a Windows user with the VS Code default PowerShell integrated terminal triggers a SpecKit workflow with the Copilot provider configured
+**Then** the `copilot` CLI receives the full prompt as a single `-p` argument, runs the workflow, and produces output in the terminal — no `too many arguments` error appears
+
+### Bug 1 — Bash / Git Bash regression check
+
+**When** a user (any platform) with a bash, zsh, or Git Bash integrated terminal triggers a SpecKit workflow with the Copilot provider
+**Then** the prompt is delivered correctly and the workflow runs as it did before the fix
+
+### Bug 2 — Default permission mode with Copilot
+
+**When** a user installs the extension fresh, selects Copilot as the provider, leaves `speckit.permissionMode` at its default (`"interactive"`), and triggers a workflow
+**Then** the extension does not produce a silently-hanging terminal — it either runs the workflow with auto-approve applied for that invocation, or it surfaces a blocking error message that names the setting to change
+
+### Bug 2 — User dismisses the validation warning
+
+**When** the existing `validatePermissionMode` toast appears and the user clicks "Keep Interactive" for Copilot
+**Then** subsequent workflow dispatches still do not silently hang — the dispatch path enforces the fix at runtime regardless of the dismissed warning
+
+### Headless background mode
+
+**When** a SpecKit feature invokes `executeHeadless` on the Copilot provider on Windows with PowerShell
+**Then** the hidden background terminal completes the command without the PowerShell-arg-splitting error and without the silent-hang permission failure
+
+### Other providers unaffected
+
+**When** a user with Claude, Gemini, Codex, Qwen, or OpenCode triggers a workflow on macOS or Linux
+**Then** no behavior change is observable — `permissionMode: "interactive"` continues to work for providers whose CLIs support interactive prompts
+
+## Non-Functional Requirements
+
+- **NFR001** (MUST): The shell-agnostic prompt-dispatch must not write the prompt content to terminal scrollback in plain view. The current temp-file pattern hides prompt bodies from scrollback; the fix must preserve that property where feasible.
+- **NFR002** (SHOULD): The fix should not require a new VS Code API version beyond the current `engines.vscode` floor (`^1.84.0`).
+
+## Out of Scope
+
+- Refactoring the `validatePermissionMode` toast UX beyond what R005 requires (e.g., redesigning the warning copy, adding "don't ask again" semantics).
+- Changing the default `speckit.permissionMode` globally for non-Copilot providers.
+- Adding new Windows-specific telemetry or diagnostics surfaces.
+- Bug fixes for unrelated PowerShell/Windows issues with other providers if they do not share the same `$(cat "...")` root cause (R007 is opt-in if uniform application is straightforward).
+- Detecting or migrating users away from PowerShell as their default shell.

--- a/specs/086-fix-copilot-windows/tasks.md
+++ b/specs/086-fix-copilot-windows/tasks.md
@@ -1,0 +1,76 @@
+# Tasks: Fix Copilot Windows Shell Compatibility
+
+**Plan**: [plan.md](./plan.md) | **Date**: 2026-04-27
+
+## Format
+
+- `[P]` marks tasks that can run in parallel with adjacent `[P]` tasks.
+- Consecutive `[P]` tasks form a **parallel group** — `/sdd:implement` spawns them as concurrent subagents.
+- Tasks without `[P]` are **gates**: they start only after all prior tasks complete.
+- Two tasks that touch the same file are never both `[P]`.
+
+---
+
+## Phase 1: Core Implementation
+
+- [x] **T001** Create `shellDetection` utility — `src/core/utils/shellDetection.ts` | R001, R002, NFR001
+  - **Do**: Create the file with `export type Shell = 'bash' | 'powershell' | 'cmd' | 'unknown'`, `export function detectShell(): Shell` that inspects `vscode.env.shell` (lowercased basename) — `pwsh`/`powershell` → `'powershell'`, `cmd` → `'cmd'`, `bash`/`zsh`/`sh` → `'bash'`, else `'unknown'` (with a `process.platform === 'win32'` default of `'powershell'` when `vscode.env.shell` is empty), and `export function formatPromptFileSubstitution(shell: Shell, absPath: string): string` returning the inline expression that, when placed inside double quotes in a command line for that shell, expands to the file's contents — `bash`/`unknown` → `$(cat "${absPath}")`, `powershell` → `$(Get-Content -Raw '${absPath}')`, `cmd` → `''` (sentinel — caller must use embed fallback). Single quotes around the path on PowerShell to avoid `$` expansion in the path.
+  - **Verify**: `npm run compile` succeeds. The new file exports `Shell`, `detectShell`, `formatPromptFileSubstitution`.
+  - **Leverage**: `src/core/utils/pathUtils.ts` — same module style and use of `process.platform` defaults.
+
+- [x] **T002** Add `buildPromptDispatchCommand` helper — `src/ai-providers/aiProvider.ts` | R001, R002, NFR001
+  - **Do**: Add `export function buildPromptDispatchCommand(opts: { cliInvocation: string; flags: string; promptFilePath: string; promptText: string }): string` that calls `detectShell()` and: for `bash`/`powershell` returns `${cliInvocation} ${flags}"${formatPromptFileSubstitution(shell, promptFilePath)}"`; for `cmd` falls back to embedding `promptText` directly with cmd.exe escaping (`"` → `""`, leading/trailing whitespace trimmed) and throws a clear `Error` if the resulting line exceeds 8000 chars; for `unknown` defaults to bash form. Update `dispatchSlashCommandViaTempFile` to use the same helper for the `$(cat …)` template (preserve the special `slashCommand` prefix and the empty-prompt branch). Re-export `Shell`, `detectShell` from this module if needed by callers.
+  - **Verify**: `npm run compile` passes. Existing call sites in `dispatchSlashCommandViaTempFile` produce the same string output for bash via a quick local check.
+  - **Leverage**: existing `dispatchSlashCommandViaTempFile` block (lines 20–62) for the temp-file/cleanup pattern.
+  - *(depends on T001)*
+
+- [x] **T003** [P] Wire Copilot provider to helper — `src/ai-providers/copilotCliProvider.ts` | R001, R002, R007
+  - **Do**: Replace the inline command construction at line 83 (`const command = \`${cliPath} ${permissionFlag}-p "$(cat "${promptFilePath}")"\`;`) and line 135 (the `commandLine` in `executeHeadless`) with `buildPromptDispatchCommand({ cliInvocation: cliPath, flags: \`${permissionFlag}-p \`, promptFilePath, promptText: cleanPrompt })`. Import the helper from `./aiProvider`.
+  - **Verify**: `npm run compile` passes. Manual: on macOS bash, dispatching a Copilot workflow still produces a working command (regression check). On a Windows PowerShell terminal, the produced string contains `Get-Content -Raw` instead of `cat`.
+  - *(depends on T002)*
+
+- [x] **T004** [P] Wire Claude provider to helper — `src/ai-providers/claudeCodeProvider.ts` | R007
+  - **Do**: Replace the four `$(cat "...")` occurrences (lines 87, 89, 147, 149 — both `executeInTerminal` and `executeHeadless`, including the `--append-system-prompt "$(cat "${systemPromptFilePath}")"` segment when present). For the prompt portion call `buildPromptDispatchCommand`. For the optional `--append-system-prompt` segment, also use `formatPromptFileSubstitution` directly so it works in PowerShell — emit `--append-system-prompt "${formatPromptFileSubstitution(shell, systemPromptFilePath)}" ` (with `cmd` falling back to a separate embed via the same fallback rules). Import helpers from `./aiProvider` and `../core/utils/shellDetection`.
+  - **Verify**: `npm run compile` passes. Existing Claude jest tests in `__tests__/` still pass (`npm test`).
+  - *(depends on T002)*
+
+- [x] **T005** [P] Wire OpenCode provider to helper — `src/ai-providers/openCodeProvider.ts` | R007
+  - **Do**: Replace lines 62 and 104 (`${cliPath} ${permissionFlag}-p "$(cat "${tempFilePath}")"`) with `buildPromptDispatchCommand({ cliInvocation: cliPath, flags: \`${permissionFlag}-p \`, promptFilePath: tempFilePath, promptText })`. Import the helper.
+  - **Verify**: `npm run compile` passes; existing tests pass.
+  - *(depends on T002)*
+
+- [x] **T006** [P] Wire Qwen provider to helper — `src/ai-providers/qwenCliProvider.ts` | R007
+  - **Do**: Replace lines 77 and 128 (`${cliPath} ${permissionFlag}-p "$(cat "${tempFilePath}")"`) with `buildPromptDispatchCommand`. Import the helper.
+  - **Verify**: `npm run compile` passes; existing tests pass.
+  - *(depends on T002)*
+
+- [x] **T007** [P] Harden `getPermissionFlagForProvider` — `src/ai-providers/permissionValidation.ts` | R003, R004, R005
+  - **Do**: Modify `getPermissionFlagForProvider(type)` so it returns `paths.autoApproveFlag` whenever `paths.autoApproveFlag !== ''` AND (`readPermissionMode() === 'auto-approve'` OR `paths.supportsInteractivePermissions === false`). Add a module-private `firedOverrideForProvider` set to fire a one-time `console.warn` (replaceable later with `outputChannel.appendLine` if a channel handle is plumbed through; for now a `console.warn` is enough to be visible in the Extension Host log). Keep the existing `validatePermissionMode` toast unchanged so the user still sees the startup warning. Update the JSDoc to describe the override.
+  - **Verify**: `npm run compile` passes. Existing call sites in `copilotCliProvider.ts` (and any other provider using `getPermissionFlag()`) keep working unchanged.
+  - **Leverage**: existing `PROVIDER_PATHS[type]` lookup pattern in the same file.
+
+- [x] **T008** [P] Unit tests for `shellDetection` — `src/core/utils/__tests__/shellDetection.test.ts` | R001, R002
+  - **Do**: Add a Jest spec with `describe('detectShell')` covering: `pwsh.exe`, `powershell.exe`, `bash`, `/bin/zsh`, `cmd.exe`, empty `vscode.env.shell` on Windows defaults to `'powershell'`, empty on darwin defaults to `'bash'`, and `'unknown'` for arbitrary paths. Add `describe('formatPromptFileSubstitution')` covering the bash, powershell, cmd, and unknown branches and verifying the PowerShell output uses single-quoted paths.
+  - **Verify**: `npm test -- shellDetection` passes.
+  - **Leverage**: `tests/__mocks__/vscode.ts` — extend the mock to allow setting `vscode.env.shell` per test (similar to `pathUtils.test.ts` setting `process.platform`).
+  - *(depends on T001)*
+
+- [x] **T009** [P] Unit tests for `buildPromptDispatchCommand` — `src/ai-providers/__tests__/promptCommand.test.ts` | R001, R002, NFR001
+  - **Do**: Cover each shell branch — bash produces `cliInvocation flags"$(cat \"path\")"`, powershell produces `cliInvocation flags"$(Get-Content -Raw 'path')"`, cmd embeds the prompt with `"` doubled, and an over-long prompt on cmd throws. Also assert that `unknown` falls back to bash form.
+  - **Verify**: `npm test -- promptCommand` passes.
+  - *(depends on T002)*
+
+- [x] **T010** [P] Unit tests for permission override — `src/ai-providers/__tests__/permissionValidation.test.ts` | R003, R004, R005
+  - **Do**: Add (or extend) tests covering the matrix: interactive + Copilot → `'--yolo '`; interactive + Claude → `''`; interactive + Qwen → `''` (Qwen `supportsInteractivePermissions: true`); auto-approve + Copilot → `'--yolo '`. Mock `vscode.workspace.getConfiguration` to drive `permissionMode` and `PROVIDER_PATHS` is real (no mock).
+  - **Verify**: `npm test -- permissionValidation` passes.
+  - *(depends on T007)*
+
+- [x] **T011** Update `package.json` config description — `package.json` | R005
+  - **Do**: Update the `speckit.permissionMode` `description` field to: `"Controls how the AI CLI handles permission prompts. 'interactive' is honored only by providers whose CLI supports interactive prompting (Claude, Gemini, Codex, Qwen, OpenCode). Copilot does not support interactive prompting and is auto-switched to auto-approve at dispatch time, regardless of this setting."` (the description already mentions auto-switch in package.json — refine to make clear it's enforced at dispatch, not just at startup).
+  - **Verify**: `npm run compile` passes. `code --install-extension` lifecycle works (visible to user via `/install-local`).
+  - *(depends on T007)*
+
+- [x] **T012** Update README.md for Windows + Copilot behavior — `README.md` | R005
+  - **Do**: Find the `Configuration` section's `permissionMode` subsection and add a callout: "**Copilot on Windows**: Copilot's CLI cannot surface permission prompts in `-p` mode, so the extension auto-switches Copilot to auto-approve at dispatch even when this setting is `interactive`. This is enforced at runtime — dismissing the startup warning will not re-enable interactive mode for Copilot." Also add a "Windows shells" note under the Copilot row in "Supported AI Providers" (or under a Platform Support / Troubleshooting section if one exists): "Copilot's prompt dispatch detects PowerShell and Git Bash automatically; cmd.exe is supported on a best-effort basis (long prompts may exceed cmd's line-length limit)."
+  - **Verify**: README renders without broken links. Per CLAUDE.md `Update docs on feature changes` rule.
+  - *(depends on T007 and T003)*

--- a/src/ai-providers/__tests__/permissionValidation.test.ts
+++ b/src/ai-providers/__tests__/permissionValidation.test.ts
@@ -1,0 +1,71 @@
+import { AIProviders } from '../../core/constants';
+
+/**
+ * Loads a fresh `permissionValidation` module (so the module-private
+ * `firedOverrideForProvider` Set starts empty) wired up to the freshly
+ * loaded `vscode` mock with `permissionMode` returning `value`.
+ */
+function loadModuleWithMode(value: 'interactive' | 'auto-approve') {
+    jest.resetModules();
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const vscode = require('vscode');
+    (vscode.workspace.getConfiguration as jest.Mock).mockReturnValue({
+        get: jest.fn((key: string, defaultValue?: unknown) => {
+            if (key === 'permissionMode') return value;
+            return defaultValue;
+        }),
+    });
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    return require('../permissionValidation') as typeof import('../permissionValidation');
+}
+
+describe('getPermissionFlagForProvider — interactive override', () => {
+    let warnSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+        warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        warnSpy.mockRestore();
+    });
+
+    it('forces auto-approve for Copilot in interactive mode (the core fix)', () => {
+        const { getPermissionFlagForProvider } = loadModuleWithMode('interactive');
+        expect(getPermissionFlagForProvider(AIProviders.COPILOT)).toBe('--yolo ');
+    });
+
+    it('returns empty string for Claude in interactive mode (supportsInteractivePermissions: true)', () => {
+        const { getPermissionFlagForProvider } = loadModuleWithMode('interactive');
+        expect(getPermissionFlagForProvider(AIProviders.CLAUDE)).toBe('');
+    });
+
+    it('returns empty string for Qwen in interactive mode (supportsInteractivePermissions: true; sanity check that override is gated)', () => {
+        const { getPermissionFlagForProvider } = loadModuleWithMode('interactive');
+        expect(getPermissionFlagForProvider(AIProviders.QWEN)).toBe('');
+    });
+
+    it('returns empty string for Gemini in interactive mode (no autoApproveFlag — override does not apply)', () => {
+        const { getPermissionFlagForProvider } = loadModuleWithMode('interactive');
+        expect(getPermissionFlagForProvider(AIProviders.GEMINI)).toBe('');
+    });
+
+    it('returns the auto-approve flag for Copilot in auto-approve mode (regression)', () => {
+        const { getPermissionFlagForProvider } = loadModuleWithMode('auto-approve');
+        expect(getPermissionFlagForProvider(AIProviders.COPILOT)).toBe('--yolo ');
+    });
+
+    it('returns the bypass flag for Claude in auto-approve mode (regression)', () => {
+        const { getPermissionFlagForProvider } = loadModuleWithMode('auto-approve');
+        expect(getPermissionFlagForProvider(AIProviders.CLAUDE)).toBe('--permission-mode bypassPermissions ');
+    });
+
+    it('warns exactly once per provider when forcing auto-approve in interactive mode', () => {
+        const { getPermissionFlagForProvider } = loadModuleWithMode('interactive');
+
+        getPermissionFlagForProvider(AIProviders.COPILOT);
+        getPermissionFlagForProvider(AIProviders.COPILOT);
+
+        expect(warnSpy).toHaveBeenCalledTimes(1);
+    });
+});

--- a/src/ai-providers/__tests__/promptCommand.test.ts
+++ b/src/ai-providers/__tests__/promptCommand.test.ts
@@ -1,0 +1,80 @@
+import { buildPromptDispatchCommand } from '../aiProvider';
+
+describe('buildPromptDispatchCommand', () => {
+    it('produces $(cat …) substitution for bash shell', () => {
+        const line = buildPromptDispatchCommand({
+            cliInvocation: 'copilot',
+            flags: '--yolo -p ',
+            promptFilePath: '/tmp/p.md',
+            promptText: 'unused',
+            shell: 'bash',
+        });
+
+        expect(line).toBe('copilot --yolo -p "$(cat "/tmp/p.md")"');
+    });
+
+    it('produces Get-Content substitution for powershell shell', () => {
+        const line = buildPromptDispatchCommand({
+            cliInvocation: 'copilot',
+            flags: '--yolo -p ',
+            promptFilePath: '/tmp/p.md',
+            promptText: 'unused',
+            shell: 'powershell',
+        });
+
+        expect(line).toBe(`copilot --yolo -p "$(Get-Content -Raw '/tmp/p.md')"`);
+    });
+
+    it('falls back to bash form for unknown shell', () => {
+        const line = buildPromptDispatchCommand({
+            cliInvocation: 'copilot',
+            flags: '--yolo -p ',
+            promptFilePath: '/tmp/p.md',
+            promptText: 'unused',
+            shell: 'unknown',
+        });
+
+        expect(line).toBe('copilot --yolo -p "$(cat "/tmp/p.md")"');
+    });
+
+    describe('cmd shell', () => {
+        it('embeds prompt directly with internal quotes doubled', () => {
+            const line = buildPromptDispatchCommand({
+                cliInvocation: 'copilot',
+                flags: '--yolo -p ',
+                promptFilePath: 'C:\\tmp\\p.md',
+                promptText: 'hello "world"',
+                shell: 'cmd',
+            });
+
+            expect(line).toContain('"hello ""world"""');
+            expect(line).not.toContain('cat');
+        });
+
+        it('embeds plain prompt text directly without substitution', () => {
+            const line = buildPromptDispatchCommand({
+                cliInvocation: 'copilot',
+                flags: '--yolo -p ',
+                promptFilePath: 'C:\\tmp\\p.md',
+                promptText: 'plain text',
+                shell: 'cmd',
+            });
+
+            expect(line).toBe('copilot --yolo -p "plain text"');
+        });
+
+        it('throws when embedded prompt exceeds the cmd.exe line limit', () => {
+            const longPrompt = 'a'.repeat(8100);
+
+            expect(() =>
+                buildPromptDispatchCommand({
+                    cliInvocation: 'copilot',
+                    flags: '--yolo -p ',
+                    promptFilePath: 'C:\\tmp\\p.md',
+                    promptText: longPrompt,
+                    shell: 'cmd',
+                })
+            ).toThrow(/cmd\.exe.*8000/);
+        });
+    });
+});

--- a/src/ai-providers/__tests__/providerRegistry.test.ts
+++ b/src/ai-providers/__tests__/providerRegistry.test.ts
@@ -33,9 +33,11 @@ describe('Provider registry', () => {
             expect(getPermissionFlagForProvider(AIProviders.COPILOT)).toBe('--yolo ');
         });
 
-        it('returns empty string for Copilot when mode is interactive', () => {
+        it('forces auto-approve for Copilot even when mode is interactive (Copilot CLI cannot surface prompts in -p mode)', () => {
             mockPermissionMode('interactive');
-            expect(getPermissionFlagForProvider(AIProviders.COPILOT)).toBe('');
+            const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+            expect(getPermissionFlagForProvider(AIProviders.COPILOT)).toBe('--yolo ');
+            warn.mockRestore();
         });
 
         it('returns empty string for providers without an auto-approve flag (Gemini, Codex)', () => {

--- a/src/ai-providers/aiProvider.ts
+++ b/src/ai-providers/aiProvider.ts
@@ -3,6 +3,34 @@ import * as fs from 'fs';
 import { AIProviders, Timing } from '../core/constants';
 import { waitForShellReady } from '../core/utils/terminalUtils';
 import { createTempFile } from '../core/utils/tempFileUtils';
+import { detectShell, formatPromptFileSubstitution, Shell } from '../core/utils/shellDetection';
+
+const CMD_LINE_MAX = 8000;
+
+export function buildPromptDispatchCommand(opts: {
+    cliInvocation: string;
+    flags: string;
+    promptFilePath: string;
+    promptText: string;
+    shell?: Shell;
+}): string {
+    const shell = opts.shell ?? detectShell();
+
+    if (shell === 'cmd') {
+        const escaped = opts.promptText.replace(/"/g, '""').trim();
+        const line = `${opts.cliInvocation} ${opts.flags}"${escaped}"`;
+        if (line.length > CMD_LINE_MAX) {
+            throw new Error(
+                `Prompt is too long for cmd.exe (${line.length} > ${CMD_LINE_MAX} chars). ` +
+                `Switch the VS Code default terminal to PowerShell or Git Bash.`
+            );
+        }
+        return line;
+    }
+
+    const substitution = formatPromptFileSubstitution(shell, opts.promptFilePath);
+    return `${opts.cliInvocation} ${opts.flags}"${substitution}"`;
+}
 
 /**
  * Dispatch a slash command to a terminal via a temp file so the full prompt
@@ -35,10 +63,16 @@ export async function dispatchSlashCommandViaTempFile(opts: {
 
     if (promptText && promptText.length > 0) {
         tempFilePath = await createTempFile(context, promptText, 'prompt', true);
-        const inner = slashCommand
-            ? `${slashCommand} $(cat "${tempFilePath}")`
-            : `$(cat "${tempFilePath}")`;
-        line = `${cliInvocation} "${inner}"`;
+        const shell = detectShell();
+        if (shell === 'cmd') {
+            const escaped = promptText.replace(/"/g, '""').trim();
+            const inner = slashCommand ? `${slashCommand} ${escaped}` : escaped;
+            line = `${cliInvocation} "${inner}"`;
+        } else {
+            const subst = formatPromptFileSubstitution(shell, tempFilePath);
+            const inner = slashCommand ? `${slashCommand} ${subst}` : subst;
+            line = `${cliInvocation} "${inner}"`;
+        }
     } else {
         line = slashCommand
             ? `${cliInvocation} "${slashCommand}"`

--- a/src/ai-providers/claudeCodeProvider.ts
+++ b/src/ai-providers/claudeCodeProvider.ts
@@ -6,8 +6,18 @@ import { ConfigManager } from '../core/utils/configManager';
 import { AIProviders, Timing } from '../core/constants';
 import { waitForShellReady, executeCommandInHiddenTerminal } from '../core/utils/terminalUtils';
 import { createTempFile } from '../core/utils/tempFileUtils';
-import { IAIProvider, AIExecutionResult, dispatchSlashCommandViaTempFile } from './aiProvider';
+import { IAIProvider, AIExecutionResult, dispatchSlashCommandViaTempFile, buildPromptDispatchCommand } from './aiProvider';
+import { detectShell, formatPromptFileSubstitution, Shell } from '../core/utils/shellDetection';
 import { getPermissionFlagForProvider } from './permissionValidation';
+
+function buildSystemPromptFlag(shell: Shell, systemPromptFilePath: string | null): string {
+    if (!systemPromptFilePath) return '';
+    if (shell === 'cmd') {
+        const content = fs.readFileSync(systemPromptFilePath, 'utf8').replace(/"/g, '""').trim();
+        return `--append-system-prompt "${content}" `;
+    }
+    return `--append-system-prompt "${formatPromptFileSubstitution(shell, systemPromptFilePath)}" `;
+}
 
 const execAsync = promisify(exec);
 
@@ -83,10 +93,14 @@ export class ClaudeCodeProvider implements IAIProvider {
                 : null;
 
             const permissionFlag = this.getPermissionFlag();
-            const systemPromptFlag = systemPromptFilePath
-                ? `--append-system-prompt "$(cat "${systemPromptFilePath}")" `
-                : '';
-            const command = `claude ${systemPromptFlag}${permissionFlag}"$(cat "${promptFilePath}")"`;
+            const shell = detectShell();
+            const command = buildPromptDispatchCommand({
+                cliInvocation: 'claude',
+                flags: `${buildSystemPromptFlag(shell, systemPromptFilePath)}${permissionFlag}`,
+                promptFilePath,
+                promptText: userPrompt,
+                shell,
+            });
 
             const terminal = vscode.window.createTerminal({
                 name: title,
@@ -143,10 +157,14 @@ export class ClaudeCodeProvider implements IAIProvider {
             : null;
 
         const permissionFlag = this.getPermissionFlag();
-        const systemPromptFlag = systemPromptFilePath
-            ? `--append-system-prompt "$(cat "${systemPromptFilePath}")" `
-            : '';
-        const commandLine = `claude ${systemPromptFlag}${permissionFlag}"$(cat "${promptFilePath}")"`;
+        const shell = detectShell();
+        const commandLine = buildPromptDispatchCommand({
+            cliInvocation: 'claude',
+            flags: `${buildSystemPromptFlag(shell, systemPromptFilePath)}${permissionFlag}`,
+            promptFilePath,
+            promptText: userPrompt,
+            shell,
+        });
 
         return executeCommandInHiddenTerminal({
             commandLine,

--- a/src/ai-providers/copilotCliProvider.ts
+++ b/src/ai-providers/copilotCliProvider.ts
@@ -7,7 +7,7 @@ import { AIProviders, CLIDefaults, Timing } from '../core/constants';
 import { waitForShellReady, executeCommandInHiddenTerminal } from '../core/utils/terminalUtils';
 import { createTempFile } from '../core/utils/tempFileUtils';
 import { ensureCliInstalled } from '../core/utils/installUtils';
-import { IAIProvider, AIExecutionResult } from './aiProvider';
+import { IAIProvider, AIExecutionResult, buildPromptDispatchCommand } from './aiProvider';
 import { getPermissionFlagForProvider } from './permissionValidation';
 
 const execAsync = promisify(exec);
@@ -80,7 +80,12 @@ export class CopilotCliProvider implements IAIProvider {
             // Strip leading slash from prompt — Copilot doesn't use slash commands
             const cleanPrompt = prompt.startsWith('/') ? prompt.substring(1) : prompt;
             const promptFilePath = await createTempFile(this.context, cleanPrompt, 'prompt', false);
-            const command = `${cliPath} ${permissionFlag}-p "$(cat "${promptFilePath}")"`;
+            const command = buildPromptDispatchCommand({
+                cliInvocation: cliPath,
+                flags: `${permissionFlag}-p `,
+                promptFilePath,
+                promptText: cleanPrompt,
+            });
 
             const terminal = vscode.window.createTerminal({
                 name: title,
@@ -132,7 +137,12 @@ export class CopilotCliProvider implements IAIProvider {
 
         const permissionFlag = this.getPermissionFlag();
         const promptFilePath = await createTempFile(this.context, cleanPrompt, 'background-prompt', false);
-        const commandLine = `${cliPath} ${permissionFlag}-p "$(cat "${promptFilePath}")"`;
+        const commandLine = buildPromptDispatchCommand({
+            cliInvocation: cliPath,
+            flags: `${permissionFlag}-p `,
+            promptFilePath,
+            promptText: cleanPrompt,
+        });
 
         return executeCommandInHiddenTerminal({
             commandLine,

--- a/src/ai-providers/openCodeProvider.ts
+++ b/src/ai-providers/openCodeProvider.ts
@@ -7,7 +7,7 @@ import { AIProviders, Timing } from '../core/constants';
 import { waitForShellReady, executeCommandInHiddenTerminal } from '../core/utils/terminalUtils';
 import { createTempFile } from '../core/utils/tempFileUtils';
 import { ensureCliInstalled } from '../core/utils/installUtils';
-import { IAIProvider, AIExecutionResult } from './aiProvider';
+import { IAIProvider, AIExecutionResult, buildPromptDispatchCommand } from './aiProvider';
 import { getPermissionFlagForProvider } from './permissionValidation';
 
 export class OpenCodeProvider implements IAIProvider {
@@ -59,7 +59,12 @@ export class OpenCodeProvider implements IAIProvider {
             const cliPath = this.getCliPath();
             const permissionFlag = this.getPermissionFlag();
             const tempFilePath = await createTempFile(this.context, prompt, 'prompt', true);
-            const command = `${cliPath} ${permissionFlag}-p "$(cat "${tempFilePath}")"`;
+            const command = buildPromptDispatchCommand({
+                cliInvocation: cliPath,
+                flags: `${permissionFlag}-p `,
+                promptFilePath: tempFilePath,
+                promptText: prompt,
+            });
 
             const terminal = vscode.window.createTerminal({
                 name: title,
@@ -101,7 +106,12 @@ export class OpenCodeProvider implements IAIProvider {
         const cliPath = this.getCliPath();
         const permissionFlag = this.getPermissionFlag();
         const tempFilePath = await createTempFile(this.context, prompt, 'background-prompt', true);
-        const commandLine = `${cliPath} ${permissionFlag}-p "$(cat "${tempFilePath}")"`;
+        const commandLine = buildPromptDispatchCommand({
+            cliInvocation: cliPath,
+            flags: `${permissionFlag}-p `,
+            promptFilePath: tempFilePath,
+            promptText: prompt,
+        });
 
         return executeCommandInHiddenTerminal({
             commandLine,

--- a/src/ai-providers/permissionValidation.ts
+++ b/src/ai-providers/permissionValidation.ts
@@ -8,10 +8,27 @@ import {
 
 const SUPPRESSED_KEY = 'speckit.permissionValidation.suppressed';
 
+const firedOverrideForProvider = new Set<AIProviderType>(); // warn once per provider
+
 export function getPermissionFlagForProvider(type: AIProviderType): string {
-    const flag = PROVIDER_PATHS[type]?.autoApproveFlag ?? '';
+    const paths = PROVIDER_PATHS[type];
+    const flag = paths?.autoApproveFlag ?? '';
     if (!flag) return '';
-    return readPermissionMode() === 'auto-approve' ? flag : '';
+
+    if (readPermissionMode() === 'auto-approve') return flag;
+
+    if (paths.supportsInteractivePermissions === false) {
+        if (!firedOverrideForProvider.has(type)) {
+            firedOverrideForProvider.add(type);
+            console.warn(
+                `[speckit] ${paths.displayName}: forcing auto-approve at dispatch — ` +
+                `the CLI cannot honor 'interactive' permissionMode in scripted mode.`
+            );
+        }
+        return flag;
+    }
+
+    return '';
 }
 
 export async function validatePermissionMode(context: vscode.ExtensionContext): Promise<void> {

--- a/src/ai-providers/qwenCliProvider.ts
+++ b/src/ai-providers/qwenCliProvider.ts
@@ -7,7 +7,7 @@ import { AIProviders, Timing } from '../core/constants';
 import { waitForShellReady, executeCommandInHiddenTerminal } from '../core/utils/terminalUtils';
 import { createTempFile } from '../core/utils/tempFileUtils';
 import { ensureCliInstalled } from '../core/utils/installUtils';
-import { IAIProvider, AIExecutionResult } from './aiProvider';
+import { IAIProvider, AIExecutionResult, buildPromptDispatchCommand } from './aiProvider';
 import { getPermissionFlagForProvider } from './permissionValidation';
 
 const execAsync = promisify(exec);
@@ -74,7 +74,12 @@ export class QwenCliProvider implements IAIProvider {
             const cliPath = this.getCliPath();
             const permissionFlag = this.getPermissionFlag();
             const tempFilePath = await createTempFile(this.context, prompt, 'prompt', true);
-            const command = `${cliPath} ${permissionFlag}-p "$(cat "${tempFilePath}")"`;
+            const command = buildPromptDispatchCommand({
+                cliInvocation: cliPath,
+                flags: `${permissionFlag}-p `,
+                promptFilePath: tempFilePath,
+                promptText: prompt,
+            });
 
             const terminal = vscode.window.createTerminal({
                 name: title,
@@ -125,7 +130,12 @@ export class QwenCliProvider implements IAIProvider {
         const cliPath = this.getCliPath();
         const permissionFlag = this.getPermissionFlag();
         const tempFilePath = await createTempFile(this.context, prompt, 'background-prompt', true);
-        const commandLine = `${cliPath} ${permissionFlag}-p "$(cat "${tempFilePath}")"`;
+        const commandLine = buildPromptDispatchCommand({
+            cliInvocation: cliPath,
+            flags: `${permissionFlag}-p `,
+            promptFilePath: tempFilePath,
+            promptText: prompt,
+        });
 
         return executeCommandInHiddenTerminal({
             commandLine,

--- a/src/core/utils/__tests__/shellDetection.test.ts
+++ b/src/core/utils/__tests__/shellDetection.test.ts
@@ -1,0 +1,94 @@
+import * as vscode from 'vscode';
+import { detectShell, formatPromptFileSubstitution } from '../shellDetection';
+
+const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')!;
+
+function setPlatform(value: string) {
+    Object.defineProperty(process, 'platform', { value, configurable: true });
+}
+
+function setShell(value: string) {
+    (vscode.env as { shell: string }).shell = value;
+}
+
+afterEach(() => {
+    Object.defineProperty(process, 'platform', originalPlatform);
+    setShell('');
+});
+
+describe('detectShell', () => {
+    it('detects pwsh.exe (Windows PowerShell 7) as powershell', () => {
+        // Use forward slashes — path.basename in this Node process is bound to the
+        // host platform (POSIX in CI/dev), so backslash-only paths return the whole
+        // string. The shell-detection logic only cares about the trailing executable.
+        setShell('C:/Program Files/PowerShell/7/pwsh.exe');
+        expect(detectShell()).toBe('powershell');
+    });
+
+    it('detects powershell.exe (Windows PowerShell 5.1) as powershell', () => {
+        setShell('C:/Windows/System32/WindowsPowerShell/v1.0/powershell.exe');
+        expect(detectShell()).toBe('powershell');
+    });
+
+    it('detects /bin/bash as bash', () => {
+        setShell('/bin/bash');
+        expect(detectShell()).toBe('bash');
+    });
+
+    it('detects /bin/zsh as bash', () => {
+        setShell('/bin/zsh');
+        expect(detectShell()).toBe('bash');
+    });
+
+    it('detects /usr/local/bin/sh as bash', () => {
+        setShell('/usr/local/bin/sh');
+        expect(detectShell()).toBe('bash');
+    });
+
+    it('detects cmd.exe as cmd', () => {
+        setShell('C:/Windows/System32/cmd.exe');
+        expect(detectShell()).toBe('cmd');
+    });
+
+    it('falls back to powershell when shell is empty on win32', () => {
+        setShell('');
+        setPlatform('win32');
+        expect(detectShell()).toBe('powershell');
+    });
+
+    it('falls back to bash when shell is empty on darwin', () => {
+        setShell('');
+        setPlatform('darwin');
+        expect(detectShell()).toBe('bash');
+    });
+
+    it('falls back to bash when shell is empty on linux', () => {
+        setShell('');
+        setPlatform('linux');
+        expect(detectShell()).toBe('bash');
+    });
+
+    it('returns unknown for an unrecognized shell path', () => {
+        setShell('/opt/fish');
+        expect(detectShell()).toBe('unknown');
+    });
+});
+
+describe('formatPromptFileSubstitution', () => {
+    it('produces $(cat "...") for bash', () => {
+        expect(formatPromptFileSubstitution('bash', '/tmp/p.md')).toBe('$(cat "/tmp/p.md")');
+    });
+
+    it('produces single-quoted Get-Content -Raw for powershell', () => {
+        expect(formatPromptFileSubstitution('powershell', 'C:\\Users\\a\\p.md'))
+            .toBe("$(Get-Content -Raw 'C:\\Users\\a\\p.md')");
+    });
+
+    it('returns empty string for cmd', () => {
+        expect(formatPromptFileSubstitution('cmd', '/anything')).toBe('');
+    });
+
+    it('falls back to bash form for unknown', () => {
+        expect(formatPromptFileSubstitution('unknown', '/tmp/p.md')).toBe('$(cat "/tmp/p.md")');
+    });
+});

--- a/src/core/utils/shellDetection.ts
+++ b/src/core/utils/shellDetection.ts
@@ -1,0 +1,30 @@
+import * as vscode from 'vscode';
+import * as path from 'path';
+
+export type Shell = 'bash' | 'powershell' | 'cmd' | 'unknown';
+
+export function detectShell(): Shell {
+    const shellPath = vscode.env.shell;
+    if (shellPath && shellPath.length > 0) {
+        const basename = path.basename(shellPath).toLowerCase().replace(/\.exe$/, '');
+        if (basename === 'pwsh' || basename === 'powershell') return 'powershell';
+        if (basename === 'cmd') return 'cmd';
+        if (basename === 'bash' || basename === 'zsh' || basename === 'sh') return 'bash';
+        return 'unknown';
+    }
+    return process.platform === 'win32' ? 'powershell' : 'bash';
+}
+
+export function formatPromptFileSubstitution(shell: Shell, absPath: string): string {
+    switch (shell) {
+        case 'powershell':
+            // Single-quoted path so `$` in the path is not expanded.
+            return `$(Get-Content -Raw '${absPath}')`;
+        case 'cmd':
+            return '';
+        case 'bash':
+        case 'unknown':
+        default:
+            return `$(cat "${absPath}")`;
+    }
+}

--- a/tests/__mocks__/vscode.ts
+++ b/tests/__mocks__/vscode.ts
@@ -130,4 +130,5 @@ export const extensions = {
 
 export const env = {
     openExternal: jest.fn(),
+    shell: '' as string,
 };


### PR DESCRIPTION
## What

- Detect the user's integrated terminal shell at dispatch time and emit shell-correct prompt syntax — `Get-Content -Raw '...'` for PowerShell, `cat "..."` for bash/zsh, embedded prompt for cmd. Routed Copilot, Claude, OpenCode, and Qwen providers through one shared `buildPromptDispatchCommand` helper.
- Force Copilot's `--yolo` flag at flag-resolution time (`getPermissionFlagForProvider`) regardless of the configured `permissionMode`, since Copilot's `-p` mode cannot surface interactive prompts and would otherwise hang silently. Emits a one-time `console.warn` so the override is visible in the Extension Host log.
- Updated `package.json` `permissionMode` description and README to document the override and Windows shell support.

## Why

Two stacked Windows-only failures made the extension unusable on default-Windows VS Code (PowerShell + Copilot): the bash-only `\$(cat \"...\")` template broke prompt dispatch with `too many arguments`, and the `interactive` permission default caused Copilot to hang silently waiting for a prompt it can never show. Both reported in #140.

## Testing

- 27 new unit tests across `shellDetection`, `buildPromptDispatchCommand`, and the `permissionValidation` override matrix (including warn-once)
- Full suite: 407/407 pass
- **Manual Windows verification still required.** These tests pin the *generated* command string per shell — they do not exercise PowerShell or Copilot CLI end-to-end. Please test on Windows + PowerShell + Copilot before merging; if you can't, ping the issue reporter on #140 with a build of this branch.

Closes #140