### PR TITLE
feat(specs): copy spec path or name from right-click menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ The sidebar, progress tracking, and workflow editor all adapt automatically to y
 
 The sidebar organizes everything your AI assistant needs: **Specs** for feature development, **Steering** for AI guidance documents, **Agents** for custom agent definitions, **Skills** for reusable capabilities, and **Hooks** for automation triggers.
 
-Specs are grouped into three collapsible sections, each with a count in the header: **Active**, **Completed**, **Archived**. Filter by name, sort by number/name/date/status, multi-select to bulk-archive or complete, and right-click for per-spec actions like Reveal in File Explorer. **Right-click a group header** to apply lifecycle actions to every spec in the group at once (e.g., *Archive all*, *Reactivate all*) — each gated by a confirmation dialog. Header badges and tree icons are color-coded by status so progress reads at a glance.
+Specs are grouped into three collapsible sections, each with a count in the header: **Active**, **Completed**, **Archived**. Filter by name, sort by number/name/date/status, multi-select to bulk-archive or complete, and right-click for per-spec actions like Reveal in File Explorer. Right-click also offers **Copy Path** (workspace-relative path) and **Copy Name** (slug only) for referencing specs in PRs, chat, or external tools. **Right-click a group header** to apply lifecycle actions to every spec in the group at once (e.g., *Archive all*, *Reactivate all*) — each gated by a confirmation dialog. Header badges and tree icons are color-coded by status so progress reads at a glance.
 
 When a step command is running, the spec shows a spinner and a live elapsed timer; a step-complete notification fires when it finishes (toggle via `speckit.notifications.stepComplete`).
 

--- a/docs/sidebar.md
+++ b/docs/sidebar.md
@@ -28,7 +28,9 @@ Ties fall back to numeric prefix then name so output is deterministic. The chose
 
 ## Right-click and multi-select
 
-Right-click a spec to access **Mark as Completed**, **Archive**, **Reactivate**, **Delete**, and **Reveal in File Explorer** (opens the spec's folder in Finder, File Explorer, or the default file manager). Menu items reflect the spec's lifecycle group — e.g., "Reactivate" appears only on completed or archived specs, "Mark as Completed" only on active ones.
+Right-click a spec to access **Mark as Completed**, **Archive**, **Reactivate**, **Delete**, **Reveal in File Explorer** (opens the spec's folder in Finder, File Explorer, or the default file manager), **Copy Path**, and **Copy Name**. Menu items reflect the spec's lifecycle group — e.g., "Reactivate" appears only on completed or archived specs, "Mark as Completed" only on active ones.
+
+**Copy Path** copies the workspace-relative spec directory (e.g. `specs/089-copy-spec-path-name`) to the clipboard; **Copy Name** copies just the slug (e.g. `089-copy-spec-path-name`). Both show a brief auto-dismiss notification and live in a `9_clipboard` group below the modification and reveal entries — useful when referencing a spec in PRs, chat, or external tools. They appear on specs in any lifecycle (active, tasks-done, completed, archived) and are not shown on document children, related docs, or group headers.
 
 **Multi-select** specs with shift-click or cmd/ctrl-click and bulk-archive, complete, or reactivate from the same right-click menu.
 

--- a/package.json
+++ b/package.json
@@ -441,6 +441,16 @@
         "command": "speckit.specs.revealInExplorer",
         "title": "Reveal in Explorer View",
         "category": "SpecKit"
+      },
+      {
+        "command": "speckit.specs.copyPath",
+        "title": "Copy Path",
+        "category": "SpecKit"
+      },
+      {
+        "command": "speckit.specs.copyName",
+        "title": "Copy Name",
+        "category": "SpecKit"
       }
     ],
     "menus": {
@@ -566,6 +576,16 @@
           "command": "speckit.openSpecSource",
           "when": "view == speckit.views.explorer && viewItem =~ /spec-document-/",
           "group": "inline"
+        },
+        {
+          "command": "speckit.specs.copyPath",
+          "when": "view == speckit.views.explorer && viewItem =~ /^spec-(active|tasks-done|completed|archived)$/",
+          "group": "9_clipboard@1"
+        },
+        {
+          "command": "speckit.specs.copyName",
+          "when": "view == speckit.views.explorer && viewItem =~ /^spec-(active|tasks-done|completed|archived)$/",
+          "group": "9_clipboard@2"
         }
       ],
       "commandPalette": [
@@ -627,6 +647,14 @@
         },
         {
           "command": "speckit.openSpecSource",
+          "when": "false"
+        },
+        {
+          "command": "speckit.specs.copyPath",
+          "when": "false"
+        },
+        {
+          "command": "speckit.specs.copyName",
           "when": "false"
         }
       ]

