### PR TITLE
docs(contributing): flesh out contributing guide and PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,14 +9,24 @@ Brief description of the changes.
 - [ ] New feature (non-breaking change adding functionality)
 - [ ] Breaking change (fix or feature causing existing functionality to change)
 - [ ] Documentation update
+- [ ] Refactor / internal-only
 
 ## Testing
 Steps to test the changes:
 1.
 
+```bash
+npm test
+```
+
+## Screenshots / GIFs
+<!-- Required for UI / webview changes. Remove this section if N/A. -->
+
 ## Checklist
-- [ ] Code follows the project's style guidelines
+- [ ] Code follows the project's style guidelines (see `CONTRIBUTING.md`)
 - [ ] Self-review completed
-- [ ] Documentation updated (if applicable)
+- [ ] Tests pass (`npm test`)
+- [ ] Updated `README.md` per the "Feature → README section map" in `CLAUDE.md` (or N/A — internal-only change)
+- [ ] Documentation updated under `docs/` (if applicable)
 - [ ] Tests added/updated (if applicable)
 - [ ] No new warnings generated

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,11 +1,8 @@
 # Contributing to SpecKit Companion
 
-Thanks for considering a contribution. This guide tells you how to get the
-extension running locally, what conventions the codebase expects, and how to
-land a PR cleanly.
+Thanks for considering a contribution. This guide tells you how to get the extension running locally, what conventions the codebase expects, and how to land a PR cleanly.
 
-If you only have five minutes, skim **Quick Start** and the **README docs
-map** sections — those two cover 80% of what reviewers care about.
+If you only have five minutes, skim **Quick Start** and the **README docs map** sections — those two cover 80% of what reviewers care about.
 
 ---
 
@@ -19,17 +16,13 @@ code .
 # then press F5 in VS Code → "Run Extension" launches the Extension Development Host
 ```
 
-The Extension Development Host is a second VS Code window with the local
-build of SpecKit Companion loaded. Open any folder in it — that's where the
-extension is active.
+The Extension Development Host is a second VS Code window with the local build of SpecKit Companion loaded. Open any folder in it — that's where the extension is active.
 
 ## Prerequisites
 
 - **Node.js 18+**
 - **VS Code 1.84+** (matches `engines.vscode` in `package.json`)
-- **An AI CLI** for testing the SpecKit features end-to-end: Claude Code,
-  Gemini CLI, GitHub Copilot CLI, Codex CLI, or Qwen CLI. You don't need all
-  of them — pick whichever you use.
+- **An AI CLI** for testing the SpecKit features end-to-end: Claude Code, Gemini CLI, GitHub Copilot CLI, Codex CLI, or Qwen CLI. You don't need all of them — pick whichever you use.
 
 ## Development Loop
 
@@ -39,9 +32,7 @@ Most contributors keep two things running:
 npm run watch   # incremental TypeScript compile
 ```
 
-Then **F5** in VS Code to launch the Extension Development Host. After a
-code change, run **Developer: Reload Window** (`Cmd+R` / `Ctrl+R`) inside
-the dev host to pick up the new build.
+Then **F5** in VS Code to launch the Extension Development Host. After a code change, run **Developer: Reload Window** (`Cmd+R` / `Ctrl+R`) inside the dev host to pick up the new build.
 
 Other build commands:
 
@@ -53,8 +44,7 @@ npm run package         # produce a .vsix
 npm run install-local   # bump patch, package, install the .vsix in your VS Code
 ```
 
-`npm run install-local` is the fastest way to dogfood a packaged build of
-your change.
+`npm run install-local` is the fastest way to dogfood a packaged build of your change.
 
 ## Tests
 
@@ -64,12 +54,8 @@ npm run test:watch      # watch mode
 npm run test:coverage   # coverage report
 ```
 
-- **Style**: BDD — `describe()` / `it()` blocks describe behaviour, not
-  implementation. Read a few existing test files in `src/**/*.test.ts`
-  before adding new ones.
-- **VS Code mock**: extension-side tests use `tests/__mocks__/vscode.ts`
-  (mapped via `jest.config.js#moduleNameMapper`). When you need a VS Code
-  API that isn't mocked yet, add it there rather than stubbing inline.
+- **Style**: BDD — `describe()` / `it()` blocks describe behaviour, not implementation. Read a few existing test files in `src/**/*.test.ts` before adding new ones.
+- **VS Code mock**: extension-side tests use `tests/__mocks__/vscode.ts` (mapped via `jest.config.js#moduleNameMapper`). When you need a VS Code API that isn't mocked yet, add it there rather than stubbing inline.
 - **Config**: Jest runs through `ts-jest` against `tsconfig.test.json`.
 
 ## Project Layout (5-second tour)
