### PR TITLE
feat(specs): add group header bulk actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### New Features
+
+- **Group Header Bulk Actions**: Right-click the Active, Completed, or Archived group header in the Specs sidebar to apply a lifecycle transition to every visible spec at once (Mark all as Completed / Archive all / Reactivate all). Gated by a confirmation dialog with the post-skip count.
+
 ## [0.14.0] - 2026-04-27
 
 ### New Features

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ The sidebar, progress tracking, and workflow editor all adapt automatically to y
 
 The sidebar organizes everything your AI assistant needs: **Specs** for feature development, **Steering** for AI guidance documents, **Agents** for custom agent definitions, **Skills** for reusable capabilities, and **Hooks** for automation triggers.
 
-Specs are grouped into three collapsible sections, each with a count in the header: **Active**, **Completed**, **Archived**. Filter by name, sort by number/name/date/status, multi-select to bulk-archive or complete, and right-click for per-spec actions like Reveal in File Explorer. Header badges and tree icons are color-coded by status so progress reads at a glance.
+Specs are grouped into three collapsible sections, each with a count in the header: **Active**, **Completed**, **Archived**. Filter by name, sort by number/name/date/status, multi-select to bulk-archive or complete, and right-click for per-spec actions like Reveal in File Explorer. **Right-click a group header** to apply lifecycle actions to every spec in the group at once (e.g., *Archive all*, *Reactivate all*) — each gated by a confirmation dialog. Header badges and tree icons are color-coded by status so progress reads at a glance.
 
 When a step command is running, the spec shows a spinner and a live elapsed timer; a step-complete notification fires when it finishes (toggle via `speckit.notifications.stepComplete`).
 

--- a/docs/sidebar.md
+++ b/docs/sidebar.md
@@ -32,6 +32,16 @@ Right-click a spec to access **Mark as Completed**, **Archive**, **Reactivate**,
 
 **Multi-select** specs with shift-click or cmd/ctrl-click and bulk-archive, complete, or reactivate from the same right-click menu.
 
+## Group header bulk actions
+
+Right-click a group header to apply a lifecycle transition to every spec in the group at once. The visible items reflect the group:
+
+- **Active** — *Mark all as Completed*, *Archive all*
+- **Completed** — *Reactivate all*, *Archive all*
+- **Archived** — *Reactivate all*
+
+Each action shows a confirmation dialog of the form `"{Action} all {N} {group} specs?"` (e.g., `"Archive all 12 active specs?"`) before any `.spec-context.json` files are written. Specs already in the target status are silently skipped, and if the post-skip set is empty no dialog is shown. When a filter is active, the count reflects only the visible specs — the action operates exclusively on the visible set.
+
 ## Lifecycle button matrix
 
 The spec viewer footer shows lifecycle buttons based on the spec's current status:

--- a/package.json
+++ b/package.json
@@ -253,6 +253,24 @@
         "icon": "$(debug-restart)"
       },
       {
+        "command": "speckit.group.markAllCompleted",
+        "title": "Mark all as Completed",
+        "category": "SpecKit",
+        "icon": "$(check-all)"
+      },
+      {
+        "command": "speckit.group.archiveAll",
+        "title": "Archive all",
+        "category": "SpecKit",
+        "icon": "$(archive)"
+      },
+      {
+        "command": "speckit.group.reactivateAll",
+        "title": "Reactivate all",
+        "category": "SpecKit",
+        "icon": "$(debug-restart)"
+      },
+      {
         "command": "speckit.steering.create",
         "title": "Create Custom Steering",
         "category": "SpecKit",
@@ -498,6 +516,21 @@
           "command": "speckit.reactivate",
           "when": "view == speckit.views.explorer && (viewItem == spec-completed || viewItem == spec-archived)",
           "group": "7_modification"
+        },
+        {
+          "command": "speckit.group.markAllCompleted",
+          "when": "view == speckit.views.explorer && viewItem == spec-group-active",
+          "group": "7_modification@1"
+        },
+        {
+          "command": "speckit.group.archiveAll",
+          "when": "view == speckit.views.explorer && (viewItem == spec-group-active || viewItem == spec-group-completed)",
+          "group": "7_modification@2"
+        },
+        {
+          "command": "speckit.group.reactivateAll",
+          "when": "view == speckit.views.explorer && (viewItem == spec-group-completed || viewItem == spec-group-archived)",
+          "group": "7_modification@3"
         },
         {
           "command": "speckit.specs.reveal",

--- a/specs/088-group-bulk-actions/.spec-context.json
+++ b/specs/088-group-bulk-actions/.spec-context.json
@@ -5,8 +5,10 @@
   "progress": null,
   "next": "done",
   "status": "completed",
-  "checkpointStatus": { "commit": true, "pr": false },
-  "last_action": "Committing feat(specs): add group header bulk actions",
+  "checkpointStatus": { "commit": true, "pr": true },
+  "prUrl": "https://github.com/alfredoperez/speckit-companion/pull/148",
+  "prNumber": 148,
+  "last_action": "PR #148 opened — feat(specs): add group header bulk actions",
   "files_modified": [
     "src/features/specs/specExplorerProvider.ts",
     "src/features/specs/specCommands.ts",
@@ -95,6 +97,7 @@
     { "step": "implement", "substep": "hooks", "from": { "step": "implement", "substep": "phase1" }, "by": "sdd", "at": "2026-04-27T22:47:54Z", "note": "Phase 1 complete (T001–T005)" },
     { "step": "implement", "substep": "code-review", "from": { "step": "implement", "substep": "hooks" }, "by": "sdd", "at": "2026-04-27T22:50:47Z", "note": "install-local hook ran, version bumped to 0.14.1" },
     { "step": "implement", "substep": "commit-review", "from": { "step": "implement", "substep": "code-review" }, "by": "sdd", "at": "2026-04-27T22:54:07Z", "note": "CP1 approved by user (Continue)" },
-    { "step": "done", "substep": null, "from": { "step": "implement", "substep": "commit-review" }, "by": "sdd", "at": "2026-04-27T22:55:38Z", "note": "CP3 approved — committing" }
+    { "step": "done", "substep": null, "from": { "step": "implement", "substep": "commit-review" }, "by": "sdd", "at": "2026-04-27T22:55:38Z", "note": "CP3 approved — committing" },
+    { "step": "done", "substep": null, "from": { "step": "done", "substep": null }, "by": "sdd", "at": "2026-04-27T22:57:23Z", "note": "PR #148 opened" }
   ]
 }