--- a/specs/089-copy-spec-path-name/.spec-context.json
+++ b/specs/089-copy-spec-path-name/.spec-context.json
@@ -1,0 +1,92 @@
+{
+  "workflow": "sdd",
+  "currentStep": "done",
+  "currentTask": null,
+  "progress": null,
+  "next": "done",
+  "status": "completed",
+  "checkpointStatus": { "commit": false, "pr": false },
+  "updated": "2026-04-27",
+  "selectedAt": "2026-04-27T23:04:37Z",
+  "specName": "Copy Spec Path / Name",
+  "branch": "main",
+  "workingBranch": "feat/089-copy-spec-path-name",
+  "type": "feat",
+  "createdAt": "2026-04-27T23:04:37Z",
+  "approach": "Add speckit.specs.copyPath and speckit.specs.copyName commands following the existing reveal-handler pattern in specCommands.ts; wire via package.json view/item/context in a new 9_clipboard group.",
+  "last_action": "CP3 approved — about to commit and push.",
+  "files_modified": [
+    "src/features/specs/specCommands.ts",
+    "package.json",
+    "src/features/specs/specCommands.test.ts",
+    "tests/__mocks__/vscode.ts",
+    "docs/sidebar.md",
+    "README.md"
+  ],
+  "task_summaries": {
+    "T001": {
+      "status": "DONE",
+      "did": "Registered speckit.specs.copyPath and speckit.specs.copyName handlers using vscode.env.clipboard.writeText + NotificationUtils.showAutoDismissNotification, mirroring the reveal-handler pattern.",
+      "files": ["src/features/specs/specCommands.ts"],
+      "concerns": []
+    },
+    "T002": {
+      "status": "DONE",
+      "did": "Declared both commands in package.json and wired view/item/context entries in a new 9_clipboard group; added when:false palette entries.",
+      "files": ["package.json"],
+      "concerns": []
+    },
+    "T003": {
+      "status": "DONE",
+      "did": "Added 8 BDD-style Jest tests (4 per handler) covering specPath path, label fallback, notification, and undefined-item no-op. Added clipboard.writeText mock to tests/__mocks__/vscode.ts.",
+      "files": ["src/features/specs/specCommands.test.ts", "tests/__mocks__/vscode.ts"],
+      "concerns": []
+    },
+    "T004": {
+      "status": "DONE",
+      "did": "Documented Copy Path / Copy Name in docs/sidebar.md under the 'Right-click and multi-select' section, noting the 9_clipboard group placement and use cases.",
+      "files": ["docs/sidebar.md"],
+      "concerns": []
+    },
+    "T005": {
+      "status": "DONE",
+      "did": "Added a one-line mention of Copy Path / Copy Name to README's 'Sidebar at a Glance' section.",
+      "files": ["README.md"],
+      "concerns": []
+    }
+  },
+  "step_summaries": {
+    "specify": {
+      "complexity": "normal",
+      "requirements": 7,
+      "scenarios": 4,
+      "key_finding": "speckit.specs.reveal/revealInExplorer in src/features/specs/specCommands.ts establishes the pattern: read item.specPath (fallback to specs/${item.label}), wired via package.json view/item/context for viewItem matching ^spec-(active|tasks-done|completed|archived)$"
+    },
+    "plan": {
+      "approach_summary": "Add speckit.specs.copyPath and speckit.specs.copyName commands following the existing reveal-handler pattern in specCommands.ts; wire via package.json view/item/context in a new 9_clipboard group.",
+      "files_planned": 5,
+      "risks": []
+    }
+  },
+  "transitions": [
+    { "step": "specify", "substep": "parsing", "from": null, "by": "sdd", "at": "2026-04-27T23:04:37Z" },
+    { "step": "specify", "substep": "exploring", "from": { "step": "specify", "substep": "parsing" }, "by": "sdd", "at": "2026-04-27T23:05:00Z" },
+    { "step": "specify", "substep": "detecting", "from": { "step": "specify", "substep": "exploring" }, "by": "sdd", "at": "2026-04-27T23:05:30Z" },
+    { "step": "specify", "substep": "writing-spec", "from": { "step": "specify", "substep": "detecting" }, "by": "sdd", "at": "2026-04-27T23:06:00Z" },
+    { "step": "specify", "substep": null, "from": { "step": "specify", "substep": "writing-spec" }, "by": "sdd", "at": "2026-04-27T23:07:00Z" },
+    { "step": "plan", "substep": "loading", "from": { "step": "specify", "substep": null }, "by": "sdd", "at": "2026-04-27T23:08:00Z" },
+    { "step": "plan", "substep": "writing-plan", "from": { "step": "plan", "substep": "loading" }, "by": "sdd", "at": "2026-04-27T23:08:30Z" },
+    { "step": "plan", "substep": null, "from": { "step": "plan", "substep": "writing-plan" }, "by": "sdd", "at": "2026-04-27T23:09:00Z" },
+    { "step": "tasks", "substep": "loading", "from": { "step": "plan", "substep": null }, "by": "sdd", "at": "2026-04-27T23:10:00Z" },
+    { "step": "tasks", "substep": "writing-tasks", "from": { "step": "tasks", "substep": "loading" }, "by": "sdd", "at": "2026-04-27T23:10:30Z" },
+    { "step": "tasks", "substep": null, "from": { "step": "tasks", "substep": "writing-tasks" }, "by": "sdd", "at": "2026-04-27T23:11:00Z" },
+    { "step": "implement", "substep": "phase1", "from": { "step": "tasks", "substep": null }, "by": "sdd", "at": "2026-04-27T23:12:00Z" },
+    { "step": "implement", "substep": "phase1", "from": { "step": "implement", "substep": "phase1" }, "by": "sdd", "at": "2026-04-27T23:13:00Z" },
+    { "step": "implement", "substep": "phase1", "from": { "step": "implement", "substep": "phase1" }, "by": "sdd", "at": "2026-04-27T23:20:00Z" },
+    { "step": "implement", "substep": "hooks", "from": { "step": "implement", "substep": "phase1" }, "by": "sdd", "at": "2026-04-27T23:21:00Z" },
+    { "step": "implement", "substep": "code-review", "from": { "step": "implement", "substep": "hooks" }, "by": "sdd", "at": "2026-04-27T23:25:00Z" },
+    { "step": "implement", "substep": "test-results", "from": { "step": "implement", "substep": "code-review" }, "by": "sdd", "at": "2026-04-27T23:30:00Z" },
+    { "step": "implement", "substep": "commit-review", "from": { "step": "implement", "substep": "test-results" }, "by": "sdd", "at": "2026-04-27T23:30:30Z" },
+    { "step": "done", "substep": null, "from": { "step": "implement", "substep": "commit-review" }, "by": "sdd", "at": "2026-04-27T23:31:00Z" }
+  ]
+}