@@ -85,21 +71,12 @@ specs/       — spec-driven development specs (one folder per feature)
 
 Two things to internalise before editing:
 
-1. **Extension isolation** (`CLAUDE.md` → "Extension Isolation"): the
-   packaged extension only ships code under `src/` plus the bundled
-   webview. Anything under `.claude/**` or `.specify/**` is the user's
-   environment, not the extension's. Don't implement extension features by
-   editing those — use `src/` code or prompt text instead.
-2. **Spec-driven development**: this project uses SDD. Non-trivial
-   features live as a folder under `specs/NNN-slug/` with `spec.md`,
-   `plan.md`, and `tasks.md`. See `specs/058-floating-toast/` or any
-   recent spec for the shape.
+1. **Extension isolation** (`CLAUDE.md` → "Extension Isolation"): the packaged extension only ships code under `src/` plus the bundled webview. Anything under `.claude/**` or `.specify/**` is the user's environment, not the extension's. Don't implement extension features by editing those — use `src/` code or prompt text instead.
+2. **Spec-driven development**: this project uses SDD. Non-trivial features live as a folder under `specs/NNN-slug/` with `spec.md`, `plan.md`, and `tasks.md`. See `specs/058-floating-toast/` or any recent spec for the shape.
 
 ## Commit Style
 
-This repo uses **Conventional Commits** with a scope. The scope is the
-primary directory or feature area touched. Skim `git log --oneline` for
-the prevailing patterns — examples from real history:
+This repo uses **Conventional Commits** with a scope. The scope is the primary directory or feature area touched. Skim `git log --oneline` for the prevailing patterns — examples from real history:
 
 ```
 feat(spec-viewer): pin header and add responsive TOC sidebar
@@ -109,17 +86,13 @@ docs(readme): refresh top-of-page positioning, add latest features
 chore: bump version to 0.13.0
 ```
 
-Types in use: `feat`, `fix`, `docs`, `refactor`, `chore`. The subject is
-imperative, lowercase, and ends without a period. Keep titles ≤ 72 chars.
+Types in use: `feat`, `fix`, `docs`, `refactor`, `chore`. The subject is imperative, lowercase, and ends without a period. Keep titles ≤ 72 chars.
 
-For `chore` commits (version bumps, release prep) the scope is usually
-omitted.
+For `chore` commits (version bumps, release prep) the scope is usually omitted.
 
 ## The README is the source of truth — keep it that way
 
-`CLAUDE.md` contains a **"Feature → README section map"** that lists, for
-every kind of change, which README section must be updated. **Read it
-before opening a PR.** Examples from that map:
+`CLAUDE.md` contains a **"Feature → README section map"** that lists, for every kind of change, which README section must be updated. **Read it before opening a PR.** Examples from that map:
 
 | You added… | Update in README… |
 |---|---|
@@ -128,43 +101,29 @@ before opening a PR.** Examples from that map:
 | A new sidebar action | `docs/sidebar.md` + the "Sidebar at a Glance" summary in README |
 | A new webview UI element | "Reading Specs" subsection + retake the screenshot |
 
-If your change is documented in `CLAUDE.md`'s map but not in the README
-after your PR, reviewers will ask. Save the round trip.
+If your change is documented in `CLAUDE.md`'s map but not in the README after your PR, reviewers will ask. Save the round trip.
 
 ## Pull Request Process
 
-1. Branch from `main` (don't stack new work on a previously-merged feature
-   branch — this repo squash-merges, so the old commits won't be in the
-   history of your new branch).
+1. Branch from `main` (don't stack new work on a previously-merged feature branch — this repo squash-merges, so the old commits won't be in the history of your new branch).
 2. Make your changes.
 3. Run `npm test` and `npm run compile`.
-4. Update `README.md` per the docs map in `CLAUDE.md`. If your change is
-   internal-only (refactor, test-only, build), say so in the PR.
-5. Open a PR using the template in `.github/pull_request_template.md`. Fill
-   in the related issue, description, screenshots (for UI changes), and
-   the checklist.
-6. Reviewers merge by squashing — keep your commits readable but don't
-   stress over rebase noise.
+4. Update `README.md` per the docs map in `CLAUDE.md`. If your change is internal-only (refactor, test-only, build), say so in the PR.
+5. Open a PR using the template in `.github/pull_request_template.md`. Fill in the related issue, description, screenshots (for UI changes), and the checklist.
+6. Reviewers merge by squashing — keep your commits readable but don't stress over rebase noise.
 
 ## References
 
 Long-form docs live under `docs/` and are linked from the README:
 