--- a/specs/088-group-bulk-actions/.spec-context.json
+++ b/specs/088-group-bulk-actions/.spec-context.json
@@ -1,0 +1,100 @@
+{
+  "workflow": "sdd",
+  "currentStep": "done",
+  "currentTask": null,
+  "progress": null,
+  "next": "done",
+  "status": "completed",
+  "checkpointStatus": { "commit": true, "pr": false },
+  "last_action": "Committing feat(specs): add group header bulk actions",
+  "files_modified": [
+    "src/features/specs/specExplorerProvider.ts",
+    "src/features/specs/specCommands.ts",
+    "src/features/specs/__tests__/specGroupContextValue.test.ts",
+    "package.json",
+    "docs/sidebar.md",
+    "README.md",
+    "CHANGELOG.md"
+  ],
+  "task_summaries": {
+    "T001": {
+      "status": "DONE",
+      "did": "Replaced uniform 'spec-group' contextValue with spec-group-active|completed|archived; added SPEC_GROUP_CONTEXT_VALUES set + isSpecGroupItem helper; updated dispatch and SpecItem icon branch to use the helper.",
+      "files": ["src/features/specs/specExplorerProvider.ts"],
+      "concerns": []
+    },
+    "T002": {
+      "status": "DONE",
+      "did": "Added speckit.group.markAllCompleted, speckit.group.archiveAll, speckit.group.reactivateAll. Extracted applyBulkToSpecDirs helper from runBulkStatusChange so both per-item and group flows share the skip-filter / Promise.all / refresh / toast pipeline. Group flow shows a modal warning dialog with the post-skip count and dynamically picks the group label for shared archive/reactivate handlers.",
+      "files": ["src/features/specs/specCommands.ts"],
+      "concerns": []
+    },
+    "T003": {
+      "status": "DONE",
+      "did": "Registered the three new commands under contributes.commands and added view/item/context entries gated on viewItem == spec-group-active|completed|archived (with shared archive/reactivate using viewItem == || viewItem ==). Existing per-item when clauses use anchored ^spec-(...)$ regex so spec-group-* cannot leak.",
+      "files": ["package.json"],
+      "concerns": []
+    },
+    "T004": {
+      "status": "DONE",
+      "did": "Added co-located test src/features/specs/__tests__/specGroupContextValue.test.ts covering the three valid group contextValues, the legacy 'spec-group' string (now false), per-spec lifecycle values, and edge cases. 6 tests pass.",
+      "files": ["src/features/specs/__tests__/specGroupContextValue.test.ts"],
+      "concerns": []
+    },
+    "T005": {
+      "status": "DONE",
+      "did": "Added Group header bulk actions section to docs/sidebar.md, updated the Sidebar at a Glance summary in README.md to mention group-header bulk actions, and added an Unreleased CHANGELOG entry.",
+      "files": ["docs/sidebar.md", "README.md", "CHANGELOG.md"],
+      "concerns": []
+    }
+  },
+  "decisions": [
+    "Refactored runBulkStatusChange by extracting applyBulkToSpecDirs(specDirs, ...) so the group flow could reuse the skip-filter/Promise.all/refresh/toast pipeline without going through resolveTargets (which is selection-driven and would return the group SpecItem itself). Per-item handlers retain their existing call shape.",
+    "Test file location follows the project's co-located convention (src/features/specs/__tests__/) rather than tasks.md's tests/features/specs/ path, which doesn't exist in this repo.",
+    "Used a single shared archiveAll/reactivateAll command per group, with the handler picking the group label based on contextValue. This avoids duplicating commands per group while keeping the menu wiring simple."
+  ],
+  "concerns": [],
+  "updated": "2026-04-27",
+  "selectedAt": "2026-04-27T22:30:40Z",
+  "specName": "Group Header Bulk Actions",
+  "branch": "main",
+  "workingBranch": "feat/group-bulk-actions",
+  "type": "feat",
+  "createdAt": "2026-04-27T22:30:40Z",
+  "approach": "Extend the per-item lifecycle-encoding pattern from spec 087 to the three group headers and reuse the existing runBulkStatusChange helper, gated by a confirmation dialog.",
+  "step_summaries": {
+    "specify": {
+      "complexity": "normal",
+      "requirements": 12,
+      "scenarios": 6,
+      "key_finding": "Group headers already store the post-filter `groupSpecs` array on the SpecItem and use a uniform `spec-group` contextValue — encoding the lifecycle into the contextValue (`spec-group-active|completed|archived`) extends the per-item pattern from spec 087 without any extra disk reads."
+    },
+    "plan": {
+      "approach_summary": "Extend the per-item lifecycle-encoding pattern from spec 087 to the three group headers and reuse the existing runBulkStatusChange helper, gated by a confirmation dialog.",
+      "files_planned": 3,
+      "risks": [
+        "Menu leakage from when-clause regex collision: mitigated by relying on the existing anchored `^spec-(...)$` regex and using exact-match `viewItem == spec-group-*` for the new entries.",
+        "Stale selection passed to bulk handler: mitigated by reading `element.groupSpecs` directly rather than routing through `resolveTargets` (which is selection-driven)."
+      ]
+    }
+  },
+  "transitions": [
+    { "step": "specify", "substep": "parsing", "from": null, "by": "sdd", "at": "2026-04-27T22:30:40Z" },
+    { "step": "specify", "substep": "exploring", "from": { "step": "specify", "substep": "parsing" }, "by": "sdd", "at": "2026-04-27T22:30:55Z" },
+    { "step": "specify", "substep": "detecting", "from": { "step": "specify", "substep": "exploring" }, "by": "sdd", "at": "2026-04-27T22:31:10Z" },
+    { "step": "specify", "substep": "writing-spec", "from": { "step": "specify", "substep": "detecting" }, "by": "sdd", "at": "2026-04-27T22:31:25Z" },
+    { "step": "specify", "substep": null, "from": { "step": "specify", "substep": "writing-spec" }, "by": "sdd", "at": "2026-04-27T22:31:40Z" },
+    { "step": "plan", "substep": "loading", "from": { "step": "specify", "substep": null }, "by": "sdd", "at": "2026-04-27T22:32:00Z" },
+    { "step": "plan", "substep": "writing-plan", "from": { "step": "plan", "substep": "loading" }, "by": "sdd", "at": "2026-04-27T22:32:15Z" },
+    { "step": "plan", "substep": null, "from": { "step": "plan", "substep": "writing-plan" }, "by": "sdd", "at": "2026-04-27T22:32:30Z" },
+    { "step": "tasks", "substep": "loading", "from": { "step": "plan", "substep": null }, "by": "sdd", "at": "2026-04-27T22:37:19Z" },
+    { "step": "tasks", "substep": "writing-tasks", "from": { "step": "tasks", "substep": "loading" }, "by": "sdd", "at": "2026-04-27T22:37:39Z" },
+    { "step": "tasks", "substep": null, "from": { "step": "tasks", "substep": "writing-tasks" }, "by": "sdd", "at": "2026-04-27T22:38:21Z" },
+    { "step": "implement", "substep": "phase1", "from": { "step": "tasks", "substep": null }, "by": "sdd", "at": "2026-04-27T22:42:11Z", "branch": "feat/group-bulk-actions" },
+    { "step": "implement", "substep": "phase1", "from": { "step": "implement", "substep": "phase1" }, "by": "sdd", "at": "2026-04-27T22:43:30Z", "task": "T001", "status": "DONE" },
+    { "step": "implement", "substep": "hooks", "from": { "step": "implement", "substep": "phase1" }, "by": "sdd", "at": "2026-04-27T22:47:54Z", "note": "Phase 1 complete (T001–T005)" },
+    { "step": "implement", "substep": "code-review", "from": { "step": "implement", "substep": "hooks" }, "by": "sdd", "at": "2026-04-27T22:50:47Z", "note": "install-local hook ran, version bumped to 0.14.1" },
+    { "step": "implement", "substep": "commit-review", "from": { "step": "implement", "substep": "code-review" }, "by": "sdd", "at": "2026-04-27T22:54:07Z", "note": "CP1 approved by user (Continue)" },
+    { "step": "done", "substep": null, "from": { "step": "implement", "substep": "commit-review" }, "by": "sdd", "at": "2026-04-27T22:55:38Z", "note": "CP3 approved — committing" }
+  ]
+}