--- a/specs/089-copy-spec-path-name/.spec-context.json
+++ b/specs/089-copy-spec-path-name/.spec-context.json
@@ -5,7 +5,9 @@
   "progress": null,
   "next": "done",
   "status": "completed",
-  "checkpointStatus": { "commit": false, "pr": false },
+  "checkpointStatus": { "commit": true, "pr": true },
+  "prUrl": "https://github.com/alfredoperez/speckit-companion/pull/149",
+  "prNumber": 149,
   "updated": "2026-04-27",
   "selectedAt": "2026-04-27T23:04:37Z",
   "specName": "Copy Spec Path / Name",
@@ -14,7 +16,7 @@
   "type": "feat",
   "createdAt": "2026-04-27T23:04:37Z",
   "approach": "Add speckit.specs.copyPath and speckit.specs.copyName commands following the existing reveal-handler pattern in specCommands.ts; wire via package.json view/item/context in a new 9_clipboard group.",
-  "last_action": "CP3 approved — about to commit and push.",
+  "last_action": "PR #149 opened — feat(specs): copy spec path or name from right-click menu",
   "files_modified": [
     "src/features/specs/specCommands.ts",
     "package.json",
@@ -87,6 +89,7 @@
     { "step": "implement", "substep": "code-review", "from": { "step": "implement", "substep": "hooks" }, "by": "sdd", "at": "2026-04-27T23:25:00Z" },
     { "step": "implement", "substep": "test-results", "from": { "step": "implement", "substep": "code-review" }, "by": "sdd", "at": "2026-04-27T23:30:00Z" },
     { "step": "implement", "substep": "commit-review", "from": { "step": "implement", "substep": "test-results" }, "by": "sdd", "at": "2026-04-27T23:30:30Z" },
-    { "step": "done", "substep": null, "from": { "step": "implement", "substep": "commit-review" }, "by": "sdd", "at": "2026-04-27T23:31:00Z" }
+    { "step": "done", "substep": null, "from": { "step": "implement", "substep": "commit-review" }, "by": "sdd", "at": "2026-04-27T23:31:00Z" },
+    { "step": "done", "substep": null, "from": { "step": "done", "substep": null }, "by": "sdd", "at": "2026-04-27T23:35:00Z" }
   ]
 }