-- [docs/architecture.md](docs/architecture.md) — module structure,
-  extension/webview boundaries, build pipeline
-- [docs/sidebar.md](docs/sidebar.md) — sidebar tree-view behaviour:
-  filters, sorts, lifecycle groups, badges, transitions
-- [docs/viewer-states.md](docs/viewer-states.md) — spec viewer state
-  machine: status lifecycle, footer buttons, badge text, step tabs
+- [docs/architecture.md](docs/architecture.md) — module structure, extension/webview boundaries, build pipeline
+- [docs/sidebar.md](docs/sidebar.md) — sidebar tree-view behaviour: filters, sorts, lifecycle groups, badges, transitions
+- [docs/viewer-states.md](docs/viewer-states.md) — spec viewer state machine: status lifecycle, footer buttons, badge text, step tabs
 - [docs/how-it-works.md](docs/how-it-works.md) — end-to-end walkthrough
-- [docs/spec-context-schema.md](docs/spec-context-schema.md) —
-  `.spec-context.json` schema reference
-- [CLAUDE.md](CLAUDE.md) — instructions for AI assistants editing this
-  repo, plus the README docs map and per-release checklist
+- [docs/spec-context-schema.md](docs/spec-context-schema.md) — `.spec-context.json` schema reference
+- [CLAUDE.md](CLAUDE.md) — instructions for AI assistants editing this repo, plus the README docs map and per-release checklist
 
-Look at a recent spec under `specs/` (for example,
-[specs/058-floating-toast/](specs/058-floating-toast/)) for an example of
-the SDD format used here.
+Look at a recent spec under `specs/` (for example, [specs/058-floating-toast/](specs/058-floating-toast/)) for an example of the SDD format used here.
 
 ## Reporting Issues
 
@@ -179,5 +138,4 @@ Please read and follow the [Code of Conduct](CODE_OF_CONDUCT.md).
 
 ## License
 
-By contributing you agree that your contributions are licensed under the
-MIT License (see [LICENSE](LICENSE)).
+By contributing you agree that your contributions are licensed under the MIT License (see [LICENSE](LICENSE)).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,82 +1,183 @@
 # Contributing to SpecKit Companion
 
-Thank you for your interest in contributing to SpecKit Companion!
+Thanks for considering a contribution. This guide tells you how to get the
+extension running locally, what conventions the codebase expects, and how to
+land a PR cleanly.
 
-## Getting Started
+If you only have five minutes, skim **Quick Start** and the **README docs
+map** sections — those two cover 80% of what reviewers care about.
 
-### Prerequisites
+---
 
-- Node.js 18+
-- VS Code 1.84+
-- Claude Code CLI (for testing SpecKit features)
-
-### Development Setup
-
-1. Fork and clone the repository
-2. Install dependencies:
-   ```bash
-   npm install
-   ```
-3. Open in VS Code:
-   ```bash
-   code .
-   ```
-4. Press `F5` to launch the Extension Development Host
-
-### Building
+## Quick Start
 
 ```bash
-# Compile TypeScript
-npm run compile
-
-# Watch mode
-npm run watch
-
-# Package as VSIX
-npm run package
+git clone https://github.com/alfredoperez/speckit-companion.git
+cd speckit-companion
+npm install
+code .
+# then press F5 in VS Code → "Run Extension" launches the Extension Development Host
 ```
 
-### Testing
+The Extension Development Host is a second VS Code window with the local
+build of SpecKit Companion loaded. Open any folder in it — that's where the
+extension is active.
+
+## Prerequisites
+
+- **Node.js 18+**
+- **VS Code 1.84+** (matches `engines.vscode` in `package.json`)
+- **An AI CLI** for testing the SpecKit features end-to-end: Claude Code,
+  Gemini CLI, GitHub Copilot CLI, Codex CLI, or Qwen CLI. You don't need all
+  of them — pick whichever you use.
+
+## Development Loop
+
+Most contributors keep two things running:
 
 ```bash
-npm test
+npm run watch   # incremental TypeScript compile
 ```
 
-## Making Changes
+Then **F5** in VS Code to launch the Extension Development Host. After a
+code change, run **Developer: Reload Window** (`Cmd+R` / `Ctrl+R`) inside
+the dev host to pick up the new build.
 
-### Code Style
+Other build commands:
 
-- Use TypeScript for all new code
-- Follow existing patterns in the codebase
-- Use constants from `src/constants/` instead of magic strings
-- Add JSDoc comments for public APIs
+```bash
+npm run compile         # one-shot TypeScript compile (src/)
+npm run package-web     # webpack production bundle (webview/)
+npm run watch-web       # webpack development watch (webview/)
+npm run package         # produce a .vsix
+npm run install-local   # bump patch, package, install the .vsix in your VS Code
+```
 
-### Commit Messages
+`npm run install-local` is the fastest way to dogfood a packaged build of
+your change.
 
-Use clear, descriptive commit messages:
-- `feat: add new feature`
-- `fix: resolve bug in X`
-- `docs: update README`
-- `refactor: reorganize module structure`
+## Tests
 