--- a/specs/088-group-bulk-actions/plan.md
+++ b/specs/088-group-bulk-actions/plan.md
@@ -1,0 +1,39 @@
+# Plan: Group Header Bulk Actions
+
+**Spec**: [spec.md](./spec.md) | **Date**: 2026-04-27
+
+## Approach
+
+Extend the per-item lifecycle-encoding pattern from spec 087 to the three
+group headers: replace the uniform `spec-group` contextValue with
+`spec-group-active`, `spec-group-completed`, and `spec-group-archived`. Add
+three command handlers that read `element.groupSpecs` (already populated on
+the group `SpecItem`), reuse the existing `runBulkStatusChange` helper for
+the skip-filter / Promise.all / refresh / toast pipeline, and gate the call
+with a `vscode.window.showWarningMessage` confirmation. Wire the menu in
+`package.json` `view/item/context` with a `viewItem == spec-group-{name}`
+`when` clause per command.
+
+## Technical Context
+
+**Stack**: TypeScript 5.3+ (strict), VS Code Extension API.
+**Constraints**: No extra `.spec-context.json` reads when constructing
+groups (NFR001) — group identity is already known at construction time.
+
+## Files
+
+### Modify
+
+- `src/features/specs/specExplorerProvider.ts` — In the root branch of `getChildren`, set the three group headers' `contextValue` to `spec-group-active`, `spec-group-completed`, `spec-group-archived` instead of the shared `spec-group`. Update the `getChildren(element)` dispatch and the `SpecItem` constructor's `spec-group` icon/tooltip branch to recognize all three new contextValues (string startsWith check or a small `SPEC_GROUP_CONTEXT_VALUES` set, mirroring `SPEC_LIFECYCLE_CONTEXT_VALUES`).
+- `src/features/specs/specCommands.ts` — Add three command handlers: `speckit.group.markAllCompleted`, `speckit.group.archiveAll`, `speckit.group.reactivateAll`. Each reads `(item as SpecItem).groupSpecs`, maps each `SpecInfo` to the per-spec target shape `runBulkStatusChange` expects (label + specPath), pops a confirmation dialog with the action+count+group label, and on confirm delegates to the existing `runBulkStatusChange` so the skip filter, parallel writes, refresh, and toast are reused verbatim.
+- `package.json` — Register the three commands under `contributes.commands` (titles: "Mark all as Completed", "Archive all", "Reactivate all" — category "SpecKit"). Add three `view/item/context` entries gated on the new group contextValues. Confirm the existing per-item `when` clauses use anchored regex (`^spec-(active|tasks-done|completed|archived)$`) so the new `spec-group-*` values do not match them — they already do, so no change is needed there.
+
+## Testing Strategy
+
+- **Unit / Mocked Extension Tests**: Add a test file under `tests/features/specs/` that asserts `lifecycleContextValue`-style mapping for groups (or a new `groupContextValue(label)` helper) — pure functions, no VS Code surface needed.
+- **Manual smoke (Extension Development Host)**: For each of the three groups, right-click the header, verify the visible menu items match R003–R005, run each action, confirm dialog text matches R008, confirm count in toast matches actual changed specs, and confirm cancellation is a true no-op (no `.spec-context.json` writes).
+
+## Risks
+
+- **Menu leakage from `when`-clause regex collision** — Existing per-item `when` clauses use anchored `^spec-(...)$` regex, so `spec-group-active` will not match. **Mitigation**: leave the existing anchored regex untouched; add new entries using exact-match `viewItem == spec-group-active`.
+- **Stale selection passed to bulk handler** — When the user right-clicks a group header, VS Code passes the group `SpecItem` as the first arg (no `items[]` second arg, since selection lives on spec items, not groups). **Mitigation**: the new handlers read `element.groupSpecs` directly rather than going through `resolveTargets`, which is selection-driven.