--- a/specs/089-copy-spec-path-name/plan.md
+++ b/specs/089-copy-spec-path-name/plan.md
@@ -1,0 +1,37 @@
+# Plan: Copy Spec Path / Name
+
+**Spec**: [spec.md](./spec.md) | **Date**: 2026-04-27
+
+## Approach
+
+Add two new commands (`speckit.specs.copyPath`, `speckit.specs.copyName`) following the exact pattern used by `speckit.specs.reveal`/`speckit.specs.revealInExplorer` in `src/features/specs/specCommands.ts`: each handler resolves the spec slug from the tree item (`item.specPath` with `specs/${item.label}` fallback), writes to `vscode.env.clipboard`, and confirms via `NotificationUtils.showAutoDismissNotification`. Wire both into `package.json` `contributes.commands`, `view/item/context` (new `9_clipboard` group, restricted to `^spec-(active|tasks-done|completed|archived)$`), and `commandPalette` with `when: false` so they stay sidebar-only.
+
+## Technical Context
+
+**Stack**: TypeScript 5.3+ (ES2022, strict), VS Code Extension API (`@types/vscode ^1.84.0`), Jest + ts-jest for tests
+**Key Dependencies**: `vscode.env.clipboard.writeText` (built-in), `NotificationUtils.showAutoDismissNotification` (existing)
+**Constraints**: No platform branching — clipboard must work on macOS/Windows/Linux uniformly; menu entries must be hidden from the command palette since they require a tree-item argument.
+
+## Files
+
+### Create
+
+- _(none)_ — fully reuses existing modules
+
+### Modify
+
+- `package.json` — declare two new commands under `contributes.commands`, add two `view/item/context` entries in a new `9_clipboard` group, add two `commandPalette` entries with `when: false`
+- `src/features/specs/specCommands.ts` — register the two new command handlers next to the existing reveal handlers (same workspace + slug-resolution pattern, plus `vscode.env.clipboard.writeText`)
+- `src/features/specs/specCommands.test.ts` — BDD-style tests for both handlers (clipboard write, notification, fallback path when `specPath` is missing)
+- `README.md` — extend the "Sidebar at a Glance" section with the new context-menu entries
+- `docs/sidebar.md` — document the two new right-click actions in the right-click menu reference table
+
+## Testing Strategy
+
+- **Unit (Jest)**: For each handler, assert `vscode.env.clipboard.writeText` is called with the expected string for both shapes — `(a)` an item with `specPath = "specs/089-copy-spec-path-name"`, and `(b)` an item with only `label` set (fallback path). Assert `NotificationUtils.showAutoDismissNotification` is invoked.
+- **Mock additions**: Add `env.clipboard.writeText` to `tests/__mocks__/vscode.ts` if not already present.
+- **Edge cases from spec**: legacy item without `specPath`; document/group context values must not show the entry (verified by `package.json` `when` clause review, not runtime).
+
+## Risks
+
+- _(none — additive feature with no shared state, no migration, no existing behavior changed)_