-### Pull Request Process
+```bash
+npm test                # full suite
+npm run test:watch      # watch mode
+npm run test:coverage   # coverage report
+```
 
-1. Create a feature branch from `main`
-2. Make your changes
-3. Ensure tests pass
-4. Update documentation if needed
-5. Submit a PR with a clear description
+- **Style**: BDD — `describe()` / `it()` blocks describe behaviour, not
+  implementation. Read a few existing test files in `src/**/*.test.ts`
+  before adding new ones.
+- **VS Code mock**: extension-side tests use `tests/__mocks__/vscode.ts`
+  (mapped via `jest.config.js#moduleNameMapper`). When you need a VS Code
+  API that isn't mocked yet, add it there rather than stubbing inline.
+- **Config**: Jest runs through `ts-jest` against `tsconfig.test.json`.
+
+## Project Layout (5-second tour)
+
+```
+src/         — extension entry, providers, managers, AI provider integrations
+webview/     — webview UIs (spec viewer, spec editor, workflow editor)
+docs/        — long-form references (linked below)
+specs/       — spec-driven development specs (one folder per feature)
+.specify/    — SpecKit CLI config / templates (NOT shipped with the extension)
+.claude/     — workspace AI setup (NOT shipped with the extension)
+```
+
+Two things to internalise before editing:
+
+1. **Extension isolation** (`CLAUDE.md` → "Extension Isolation"): the
+   packaged extension only ships code under `src/` plus the bundled
+   webview. Anything under `.claude/**` or `.specify/**` is the user's
+   environment, not the extension's. Don't implement extension features by
+   editing those — use `src/` code or prompt text instead.
+2. **Spec-driven development**: this project uses SDD. Non-trivial
+   features live as a folder under `specs/NNN-slug/` with `spec.md`,
+   `plan.md`, and `tasks.md`. See `specs/058-floating-toast/` or any
+   recent spec for the shape.
+
+## Commit Style
+
+This repo uses **Conventional Commits** with a scope. The scope is the
+primary directory or feature area touched. Skim `git log --oneline` for
+the prevailing patterns — examples from real history:
+
+```
+feat(spec-viewer): pin header and add responsive TOC sidebar
+fix(workflow-editor): remove custom editor that hijacked diff view
+feat(specs): copy spec path or name from right-click menu
+docs(readme): refresh top-of-page positioning, add latest features
+chore: bump version to 0.13.0
+```
+
+Types in use: `feat`, `fix`, `docs`, `refactor`, `chore`. The subject is
+imperative, lowercase, and ends without a period. Keep titles ≤ 72 chars.
+
+For `chore` commits (version bumps, release prep) the scope is usually
+omitted.
+
+## The README is the source of truth — keep it that way
+
+`CLAUDE.md` contains a **"Feature → README section map"** that lists, for
+every kind of change, which README section must be updated. **Read it
+before opening a PR.** Examples from that map:
+
+| You added… | Update in README… |
+|---|---|
+| A new AI provider | "Supported AI Providers" matrix + provider count + `package.json` enum |
+| A new configuration setting | "Configuration" section (JSON example + value table) |
+| A new sidebar action | `docs/sidebar.md` + the "Sidebar at a Glance" summary in README |
+| A new webview UI element | "Reading Specs" subsection + retake the screenshot |
+
+If your change is documented in `CLAUDE.md`'s map but not in the README
+after your PR, reviewers will ask. Save the round trip.
+
+## Pull Request Process
+
+1. Branch from `main` (don't stack new work on a previously-merged feature
+   branch — this repo squash-merges, so the old commits won't be in the
+   history of your new branch).
+2. Make your changes.
+3. Run `npm test` and `npm run compile`.
+4. Update `README.md` per the docs map in `CLAUDE.md`. If your change is
+   internal-only (refactor, test-only, build), say so in the PR.
+5. Open a PR using the template in `.github/pull_request_template.md`. Fill
+   in the related issue, description, screenshots (for UI changes), and
+   the checklist.
+6. Reviewers merge by squashing — keep your commits readable but don't
+   stress over rebase noise.
+
+## References
+
+Long-form docs live under `docs/` and are linked from the README:
+
+- [docs/architecture.md](docs/architecture.md) — module structure,
+  extension/webview boundaries, build pipeline
+- [docs/sidebar.md](docs/sidebar.md) — sidebar tree-view behaviour:
+  filters, sorts, lifecycle groups, badges, transitions
+- [docs/viewer-states.md](docs/viewer-states.md) — spec viewer state
+  machine: status lifecycle, footer buttons, badge text, step tabs
+- [docs/how-it-works.md](docs/how-it-works.md) — end-to-end walkthrough
+- [docs/spec-context-schema.md](docs/spec-context-schema.md) —
+  `.spec-context.json` schema reference
+- [CLAUDE.md](CLAUDE.md) — instructions for AI assistants editing this
+  repo, plus the README docs map and per-release checklist
+
+Look at a recent spec under `specs/` (for example,
+[specs/058-floating-toast/](specs/058-floating-toast/)) for an example of
+the SDD format used here.
 
 ## Reporting Issues
 