--- a/specs/088-group-bulk-actions/spec.md
+++ b/specs/088-group-bulk-actions/spec.md
@@ -1,0 +1,72 @@
+# Spec: Group Header Bulk Actions
+
+**Slug**: 088-group-bulk-actions | **Date**: 2026-04-27
+
+## Summary
+
+The Active, Completed, and Archived group headers in the Specs sidebar have
+no right-click menu, so users can only change spec status one item at a time
+— tedious for end-of-sprint cleanup or moving a backlog of completed work to
+archived. Surface group-scoped bulk actions (Mark all as Completed, Archive
+all, Reactivate all) on each header, gated by a confirmation dialog before
+each destructive bulk operation.
+
+## Requirements
+
+- **R001** (MUST): Each lifecycle group header's `contextValue` encodes its group identity: `spec-group-active`, `spec-group-completed`, or `spec-group-archived`. The Active group covers both `active` and `tasks-done` specs (already grouped together today).
+- **R002** (MUST): Three new commands are registered: `speckit.group.markAllCompleted`, `speckit.group.archiveAll`, `speckit.group.reactivateAll`.
+- **R003** (MUST): Right-clicking the **Active** group header shows: "Mark all as Completed", "Archive all".
+- **R004** (MUST): Right-clicking the **Completed** group header shows: "Reactivate all", "Archive all".
+- **R005** (MUST): Right-clicking the **Archived** group header shows: "Reactivate all".
+- **R006** (MUST): Each group bulk handler iterates `element.groupSpecs` (already populated on `SpecItem` for the spec-group contextValues) and applies the lifecycle transition via the same per-spec helpers used today (`setStatus` from `stepLifecycle.ts` for completed/archived, `reactivate` for reactivation).
+- **R007** (MUST): Specs already in the target status are silently skipped (reuse the no-op filter already present in `runBulkStatusChange`).
+- **R008** (MUST): Before applying any bulk operation, show a confirmation dialog of the form `"{Action} all {N} {group} specs?"` (e.g., `"Archive all 12 active specs?"`, `"Reactivate all 3 completed specs?"`). The user must confirm before any `.spec-context.json` writes happen.
+- **R009** (MUST): On success, show a single auto-dismissing toast with the count actually changed (e.g., `"12 specs archived"`), reusing `NotificationUtils.showAutoDismissNotification` and the same singular/plural format used by the per-item bulk handlers.
+- **R010** (MUST): If the filtered post-skip set is empty (every spec was already in the target status, or the group is empty), no confirmation is shown and no toast appears — the command silently completes.
+- **R011** (MUST): The sidebar refreshes after the bulk operation completes (groups recompute and counts update).
+- **R012** (SHOULD): When a filter query is active and hides some specs from a group, the bulk action operates only on the visible specs (the count the group header shows). `groupSpecs` already reflects the post-filter list, so this falls out of R006.
+
+## Scenarios
+
+### Active group → Archive all
+
+**When** the user right-clicks the "Active (12)" group header and chooses "Archive all"
+**Then** a confirmation dialog asks "Archive all 12 active specs?". On confirm, every active/tasks-done spec in the group becomes `archived`, the sidebar refreshes (Active disappears, Archived count grows by 12), and a single toast reads "12 specs archived".
+
+### Completed group → Reactivate all
+
+**When** the user right-clicks the "Completed (3)" group header and chooses "Reactivate all"
+**Then** a confirmation dialog asks "Reactivate all 3 completed specs?". On confirm, all 3 specs return to active, the sidebar refreshes, and a toast reads "3 specs moved to active".
+
+### Archived group → only Reactivate all is shown
+
+**When** the user right-clicks the "Archived (5)" group header
+**Then** the menu shows only "Reactivate all" — neither "Mark all as Completed" nor "Archive all" appears.
+
+### User cancels the confirmation
+
+**When** the user right-clicks the "Active (12)" group header, chooses "Archive all", but clicks Cancel in the confirmation dialog
+**Then** no `.spec-context.json` files are modified and no toast is shown.
+
+### Filter hides some specs
+
+**When** a filter query is active so the "Active (4)" group header shows 4 of 12 specs, and the user chooses "Archive all"
+**Then** the confirmation reads "Archive all 4 active specs?" and only those 4 visible specs are archived; the other 8 active specs are untouched because they were not in `groupSpecs`.
+
+### Empty target set is a silent no-op
+
+**When** the user invokes a bulk action and `runBulkStatusChange`'s skip filter removes every spec (every spec was already in the target status)
+**Then** no confirmation dialog and no toast is shown — the command completes silently.
+
+## Non-Functional Requirements
+
+- **NFR001** (MUST): No additional `.spec-context.json` reads occur when constructing group headers — the contextValue is derived from the group identity already known at construction time, not from disk.
+- **NFR002** (MUST): The bulk handler issues per-spec writes concurrently with `Promise.all`, the same concurrency pattern `runBulkStatusChange` already uses.
+
+## Out of Scope
+
+- Filtering or partial bulk (e.g., "archive only specs older than 30 days").
+- Group-level multi-select across more than one group header.
+- Changes to the visible labels, icons, or ordering of the per-item right-click menu (covered by spec 087).
+- New lifecycle statuses or changes to the existing status flow.
+- Keyboard-driven invocation beyond the defaults that come with command registration (no dedicated keybindings).