--- a/specs/089-copy-spec-path-name/spec.md
+++ b/specs/089-copy-spec-path-name/spec.md
@@ -1,0 +1,51 @@
+# Spec: Copy Spec Path / Name
+
+**Slug**: 089-copy-spec-path-name | **Date**: 2026-04-27
+
+## Summary
+
+Add right-click menu entries on spec items in the sidebar to copy the spec's workspace-relative path or its slug to the clipboard. This makes it trivial to reference a spec in chat, PRs, commits, or external tools without retyping the directory name.
+
+## Requirements
+
+- **R001** (MUST): Right-clicking a spec item (any lifecycle: active, tasks-done, completed, archived) shows two new context-menu entries: **Copy Path** and **Copy Name**.
+- **R002** (MUST): **Copy Path** writes the workspace-relative spec directory path to the system clipboard (e.g. `specs/089-copy-spec-path-name`). Forward slashes only — no leading slash, no platform-specific separators.
+- **R003** (MUST): **Copy Name** writes the spec slug (the directory name, e.g. `089-copy-spec-path-name`) to the system clipboard.
+- **R004** (MUST): After copying, show a transient confirmation notification (e.g. `Copied "specs/089-copy-spec-path-name"`) using the same auto-dismiss pattern other sidebar actions use.
+- **R005** (SHOULD): Both entries appear under a dedicated `9_clipboard` group in the context menu, placed below the existing `7_modification` and reveal entries so destructive/navigation actions stay visually primary.
+- **R006** (SHOULD): The copy entries are hidden from the command palette (registered with `when: false` like other internal sidebar commands), since they require a tree-item argument.
+- **R007** (MAY): Entries are only shown for spec items, not for document children (`spec-document-*`), related docs, or group headers.
+
+## Scenarios
+
+### Copy path on a spec
+
+**When** the user right-clicks an active spec named `089-copy-spec-path-name` and chooses **Copy Path**
+**Then** the clipboard contains `specs/089-copy-spec-path-name` and a brief notification confirms the copy
+
+### Copy name on an archived spec
+
+**When** the user right-clicks an archived spec and chooses **Copy Name**
+**Then** the clipboard contains the slug only (e.g. `045-update-docs`) and a brief notification confirms the copy
+
+### Spec item missing specPath fallback
+
+**When** a tree item has no `specPath` set (legacy/edge case)
+**Then** the command falls back to `specs/${item.label}` for the path and `${item.label}` for the name, matching the convention used by `speckit.specs.reveal` and `speckit.delete`
+
+### Document child item
+
+**When** the user right-clicks a child document inside a spec (e.g. `spec.md`, `plan.md`)
+**Then** the **Copy Path** / **Copy Name** entries do not appear (this menu is for the spec, not its files)
+
+## Non-Functional Requirements
+
+- **NFR001** (MUST): Clipboard write happens via `vscode.env.clipboard.writeText` so it works on macOS, Windows, and Linux without platform branching.
+- **NFR002** (SHOULD): Notification uses `NotificationUtils.showAutoDismissNotification` to match the look/feel of `delete`, `archive`, `reactivate`, and other sidebar actions.
+
+## Out of Scope
+
+- Copying a spec's full absolute filesystem path. Workspace-relative is what's useful in PRs and chat.
+- Copying individual document paths (`spec.md`, `plan.md`, `tasks.md`). VS Code's built-in **Copy Path / Copy Relative Path** on document children already covers that.
+- Drag-and-drop or keyboard shortcut bindings for these actions (right-click only for now).
+- Multi-select bulk copy. The existing bulk-action infrastructure is geared toward state changes, not clipboard joins; revisit only if users ask for it.

