### PR TITLE
fix(spec-viewer): stop refine from wiping plan.md via slash command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Bug Fixes
+
+- **Refine No Longer Wipes plan.md**: The Refine button used to dispatch the per-step slash command (e.g. `/speckit.plan`), whose first action copies the plan template over the existing file. Refinement now sends a direct-edit prompt that names the target file and forbids running setup scripts or regenerating from a template, applied uniformly to spec / plan / tasks (#153).
+
 ## [0.15.0] - 2026-04-27
 
 ### New Features

--- a/specs/093-fix-refine-overwrite/.spec-context.json
+++ b/specs/093-fix-refine-overwrite/.spec-context.json
@@ -1,0 +1,65 @@
+{
+  "workflow": "sdd",
+  "currentStep": "implement",
+  "currentTask": null,
+  "progress": "code-review",
+  "next": "implement",
+  "updated": "2026-05-03",
+  "selectedAt": "2026-05-03T19:56:13Z",
+  "specName": "Fix Refine Template Overwrite",
+  "branch": "main",
+  "workingBranch": "fix/fix-refine-overwrite",
+  "type": "fix",
+  "auto": true,
+  "createdAt": "2026-05-03T19:56:13Z",
+  "approach": "Replace the slash-command refinement dispatch in handleSubmitRefinements with a freeform direct-edit prompt that names the target file and explicitly forbids running setup scripts, regenerating from a template, or replacing the file. Apply uniformly to spec/plan/tasks. Leave executeStepInTerminal (the legitimate slash-command path used by step-advance buttons) untouched.",
+  "last_action": "install-local hook done — vsix v0.15.1 installed; entering CP1 code review",
+  "files_modified": [
+    "src/features/spec-viewer/messageHandlers.ts",
+    "src/features/spec-viewer/__tests__/messageHandlers.test.ts",
+    "CHANGELOG.md"
+  ],
+  "task_summaries": {
+    "T001": {
+      "status": "DONE",
+      "did": "Rewrote handleSubmitRefinements to build a direct-edit prompt that names the target file and forbids regen/setup-script/file-replace, dropping the slash-command dispatch.",
+      "files": ["src/features/spec-viewer/messageHandlers.ts"],
+      "concerns": []
+    },
+    "T002": {
+      "status": "DONE",
+      "did": "Added a submitRefinements describe block (4 tests) asserting prompt does not start with /, contains DO-NOT guardrails, includes the user comments, and uses the same path for spec/tasks docs.",
+      "files": ["src/features/spec-viewer/__tests__/messageHandlers.test.ts"],
+      "concerns": []
+    },
+    "T003": {
+      "status": "DONE",
+      "did": "Added a Bug Fixes entry under CHANGELOG Unreleased referencing #153. README was checked — Refine has no dedicated section, so the fix is internal-behavior only and no README change is required.",
+      "files": ["CHANGELOG.md"],
+      "concerns": []
+    }
+  },
+  "step_summaries": {
+    "specify": {
+      "complexity": "minimal",
+      "requirements": 5,
+      "scenarios": 3,
+      "key_finding": "Refinement reuses the per-step slash command via resolveWorkflowSteps in handleSubmitRefinements; executeStepInTerminal is a separate path and stays untouched."
+    }
+  },
+  "transitions": [
+    { "step": "specify", "substep": "parsing", "from": null, "by": "sdd", "at": "2026-05-03T19:56:13Z" },
+    { "step": "specify", "substep": "exploring", "from": { "step": "specify", "substep": "parsing" }, "by": "sdd", "at": "2026-05-03T19:56:14Z" },
+    { "step": "specify", "substep": "detecting", "from": { "step": "specify", "substep": "exploring" }, "by": "sdd", "at": "2026-05-03T19:56:15Z" },
+    { "step": "specify", "substep": "writing-spec", "from": { "step": "specify", "substep": "detecting" }, "by": "sdd", "at": "2026-05-03T19:56:16Z" },
+    { "step": "tasks", "substep": null, "from": { "step": "specify", "substep": "writing-spec" }, "by": "sdd", "at": "2026-05-03T19:56:17Z" },
+    { "step": "tasks", "substep": null, "from": { "step": "tasks", "substep": null }, "by": "sdd", "at": "2026-05-03T19:56:18Z" },
+    { "step": "implement", "substep": "phase1", "from": { "step": "tasks", "substep": null }, "by": "sdd", "at": "2026-05-03T19:57:00Z" },
+    { "step": "implement", "substep": "phase1", "from": { "step": "implement", "substep": "phase1" }, "by": "sdd", "at": "2026-05-03T19:57:01Z" },
+    { "step": "implement", "substep": "phase1", "from": { "step": "implement", "substep": "phase1" }, "by": "sdd", "at": "2026-05-03T19:57:30Z" },
+    { "step": "implement", "substep": "phase1", "from": { "step": "implement", "substep": "phase1" }, "by": "sdd", "at": "2026-05-03T19:58:00Z" },
+    { "step": "implement", "substep": "phase1", "from": { "step": "implement", "substep": "phase1" }, "by": "sdd", "at": "2026-05-03T19:58:30Z" },
+    { "step": "implement", "substep": "hooks", "from": { "step": "implement", "substep": "phase1" }, "by": "sdd", "at": "2026-05-03T19:58:45Z" },
+    { "step": "implement", "substep": "code-review", "from": { "step": "implement", "substep": "hooks" }, "by": "sdd", "at": "2026-05-03T19:59:00Z" }
+  ]
+}

--- a/specs/093-fix-refine-overwrite/.spec-context.json
+++ b/specs/093-fix-refine-overwrite/.spec-context.json
@@ -1,19 +1,23 @@
 {
   "workflow": "sdd",
-  "currentStep": "implement",
+  "currentStep": "done",
   "currentTask": null,
-  "progress": "code-review",
-  "next": "implement",
+  "progress": null,
+  "next": "done",
+  "status": "completed",
   "updated": "2026-05-03",
   "selectedAt": "2026-05-03T19:56:13Z",
   "specName": "Fix Refine Template Overwrite",
   "branch": "main",
   "workingBranch": "fix/fix-refine-overwrite",
   "type": "fix",
-  "auto": true,
+  "auto": false,
   "createdAt": "2026-05-03T19:56:13Z",
+  "prUrl": "https://github.com/alfredoperez/speckit-companion/pull/155",
+  "prNumber": 155,
+  "checkpointStatus": { "commit": true, "pr": true },
   "approach": "Replace the slash-command refinement dispatch in handleSubmitRefinements with a freeform direct-edit prompt that names the target file and explicitly forbids running setup scripts, regenerating from a template, or replacing the file. Apply uniformly to spec/plan/tasks. Leave executeStepInTerminal (the legitimate slash-command path used by step-advance buttons) untouched.",
-  "last_action": "install-local hook done — vsix v0.15.1 installed; entering CP1 code review",
+  "last_action": "PR #155 opened — fix(spec-viewer): stop refine from wiping plan.md via slash command",
   "files_modified": [
     "src/features/spec-viewer/messageHandlers.ts",
     "src/features/spec-viewer/__tests__/messageHandlers.test.ts",
@@ -60,6 +64,9 @@
     { "step": "implement", "substep": "phase1", "from": { "step": "implement", "substep": "phase1" }, "by": "sdd", "at": "2026-05-03T19:58:00Z" },
     { "step": "implement", "substep": "phase1", "from": { "step": "implement", "substep": "phase1" }, "by": "sdd", "at": "2026-05-03T19:58:30Z" },
     { "step": "implement", "substep": "hooks", "from": { "step": "implement", "substep": "phase1" }, "by": "sdd", "at": "2026-05-03T19:58:45Z" },
-    { "step": "implement", "substep": "code-review", "from": { "step": "implement", "substep": "hooks" }, "by": "sdd", "at": "2026-05-03T19:59:00Z" }
+    { "step": "implement", "substep": "code-review", "from": { "step": "implement", "substep": "hooks" }, "by": "sdd", "at": "2026-05-03T19:59:00Z" },
+    { "step": "implement", "substep": "test-results", "from": { "step": "implement", "substep": "code-review" }, "by": "sdd", "at": "2026-05-03T19:59:30Z" },
+    { "step": "implement", "substep": "commit-review", "from": { "step": "implement", "substep": "test-results" }, "by": "sdd", "at": "2026-05-03T20:00:00Z" },
+    { "step": "done", "substep": null, "from": { "step": "implement", "substep": "commit-review" }, "by": "sdd", "at": "2026-05-03T20:00:30Z" }
   ]
 }

--- a/specs/093-fix-refine-overwrite/plan.md
+++ b/specs/093-fix-refine-overwrite/plan.md
@@ -1,0 +1,21 @@
+# Plan: Fix Refine Template Overwrite
+
+**Spec**: [spec.md](./spec.md)
+
+## Approach
+
+In `src/features/spec-viewer/messageHandlers.ts`, `handleSubmitRefinements` (lines 562–592) builds a slash-command prompt — `\`/${currentStep.command} ${targetPath}${context}\`` — and pipes it to the AI CLI. Replace that with a freeform direct-edit prompt that names the target file (`{spec,plan,tasks}.md` derived from `instance.state.currentDocument`) and explicitly forbids running setup scripts, regenerating from a template, or replacing the file. The `resolveWorkflowSteps` lookup (used here only to derive the slash-command name) is no longer needed for this path; refinement is the same operation regardless of step.
+
+`executeStepInTerminal` (lines 297–310), which the regular step-advance buttons use, is left untouched.
+
+## Files
+
+### Modify
+
+- `src/features/spec-viewer/messageHandlers.ts` — rewrite the body of `handleSubmitRefinements`: drop the workflow-step lookup; build a direct-edit prompt with explicit "do not regenerate" guardrails; pass it to `deps.executeInTerminal`. Keep the existing `refinementText` bullet formatting (lines 573–575).
+- `src/features/spec-viewer/__tests__/messageHandlers.test.ts` — add a `submitRefinements` describe block asserting prompt shape (no slash prefix, contains guardrail strings, contains line-anchored bullets).
+
+## Testing Strategy
+
+- **Manual**: With the extension installed locally, open a spec at the plan step, add line comments, click Refine. Confirm via the SpecViewer output channel that the dispatched prompt starts with the direct-edit instruction (not `/speckit.plan`) and that `plan.md` retains its existing content after the AI run.
+- **Unit**: Add a test in `src/features/spec-viewer/__tests__/messageHandlers.test.ts` that captures the prompt passed to `executeInTerminal` for a `submitRefinements` message and asserts: (a) it does NOT start with `/`, (b) it contains the "DO NOT" guardrail language, (c) it includes the bulleted line comments.

--- a/specs/093-fix-refine-overwrite/spec.md
+++ b/specs/093-fix-refine-overwrite/spec.md
@@ -1,0 +1,38 @@
+# Spec: Fix Refine Template Overwrite
+
+**Slug**: 093-fix-refine-overwrite | **Date**: 2026-05-03
+
+## Summary
+
+The Refine button in the spec viewer dispatches the per-step slash command (e.g. `/speckit.plan`) plus refinement context. For the plan step, that command's first action is `setup-plan.sh`, which copies the plan template OVER the user's existing `plan.md` and destroys their work (issue #153). Replace the slash-command dispatch with a freeform direct-edit prompt so refinement edits the existing file in place across all three doc types.
+
+## Requirements
+
+- **R001** (MUST): The refinement code path in `handleSubmitRefinements` MUST NOT dispatch any per-step slash command (`/speckit.plan`, `/speckit.specify`, `/speckit.tasks`, or any equivalent from a custom workflow).
+- **R002** (MUST): The refinement prompt MUST instruct the AI to edit the target file in place and explicitly forbid running setup scripts, regenerating from a template, or replacing the file.
+- **R003** (MUST): The fix MUST apply uniformly to all three refinable doc types (`spec`, `plan`, `tasks`).
+- **R004** (MUST): The regular step-execution path (`executeStepInTerminal`, used when the user clicks a step button to advance) MUST continue to dispatch the per-step slash command unchanged — only the refinement path is rewired.
+- **R005** (SHOULD): The refinement prompt SHOULD include the user's line-anchored comments verbatim (line number, line content snippet, comment) using the same bullet format the current implementation produces.
+
+## Scenarios
+
+### Plan refinement preserves existing content
+
+**When** the user adds line comments on `plan.md` and clicks "Refine"
+**Then** the AI receives a direct-edit prompt that targets `plan.md` and explicitly forbids running `setup-plan.sh` or replacing the file, and the existing plan content is preserved.
+
+### Spec and tasks refinement use the same direct-edit path
+
+**When** the user submits refinements on `spec.md` or `tasks.md`
+**Then** the dispatched prompt does not invoke `/speckit.specify` or `/speckit.tasks`; it instructs the AI to edit the file in place using the same forbid-regeneration language as plan refinement.
+
+### Step-execution path is unchanged
+
+**When** the user clicks a step button (e.g. "Plan") to advance to a new phase
+**Then** `executeStepInTerminal` still dispatches `/speckit.plan` (or the workflow's configured command) — refinement-only changes do not regress the create-from-template flow.
+
+## Out of Scope
+
+- Fixing the SpecKit CLI's `/speckit.plan` skill (lives outside this extension; users install it separately).
+- Changes to the line-comment UI in the webview.
+- Lifecycle/status updates for refinement runs — refinement is an in-place edit and should not advance `.spec-context.json` step state.

--- a/specs/093-fix-refine-overwrite/tasks.md
+++ b/specs/093-fix-refine-overwrite/tasks.md
@@ -1,0 +1,21 @@
+# Tasks: Fix Refine Template Overwrite
+
+**Plan**: [plan.md](./plan.md)
+
+> Format reference: `[P]` markers and parallel groups — see `skills/tasks/SKILL.md` § Phase rules.
+
+## Phase 1: Core Implementation
+
+- [x] **T001** Replace slash-command refinement prompt with direct-edit prompt — `src/features/spec-viewer/messageHandlers.ts` | R001, R002, R003, R005
+  - **Do**: Rewrite the body of `handleSubmitRefinements` (currently lines 562–592). Remove the `resolveWorkflowSteps` lookup and the `currentStep` derivation. Map `instance.state.currentDocument` → `${currentDocument}.md` for the target filename. Build the prompt as: `Edit ${targetPath}/${filename} in place to apply ONLY these line-specific refinements. DO NOT regenerate from any template. DO NOT run any setup script (e.g. setup-spec.sh, setup-plan.sh, setup-tasks.sh). DO NOT replace the file — make targeted edits only.\n\nRefinements requested:\n${refinementText}`. Pass to `deps.executeInTerminal`. Keep the existing `refinementText` formatting at lines 573–575 unchanged.
+  - **Verify**: `npm run compile` passes. With the extension running locally, trigger a refinement and confirm the SpecViewer output channel logs a prompt starting with "Edit " (not "/speckit.").
+  - **Leverage**: Existing function signature, `refinementText` bullet formatting (lines 573–575), and `deps.executeInTerminal` plumbing.
+
+- [x] **T002** [P] Add unit test for refinement prompt shape — `src/features/spec-viewer/__tests__/messageHandlers.test.ts` | R001, R002, R005
+  - **Do**: Add a `describe('submitRefinements')` block that builds a fake handler dependency with a stubbed `executeInTerminal` that captures its argument. Dispatch a `submitRefinements` message with two refinements. Assert: (a) the captured prompt does NOT start with `/`, (b) it contains the strings `DO NOT regenerate` and `DO NOT run any setup script`, (c) it includes both refinements' line numbers in the bulleted list.
+  - **Verify**: `npm test` passes; the new test runs and asserts pass.
+  - **Leverage**: Existing test patterns in `messageHandlers.test.ts` (e.g. the spec-state shape at line 44 / 265).
+
+- [x] **T003** *(depends on T001, T002)* Update README if user-facing behavior changed — `README.md` | R002
+  - **Do**: Per CLAUDE.md, when user-facing behavior changes, update README. The Refine button's behavior is documented under the spec viewer / refinements section. Add a one-line clarification that Refine performs a targeted in-place edit (does not re-run the per-step command). If no Refine documentation exists, skip with a note in the PR description.
+  - **Verify**: `git diff README.md` shows the clarification or PR description notes "no README change required (Refine is not currently documented)".

--- a/src/features/spec-viewer/__tests__/messageHandlers.test.ts
+++ b/src/features/spec-viewer/__tests__/messageHandlers.test.ts
@@ -322,3 +322,79 @@ describe('messageHandlers - stepperClick', () => {
         expect(updateStepProgress).not.toHaveBeenCalled();
     });
 });
+
+describe('messageHandlers - submitRefinements', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    function dispatchRefinements(currentDocument: 'spec' | 'plan' | 'tasks') {
+        const deps = createMockDeps({
+            getInstance: jest.fn().mockReturnValue({
+                state: {
+                    specDirectory: SPEC_DIR,
+                    specName: 'my-feature',
+                    currentDocument,
+                    availableDocuments: [],
+                },
+                debounceTimer: undefined,
+            }),
+        });
+        const handler = createMessageHandlers(SPEC_DIR, deps);
+
+        const refinements = [
+            { lineNum: 5, lineContent: 'first line content', comment: 'tighten wording' },
+            { lineNum: 12, lineContent: 'second line content', comment: 'add detail' },
+        ];
+
+        return { deps, handler, refinements };
+    }
+
+    it('does not invoke a slash command (avoids running setup-plan.sh)', async () => {
+        const { deps, handler, refinements } = dispatchRefinements('plan');
+
+        await handler({ type: 'submitRefinements', refinements } as any);
+
+        expect(deps.executeInTerminal).toHaveBeenCalledTimes(1);
+        const prompt = (deps.executeInTerminal as jest.Mock).mock.calls[0][0] as string;
+        expect(prompt.startsWith('/')).toBe(false);
+        expect(prompt).not.toMatch(/\/speckit\./);
+    });
+
+    it('includes guardrails forbidding template regen and setup scripts', async () => {
+        const { deps, handler, refinements } = dispatchRefinements('plan');
+
+        await handler({ type: 'submitRefinements', refinements } as any);
+
+        const prompt = (deps.executeInTerminal as jest.Mock).mock.calls[0][0] as string;
+        expect(prompt).toContain('DO NOT regenerate');
+        expect(prompt).toContain('DO NOT run any setup script');
+        expect(prompt).toContain('DO NOT replace the file');
+    });
+
+    it('targets the correct doc filename and includes the user comments', async () => {
+        const { deps, handler, refinements } = dispatchRefinements('plan');
+
+        await handler({ type: 'submitRefinements', refinements } as any);
+
+        const prompt = (deps.executeInTerminal as jest.Mock).mock.calls[0][0] as string;
+        expect(prompt).toContain(`${SPEC_DIR}/plan.md`);
+        expect(prompt).toContain('Line 5');
+        expect(prompt).toContain('Line 12');
+        expect(prompt).toContain('tighten wording');
+        expect(prompt).toContain('add detail');
+    });
+
+    it('uses the same direct-edit path for spec and tasks', async () => {
+        for (const doc of ['spec', 'tasks'] as const) {
+            const { deps, handler, refinements } = dispatchRefinements(doc);
+
+            await handler({ type: 'submitRefinements', refinements } as any);
+
+            const prompt = (deps.executeInTerminal as jest.Mock).mock.calls[0][0] as string;
+            expect(prompt.startsWith('/')).toBe(false);
+            expect(prompt).toContain(`${SPEC_DIR}/${doc}.md`);
+            expect(prompt).toContain('DO NOT regenerate');
+        }
+    });
+});