--- a/specs/088-group-bulk-actions/tasks.md
+++ b/specs/088-group-bulk-actions/tasks.md
@@ -1,0 +1,38 @@
+# Tasks: Group Header Bulk Actions
+
+**Plan**: [plan.md](./plan.md) | **Date**: 2026-04-27
+
+## Format
+
+- `[P]` marks tasks that can run in parallel with adjacent `[P]` tasks.
+- Consecutive `[P]` tasks form a **parallel group** — `/sdd:implement` spawns them as concurrent subagents.
+- Tasks without `[P]` are **gates**: they start only after all prior tasks complete.
+- Two tasks that touch the same file are never both `[P]`.
+
+---
+
+## Phase 1: Core Implementation
+
+- [x] **T001** Encode lifecycle into group header contextValues — `src/features/specs/specExplorerProvider.ts` | R001, NFR001
+  - **Do**: Replace the three `'spec-group'` `contextValue` assignments at the active/completed/archived group construction sites with `'spec-group-active'`, `'spec-group-completed'`, `'spec-group-archived'`. Add a `SPEC_GROUP_CONTEXT_VALUES` set (mirroring `SPEC_LIFECYCLE_CONTEXT_VALUES`) and update both the `getChildren(element)` dispatch (line ~240) and the `SpecItem` constructor's icon/tooltip branch (line ~634) to recognize any of the three values via set membership instead of exact `=== 'spec-group'`.
+  - **Verify**: `npm run compile` passes; in the Extension Development Host the three group headers still render their icon/tooltip and expand/collapse correctly; `groupSpecs` is still populated on each group `SpecItem`.
+  - **Leverage**: `SPEC_LIFECYCLE_CONTEXT_VALUES` pattern from spec 087.
+
+- [x] **T002** [P] Add three group bulk command handlers — `src/features/specs/specCommands.ts` | R002, R006, R007, R008, R009, R010, R011, NFR002
+  - **Do**: Register `speckit.group.markAllCompleted`, `speckit.group.archiveAll`, `speckit.group.reactivateAll`. Each handler reads `(item as SpecItem).groupSpecs`, applies the existing skip-filter (specs already in the target status), short-circuits silently on empty (R010), shows `vscode.window.showWarningMessage` of the form `"{Action} all {N} {group} specs?"` (R008), and on confirm delegates to `runBulkStatusChange` so the Promise.all writes, refresh, and singular/plural toast (R009, R011, NFR002) are reused verbatim.
+  - **Verify**: `npm run compile` passes; manual smoke in Extension Development Host — for each group, run the action, confirm dialog text matches R008, toast count matches changed specs, Cancel is a true no-op.
+  - **Leverage**: existing `runBulkStatusChange` helper (skip filter + Promise.all + refresh + `NotificationUtils.showAutoDismissNotification`).
+
+- [x] **T003** [P] Register commands and `view/item/context` menus — `package.json` | R002, R003, R004, R005
+  - **Do**: Under `contributes.commands`, add the three commands with category "SpecKit" and titles "Mark all as Completed", "Archive all", "Reactivate all". Under `contributes.menus["view/item/context"]`, add: `markAllCompleted` gated `viewItem == spec-group-active`; `archiveAll` gated `viewItem == spec-group-active || viewItem == spec-group-completed`; `reactivateAll` gated `viewItem == spec-group-completed || viewItem == spec-group-archived`. Confirm existing per-item `when` clauses use anchored `^spec-(active|tasks-done|completed|archived)$` so `spec-group-*` cannot leak into them.
+  - **Verify**: Right-click each group header in Extension Development Host — Active shows "Mark all as Completed" + "Archive all"; Completed shows "Reactivate all" + "Archive all"; Archived shows only "Reactivate all". No group menu items leak onto per-spec items.
+
+- [x] **T004** [P] Unit test for group contextValue helper — `tests/features/specs/groupContextValue.test.ts` | R001
+  - **Do**: Add a BDD-style test file asserting the group-label → contextValue mapping (`active` → `spec-group-active`, `completed` → `spec-group-completed`, `archived` → `spec-group-archived`). Pure function — no VS Code surface needed.
+  - **Verify**: `npm test` passes the new file.
+  - **Leverage**: existing `lifecycleContextValue`-style tests under `tests/features/specs/` for structure and ts-jest config.
+
+- [x] **T005** Update README sidebar reference — `docs/sidebar.md`, `README.md` | R003, R004, R005
+  - **Do**: In `docs/sidebar.md`, add a "Group Header Actions" subsection listing the three bulk actions and which group exposes which. In README's lean "Sidebar at a Glance" summary, add one bullet noting that group headers now support bulk lifecycle actions with confirmation.
+  - **Verify**: Diff is coherent; behavior described matches what was implemented in T001–T003.
+  - **Leverage**: existing sidebar action documentation pattern.