--- a/specs/089-copy-spec-path-name/tasks.md
+++ b/specs/089-copy-spec-path-name/tasks.md
@@ -1,0 +1,40 @@
+# Tasks: Copy Spec Path / Name
+
+**Plan**: [plan.md](./plan.md) | **Date**: 2026-04-27
+
+## Format
+
+- `[P]` marks tasks that can run in parallel with adjacent `[P]` tasks.
+- Consecutive `[P]` tasks form a **parallel group** — `/sdd:implement` spawns them as concurrent subagents.
+- Tasks without `[P]` are **gates**: they start only after all prior tasks complete.
+- Two tasks that touch the same file are never both `[P]`.
+
+---
+
+## Phase 1: Core Implementation
+
+- [x] **T001** Register `speckit.specs.copyPath` and `speckit.specs.copyName` handlers — `src/features/specs/specCommands.ts` | R002, R003, R004, NFR001, NFR002
+  - **Do**: Inside `registerSpecKitCommands`, add two `vscode.commands.registerCommand` blocks immediately after the existing `speckit.specs.reveal` handler (~line 233). Each handler resolves the slug via `const slug = (item.specPath?.replace(/^specs\//, '')) ?? item.label;` and the relative path via `const relativePath = item.specPath || \`specs/${item.label}\`;`. The path handler calls `vscode.env.clipboard.writeText(relativePath)` then `NotificationUtils.showAutoDismissNotification(\`Copied "${relativePath}"\`)`. The name handler calls `vscode.env.clipboard.writeText(slug)` then `NotificationUtils.showAutoDismissNotification(\`Copied "${slug}"\`)`. Bail early if `item` is undefined.
+  - **Verify**: `npm run compile` passes with no TS errors.
+  - **Leverage**: `src/features/specs/specCommands.ts:193-233` (`speckit.specs.reveal` / `speckit.specs.revealInExplorer`) — same item-shape, same fallback pattern, same notification helper at line 184.
+
+- [x] **T002** Declare commands and wire context-menu entries — `package.json` | R001, R005, R006, R007
+  - **Do**:
+    1. In `contributes.commands` (around line 117), add two entries: `{ "command": "speckit.specs.copyPath", "title": "Copy Path", "category": "SpecKit" }` and `{ "command": "speckit.specs.copyName", "title": "Copy Name", "category": "SpecKit" }`.
+    2. In `contributes.menus["view/item/context"]` (around line 494), append two new entries with `"when": "view == speckit.views.explorer && viewItem =~ /^spec-(active|tasks-done|completed|archived)$/"` and `"group": "9_clipboard@1"` / `"9_clipboard@2"`.
+    3. In `contributes.menus["commandPalette"]` (around line 571), add two entries with `"when": "false"` so they don't surface there.
+  - **Verify**: `npm run compile` passes; manually inspect `package.json` JSON validity.
+  - **Leverage**: existing `speckit.delete` and `speckit.specs.revealInExplorer` declarations in `package.json:494-553` for menu shape; `speckit.openSpecSource` at line 629 for the `when: false` palette pattern.
+
+- [x] **T003** [P] *(depends on T001)* Add Jest tests for both handlers — `src/features/specs/specCommands.test.ts` | R002, R003, R004, NFR001
+  - **Do**: Add two new `describe` blocks (`'speckit.specs.copyPath command handler'` and `'speckit.specs.copyName command handler'`) modeled on the existing `'speckit.specs.revealInExplorer command handler'` block (~line 445). For each handler, cover (a) item with `specPath = 'specs/089-copy-spec-path-name'` → asserts `vscode.env.clipboard.writeText` called with `'specs/089-copy-spec-path-name'` (path) or `'089-copy-spec-path-name'` (name), (b) fallback when only `label` is set, and (c) notification is shown via `NotificationUtils.showAutoDismissNotification`. If `tests/__mocks__/vscode.ts` lacks `env.clipboard.writeText`, add a `jest.fn()` for it.
+  - **Verify**: `npm test -- --testPathPattern=specCommands` passes including the new cases.
+  - **Leverage**: `src/features/specs/specCommands.test.ts:445-520` (revealInExplorer test block).
+
+- [x] **T004** [P] *(depends on T001, T002)* Document new actions in sidebar reference — `docs/sidebar.md` | R001
+  - **Do**: Add **Copy Path** and **Copy Name** rows to the right-click menu reference table for spec items. Note they appear in a `9_clipboard` group below the modification and reveal entries.
+  - **Verify**: `docs/sidebar.md` renders cleanly (no broken table rows); links open.
+
+- [x] **T005** [P] *(depends on T001, T002)* Update README sidebar summary — `README.md` | R001
+  - **Do**: Extend the "Sidebar at a Glance" section to mention the two new context-menu entries (Copy Path / Copy Name) on spec items, in one or two lines that link out to `docs/sidebar.md` for the full table.
+  - **Verify**: README renders cleanly; the per-release checklist note about "New sidebar action / right-click menu item" is satisfied.