-Use GitHub Issues with the provided templates:
-- **Bug Report**: For unexpected behavior
-- **Feature Request**: For new functionality
+Use GitHub Issues with the templates under `.github/ISSUE_TEMPLATE/`:
+
+- **Bug Report** — for unexpected behaviour
+- **Feature Request** — for new functionality
 
 ## Code of Conduct
 
-Please read and follow our [Code of Conduct](CODE_OF_CONDUCT.md).
+Please read and follow the [Code of Conduct](CODE_OF_CONDUCT.md).
 
 ## License
 
-By contributing, you agree that your contributions will be licensed under the MIT License.
+By contributing you agree that your contributions are licensed under the
+MIT License (see [LICENSE](LICENSE)).

--- a/README.md
+++ b/README.md
@@ -500,6 +500,13 @@ npm run package
 | Windows WSL  | Yes      | Supported                                                                   |
 | Windows      | Yes      | All bash-only providers (Copilot, Claude, OpenCode, Qwen) auto-detect PowerShell and use the equivalent `Get-Content -Raw` substitution; cmd.exe is supported on a best-effort basis (long prompts may exceed cmd's 8191-char line limit — switch to PowerShell or Git Bash if you hit it). |
 
+## Contributing
+
+PRs welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for local setup,
+the `F5` dev-host loop, test conventions, the Conventional Commit style
+this repo uses, and the README docs map you should follow before opening
+a PR.
+
 ## Acknowledgments
 
 This project started from the amazing work at https://github.com/notdp/kiro-for-cc

--- a/README.md
+++ b/README.md
@@ -502,10 +502,7 @@ npm run package
 
 ## Contributing
 
-PRs welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for local setup,
-the `F5` dev-host loop, test conventions, the Conventional Commit style
-this repo uses, and the README docs map you should follow before opening
-a PR.
+PRs welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for local setup, the `F5` dev-host loop, test conventions, the Conventional Commit style this repo uses, and the README docs map you should follow before opening a PR.
 
 ## Acknowledgments
 

--- a/specs/091-contributing-guide/.spec-context.json
+++ b/specs/091-contributing-guide/.spec-context.json
@@ -1,0 +1,61 @@
+{
+  "workflow": "sdd",
+  "currentStep": "implement",
+  "currentTask": null,
+  "progress": "commit-review",
+  "next": "implement",
+  "updated": "2026-04-28",
+  "selectedAt": "2026-04-28T16:02:51Z",
+  "specName": "Contributing Guide",
+  "branch": "main",
+  "workingBranch": "docs/contributing-guide",
+  "type": "docs",
+  "createdAt": "2026-04-28T16:02:51Z",
+  "approach": "Rewrite CONTRIBUTING.md and .github/pull_request_template.md in place. Anchor in conventions already encoded in CLAUDE.md and README.md (Conventional Commit scopes, the README docs map, the F5 dev loop) rather than inventing new ones.",
+  "last_action": "CP1 approved by user — proceeding to CP3.",
+  "files_modified": [
+    "CONTRIBUTING.md",
+    ".github/pull_request_template.md",
+    "README.md"
+  ],
+  "task_summaries": {
+    "T001": {
+      "status": "DONE",
+      "did": "Rewrote CONTRIBUTING.md from a thin stub to a full guide: Quick Start, Prerequisites, Dev Loop with F5 + npm run watch, Tests with BDD style + tests/__mocks__/vscode.ts note, Packaging incl. install-local, Project Layout with extension-isolation note, Conventional Commits with real-history examples, README docs-map rule from CLAUDE.md, full References list pointing at docs/architecture.md, sidebar.md, viewer-states.md, how-it-works.md, spec-context-schema.md, CLAUDE.md, and specs/058-floating-toast/.",
+      "files": ["CONTRIBUTING.md"],
+      "concerns": []
+    },
+    "T002": {
+      "status": "DONE",
+      "did": "Extended .github/pull_request_template.md: added Refactor/internal-only to Type of Change; added a Screenshots/GIFs section for UI changes; tightened Testing with an explicit npm test code block; added README docs-map checkbox and Tests-pass checkbox to the Checklist; added a docs/ update checkbox.",
+      "files": [".github/pull_request_template.md"],
+      "concerns": []
+    },
+    "T003": {
+      "status": "DONE",
+      "did": "Added a 'Contributing' section to README.md between Development and Acknowledgments, pointing readers at CONTRIBUTING.md with a one-paragraph hook covering setup, F5 loop, commit style, and the docs map.",
+      "files": ["README.md"],
+      "concerns": []
+    }
+  },
+  "step_summaries": {
+    "specify": {
+      "complexity": "minimal",
+      "requirements": 9,
+      "scenarios": 3,
+      "key_finding": "CONTRIBUTING.md and .github/pull_request_template.md already exist as basic stubs — this is an enhancement to align both with the project's real conventions (Conventional Commit scopes, README docs map in CLAUDE.md, F5 dev-host loop)."
+    }
+  },
+  "transitions": [
+    { "step": "specify", "substep": "parsing", "from": null, "by": "sdd", "at": "2026-04-28T16:02:51Z" },
+    { "step": "specify", "substep": "exploring", "from": { "step": "specify", "substep": "parsing" }, "by": "sdd", "at": "2026-04-28T16:02:52Z" },
+    { "step": "specify", "substep": "detecting", "from": { "step": "specify", "substep": "exploring" }, "by": "sdd", "at": "2026-04-28T16:02:53Z" },
+    { "step": "specify", "substep": "writing-spec", "from": { "step": "specify", "substep": "detecting" }, "by": "sdd", "at": "2026-04-28T16:02:54Z" },
+    { "step": "tasks", "substep": null, "from": { "step": "specify", "substep": "writing-spec" }, "by": "sdd", "at": "2026-04-28T16:02:55Z" },
+    { "step": "implement", "substep": "phase1", "from": { "step": "tasks", "substep": null }, "by": "sdd", "at": "2026-04-28T16:03:00Z" },
+    { "step": "implement", "substep": "phase1", "from": { "step": "implement", "substep": "phase1" }, "by": "sdd", "at": "2026-04-28T16:03:30Z" },
+    { "step": "implement", "substep": "hooks", "from": { "step": "implement", "substep": "phase1" }, "by": "sdd", "at": "2026-04-28T16:04:00Z" },
+    { "step": "implement", "substep": "code-review", "from": { "step": "implement", "substep": "hooks" }, "by": "sdd", "at": "2026-04-28T16:05:00Z" },
+    { "step": "implement", "substep": "commit-review", "from": { "step": "implement", "substep": "code-review" }, "by": "sdd", "at": "2026-04-28T16:06:00Z" }
+  ]
+}

--- a/specs/091-contributing-guide/.spec-context.json
+++ b/specs/091-contributing-guide/.spec-context.json
@@ -1,9 +1,11 @@
 {
   "workflow": "sdd",
-  "currentStep": "implement",
+  "currentStep": "done",
   "currentTask": null,
-  "progress": "commit-review",
-  "next": "implement",
+  "progress": null,
+  "next": "done",
+  "status": "completed",
+  "checkpointStatus": { "commit": true, "pr": true },
   "updated": "2026-04-28",
   "selectedAt": "2026-04-28T16:02:51Z",
   "specName": "Contributing Guide",
@@ -11,8 +13,10 @@
   "workingBranch": "docs/contributing-guide",
   "type": "docs",
   "createdAt": "2026-04-28T16:02:51Z",
+  "prUrl": "https://github.com/alfredoperez/speckit-companion/pull/151",
+  "prNumber": 151,
   "approach": "Rewrite CONTRIBUTING.md and .github/pull_request_template.md in place. Anchor in conventions already encoded in CLAUDE.md and README.md (Conventional Commit scopes, the README docs map, the F5 dev loop) rather than inventing new ones.",
-  "last_action": "CP1 approved by user — proceeding to CP3.",
+  "last_action": "PR #151 opened — docs(contributing): flesh out contributing guide and PR template",
   "files_modified": [
     "CONTRIBUTING.md",
     ".github/pull_request_template.md",
@@ -56,6 +60,7 @@
     { "step": "implement", "substep": "phase1", "from": { "step": "implement", "substep": "phase1" }, "by": "sdd", "at": "2026-04-28T16:03:30Z" },
     { "step": "implement", "substep": "hooks", "from": { "step": "implement", "substep": "phase1" }, "by": "sdd", "at": "2026-04-28T16:04:00Z" },
     { "step": "implement", "substep": "code-review", "from": { "step": "implement", "substep": "hooks" }, "by": "sdd", "at": "2026-04-28T16:05:00Z" },
-    { "step": "implement", "substep": "commit-review", "from": { "step": "implement", "substep": "code-review" }, "by": "sdd", "at": "2026-04-28T16:06:00Z" }
+    { "step": "implement", "substep": "commit-review", "from": { "step": "implement", "substep": "code-review" }, "by": "sdd", "at": "2026-04-28T16:06:00Z" },
+    { "step": "done", "substep": null, "from": { "step": "implement", "substep": "commit-review" }, "by": "sdd", "at": "2026-04-28T16:08:00Z" }
   ]
 }

--- a/specs/091-contributing-guide/plan.md
+++ b/specs/091-contributing-guide/plan.md
@@ -1,0 +1,14 @@
+# Plan: Contributing Guide
+
+**Spec**: [spec.md](./spec.md) | **Date**: 2026-04-28
+
+## Approach
+
+Rewrite the existing `CONTRIBUTING.md` and `.github/pull_request_template.md` in place. Anchor the rewrite in the conventions already encoded in `CLAUDE.md` and `README.md` rather than inventing new ones — the goal is to surface the rules contributors are silently expected to follow (Conventional Commit scopes, the README docs map, the F5 dev loop), not add new process.
+
+## Files to Change
+
+### Modify
+
+- `CONTRIBUTING.md` — expand from the current 80-line stub to a full guide: prerequisites, setup with `F5` dev-host, build/watch/package commands, test suite (with BDD style + `tests/__mocks__/vscode.ts` note), Conventional Commit scopes with real examples, link to the README docs map and `docs/` deep references, mention `specs/` as the SDD template directory, mention `npm run install-local`.
+- `.github/pull_request_template.md` — extend the existing template: keep the related-issue/description/type-of-change/testing/checklist scaffolding, add a "Updated README per docs map (or N/A)" checkbox, add a "Screenshots / GIFs (UI changes only)" slot, tighten the testing section to reference `npm test`.

--- a/specs/091-contributing-guide/spec.md
+++ b/specs/091-contributing-guide/spec.md
@@ -1,0 +1,42 @@
+# Spec: Contributing Guide
+
+**Slug**: 091-contributing-guide | **Date**: 2026-04-28
+
+## Summary
+
+Flesh out the contributor onboarding surface so an outside developer can clone, run, and submit a PR without asking. The current `CONTRIBUTING.md` is a thin stub and the PR template is generic — this spec rewrites both to match the project's real conventions (Conventional Commits with scopes, the "update README per the docs map" rule, the F5 dev-host loop) and points at the existing `docs/` references.
+
+## Requirements
+
+- **R001** (MUST): `CONTRIBUTING.md` covers prerequisites (Node, VS Code, an AI CLI), local setup (`npm install`), the `F5` Extension Development Host loop, and `npm run watch` for auto-recompile.
+- **R002** (MUST): `CONTRIBUTING.md` documents the Conventional Commits style with scopes used in this repo (e.g., `feat(spec-viewer):`, `fix(workflow-editor):`, `docs(readme):`, `chore:`) with at least three real-shape examples.
+- **R003** (MUST): `CONTRIBUTING.md` links to `docs/architecture.md`, `docs/sidebar.md`, `docs/viewer-states.md`, and `CLAUDE.md` so contributors find the deep references without searching.
+- **R004** (MUST): `CONTRIBUTING.md` calls out the README docs-map rule from `CLAUDE.md` — user-facing changes must update `README.md` in the section the map points to — and tells contributors to skim the map before opening a PR.
+- **R005** (MUST): `.github/pull_request_template.md` includes a checkbox for "Updated `README.md` per the docs map (or N/A — internal change)" and a checkbox for tests passing (`npm test`).
+- **R006** (SHOULD): `CONTRIBUTING.md` documents how to run the test suite (`npm test`, `npm run test:watch`) and notes the BDD `describe`/`it` style and the VS Code mock at `tests/__mocks__/vscode.ts`.
+- **R007** (SHOULD): `CONTRIBUTING.md` mentions the `npm run install-local` shortcut for testing the packaged extension end-to-end.
+- **R008** (SHOULD): `CONTRIBUTING.md` notes the project uses spec-driven development under `specs/` and points at one or two example specs as a template for new feature work.
+- **R009** (MAY): PR template adds a one-line "Screenshots / GIFs" section for UI changes, since the project has visual-heavy webview features.
+
+## Scenarios
+
+### First-time contributor opens the repo
+
+**When** a developer who has never touched the codebase reads `CONTRIBUTING.md` top-to-bottom
+**Then** they can install dependencies, launch the Extension Development Host with `F5`, run the test suite, and identify which doc to update for their change — without opening a second tab to ask.
+
+### Contributor opens a pull request
+
+**When** a contributor opens a PR in GitHub
+**Then** the template renders with checkboxes for the README docs-map update, tests passing, a link to the related issue, and (for UI changes) a screenshots slot.
+
+### Contributor writes a commit message
+
+**When** a contributor stages a commit for a fix in the spec viewer
+**Then** the guide gives them the exact shape (`fix(spec-viewer): <description>`) and at least one real example they can mimic.
+
+## Out of Scope
+
+- Code of Conduct rewrite (existing `CODE_OF_CONDUCT.md` link is sufficient).
+- New CI workflows, lint configs, or commitlint enforcement — guidance is documentary, not enforced via tooling.
+- Issue templates (`.github/ISSUE_TEMPLATE/` already exists and is not part of this issue).

--- a/specs/091-contributing-guide/tasks.md
+++ b/specs/091-contributing-guide/tasks.md
@@ -1,0 +1,29 @@
+# Tasks: Contributing Guide
+
+**Plan**: [plan.md](./plan.md) | **Date**: 2026-04-28
+
+## Format
+
+- `[P]` marks tasks that can run in parallel with adjacent `[P]` tasks.
+- Consecutive `[P]` tasks form a **parallel group** — `/sdd:implement` spawns them as concurrent subagents.
+- Tasks without `[P]` are **gates**: they start only after all prior tasks complete.
+- Two tasks that touch the same file are never both `[P]`.
+
+---
+
+## Phase 1: Core Implementation
+
+- [x] **T001** [P] Rewrite CONTRIBUTING.md — `CONTRIBUTING.md` | R001, R002, R003, R004, R006, R007, R008
+  - **Do**: Replace the existing stub with a fuller guide. Sections: Prerequisites (Node 18+, VS Code 1.84+, an AI CLI), Setup (`npm install`, open in VS Code, **press `F5` to launch the Extension Development Host**), Development Loop (`npm run watch` for auto-recompile while the dev host runs; reload the dev-host window to pick up changes), Tests (`npm test`, `npm run test:watch`, BDD `describe`/`it` style, mock at `tests/__mocks__/vscode.ts`), Packaging (`npm run package`, `npm run install-local` for end-to-end testing of the packaged `.vsix`), Commit Style (Conventional Commits with scopes — give real examples like `feat(spec-viewer): pin header and add responsive TOC sidebar`, `fix(workflow-editor): remove custom editor that hijacked diff view`, `docs(readme): refresh top-of-page positioning`, `chore: bump version to 0.13.0`), PR Process (link to PR template, mention the README docs map in `CLAUDE.md` is the source of truth for which README section to update), References (link `docs/architecture.md`, `docs/sidebar.md`, `docs/viewer-states.md`, `CLAUDE.md`, and call out `specs/` as the SDD spec directory with a pointer to a recent example like `specs/058-floating-toast/`).
+  - **Verify**: File reads cleanly top-to-bottom; every promised link resolves to an existing file; commit examples match real history (`git log --oneline | head -20`).
+  - **Leverage**: Existing `CONTRIBUTING.md` for structure; `CLAUDE.md` "Feature → README section map" for the docs-map rule; recent commits for real-shape examples.
+
+- [x] **T002** [P] Extend the PR template — `.github/pull_request_template.md` | R005, R009
+  - **Do**: Keep the existing scaffolding (Related Issue / Description / Type of Change / Testing / Checklist). Add to the Checklist: `- [ ] Updated README.md per the docs map in CLAUDE.md (or N/A — internal-only change)` and `- [ ] Tests pass (npm test)`. Add a new top-level section `## Screenshots / GIFs` with a one-line note "Required for UI changes; remove if N/A." Tighten the Testing section so the placeholder reads `Steps to test: …` followed by `npm test` for the unit suite.
+  - **Verify**: Template renders correctly when opening a new PR draft; no broken markdown.
+  - **Leverage**: Existing template structure.
+
+- [x] **T003** Cross-check README and per-release checklist *(depends on T001, T002)* — `README.md` | R004
+  - **Do**: Skim README to confirm a Contributing section exists or add a one-liner pointing to `CONTRIBUTING.md` if missing. Do **not** restructure README — just ensure new contributors land on the guide.
+  - **Verify**: From the README, a reader can reach `CONTRIBUTING.md` in one click.
+  - **Leverage**: Existing README structure.


### PR DESCRIPTION
## What

- Rewrite `CONTRIBUTING.md` with Quick Start, F5 dev-host loop, BDD test conventions, packaging, Conventional Commit examples drawn from real history, the README docs-map rule, and a full References block linking `docs/` and `CLAUDE.md`.
- Extend `.github/pull_request_template.md` with a Screenshots/GIFs section, an explicit `npm test` block, and checkboxes for tests-pass, README docs-map update, and `docs/` updates.
- Add a `## Contributing` section to `README.md` between Development and Acknowledgments pointing at `CONTRIBUTING.md`.

## Why

Lowers the bar for outside contributions and sets expectations contributors are otherwise expected to absorb from `CLAUDE.md` and the commit history.

## Testing

- Read `CONTRIBUTING.md` top-to-bottom; every internal link resolves to an existing file or directory.
- Open a PR draft; new template renders with the docs-map checkbox, tests-pass checkbox, and Screenshots section.
- From `README.md`, the new `## Contributing` link reaches `CONTRIBUTING.md` in one click.

Closes #114