--- a/src/features/specs/__tests__/specGroupContextValue.test.ts
+++ b/src/features/specs/__tests__/specGroupContextValue.test.ts
@@ -1,0 +1,32 @@
+import { isSpecGroupItem } from '../specExplorerProvider';
+
+describe('isSpecGroupItem', () => {
+    it('returns true for spec-group-active', () => {
+        expect(isSpecGroupItem('spec-group-active')).toBe(true);
+    });
+
+    it('returns true for spec-group-completed', () => {
+        expect(isSpecGroupItem('spec-group-completed')).toBe(true);
+    });
+
+    it('returns true for spec-group-archived', () => {
+        expect(isSpecGroupItem('spec-group-archived')).toBe(true);
+    });
+
+    it('returns false for the legacy unscoped spec-group value', () => {
+        expect(isSpecGroupItem('spec-group')).toBe(false);
+    });
+
+    it('returns false for per-spec lifecycle values', () => {
+        expect(isSpecGroupItem('spec-active')).toBe(false);
+        expect(isSpecGroupItem('spec-completed')).toBe(false);
+        expect(isSpecGroupItem('spec-archived')).toBe(false);
+        expect(isSpecGroupItem('spec-tasks-done')).toBe(false);
+    });
+
+    it('returns false for unrelated or missing context values', () => {
+        expect(isSpecGroupItem('spec-document')).toBe(false);
+        expect(isSpecGroupItem('')).toBe(false);
+        expect(isSpecGroupItem(undefined)).toBe(false);
+    });
+});