--- a/src/features/specs/specCommands.test.ts
+++ b/src/features/specs/specCommands.test.ts
@@ -533,3 +533,103 @@ describe('speckit.create command handler', () => {
         expect(vscode.window.showInformationMessage).not.toHaveBeenCalled();
     });
 });
+
+describe('speckit.specs.copyPath command handler', () => {
+    const mockClipboardWriteText = (vscode.env as any).clipboard.writeText as jest.Mock;
+
+    it('writes specPath to clipboard when item.specPath is set', async () => {
+        const context = createMockContext();
+        const handlers = captureCommandHandlers(context);
+        const handler = handlers.get('speckit.specs.copyPath')!;
+
+        await handler({ label: '089-copy-spec-path-name', specPath: 'specs/089-copy-spec-path-name' });
+
+        expect(mockClipboardWriteText).toHaveBeenCalledTimes(1);
+        expect(mockClipboardWriteText).toHaveBeenCalledWith('specs/089-copy-spec-path-name');
+    });
+
+    it('falls back to specs/${label} when specPath is missing', async () => {
+        const context = createMockContext();
+        const handlers = captureCommandHandlers(context);
+        const handler = handlers.get('speckit.specs.copyPath')!;
+
+        await handler({ label: 'my-spec' });
+
+        expect(mockClipboardWriteText).toHaveBeenCalledTimes(1);
+        expect(mockClipboardWriteText).toHaveBeenCalledWith('specs/my-spec');
+    });
+
+    it('shows an auto-dismiss notification after copying', async () => {
+        const context = createMockContext();
+        const handlers = captureCommandHandlers(context);
+        const handler = handlers.get('speckit.specs.copyPath')!;
+
+        await handler({ label: 'my-spec', specPath: 'specs/my-spec' });
+
+        expect(NotificationUtils.showAutoDismissNotification).toHaveBeenCalledTimes(1);
+        expect(NotificationUtils.showAutoDismissNotification).toHaveBeenCalledWith(
+            expect.stringContaining('Copied')
+        );
+    });
+
+    it('does nothing when item is undefined', async () => {
+        const context = createMockContext();
+        const handlers = captureCommandHandlers(context);
+        const handler = handlers.get('speckit.specs.copyPath')!;
+
+        await handler(undefined);
+
+        expect(mockClipboardWriteText).not.toHaveBeenCalled();
+        expect(NotificationUtils.showAutoDismissNotification).not.toHaveBeenCalled();
+    });
+});
+
+describe('speckit.specs.copyName command handler', () => {
+    const mockClipboardWriteText = (vscode.env as any).clipboard.writeText as jest.Mock;
+
+    it('writes slug (specPath without specs/ prefix) when specPath is set', async () => {
+        const context = createMockContext();
+        const handlers = captureCommandHandlers(context);
+        const handler = handlers.get('speckit.specs.copyName')!;
+
+        await handler({ label: '089-copy-spec-path-name', specPath: 'specs/089-copy-spec-path-name' });
+
+        expect(mockClipboardWriteText).toHaveBeenCalledTimes(1);
+        expect(mockClipboardWriteText).toHaveBeenCalledWith('089-copy-spec-path-name');
+    });
+
+    it('falls back to label when specPath is missing', async () => {
+        const context = createMockContext();
+        const handlers = captureCommandHandlers(context);
+        const handler = handlers.get('speckit.specs.copyName')!;
+
+        await handler({ label: 'my-spec' });
+
+        expect(mockClipboardWriteText).toHaveBeenCalledTimes(1);
+        expect(mockClipboardWriteText).toHaveBeenCalledWith('my-spec');
+    });
+
+    it('shows an auto-dismiss notification after copying', async () => {
+        const context = createMockContext();
+        const handlers = captureCommandHandlers(context);
+        const handler = handlers.get('speckit.specs.copyName')!;
+
+        await handler({ label: 'my-spec', specPath: 'specs/my-spec' });
+
+        expect(NotificationUtils.showAutoDismissNotification).toHaveBeenCalledTimes(1);
+        expect(NotificationUtils.showAutoDismissNotification).toHaveBeenCalledWith(
+            expect.stringContaining('Copied')
+        );
+    });
+
+    it('does nothing when item is undefined', async () => {
+        const context = createMockContext();
+        const handlers = captureCommandHandlers(context);
+        const handler = handlers.get('speckit.specs.copyName')!;
+
+        await handler(undefined);
+
+        expect(mockClipboardWriteText).not.toHaveBeenCalled();
+        expect(NotificationUtils.showAutoDismissNotification).not.toHaveBeenCalled();
+    });
+});