--- a/src/features/spec-viewer/messageHandlers.ts
+++ b/src/features/spec-viewer/messageHandlers.ts
@@ -557,7 +557,10 @@ async function handleOpenFile(
 }
 
 /**
- * Handle submit refinements - run current phase command with refinement context
+ * Handle submit refinements — dispatch a direct-edit prompt for the current
+ * doc. We deliberately avoid invoking any per-step slash command (e.g.
+ * /speckit.plan) because some of those commands re-run setup scripts that
+ * overwrite the existing file from a template (see issue #153).
  */
 async function handleSubmitRefinements(
     specDirectory: string,
@@ -568,25 +571,23 @@ async function handleSubmitRefinements(
     if (!instance) return;
 
     const docType = instance.state.currentDocument;
+    const filename = `${docType}.md`;
+    const targetPath = instance.state.changeRoot || specDirectory;
 
-    // Format refinements as context string
     const refinementText = refinements
         .map(r => `- Line ${r.lineNum} ("${r.lineContent.slice(0, 50)}${r.lineContent.length > 50 ? '...' : ''}"): ${r.comment}`)
         .join('\n');
 
-    const context = `\n\nRefinements requested:\n${refinementText}`;
+    const prompt = [
+        `Edit ${targetPath}/${filename} in place to apply ONLY these line-specific refinements.`,
+        `DO NOT regenerate from any template.`,
+        `DO NOT run any setup script (e.g. setup-spec.sh, setup-plan.sh, setup-tasks.sh).`,
+        `DO NOT replace the file — make targeted edits only.`,
+        ``,
+        `Refinements requested:`,
+        refinementText,
+    ].join('\n');
 
-    // Determine command from workflow steps
-    const steps = await deps.resolveWorkflowSteps(specDirectory);
-    const currentStep = steps.find(s => s.name === docType);
-
-    if (currentStep) {
-        const targetPath = instance.state.changeRoot || specDirectory;
-        const label = currentStep.label || currentStep.name;
-        const prompt = `/${currentStep.command} ${targetPath}${context}`;
-        deps.outputChannel.appendLine(`[SpecViewer] Submitting ${refinements.length} refinements for ${docType}`);
-        await deps.executeInTerminal(prompt);
-    } else {
-        deps.outputChannel.appendLine(`[SpecViewer] No workflow step found for: ${docType}`);
-    }
+    deps.outputChannel.appendLine(`[SpecViewer] Submitting ${refinements.length} refinements for ${docType} (direct edit)`);
+    await deps.executeInTerminal(prompt);
 }


### PR DESCRIPTION
## What

- Refine no longer dispatches `/speckit.plan` (or any per-step slash command), so `setup-plan.sh` is no longer triggered and the existing plan.md is preserved
- Direct-edit prompt is uniform across spec / plan / tasks refinements
- 4 new unit tests in `messageHandlers.test.ts` lock in prompt shape (no slash, guardrails present, line-anchored comments included)

## Why

Adding line comments and clicking Refine on the plan view ran the `/speckit.plan` slash command, whose first step copies the plan template over the user's existing plan.md — destroying the content the AI was supposed to refine (issue #153).

## Testing

- `npm test` — 428 tests pass (40 suites, 6.2s)
- `npm run compile` — clean
- Manual: open a spec at the plan step, add line comments, click Refine; SpecViewer output channel logs prompt starting with "Edit …" rather than "/speckit.plan", and plan.md content is preserved

Closes #153