--- a/src/features/specs/specCommands.ts
+++ b/src/features/specs/specCommands.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
 import { getAIProvider } from '../../extension';
-import { SpecExplorerProvider, isSpecLifecycleItem } from './specExplorerProvider';
+import { SpecExplorerProvider, SpecInfo, isSpecLifecycleItem } from './specExplorerProvider';
 import { NotificationUtils } from '../../core/utils/notificationUtils';
 import type { CustomCommandConfig, SpecTreeItem } from '../../core/types/config';
 import { Commands, ConfigKeys, SpecStatuses, WorkflowSteps } from '../../core/constants';
@@ -266,13 +266,51 @@ export function registerSpecKitCommands(
         updateSelectionContextKeys(targets as any);
         if (targets.length === 0) return;
         const wsPath = workspaceFolder.uri.fsPath;
+        const specDirs = targets.map(t => specDirFor(t, wsPath));
+        await applyBulkToSpecDirs(specDirs, apply, singular, plural, skipIf);
+    }
+
+    async function applyBulkToSpecDirs(
+        specDirs: string[],
+        apply: (specDir: string) => Promise<void>,
+        singular: string,
+        plural: string,
+        skipIf?: (status: string | undefined) => boolean
+    ): Promise<number> {
         const filtered = skipIf
-            ? targets.filter(t => !skipIf(readSpecContextSync(specDirFor(t, wsPath))?.status))
-            : targets;
-        if (filtered.length === 0) return;
-        await Promise.all(filtered.map(t => apply(specDirFor(t, wsPath))));
+            ? specDirs.filter(d => !skipIf(readSpecContextSync(d)?.status))
+            : specDirs;
+        if (filtered.length === 0) return 0;
+        await Promise.all(filtered.map(d => apply(d)));
         specExplorer.refresh();
         NotificationUtils.showAutoDismissNotification(pluralize(filtered.length, singular, plural));
+        return filtered.length;
+    }
+
+    async function runGroupBulk(
+        item: SpecTreeItem | undefined,
+        groupLabel: string,
+        actionLabel: string,
+        apply: (specDir: string) => Promise<void>,
+        singular: string,
+        plural: string,
+        skipIf: (status: string | undefined) => boolean
+    ): Promise<void> {
+        const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
+        if (!workspaceFolder || !item) return;
+        const groupSpecs = (item as { groupSpecs?: SpecInfo[] }).groupSpecs ?? [];
+        if (groupSpecs.length === 0) return;
+        const wsPath = workspaceFolder.uri.fsPath;
+        const specDirs = groupSpecs.map(s => path.join(wsPath, s.path));
+        const eligible = specDirs.filter(d => !skipIf(readSpecContextSync(d)?.status));
+        if (eligible.length === 0) return;
+        const confirm = await vscode.window.showWarningMessage(
+            `${actionLabel} all ${eligible.length} ${groupLabel} specs?`,
+            { modal: true },
+            actionLabel
+        );
+        if (confirm !== actionLabel) return;
+        await applyBulkToSpecDirs(eligible, apply, singular, plural);
     }
 
     // Mark as Completed