--- a/src/features/specs/specCommands.ts
+++ b/src/features/specs/specCommands.ts
@@ -232,6 +232,26 @@ export function registerSpecKitCommands(
         })
     );
 
+    // Copy the spec's workspace-relative path (e.g. "specs/089-copy-spec-path-name") to the clipboard.
+    context.subscriptions.push(
+        vscode.commands.registerCommand('speckit.specs.copyPath', async (item: SpecTreeItem) => {
+            if (!item) return;
+            const relativePath = item.specPath || `specs/${item.label}`;
+            await vscode.env.clipboard.writeText(relativePath);
+            NotificationUtils.showAutoDismissNotification(`Copied "${relativePath}"`);
+        })
+    );
+
+    // Copy the spec's slug (the directory name, e.g. "089-copy-spec-path-name") to the clipboard.
+    context.subscriptions.push(
+        vscode.commands.registerCommand('speckit.specs.copyName', async (item: SpecTreeItem) => {
+            if (!item) return;
+            const slug = item.specPath ? item.specPath.replace(/^specs\//, '') : String(item.label);
+            await vscode.env.clipboard.writeText(slug);
+            NotificationUtils.showAutoDismissNotification(`Copied "${slug}"`);
+        })
+    );
+
     // Open source file from sidebar inline action
     context.subscriptions.push(
         vscode.commands.registerCommand('speckit.openSpecSource', async (item: vscode.TreeItem & { fileUri?: vscode.Uri }) => {

--- a/tests/__mocks__/vscode.ts
+++ b/tests/__mocks__/vscode.ts
@@ -131,4 +131,7 @@ export const extensions = {
 export const env = {
     openExternal: jest.fn(),
     shell: '' as string,
+    clipboard: {
+        writeText: jest.fn().mockResolvedValue(undefined),
+    },
 };


### PR DESCRIPTION
## What

- Right-click a spec → **Copy Path** copies the workspace-relative path (e.g. `specs/089-copy-spec-path-name`) to the clipboard.
- Right-click a spec → **Copy Name** copies just the slug (e.g. `089-copy-spec-path-name`).
- Both entries live in a new `9_clipboard` menu group, below the modification and reveal entries.
- Hidden from the command palette; appear only on spec items (not document children, related docs, or group headers).

## Why

Makes it trivial to reference a spec in chat, PRs, or external tools without retyping the directory name.

## Testing

- 8 new Jest tests for both handlers (specPath path, label fallback, notification, undefined-item no-op).
- Full suite: 424/424 passing.
- Compiled and packaged via `/install-local`; verified context-menu entries appear and copy works.

Closes #106