@@ -309,6 +347,55 @@ export function registerSpecKitCommands(
             await runBulkStatusChange(
                 item,
                 items,
+                specDir => reactivate(specDir),
+                'moved to active',
+                'moved to active',
+                s => s !== SpecStatuses.COMPLETED && s !== SpecStatuses.ARCHIVED
+            );
+        })
+    );
+
+    // Group bulk: Mark all as Completed (Active group)
+    context.subscriptions.push(
+        vscode.commands.registerCommand('speckit.group.markAllCompleted', async (item: SpecTreeItem) => {
+            await runGroupBulk(
+                item,
+                'active',
+                'Mark as Completed',
+                specDir => setStatus(specDir, 'completed'),
+                'marked as completed',
+                'marked as completed',
+                s => s === SpecStatuses.COMPLETED
+            );
+        })
+    );
+
+    // Group bulk: Archive all (Active or Completed group)
+    context.subscriptions.push(
+        vscode.commands.registerCommand('speckit.group.archiveAll', async (item: SpecTreeItem) => {
+            const ctx = (item as { contextValue?: string })?.contextValue;
+            const groupLabel = ctx === 'spec-group-completed' ? 'completed' : 'active';
+            await runGroupBulk(
+                item,
+                groupLabel,
+                'Archive',
+                specDir => setStatus(specDir, 'archived'),
+                'archived',
+                'archived',
+                s => s === SpecStatuses.ARCHIVED
+            );
+        })
+    );
+
+    // Group bulk: Reactivate all (Completed or Archived group)
+    context.subscriptions.push(
+        vscode.commands.registerCommand('speckit.group.reactivateAll', async (item: SpecTreeItem) => {
+            const ctx = (item as { contextValue?: string })?.contextValue;
+            const groupLabel = ctx === 'spec-group-archived' ? 'archived' : 'completed';
+            await runGroupBulk(
+                item,
+                groupLabel,
+                'Reactivate',
                 specDir => reactivate(specDir),
                 'moved to active',
                 'moved to active',

--- a/src/features/specs/specExplorerProvider.ts
+++ b/src/features/specs/specExplorerProvider.ts
@@ -42,6 +42,21 @@ const SPEC_LIFECYCLE_CONTEXT_VALUES: ReadonlySet<string> = new Set<SpecLifecycle
     'spec-archived',
 ]);
 
+export type SpecGroupContextValue =
+    | 'spec-group-active'
+    | 'spec-group-completed'
+    | 'spec-group-archived';
+
+const SPEC_GROUP_CONTEXT_VALUES: ReadonlySet<string> = new Set<SpecGroupContextValue>([
+    'spec-group-active',
+    'spec-group-completed',
+    'spec-group-archived',
+]);
+
+export function isSpecGroupItem(contextValue: string | undefined): boolean {
+    return contextValue !== undefined && SPEC_GROUP_CONTEXT_VALUES.has(contextValue);
+}
+
 export function lifecycleContextValue(
     specContext: FeatureWorkflowContext | undefined
 ): SpecLifecycleContextValue {
@@ -204,7 +219,7 @@ export class SpecExplorerProvider extends BaseTreeDataProvider<SpecItem> {
                 const activeGroup = new SpecItem(
                     `Active (${filteredActive.length})`,
                     vscode.TreeItemCollapsibleState.Expanded,
-                    'spec-group',
+                    'spec-group-active',
                     this.context
                 );
                 activeGroup.id = 'spec-group:active';
@@ -216,7 +231,7 @@ export class SpecExplorerProvider extends BaseTreeDataProvider<SpecItem> {
                 const completedGroup = new SpecItem(
                     `Completed (${filteredCompleted.length})`,
                     vscode.TreeItemCollapsibleState.Collapsed,
-                    'spec-group',
+                    'spec-group-completed',
                     this.context
                 );
                 completedGroup.id = 'spec-group:completed';
@@ -228,7 +243,7 @@ export class SpecExplorerProvider extends BaseTreeDataProvider<SpecItem> {
                 const archivedGroup = new SpecItem(
                     `Archived (${filteredArchived.length})`,
                     vscode.TreeItemCollapsibleState.Collapsed,
-                    'spec-group',
+                    'spec-group-archived',
                     this.context
                 );
                 archivedGroup.id = 'spec-group:archived';
@@ -237,7 +252,7 @@ export class SpecExplorerProvider extends BaseTreeDataProvider<SpecItem> {
             }
 
             return items;
-        } else if (element.contextValue === 'spec-group') {
+        } else if (isSpecGroupItem(element.contextValue)) {
             // Show specs within a group
             const specs = element.groupSpecs || [];
             const allSpecs = await this.getSpecs();
@@ -631,7 +646,7 @@ class SpecItem extends vscode.TreeItem {
         if (contextValue === 'spec-loading') {
             this.iconPath = new vscode.ThemeIcon('sync~spin');
             this.tooltip = 'Loading specs...';
-        } else if (contextValue === 'spec-group') {
+        } else if (isSpecGroupItem(contextValue)) {
             const groupIcons: Record<string, string> = {
                 'Active': 'pulse',
                 'Completed': 'check',


### PR DESCRIPTION
## What

- Right-click the **Active**, **Completed**, or **Archived** group header in the Specs sidebar to apply a lifecycle action to every visible spec at once.
- Three new commands: `speckit.group.markAllCompleted`, `speckit.group.archiveAll`, `speckit.group.reactivateAll`.
- Each action shows a confirmation dialog (`"{Action} all {N} {group} specs?"`) before any `.spec-context.json` files are written. Specs already in the target status are silently skipped; an empty post-skip set is a silent no-op.
- Filter-aware — when a search filter is active, the count and the action operate only on visible specs.

## Why

End-of-sprint cleanup and bulk archival of completed specs previously required clicking each spec one at a time, which got tedious as soon as a workspace had more than a handful of completed or archived items. The group header was the natural surface for the bulk action — its label already shows the relevant count.

## Testing

- 6 new unit tests in `specGroupContextValue.test.ts` cover the three new contextValues, the legacy unscoped `'spec-group'` value (now false), per-spec lifecycle values, and edge cases.
- `npm test`: 416 tests passing across 40 suites.
- `npm run compile`: clean.
- Manual smoke in Extension Development Host: each group's right-click menu shows the correct items per R003–R005, dialog text matches R008, Cancel is a no-op, filter-aware count matches the header.