### PR TITLE
feat(spec-viewer): viewer state machine — quiet footer, dynamic Approve, Storybook coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ The spec viewer is built for fast scanning of long-form specs:
 - **Quiet content**: when the structured header has the metadata, in-content duplicates (the `Input:` block, repeated branch chips, literal `Slug:`/`Date:` paragraphs) are suppressed so the body is just the spec content.
 - **Diagrams**: wide mermaid diagrams scroll horizontally inside the prose column instead of bleeding past it. Each diagram has its own `−` / Reset / `+` zoom controls.
 - **Activity panel**: an `Activity` toggle on the right side of the navigation bar swaps the markdown pane for a card-stack overview of everything `.spec-context.json` carries — *Approach* (one-line strategy + status pill + PR link + commit/PR checkpoints + last action), *Phases* (per-step duration and recorded substeps with actor badges), *Tasks* (per-`T###` status, summary, file chips, inline concerns), *Decisions*, *Concerns*, and *Files touched* (clickable). Each card hides itself when its data is missing, so a lean speckit-style spec collapses to just *Phases*. Visibility is gated by the `speckit.viewer.activityPanel` setting — `"off"` (hide toggle), `"beta"` (default; toggle shows a *beta* pill), `"on"` (toggle without the pill). Substep timestamps are intentionally not surfaced as durations because SDD/AI emit them by hand and they're not reliable; only step-level boundaries (extension-stamped) get duration text.
+- **Quiet, intentional footer**: the viewer footer surfaces only what fits the current moment. While a step is mid-generation it shows `Regenerate` and a forward button labelled with the next phase (`Plan` / `Tasks` / `Implement` / `Complete`). `Archive` and `Mark Completed` only appear once the spec reaches a closure-eligible stage (`ready-to-implement` and beyond), and the SDD `Auto` button has moved to the **Create New Spec** form (next to `Submit`) so it's the explicit first-time choice rather than a viewer-side surprise. The `Edit Source` button is gone too — use the sidebar's inline `Open Source File` action instead. See [`docs/viewer-states.md`](./docs/viewer-states.md) for the full footer state matrix.
 
 ### Custom Workflows & Commands
 
@@ -446,8 +447,10 @@ The full JSON Schema lives at
 
 The extension itself records `stepHistory[step].startedAt` /
 `completedAt` and the canonical `status` whenever a step is dispatched
-(via the SpecKit commands or the viewer's Approve / Regenerate buttons),
-and when a spawned terminal closes, independent of AI cooperation. Spec
+(via the SpecKit commands or the viewer's next-step / Regenerate
+buttons — the next-step button is labelled with the upcoming phase
+name, e.g. `Plan`, `Tasks`, `Implement`, or `Complete` on the final
+step), and when a spawned terminal closes, independent of AI cooperation. Spec
 status changes (`Mark as Completed`, `Archive`, `Reactivate`) write the
 canonical status and append a transition entry, no longer relying on the
 legacy `setSpecStatus` path. Write failures log to the SpecKit output

--- a/docs/viewer-states.md
+++ b/docs/viewer-states.md
@@ -8,8 +8,22 @@
 >
 > **Canonical statuses**: `draft` → `specifying` → `specified` → `planning`
 > → `planned` → `tasking` → `ready-to-implement` → `implementing` →
-> `completed` → `archived`. Legacy `active`/`tasks-done` are migrated by
-> `normalizeSpecContext` at read time.
+> `implemented` → `completed` → `archived`. Legacy `active`/`tasks-done`
+> are migrated by `normalizeSpecContext` at read time.
+>
+> **Final approval gate (`implemented`)**: When the AI finishes the
+> `implement` step, `setStepCompleted('implement')` writes
+> `status='implemented'` rather than jumping straight to `completed`.
+> Terminal `completed` is reached only when the user clicks
+> `Mark Completed` (the spec-scope action that calls
+> `completeSpec`). This keeps the user in control of when a spec is
+> truly closed.
+>
+> **Visible-label overrides**: The viewer's status badge uses friendlier
+> labels for two canonical keys without changing the on-disk values:
+> `tasking` renders as `Creating Tasks` and `ready-to-implement` renders
+> as `Tasks Created`. Other statuses use the default hyphen-split
+> capitalization (`Implemented`, `Implementing`, `Specifying`, …).
 >
 > **Badge/pulse/highlight rules**:
 > - Step badge = `completed` if `stepHistory[step].completedAt` is set
@@ -41,9 +55,81 @@
 >
 > **Footer scope tooltips**: Every footer button declares
 > `scope: 'spec' | 'step'` and tooltips are auto-suffixed with
-> "(Affects whole spec)" / "(Affects this step)". SDD `Auto` appears only
-> on the Specify tab during `draft`/`specifying` for `sdd`/`sdd-fast`
-> workflows.
+> "(Affects whole spec)" / "(Affects this step)".
+>
+> **Edit Source moved to the sidebar**: The viewer footer no longer has
+> an `Edit Source` button. The same affordance lives on each spec/step
+> row in the sidebar tree as the inline `Open Source File` action
+> (`speckit.openSpecSource`, `$(go-to-file)` icon).
+>
+> **Auto moved to the Create New Spec form**: SDD `Auto` is no longer
+> a viewer footer button. It is the canonical first-time entry point
+> for the SDD pipeline and lives in the spec-editor webview as the
+> `Auto Mode` button next to `Submit`. By the time the spec viewer
+> opens, the user has already chosen between Submit and Auto Mode.
+>
+> **Start removed**: There is no `Start` button. The viewer only opens
+> after a step has been initiated (no realistic state where Start
+> would apply).
+>
+> **Closure-eligible gate (`isSpecDone`)**: `Archive` and `Mark
+> Completed` are hidden until the spec reaches the final approval
+> gate — `status` ∈ {`implemented`, `completed`}. While the AI is
+> still creating tasks or building, the footer stays focused on the
+> forward action; the sidebar's per-row Archive remains as the
+> escape hatch. `Archive` stays visible on `completed`; `Mark
+> Completed` does not (the spec is already terminal-completed).
+>
+> **Footer left/right split**: The renderer routes catalog actions
+> into two zones:
+> - **Left** (`actions-left`): `Regenerate` only — outlined "redo
+>   this step" tool sits alone so the eye finds it without
+>   competing with lifecycle controls.
+> - **Right** (`actions-right`): `Refine`, `Approve` (forward),
+>   `Reactivate`, `Archive`, `Mark Completed`. Closure controls
+>   share the right side with the forward button so the user's
+>   "what do I do next" decision is in one place.
+>
+> **Refine scope**: Refine appears only at pause states with a
+> markdown doc to comment on (`Specified`, `Planned`,
+> `Tasks Created`). It does not surface at `Implemented` — at that
+> stage the artifact is the code, not a markdown doc, and the
+> right surfaces are `Mark Completed` / `Archive`.
+>
+> **Dynamic Approve label**: The `Approve` button's visible label is
+> derived from the active workflow's step ordering — it shows the next
+> step's label (e.g. `Plan`, `Tasks`, `Implement`) so clicking it
+> announces what comes next. Falls back to `Approve` when the
+> workflow definition is missing.
+>
+> **Approve advance window**: `Approve` stays visible across the
+> "step done, next step not started" pauses (`specified` /
+> `planned` / `ready-to-implement`) so the user can dispatch the
+> next phase from the viewer footer. It hides once a later step
+> actually starts, and on the final step (`implement`) once
+> `completedAt` is set — at `implemented` the spec-scope
+> `Mark Completed` is the right surface, not `Approve`.
+>
+> **Hide-during-in-flight**: While a step is mid-generation
+> (`startedAt` set, no `completedAt`), the renderer in
+> `webview/src/spec-viewer/components/FooterActions.tsx` filters
+> out *every* footer entry instead of rendering disabled buttons.
+> The catalog still emits the catalog-correct array — the hide is
+> at the render layer. The header status badge plus the active
+> step's pulse are the "AI is working" cues; the sidebar's per-row
+> Archive remains as an escape hatch.
+>
+> **Step-tab in-flight pill size**: The active step's
+> `.step-status` badge stays at the same 16×16 size as the
+> completed checkmark while empty, only widening to a pill when
+> there's a `taskCompletionPercent` to show on the implement step.
+> Implemented via `:not(:empty)` in
+> `webview/styles/spec-viewer/_navigation.css`.
+>
+> **Footer overflow note (future-proofing)**: After this redesign
+> the right-side bar typically holds 1–3 buttons. If more lifecycle
+> actions are added later, group secondary entries into an overflow
+> `⋯` menu — keep the dynamic next-step button as the primary surface.
 
 ## Status Lifecycle
 

--- a/specs/093-fix-refine-overwrite/.spec-context.json
+++ b/specs/093-fix-refine-overwrite/.spec-context.json
@@ -1,6 +1,6 @@
 {
   "workflow": "sdd",
-  "currentStep": "done",
+  "currentStep": "specify",
   "currentTask": null,
   "progress": null,
   "next": "done",
@@ -15,7 +15,10 @@
   "createdAt": "2026-05-03T19:56:13Z",
   "prUrl": "https://github.com/alfredoperez/speckit-companion/pull/155",
   "prNumber": 155,
-  "checkpointStatus": { "commit": true, "pr": true },
+  "checkpointStatus": {
+    "commit": true,
+    "pr": true
+  },
   "approach": "Replace the slash-command refinement dispatch in handleSubmitRefinements with a freeform direct-edit prompt that names the target file and explicitly forbids running setup scripts, regenerating from a template, or replacing the file. Apply uniformly to spec/plan/tasks. Leave executeStepInTerminal (the legitimate slash-command path used by step-advance buttons) untouched.",
   "last_action": "PR #155 opened — fix(spec-viewer): stop refine from wiping plan.md via slash command",
   "files_modified": [
@@ -27,19 +30,25 @@
     "T001": {
       "status": "DONE",
       "did": "Rewrote handleSubmitRefinements to build a direct-edit prompt that names the target file and forbids regen/setup-script/file-replace, dropping the slash-command dispatch.",
-      "files": ["src/features/spec-viewer/messageHandlers.ts"],
+      "files": [
+        "src/features/spec-viewer/messageHandlers.ts"
+      ],
       "concerns": []
     },
     "T002": {
       "status": "DONE",
       "did": "Added a submitRefinements describe block (4 tests) asserting prompt does not start with /, contains DO-NOT guardrails, includes the user comments, and uses the same path for spec/tasks docs.",
-      "files": ["src/features/spec-viewer/__tests__/messageHandlers.test.ts"],
+      "files": [
+        "src/features/spec-viewer/__tests__/messageHandlers.test.ts"
+      ],
       "concerns": []
     },
     "T003": {
       "status": "DONE",
       "did": "Added a Bug Fixes entry under CHANGELOG Unreleased referencing #153. README was checked — Refine has no dedicated section, so the fix is internal-behavior only and no README change is required.",
-      "files": ["CHANGELOG.md"],
+      "files": [
+        "CHANGELOG.md"
+      ],
       "concerns": []
     }
   },
@@ -52,21 +61,168 @@
     }
   },
   "transitions": [
-    { "step": "specify", "substep": "parsing", "from": null, "by": "sdd", "at": "2026-05-03T19:56:13Z" },
-    { "step": "specify", "substep": "exploring", "from": { "step": "specify", "substep": "parsing" }, "by": "sdd", "at": "2026-05-03T19:56:14Z" },
-    { "step": "specify", "substep": "detecting", "from": { "step": "specify", "substep": "exploring" }, "by": "sdd", "at": "2026-05-03T19:56:15Z" },
-    { "step": "specify", "substep": "writing-spec", "from": { "step": "specify", "substep": "detecting" }, "by": "sdd", "at": "2026-05-03T19:56:16Z" },
-    { "step": "tasks", "substep": null, "from": { "step": "specify", "substep": "writing-spec" }, "by": "sdd", "at": "2026-05-03T19:56:17Z" },
-    { "step": "tasks", "substep": null, "from": { "step": "tasks", "substep": null }, "by": "sdd", "at": "2026-05-03T19:56:18Z" },
-    { "step": "implement", "substep": "phase1", "from": { "step": "tasks", "substep": null }, "by": "sdd", "at": "2026-05-03T19:57:00Z" },
-    { "step": "implement", "substep": "phase1", "from": { "step": "implement", "substep": "phase1" }, "by": "sdd", "at": "2026-05-03T19:57:01Z" },
-    { "step": "implement", "substep": "phase1", "from": { "step": "implement", "substep": "phase1" }, "by": "sdd", "at": "2026-05-03T19:57:30Z" },
-    { "step": "implement", "substep": "phase1", "from": { "step": "implement", "substep": "phase1" }, "by": "sdd", "at": "2026-05-03T19:58:00Z" },
-    { "step": "implement", "substep": "phase1", "from": { "step": "implement", "substep": "phase1" }, "by": "sdd", "at": "2026-05-03T19:58:30Z" },
-    { "step": "implement", "substep": "hooks", "from": { "step": "implement", "substep": "phase1" }, "by": "sdd", "at": "2026-05-03T19:58:45Z" },
-    { "step": "implement", "substep": "code-review", "from": { "step": "implement", "substep": "hooks" }, "by": "sdd", "at": "2026-05-03T19:59:00Z" },
-    { "step": "implement", "substep": "test-results", "from": { "step": "implement", "substep": "code-review" }, "by": "sdd", "at": "2026-05-03T19:59:30Z" },
-    { "step": "implement", "substep": "commit-review", "from": { "step": "implement", "substep": "test-results" }, "by": "sdd", "at": "2026-05-03T20:00:00Z" },
-    { "step": "done", "substep": null, "from": { "step": "implement", "substep": "commit-review" }, "by": "sdd", "at": "2026-05-03T20:00:30Z" }
-  ]
+    {
+      "step": "specify",
+      "substep": "parsing",
+      "from": null,
+      "by": "sdd",
+      "at": "2026-05-03T19:56:13Z"
+    },
+    {
+      "step": "specify",
+      "substep": "exploring",
+      "from": {
+        "step": "specify",
+        "substep": "parsing"
+      },
+      "by": "sdd",
+      "at": "2026-05-03T19:56:14Z"
+    },
+    {
+      "step": "specify",
+      "substep": "detecting",
+      "from": {
+        "step": "specify",
+        "substep": "exploring"
+      },
+      "by": "sdd",
+      "at": "2026-05-03T19:56:15Z"
+    },
+    {
+      "step": "specify",
+      "substep": "writing-spec",
+      "from": {
+        "step": "specify",
+        "substep": "detecting"
+      },
+      "by": "sdd",
+      "at": "2026-05-03T19:56:16Z"
+    },
+    {
+      "step": "tasks",
+      "substep": null,
+      "from": {
+        "step": "specify",
+        "substep": "writing-spec"
+      },
+      "by": "sdd",
+      "at": "2026-05-03T19:56:17Z"
+    },
+    {
+      "step": "tasks",
+      "substep": null,
+      "from": {
+        "step": "tasks",
+        "substep": null
+      },
+      "by": "sdd",
+      "at": "2026-05-03T19:56:18Z"
+    },
+    {
+      "step": "implement",
+      "substep": "phase1",
+      "from": {
+        "step": "tasks",
+        "substep": null
+      },
+      "by": "sdd",
+      "at": "2026-05-03T19:57:00Z"
+    },
+    {
+      "step": "implement",
+      "substep": "phase1",
+      "from": {
+        "step": "implement",
+        "substep": "phase1"
+      },
+      "by": "sdd",
+      "at": "2026-05-03T19:57:01Z"
+    },
+    {
+      "step": "implement",
+      "substep": "phase1",
+      "from": {
+        "step": "implement",
+        "substep": "phase1"
+      },
+      "by": "sdd",
+      "at": "2026-05-03T19:57:30Z"
+    },
+    {
+      "step": "implement",
+      "substep": "phase1",
+      "from": {
+        "step": "implement",
+        "substep": "phase1"
+      },
+      "by": "sdd",
+      "at": "2026-05-03T19:58:00Z"
+    },
+    {
+      "step": "implement",
+      "substep": "phase1",
+      "from": {
+        "step": "implement",
+        "substep": "phase1"
+      },
+      "by": "sdd",
+      "at": "2026-05-03T19:58:30Z"
+    },
+    {
+      "step": "implement",
+      "substep": "hooks",
+      "from": {
+        "step": "implement",
+        "substep": "phase1"
+      },
+      "by": "sdd",
+      "at": "2026-05-03T19:58:45Z"
+    },
+    {
+      "step": "implement",
+      "substep": "code-review",
+      "from": {
+        "step": "implement",
+        "substep": "hooks"
+      },
+      "by": "sdd",
+      "at": "2026-05-03T19:59:00Z"
+    },
+    {
+      "step": "implement",
+      "substep": "test-results",
+      "from": {
+        "step": "implement",
+        "substep": "code-review"
+      },
+      "by": "sdd",
+      "at": "2026-05-03T19:59:30Z"
+    },
+    {
+      "step": "implement",
+      "substep": "commit-review",
+      "from": {
+        "step": "implement",
+        "substep": "test-results"
+      },
+      "by": "sdd",
+      "at": "2026-05-03T20:00:00Z"
+    },
+    {
+      "step": "done",
+      "substep": null,
+      "from": {
+        "step": "implement",
+        "substep": "commit-review"
+      },
+      "by": "sdd",
+      "at": "2026-05-03T20:00:30Z"
+    }
+  ],
+  "stepHistory": {
+    "specify": {
+      "startedAt": "2026-05-08T16:13:31.338Z",
+      "completedAt": null
+    }
+  }
 }

--- a/specs/094-viewer-state-machine/.spec-context.json
+++ b/specs/094-viewer-state-machine/.spec-context.json
@@ -1,0 +1,147 @@
+{
+  "workflow": "sdd",
+  "currentStep": "implement",
+  "currentTask": "T008",
+  "progress": null,
+  "next": "done",
+  "status": "implementing",
+  "updated": "2026-05-08",
+  "selectedAt": "2026-05-08T17:00:00Z",
+  "specName": "Viewer State Machine",
+  "branch": "main",
+  "workingBranch": "feat/094-viewer-state-machine",
+  "type": "feat",
+  "auto": false,
+  "createdAt": "2026-05-08T17:00:00Z",
+  "approach": "Quiet the spec viewer footer during the awaiting-approval window (a step has startedAt but no completedAt) by hiding Archive, Mark Completed, and SDD Auto. Restrict Auto to pure draft (cold start). Relabel the generic Approve button to the next workflow step (Plan / Tasks / Implement / Complete) so the forward action is self-describing. Document the full state machine for stepper, header, footer, and timeline in docs/viewer-states.md so future work has a single source of truth.",
+  "last_action": "Implemented footer state-machine fix and drafted spec/plan/tasks. v0.15.1 installed locally.",
+  "files_modified": [
+    "src/features/spec-viewer/footerActions.ts",
+    "src/features/spec-viewer/stateDerivation.ts",
+    "src/features/spec-viewer/specViewerProvider.ts",
+    "tests/unit/spec-viewer/footerActions.spec.ts",
+    "docs/viewer-states.md",
+    "README.md"
+  ],
+  "task_summaries": {
+    "T001": {
+      "status": "DONE",
+      "did": "Added isAwaitingApproval predicate; tightened Archive, Mark Completed, and SDD Auto visibleWhen rules.",
+      "files": ["src/features/spec-viewer/footerActions.ts"],
+      "concerns": []
+    },
+    "T002": {
+      "status": "DONE",
+      "did": "Added getApproveLabel helper; getFooterActions now rewrites the visible Approve action's label using workflow steps.",
+      "files": ["src/features/spec-viewer/footerActions.ts"],
+      "concerns": []
+    },
+    "T003": {
+      "status": "DONE",
+      "did": "deriveViewerState accepts optional workflowSteps and forwards to getFooterActions; both provider call sites resolve workflow.steps and pass them.",
+      "files": [
+        "src/features/spec-viewer/stateDerivation.ts",
+        "src/features/spec-viewer/specViewerProvider.ts"
+      ],
+      "concerns": []
+    },
+    "T004": {
+      "status": "DONE",
+      "did": "Added Awaiting-approval suppression test cases (4 scenarios).",
+      "files": ["tests/unit/spec-viewer/footerActions.spec.ts"],
+      "concerns": []
+    },
+    "T005": {
+      "status": "DONE",
+      "did": "Added getApproveLabel cases (5) and dynamic Approve label cases in getFooterActions (2).",
+      "files": ["tests/unit/spec-viewer/footerActions.spec.ts"],
+      "concerns": []
+    },
+    "T006": {
+      "status": "DONE",
+      "did": "Documented awaiting-approval suppression, draft-only Auto rule, dynamic Approve label, and overflow-menu future-proofing note.",
+      "files": ["docs/viewer-states.md"],
+      "concerns": []
+    },
+    "T007": {
+      "status": "DONE",
+      "did": "Added Reading Specs bullet for the quiet awaiting-approval footer; updated lifecycle-writes paragraph to reflect dynamic next-step button name.",
+      "files": ["README.md"],
+      "concerns": []
+    },
+    "T008": {
+      "status": "PENDING",
+      "did": "Manual smoke deferred to user — v0.15.1 installed via /install-local; needs reload + verification in ngx-dev-toolbar.",
+      "files": [],
+      "concerns": [
+        "T008 is the manual verification step; mark DONE after the user confirms the footer renders correctly post-reload."
+      ]
+    }
+  },
+  "step_summaries": {
+    "specify": {
+      "complexity": "normal",
+      "requirements": 8,
+      "scenarios": 10,
+      "key_finding": "Footer button visibility is hard-coded in extension TypeScript; user config (.vscode/settings.json) cannot influence it. Both ngx-dev-toolbar and speckit-companion ship byte-identical sdd workflow definitions, so the screenshot is reproducible in either project."
+    },
+    "plan": {
+      "complexity": "normal",
+      "key_finding": "Plumb workflowSteps through deriveViewerState rather than importing workflowManager into footerActions, to keep footerActions free of vscode dependency (matches existing test mock pattern in stateDerivation.test.ts)."
+    },
+    "implement": {
+      "complexity": "normal",
+      "tests_added": 11,
+      "tests_total": 490,
+      "key_finding": "All 490 tests pass. Compile clean. v0.15.1 packaged and installed."
+    }
+  },
+  "transitions": [
+    {
+      "step": "specify",
+      "substep": null,
+      "from": null,
+      "by": "extension",
+      "at": "2026-05-08T17:00:00Z"
+    },
+    {
+      "step": "plan",
+      "substep": null,
+      "from": { "step": "specify", "substep": null },
+      "by": "extension",
+      "at": "2026-05-08T17:05:00Z"
+    },
+    {
+      "step": "tasks",
+      "substep": null,
+      "from": { "step": "plan", "substep": null },
+      "by": "extension",
+      "at": "2026-05-08T17:08:00Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "from": { "step": "tasks", "substep": null },
+      "by": "extension",
+      "at": "2026-05-08T17:10:00Z"
+    }
+  ],
+  "stepHistory": {
+    "specify": {
+      "startedAt": "2026-05-08T17:00:00Z",
+      "completedAt": "2026-05-08T17:05:00Z"
+    },
+    "plan": {
+      "startedAt": "2026-05-08T17:05:00Z",
+      "completedAt": "2026-05-08T17:08:00Z"
+    },
+    "tasks": {
+      "startedAt": "2026-05-08T17:08:00Z",
+      "completedAt": "2026-05-08T17:10:00Z"
+    },
+    "implement": {
+      "startedAt": "2026-05-08T17:10:00Z",
+      "completedAt": null
+    }
+  }
+}

--- a/specs/094-viewer-state-machine/plan.md
+++ b/specs/094-viewer-state-machine/plan.md
@@ -1,0 +1,91 @@
+# Plan: Viewer State Machine — Stepper, Header, Footer, Timeline
+
+**Spec**: [spec.md](./spec.md)
+
+## Approach
+
+Two kinds of work, separated cleanly:
+
+1. **Footer behavior changes** (R001–R004) — code-level changes in
+   `src/features/spec-viewer/footerActions.ts` to introduce the
+   `isAwaitingApproval` predicate, restrict `Auto` to pure draft,
+   and rewrite the `Approve` action's `label` based on the active
+   workflow's next step. Plumbed via an optional `workflowSteps`
+   parameter through `deriveViewerState` → `getFooterActions`.
+2. **Documentation** (R005–R007) — capture the existing stepper,
+   header, and timeline state derivation rules in
+   `docs/viewer-states.md` so future contributors can read one
+   document for the full state machine.
+
+R008 (testability) is satisfied by the existing pure-function
+architecture (`stateDerivation.ts`, `footerActions.ts`); no
+refactor needed.
+
+## Files
+
+### Modify
+
+- `src/features/spec-viewer/footerActions.ts`
+  - Add `isAwaitingApproval(ctx, step)` predicate.
+  - Tighten `ARCHIVE` and `COMPLETE` `visibleWhen` to also exclude
+    awaiting-approval.
+  - Tighten `SDD_AUTO` `visibleWhen` to require
+    `status === 'draft'` only.
+  - Add `getApproveLabel(currentStep, workflowSteps)` helper that
+    looks up the next step's label.
+  - Extend `getFooterActions(ctx, step, workflowSteps?)` to rewrite
+    the Approve action's `label` after filtering.
+- `src/features/spec-viewer/stateDerivation.ts`
+  - `deriveViewerState` accepts an optional `workflowSteps:
+    WorkflowStepConfig[]` and forwards it to `getFooterActions`.
+- `src/features/spec-viewer/specViewerProvider.ts`
+  - Both `deriveViewerState` call sites resolve workflow steps via
+    `(getWorkflow(specCtx.workflow) || DEFAULT_WORKFLOW).steps` and
+    pass them in.
+- `tests/unit/spec-viewer/footerActions.spec.ts`
+  - Add cases for awaiting-approval suppression on specify and on
+    plan, restoration after completion, cold-start draft, dynamic
+    next-step label per step, and fallback when no workflow is
+    provided.
+- `docs/viewer-states.md`
+  - Document the awaiting-approval suppression block, the dynamic
+    Approve label rule, the cold-start `draft` exception for Auto,
+    and a forward-looking overflow-menu note.
+- `README.md`
+  - Reading Specs: brief mention of the quiet awaiting-approval
+    footer.
+  - Lifecycle-writes paragraph: clarify that the next-step button
+    is dynamically labelled (`Plan`, `Tasks`, `Implement`,
+    `Complete`).
+
+### Create
+
+- `specs/094-viewer-state-machine/{spec.md, plan.md, tasks.md,
+  .spec-context.json}` (this folder).
+
+## Testing Strategy
+
+- **Unit**: extend `tests/unit/spec-viewer/footerActions.spec.ts`
+  with cases enumerated above. All must run via existing
+  `ts-jest` config without VS Code stubs (footerActions stays free
+  of `vscode` imports — workflow lookup happens at the provider
+  edge).
+- **Manual**: `/install-local`, then in `ngx-dev-toolbar`:
+  1. Run `/sdd:specify`. Viewer footer = `Edit Source`,
+     `Regenerate`, `Plan`. ✅
+  2. Click `Plan` → footer becomes `Edit Source`, `Regenerate`,
+     `Tasks`. ✅
+  3. On the final implement step, button reads `Complete`. ✅
+  4. Manually edit `.spec-context.json` to `status: "draft"` with
+     empty `stepHistory` — Auto should be visible. ✅
+- **Regression**: full `npm test` (490+ tests).
+
+## Out of Scope
+
+- Refactoring the webview's footer renderer
+  (`webview/src/spec-viewer/components/FooterActions.tsx`). It
+  already consumes `viewerState.footer[]` and was not touched —
+  the dynamic label flows through transparently.
+- Stepper / header / timeline behavior changes — those are
+  documented as-is. No code edits to those subsystems in this
+  branch.

--- a/specs/094-viewer-state-machine/spec.md
+++ b/specs/094-viewer-state-machine/spec.md
@@ -1,0 +1,174 @@
+# Spec: Viewer State Machine — Stepper, Header, Footer, Timeline
+
+**Slug**: 094-viewer-state-machine | **Date**: 2026-05-08
+
+## Summary
+
+The spec viewer's UI surfaces (stepper tabs, header badges, footer
+actions, activity panel) all derive their visible state from
+`.spec-context.json`. The rules are scattered across `footerActions.ts`,
+`stateDerivation.ts`, and the webview components, and only partially
+documented in `docs/viewer-states.md`. This spec captures the full state
+machine as user-facing scenarios so the visible behavior at every
+status × step combination is intentional, testable, and documented.
+
+The immediate trigger was the footer-button noise during the
+just-generated-spec window (issue surfaced from `ngx-dev-toolbar`):
+`Archive`, `Mark Completed`, `Auto`, `Regenerate`, and `Approve` all
+appeared simultaneously the moment `/sdd:specify` finished, even
+though most of those actions were premature for a spec the user
+hadn't reviewed yet. The footer cleanup is included here, but the
+broader goal is a documented state machine across all four surfaces.
+
+## Requirements
+
+- **R001** (MUST): While a step has `startedAt` set but not yet
+  `completedAt` and the spec hasn't moved past it
+  (`isAwaitingApproval`), the footer MUST hide the lifecycle actions
+  `Archive`, `Mark Completed`, and `Auto`.
+- **R002** (MUST): The SDD `Auto` button MUST only appear on the
+  Specify tab while `status === 'draft'` (true cold start) for
+  `sdd`/`sdd-fast` workflows. Once specify has started
+  (`status === 'specifying'`), Auto MUST be hidden.
+- **R003** (MUST): The forward action button (formerly `Approve`)
+  MUST display the next step's label from the active workflow
+  (`Plan` → `Tasks` → `Implement`). On the final step it MUST read
+  `Complete`. When workflow steps are unavailable it MUST fall back
+  to `Approve`.
+- **R004** (MUST): The footer MUST always serialize a `label` per
+  action; the underlying action `id` (used by message handlers) MUST
+  remain `'approve'` so behavior on click is unchanged.
+- **R005** (SHOULD): Stepper tab visual state MUST be derivable from
+  `.spec-context.json` alone — `not-started` (no `startedAt`),
+  `in-progress` (`startedAt` set, not inferred-completed),
+  `completed` (`completedAt` set OR step precedes `currentStep`).
+- **R006** (SHOULD): The header status badge MUST reflect the
+  canonical `status` field from `.spec-context.json` and MUST
+  surface as the only visual signal of overall lifecycle state
+  (`draft`, `specifying`, `specified`, … `completed`, `archived`).
+- **R007** (SHOULD): The Activity / timeline panel MUST render
+  step-level boundaries (extension-stamped `startedAt` /
+  `completedAt`) with durations. Substep boundaries (AI-emitted)
+  MUST be rendered without durations because the timestamps are
+  not reliable.
+- **R008** (MUST): All state transitions surfaced in the viewer MUST
+  be testable via pure functions that take a `SpecContext` (no
+  filesystem reads, no live VS Code APIs).
+
+## Scenarios
+
+### Footer — just-generated, awaiting first approval
+
+**Given** a fresh spec where `/sdd:specify` has just written
+`spec.md` and set `status='specifying'`, `stepHistory.specify.startedAt`,
+`completedAt=null`
+**When** the user opens the viewer on the Specify tab
+**Then** the footer shows only `Edit Source`, `Regenerate`, and
+`Plan` (the dynamic next-step button). `Archive`, `Mark Completed`,
+and `Auto` are hidden until specify is approved.
+
+### Footer — step approved, lifecycle returns
+
+**When** the user clicks the forward button (`Plan`) and the
+extension marks specify completed (`status='specified'`,
+`stepHistory.specify.completedAt` set)
+**Then** the next viewer refresh shows `Edit Source`, `Archive`,
+`Mark Completed`, and `Start` (on the Plan tab) — the full
+lifecycle bar is restored.
+
+### Footer — pure draft (cold start)
+
+**Given** a spec folder created with no AI generation yet
+(`status='draft'`, `stepHistory={}`)
+**When** the user opens the viewer on the Specify tab
+**Then** the footer shows `Edit Source`, `Start`, `Auto`, `Archive`,
+and `Mark Completed`. Auto is appropriate here because nothing has
+started; the user can still abandon (Archive) or shortcut
+(Mark Completed) a placeholder.
+
+### Footer — terminal states
+
+**Given** `status='completed'` or `'archived'`
+**Then** the footer shows `Edit Source`, `Reactivate`, and (for
+`completed`) `Archive`. All step-scoped actions (`Start`,
+`Regenerate`, `Approve`) are suppressed regardless of `stepHistory`.
+
+### Footer — dynamic next-step label
+
+**Given** an in-progress step under the `sdd` workflow with steps
+`specify → plan → tasks → implement`
+**Then** the forward button label MUST be:
+- `Plan` while on `specify`
+- `Tasks` while on `plan`
+- `Implement` while on `tasks`
+- `Complete` while on `implement`
+
+### Stepper — visual state per step
+
+**Given** a `.spec-context.json` with `currentStep='plan'`,
+`stepHistory.specify.completedAt` set, `stepHistory.plan.startedAt`
+set
+**Then** the stepper shows: `specify` as `completed` (green ✓),
+`plan` as `in-progress` (pulsing accent), `tasks` and `implement`
+as `not-started` (muted). The stepper renders identically whether
+the user is viewing the Plan tab or has clicked back into Specify
+to review (clicking a tab does NOT mutate `currentStep`).
+
+### Stepper — viewed step indicator
+
+**Given** the user is viewing a step earlier than `currentStep`
+(reviewing a completed phase)
+**Then** the active tab gets a dashed `.reviewing` outline so it's
+clear the user is reviewing a prior phase rather than the live one.
+The header badge continues to reflect the spec's true workflow
+state (e.g. `Planning`), not the viewed tab.
+
+### Header — status badge progression
+
+**Given** the canonical status sequence `draft → specifying →
+specified → planning → planned → tasking → ready-to-implement →
+implementing → completed → archived`
+**Then** the header status pill MUST update on every viewer
+refresh to reflect the current status, with color tier (per
+`docs/sidebar.md` "Header badge color tiers") matching the status
+class (in-progress vs. ready vs. terminal).
+
+### Header — branch and date metadata
+
+**When** the spec context has `branch` and a `selectedAt` /
+`createdAt`
+**Then** the header surfaces a `[STATUS] [⌥ branch] · date`
+cluster under the title. None of these fields advance state
+themselves; they are read-only metadata.
+
+### Activity / Timeline panel — step durations vs substeps
+
+**Given** the user toggles the Activity panel
+**Then** the *Phases* card shows each step's start → end with a
+duration computed from `stepHistory[step].startedAt` /
+`completedAt`. Substep entries (AI-emitted, e.g. `parsing`,
+`writing-spec`) appear under each phase WITHOUT durations because
+their timestamps are not extension-stamped and not reliable for
+arithmetic.
+
+### Activity / Timeline — visibility setting
+
+**Given** `speckit.viewer.activityPanel === 'off'`
+**Then** the Activity toggle does not appear in the navigation bar.
+**Given** `'beta'` (default)
+**Then** the toggle appears with a *beta* pill.
+**Given** `'on'`
+**Then** the toggle appears without a pill.
+
+## Out of Scope
+
+- The internal markdown rendering pipeline (preprocessors,
+  scenario expansions) — covered elsewhere.
+- Sidebar tree state (covered by `docs/sidebar.md`).
+- Spec creation flow / `.spec-context.json` writer logic — those
+  produce the state; this spec only describes how the viewer
+  *renders* it.
+- Tooltip copy refinements; this spec defines what shows, not the
+  exact wording.
+- A redesigned overflow `⋯` menu for excess footer buttons. Noted
+  as future-proofing in `docs/viewer-states.md` but not built here.

--- a/specs/094-viewer-state-machine/tasks.md
+++ b/specs/094-viewer-state-machine/tasks.md
@@ -1,0 +1,47 @@
+# Tasks: Viewer State Machine — Stepper, Header, Footer, Timeline
+
+**Plan**: [plan.md](./plan.md)
+
+> Format reference: `[P]` markers and parallel groups — see `skills/tasks/SKILL.md` § Phase rules.
+
+## Phase 1: Footer Behavior
+
+- [x] **T001** Add `isAwaitingApproval` predicate and tighten visibility rules — `src/features/spec-viewer/footerActions.ts` | R001, R002
+  - **Do**: Add a private `isAwaitingApproval(ctx, step)` helper that returns true when `step.startedAt` is set, `completedAt` is null, and the step is not inferred-completed. Update `ARCHIVE.visibleWhen` and `COMPLETE.visibleWhen` to also require `!isAwaitingApproval(ctx, step)`. Tighten `SDD_AUTO.visibleWhen` from `status ∈ {draft, specifying}` to `status === 'draft'`.
+  - **Verify**: `npm run compile` passes; existing footerActions tests still pass.
+  - **Leverage**: `isStepCompleted` from `stateDerivation.ts`; the existing `FOOTER_ACTIONS` array.
+
+- [x] **T002** [P] Add `getApproveLabel` helper and use it in `getFooterActions` — `src/features/spec-viewer/footerActions.ts` | R003, R004
+  - **Do**: Export `getApproveLabel(currentStep, workflowSteps?)` that finds the step's index in `workflowSteps`, returns the next step's `label` (or capitalized `name`), `'Complete'` if final, `'Approve'` if missing/unknown. Extend `getFooterActions(ctx, step, workflowSteps?)` to map the visible Approve action to a fresh object with the dynamic `label`. Keep the action `id` `'approve'` so click handlers stay unchanged.
+  - **Verify**: Compile passes; new label flows through serialization in `specViewerProvider.ts:306-311` (already uses `a.label`).
+  - **Leverage**: `WorkflowStepConfig` from `src/features/workflows/types.ts`.
+
+- [x] **T003** *(depends on T002)* Thread `workflowSteps` through derivation — `src/features/spec-viewer/stateDerivation.ts`, `src/features/spec-viewer/specViewerProvider.ts` | R003
+  - **Do**: `deriveViewerState(ctx, activeStep?, workflowSteps?)` accepts an optional third parameter and forwards it to `getFooterActions`. Both call sites in `specViewerProvider.ts` (`refreshContextIfDisplaying` and the documentType-update handler) resolve `(getWorkflow(specCtx.workflow) || DEFAULT_WORKFLOW).steps` and pass it.
+  - **Verify**: Compile passes; existing `stateDerivation.test.ts` mock keeps working.
+
+## Phase 2: Tests
+
+- [x] **T004** [P] Awaiting-approval suppression cases — `tests/unit/spec-viewer/footerActions.spec.ts` | R001, R002
+  - **Do**: Add `describe('Awaiting-approval window')` with: (a) freshly generated specify (`status='specifying'`, `startedAt` set) hides Archive, Mark Completed, Auto; (b) Plan tab while planning hides Archive/Mark Completed; (c) post-completion (`status='specified'`, `completedAt` set) restores Archive/Mark Completed and hides Approve; (d) cold-start `draft` keeps Auto and Start visible.
+  - **Verify**: `npm test -- --testPathPattern=footerActions` all green.
+
+- [x] **T005** [P] Dynamic Approve label cases — `tests/unit/spec-viewer/footerActions.spec.ts` | R003, R004
+  - **Do**: Add `describe('getApproveLabel')` covering next-step labels for each step in the SDD workflow, `'Complete'` on the final step, fallback `'Approve'` when steps array is undefined/empty/unmatched, and capitalized name when label is missing. Add a `describe('getFooterActions Approve label is dynamic')` asserting the visible Approve action's label is `'Plan'` on specify when steps are passed and `'Approve'` when omitted.
+  - **Verify**: `npm test` all green (490+ tests).
+
+## Phase 3: Documentation
+
+- [x] **T006** Update viewer-states doc — `docs/viewer-states.md` | R001–R007
+  - **Do**: In the "Footer scope tooltips" header block, add: (a) the awaiting-approval suppression rule, (b) the cold-start `draft`-only Auto rule, (c) the dynamic next-step Approve label, (d) a forward-looking overflow `⋯` menu note.
+  - **Verify**: Doc renders cleanly; cross-references to `footerActions.ts` still valid.
+
+- [x] **T007** [P] Update README — `README.md` | R001, R003
+  - **Do**: In the "Reading Specs" section add a bullet describing the quiet awaiting-approval footer and dynamic next-step button. In the lifecycle-writes paragraph (~line 449), update "Approve / Regenerate buttons" wording to clarify the next-step button is dynamically labelled (`Plan`, `Tasks`, `Implement`, or `Complete`).
+  - **Verify**: README references stay consistent with `docs/viewer-states.md`.
+
+## Phase 4: Manual Verification
+
+- [ ] **T008** *(depends on T001–T007)* Manual smoke in `ngx-dev-toolbar` — | R001–R004
+  - **Do**: `/install-local` (already done — v0.15.1). In `ngx-dev-toolbar`, run `/sdd:specify some-feature`. Verify the viewer footer on the Specify tab shows only `Edit Source`, `Regenerate`, `Plan`. Click `Plan` and confirm the footer transitions correctly. Step through to Implement and confirm the button reads `Complete`. Manually patch a `.spec-context.json` to pure `draft` and confirm Auto reappears.
+  - **Verify**: Screenshot the Specify-tab footer pre/post fix. Compare against `image-3-stateful-axolotl.png`.

--- a/src/core/types/specContext.ts
+++ b/src/core/types/specContext.ts
@@ -31,6 +31,7 @@ export type Status =
     | 'tasking'
     | 'ready-to-implement'
     | 'implementing'
+    | 'implemented'
     | 'completed'
     | 'archived';
 
@@ -43,6 +44,7 @@ export const STATUSES: Status[] = [
     'tasking',
     'ready-to-implement',
     'implementing',
+    'implemented',
     'completed',
     'archived',
 ];

--- a/src/features/spec-viewer/footerActions.ts
+++ b/src/features/spec-viewer/footerActions.ts
@@ -3,18 +3,23 @@
  *
  * - Every action declares `scope: 'spec' | 'step'` (FR-009).
  * - Tooltips are auto-suffixed with a scope phrase at render time.
- * - SDD `Auto` is only visible on the Specify tab during `draft`/`specifying`
- *   for `sdd`/`sdd-fast` workflows (FR-010).
+ * - The `Approve` button's visible label is the next step's label
+ *   (e.g. `Plan`, `Tasks`, `Implement`) when a workflow definition is
+ *   provided, falling back to `Approve` / `Complete`.
+ * - `Archive` and `Mark Completed` are gated by `isSpecDone(ctx)` so
+ *   they only surface once the spec has reached the closure-eligible
+ *   stages (`ready-to-implement` / `implementing` / `completed`). The
+ *   user never sees them while a step is mid-generation.
+ * - The legacy `Start` and `SDD_AUTO` actions have been removed:
+ *   - `Start` is structurally unreachable — the viewer only opens
+ *     after a step has been initiated.
+ *   - Auto belongs in the Create-New-Spec UI (`Auto Mode` next to
+ *     `Submit`), not in the post-creation viewer footer.
  */
 
-import { FooterAction, SpecContext, StepName } from '../../core/types/specContext';
-import { isStepCompleted } from './stateDerivation';
-import {
-    SpecStatuses,
-    APPROVAL_GATED_WORKFLOWS,
-    FooterActionIds,
-    WorkflowSteps,
-} from '../../core/constants';
+import { FooterAction, SpecContext, StepName, STEP_NAMES } from '../../core/types/specContext';
+import { SpecStatuses, FooterActionIds } from '../../core/constants';
+import type { WorkflowStepConfig } from '../workflows/types';
 
 const SCOPE_SUFFIX: Record<'spec' | 'step', string> = {
     spec: 'Affects whole spec',
@@ -30,13 +35,80 @@ function isTerminal(status: string | undefined): boolean {
     return status === SpecStatuses.COMPLETED || status === SpecStatuses.ARCHIVED;
 }
 
+/**
+ * True once the spec has reached a closure-eligible stage. Tightened
+ * to just `implemented` + `completed`: while the AI is still creating
+ * tasks or building (`tasks-created`, `implementing`), the footer
+ * stays focused on the forward action and the sidebar's per-row
+ * Archive remains the escape hatch. `Mark Completed` and `Archive`
+ * only appear once the build is done and the user is at the final
+ * approval gate.
+ */
+function isSpecDone(ctx: SpecContext): boolean {
+    return (
+        ctx.status === 'implemented' ||
+        ctx.status === SpecStatuses.COMPLETED
+    );
+}
+
+/**
+ * Decide whether `Approve` should surface for `step`.
+ *
+ * Visible when:
+ * - the step has been started, AND
+ * - no later step in `STEP_NAMES` has acquired a `startedAt` (the
+ *   workflow has not moved past this tab), AND
+ * - either the step is in flight (no `completedAt`) OR there's still
+ *   a later step in the workflow to advance to.
+ *
+ * The "later step exists" check is what hides `Approve` once the
+ * final step (`implement`) has its `completedAt` — at that point the
+ * spec-scope `Mark Completed` is the right surface, not Approve.
+ */
+function shouldShowApprove(ctx: SpecContext, step: StepName): boolean {
+    const entry = ctx.stepHistory[step];
+    if (!entry?.startedAt) return false;
+    const idx = STEP_NAMES.indexOf(step);
+    if (idx < 0) return false;
+    // Any later step started → workflow has moved past this tab.
+    for (let i = idx + 1; i < STEP_NAMES.length; i++) {
+        if (ctx.stepHistory[STEP_NAMES[i]]?.startedAt) return false;
+    }
+    // Step in flight → always show.
+    if (!entry.completedAt) return true;
+    // Step is done → only show if there's a later step left to dispatch.
+    return idx < STEP_NAMES.length - 1;
+}
+
+/**
+ * Resolve the visible label for the `Approve` action based on the active
+ * workflow's step ordering. Returns the next step's label, or `Complete`
+ * for the final step, or `Approve` if the workflow definition is missing.
+ */
+export function getApproveLabel(
+    currentStep: StepName,
+    workflowSteps: WorkflowStepConfig[] | undefined
+): string {
+    if (!workflowSteps || workflowSteps.length === 0) return 'Approve';
+    const idx = workflowSteps.findIndex(s => s.name === currentStep);
+    if (idx < 0) return 'Approve';
+    const next = workflowSteps[idx + 1];
+    if (!next) return 'Complete';
+    return next.label ?? capitalize(next.name);
+}
+
+function capitalize(s: string): string {
+    return s.length === 0 ? s : s.charAt(0).toUpperCase() + s.slice(1);
+}
+
 export const FOOTER_ACTIONS: FooterAction[] = [
     {
         id: FooterActionIds.ARCHIVE,
         label: 'Archive',
         scope: 'spec',
         tooltip: 'Archive this spec',
-        visibleWhen: (ctx) => ctx.status !== SpecStatuses.ARCHIVED,
+        visibleWhen: (ctx) =>
+            ctx.status !== SpecStatuses.ARCHIVED && isSpecDone(ctx),
     },
     {
         id: FooterActionIds.REACTIVATE,
@@ -51,18 +123,7 @@ export const FOOTER_ACTIONS: FooterAction[] = [
         label: 'Mark Completed',
         scope: 'spec',
         tooltip: 'Mark this spec as completed',
-        visibleWhen: (ctx) => !isTerminal(ctx.status),
-    },
-    {
-        id: FooterActionIds.START,
-        label: 'Start',
-        scope: 'step',
-        tooltip: 'Start this step',
-        visibleWhen: (ctx, step) => {
-            if (isTerminal(ctx.status)) return false;
-            const entry = ctx.stepHistory[step];
-            return !entry?.startedAt;
-        },
+        visibleWhen: (ctx) => !isTerminal(ctx.status) && isSpecDone(ctx),
     },
     {
         id: FooterActionIds.REGENERATE,
@@ -82,25 +143,20 @@ export const FOOTER_ACTIONS: FooterAction[] = [
         tooltip: 'Approve this step and continue',
         visibleWhen: (ctx, step) => {
             if (isTerminal(ctx.status)) return false;
-            const entry = ctx.stepHistory[step];
-            return !!entry?.startedAt && !isStepCompleted(step, ctx.currentStep, ctx.stepHistory);
+            return shouldShowApprove(ctx, step);
         },
-    },
-    {
-        id: FooterActionIds.SDD_AUTO,
-        label: 'Auto',
-        scope: 'spec',
-        tooltip: 'Run the full SDD pipeline automatically',
-        visibleWhen: (ctx, step) =>
-            APPROVAL_GATED_WORKFLOWS.includes(ctx.workflow) &&
-            step === WorkflowSteps.SPECIFY &&
-            (ctx.status === 'draft' || ctx.status === 'specifying'),
     },
 ];
 
 export function getFooterActions(
     ctx: SpecContext,
-    step: StepName
+    step: StepName,
+    workflowSteps?: WorkflowStepConfig[]
 ): FooterAction[] {
-    return FOOTER_ACTIONS.filter(a => a.visibleWhen(ctx, step));
+    const visible = FOOTER_ACTIONS.filter(a => a.visibleWhen(ctx, step));
+    return visible.map(a =>
+        a.id === FooterActionIds.APPROVE
+            ? { ...a, label: getApproveLabel(step, workflowSteps) }
+            : a
+    );
 }

--- a/src/features/spec-viewer/specViewerProvider.ts
+++ b/src/features/spec-viewer/specViewerProvider.ts
@@ -300,7 +300,8 @@ export class SpecViewerProvider {
       const active: StepName = STEP_NAMES.includes(specCtx.currentStep as StepName)
         ? (specCtx.currentStep as StepName)
         : 'specify';
-      const derived = deriveViewerState(specCtx, active);
+      const wfSteps = (getWorkflow(specCtx.workflow) || DEFAULT_WORKFLOW).steps;
+      const derived = deriveViewerState(specCtx, active, wfSteps);
       const viewerState: CoreViewerState = {
         ...derived,
         footer: derived.footer.map(a => ({
@@ -913,7 +914,8 @@ export class SpecViewerProvider {
           const active: StepName = (STEP_NAMES.includes(specCtx.currentStep as StepName)
             ? (specCtx.currentStep as StepName)
             : 'specify');
-          const derived = deriveViewerState(specCtx, active);
+          const wfSteps = (getWorkflow(specCtx.workflow) || DEFAULT_WORKFLOW).steps;
+          const derived = deriveViewerState(specCtx, active, wfSteps);
           viewerState = {
             ...derived,
             footer: derived.footer.map(a => ({

--- a/src/features/spec-viewer/stateDerivation.ts
+++ b/src/features/spec-viewer/stateDerivation.ts
@@ -22,6 +22,7 @@ import {
 } from '../../core/types/specContext';
 import { getFooterActions } from './footerActions';
 import { deriveStepHistory } from '../specs/stepHistoryDerivation';
+import type { WorkflowStepConfig } from '../workflows/types';
 
 /**
  * Pull a tolerated extra field from `SpecContext` (it has a permissive
@@ -149,7 +150,8 @@ export function deriveActiveSubstep(
 
 export function deriveViewerState(
     ctx: SpecContext,
-    activeStep: StepName = ctx.currentStep
+    activeStep: StepName = ctx.currentStep,
+    workflowSteps?: WorkflowStepConfig[]
 ): ViewerState {
     return {
         status: ctx.status,
@@ -158,7 +160,7 @@ export function deriveViewerState(
         pulse: derivePulse(ctx),
         highlights: deriveHighlights(ctx),
         activeSubstep: deriveActiveSubstep(ctx),
-        footer: getFooterActions(ctx, activeStep),
+        footer: getFooterActions(ctx, activeStep, workflowSteps),
         transitions: ctx.transitions ?? [],
         // Derive stepHistory from the reliable transitions[] sequence rather
         // than trusting the on-disk stepHistory (AI-typed, unreliable).

--- a/src/features/specs/specContextWriter.ts
+++ b/src/features/specs/specContextWriter.ts
@@ -216,7 +216,12 @@ function deriveCompletedStatus(step: StepName): SpecContext['status'] {
         case 'analyze':
             return 'ready-to-implement';
         case 'implement':
-            return 'completed';
+            // The implement step finishing means the AI is done writing code,
+            // but the spec is not yet terminally completed. The user has to
+            // click "Mark Completed" to advance from `implemented` →
+            // `completed`. That final approval gate keeps the user in
+            // control of when the spec is truly closed.
+            return 'implemented';
     }
 }
 

--- a/tests/unit/spec-viewer/footerActions.spec.ts
+++ b/tests/unit/spec-viewer/footerActions.spec.ts
@@ -1,15 +1,24 @@
 import {
     getFooterActions,
+    getApproveLabel,
     withScopeSuffix,
     FOOTER_ACTIONS,
 } from '../../../src/features/spec-viewer/footerActions';
 import { SpecContext } from '../../../src/core/types/specContext';
+import type { WorkflowStepConfig } from '../../../src/features/workflows/types';
 import {
     SpecStatuses,
     Workflows,
     FooterActionIds,
     WorkflowSteps,
 } from '../../../src/core/constants';
+
+const SDD_STEPS: WorkflowStepConfig[] = [
+    { name: 'specify', label: 'Specification', command: 'sdd:specify', file: 'spec.md' },
+    { name: 'plan', label: 'Plan', command: 'sdd:plan', file: 'plan.md' },
+    { name: 'tasks', label: 'Tasks', command: 'sdd:tasks', file: 'tasks.md' },
+    { name: 'implement', label: 'Implement', command: 'sdd:implement', actionOnly: true },
+];
 
 function baseCtx(overrides: Partial<SpecContext> = {}): SpecContext {
     return {
@@ -33,38 +42,16 @@ describe('getFooterActions (US6 — scope + visibility)', () => {
         }
     });
 
-    it('SDD Auto only visible on Specify during draft/specifying for sdd/sdd-fast', () => {
-        const ctx = baseCtx({ workflow: Workflows.SDD, status: 'draft' });
-        const actions = getFooterActions(ctx, WorkflowSteps.SPECIFY);
-        expect(actions.find(a => a.id === FooterActionIds.SDD_AUTO)).toBeDefined();
-
-        // Wrong step → hidden
-        expect(
-            getFooterActions(ctx, WorkflowSteps.PLAN).find(a => a.id === FooterActionIds.SDD_AUTO)
-        ).toBeUndefined();
-
-        // Wrong status → hidden
-        expect(
-            getFooterActions(
-                baseCtx({ workflow: Workflows.SDD, status: 'planning' }),
-                WorkflowSteps.SPECIFY
-            ).find(a => a.id === FooterActionIds.SDD_AUTO)
-        ).toBeUndefined();
-
-        // Wrong workflow → hidden
-        expect(
-            getFooterActions(
-                baseCtx({ workflow: Workflows.SPECKIT_COMPANION, status: 'draft' }),
-                WorkflowSteps.SPECIFY
-            ).find(a => a.id === FooterActionIds.SDD_AUTO)
-        ).toBeUndefined();
+    it('Start and SDD Auto are no longer part of the footer catalog', () => {
+        const ids = FOOTER_ACTIONS.map(a => a.id);
+        expect(ids).not.toContain(FooterActionIds.START);
+        expect(ids).not.toContain(FooterActionIds.SDD_AUTO);
     });
 
     it('Regenerate hidden when step has no startedAt (acceptance 4)', () => {
         const ctx = baseCtx();
         const actions = getFooterActions(ctx, WorkflowSteps.PLAN);
         expect(actions.find(a => a.id === FooterActionIds.REGENERATE)).toBeUndefined();
-        expect(actions.find(a => a.id === FooterActionIds.START)).toBeDefined();
     });
 
     it('Regenerate visible once step has been started', () => {
@@ -94,7 +81,6 @@ describe('getFooterActions (US6 — scope + visibility)', () => {
         });
         const actions = getFooterActions(ctx, WorkflowSteps.TASKS);
         const ids = actions.map(a => a.id);
-        expect(ids).not.toContain(FooterActionIds.START);
         expect(ids).not.toContain(FooterActionIds.REGENERATE);
         expect(ids).not.toContain(FooterActionIds.APPROVE);
         // Spec-scoped actions still apply for terminal-state lifecycle.
@@ -109,9 +95,281 @@ describe('getFooterActions (US6 — scope + visibility)', () => {
         });
         const actions = getFooterActions(ctx, WorkflowSteps.TASKS);
         const ids = actions.map(a => a.id);
-        expect(ids).not.toContain(FooterActionIds.START);
         expect(ids).not.toContain(FooterActionIds.REGENERATE);
         expect(ids).not.toContain(FooterActionIds.APPROVE);
         expect(ids).toContain(FooterActionIds.REACTIVATE);
+    });
+});
+
+describe('isSpecDone gate — Archive / Mark Completed visibility', () => {
+    // Below the closure-eligible threshold: Archive and Mark Completed
+    // must stay hidden so the footer stays focused on the forward
+    // action while the AI is still building.
+    const NOT_DONE_STATUSES: SpecContext['status'][] = [
+        'draft',
+        'specifying',
+        'specified',
+        'planning',
+        'planned',
+        'tasking',
+        'ready-to-implement',
+        'implementing',
+    ];
+
+    for (const status of NOT_DONE_STATUSES) {
+        it(`hides Archive and Mark Completed when status='${status}'`, () => {
+            const ctx = baseCtx({
+                workflow: Workflows.SDD,
+                status,
+                currentStep: WorkflowSteps.SPECIFY,
+            });
+            const ids = getFooterActions(ctx, WorkflowSteps.SPECIFY).map(a => a.id);
+            expect(ids).not.toContain(FooterActionIds.ARCHIVE);
+            expect(ids).not.toContain(FooterActionIds.COMPLETE);
+        });
+    }
+
+    it("shows Archive and Mark Completed when status='implemented' (final approval gate)", () => {
+        const ctx = baseCtx({
+            workflow: Workflows.SDD,
+            status: 'implemented',
+            currentStep: WorkflowSteps.IMPLEMENT,
+            stepHistory: {
+                implement: { startedAt: 'a', completedAt: 'b' },
+            },
+        });
+        const ids = getFooterActions(ctx, WorkflowSteps.IMPLEMENT).map(a => a.id);
+        expect(ids).toContain(FooterActionIds.ARCHIVE);
+        expect(ids).toContain(FooterActionIds.COMPLETE);
+    });
+
+    it("shows Archive, Mark Completed, and Regenerate when status='implemented'", () => {
+        // After the AI finishes the implement step, status moves to
+        // 'implemented' (not directly to 'completed'). The user sees:
+        // - Archive / Mark Completed (closure-eligible),
+        // - Regenerate (still useful — user can ask the AI to redo the
+        //   implementation if they don't like it),
+        // - Approve is hidden because the step is completed (no further
+        //   step to advance to in the workflow).
+        const ctx = baseCtx({
+            workflow: Workflows.SDD,
+            status: 'implemented',
+            currentStep: WorkflowSteps.IMPLEMENT,
+            stepHistory: {
+                implement: { startedAt: 'a', completedAt: 'b' },
+            },
+        });
+        const ids = getFooterActions(ctx, WorkflowSteps.IMPLEMENT).map(a => a.id);
+        expect(ids).toContain(FooterActionIds.ARCHIVE);
+        expect(ids).toContain(FooterActionIds.COMPLETE);
+        expect(ids).toContain(FooterActionIds.REGENERATE);
+        expect(ids).not.toContain(FooterActionIds.APPROVE);
+    });
+
+    it("shows Archive but hides Mark Completed when status='completed' (terminal)", () => {
+        const ctx = baseCtx({
+            workflow: Workflows.SDD,
+            status: SpecStatuses.COMPLETED,
+            currentStep: WorkflowSteps.IMPLEMENT,
+        });
+        const ids = getFooterActions(ctx, WorkflowSteps.IMPLEMENT).map(a => a.id);
+        expect(ids).toContain(FooterActionIds.ARCHIVE);
+        // Mark Completed hides because the spec is already terminal-completed.
+        expect(ids).not.toContain(FooterActionIds.COMPLETE);
+    });
+
+    it('keeps Archive hidden when archived (already in terminal-archived)', () => {
+        const ctx = baseCtx({
+            workflow: Workflows.SDD,
+            status: SpecStatuses.ARCHIVED,
+            currentStep: WorkflowSteps.IMPLEMENT,
+        });
+        const ids = getFooterActions(ctx, WorkflowSteps.IMPLEMENT).map(a => a.id);
+        expect(ids).not.toContain(FooterActionIds.ARCHIVE);
+    });
+});
+
+describe('Approve advance button across the lifecycle', () => {
+    // After spec 094 second pass: the Approve action stays visible at
+    // the "step done, next step not started" pauses so the user can
+    // dispatch the next phase from the viewer footer.
+
+    it("stays visible at status='specified' so user can click Plan", () => {
+        const ctx = baseCtx({
+            workflow: Workflows.SDD,
+            status: 'specified',
+            currentStep: WorkflowSteps.SPECIFY,
+            stepHistory: { specify: { startedAt: 'a', completedAt: 'b' } },
+        });
+        const actions = getFooterActions(ctx, WorkflowSteps.SPECIFY, SDD_STEPS);
+        const approve = actions.find(a => a.id === FooterActionIds.APPROVE);
+        expect(approve).toBeDefined();
+        expect(approve!.label).toBe('Plan');
+    });
+
+    it("stays visible at status='planned' so user can click Tasks", () => {
+        const ctx = baseCtx({
+            workflow: Workflows.SDD,
+            status: 'planned',
+            currentStep: WorkflowSteps.PLAN,
+            stepHistory: {
+                specify: { startedAt: 'a', completedAt: 'b' },
+                plan: { startedAt: 'c', completedAt: 'd' },
+            },
+        });
+        const actions = getFooterActions(ctx, WorkflowSteps.PLAN, SDD_STEPS);
+        const approve = actions.find(a => a.id === FooterActionIds.APPROVE);
+        expect(approve).toBeDefined();
+        expect(approve!.label).toBe('Tasks');
+    });
+
+    it("stays visible at status='ready-to-implement' so user can click Implement", () => {
+        const ctx = baseCtx({
+            workflow: Workflows.SDD,
+            status: 'ready-to-implement',
+            currentStep: WorkflowSteps.TASKS,
+            stepHistory: {
+                specify: { startedAt: 'a', completedAt: 'b' },
+                plan: { startedAt: 'c', completedAt: 'd' },
+                tasks: { startedAt: 'e', completedAt: 'f' },
+            },
+        });
+        const actions = getFooterActions(ctx, WorkflowSteps.TASKS, SDD_STEPS);
+        const approve = actions.find(a => a.id === FooterActionIds.APPROVE);
+        expect(approve).toBeDefined();
+        expect(approve!.label).toBe('Implement');
+    });
+
+    it("hides at status='implemented' (last step done, no later step exists)", () => {
+        // Implement is the final step; there's no later step to advance
+        // to. Mark Completed is the right surface here, not Approve.
+        const ctx = baseCtx({
+            workflow: Workflows.SDD,
+            status: 'implemented',
+            currentStep: WorkflowSteps.IMPLEMENT,
+            stepHistory: {
+                implement: { startedAt: 'a', completedAt: 'b' },
+            },
+        });
+        const ids = getFooterActions(ctx, WorkflowSteps.IMPLEMENT, SDD_STEPS).map(a => a.id);
+        expect(ids).not.toContain(FooterActionIds.APPROVE);
+    });
+
+    it('hides on the specify tab once a later step has started', () => {
+        const ctx = baseCtx({
+            workflow: Workflows.SDD,
+            status: 'planning',
+            currentStep: WorkflowSteps.PLAN,
+            stepHistory: {
+                specify: { startedAt: 'a', completedAt: 'b' },
+                plan: { startedAt: 'c', completedAt: null },
+            },
+        });
+        // Viewing the SPECIFY tab while the workflow has moved into PLAN.
+        const ids = getFooterActions(ctx, WorkflowSteps.SPECIFY, SDD_STEPS).map(a => a.id);
+        expect(ids).not.toContain(FooterActionIds.APPROVE);
+    });
+});
+
+describe('In-flight footer (the screenshot scenario)', () => {
+    it('reproduces the user-reported screenshot: only Regenerate + dynamic Approve', () => {
+        // After /sdd:specify runs: status=specifying, specify.startedAt set,
+        // completedAt=null. Footer must NOT show Edit Source (removed
+        // entirely), Archive, Mark Completed, Auto, or Start.
+        const ctx = baseCtx({
+            workflow: Workflows.SDD,
+            status: 'specifying',
+            currentStep: WorkflowSteps.SPECIFY,
+            stepHistory: { specify: { startedAt: 'a', completedAt: null } },
+        });
+        const ids = getFooterActions(ctx, WorkflowSteps.SPECIFY, SDD_STEPS).map(a => a.id);
+        expect(ids).not.toContain(FooterActionIds.ARCHIVE);
+        expect(ids).not.toContain(FooterActionIds.COMPLETE);
+        expect(ids).not.toContain(FooterActionIds.START);
+        expect(ids).not.toContain(FooterActionIds.SDD_AUTO);
+        expect(ids).toContain(FooterActionIds.REGENERATE);
+        expect(ids).toContain(FooterActionIds.APPROVE);
+    });
+
+    it('on plan tab while planning: Regenerate + Approve labelled "Tasks"', () => {
+        const ctx = baseCtx({
+            workflow: Workflows.SDD,
+            status: 'planning',
+            currentStep: WorkflowSteps.PLAN,
+            stepHistory: {
+                specify: { startedAt: 'a', completedAt: 'b' },
+                plan: { startedAt: 'c', completedAt: null },
+            },
+        });
+        const actions = getFooterActions(ctx, WorkflowSteps.PLAN, SDD_STEPS);
+        const approve = actions.find(a => a.id === FooterActionIds.APPROVE);
+        expect(approve!.label).toBe('Tasks');
+        expect(actions.map(a => a.id)).not.toContain(FooterActionIds.ARCHIVE);
+    });
+
+    it('pure draft (no startedAt) renders no buttons at all', () => {
+        // The viewer never realistically opens at status=draft with empty
+        // stepHistory, but if it did the footer would be empty: Edit Source
+        // is gone, Start/Auto are removed, Archive/Mark Completed are gated
+        // out, Regenerate needs startedAt, Approve needs startedAt too.
+        const ctx = baseCtx({ workflow: Workflows.SDD, status: 'draft' });
+        const ids = getFooterActions(ctx, WorkflowSteps.SPECIFY).map(a => a.id);
+        expect(ids).toEqual([]);
+    });
+});
+
+describe('getApproveLabel', () => {
+    it('returns next step label when one exists', () => {
+        expect(getApproveLabel('specify', SDD_STEPS)).toBe('Plan');
+        expect(getApproveLabel('plan', SDD_STEPS)).toBe('Tasks');
+        expect(getApproveLabel('tasks', SDD_STEPS)).toBe('Implement');
+    });
+
+    it('returns "Complete" for the final step', () => {
+        expect(getApproveLabel('implement', SDD_STEPS)).toBe('Complete');
+    });
+
+    it('falls back to "Approve" when no workflow steps provided', () => {
+        expect(getApproveLabel('specify', undefined)).toBe('Approve');
+        expect(getApproveLabel('specify', [])).toBe('Approve');
+    });
+
+    it('falls back to "Approve" when current step is not in workflow', () => {
+        expect(getApproveLabel('clarify', SDD_STEPS)).toBe('Approve');
+    });
+
+    it('uses capitalized step name when label is missing', () => {
+        const stepsNoLabel: WorkflowStepConfig[] = [
+            { name: 'specify', command: 'x' },
+            { name: 'plan', command: 'y' },
+        ];
+        expect(getApproveLabel('specify', stepsNoLabel)).toBe('Plan');
+    });
+});
+
+describe('getFooterActions Approve label is dynamic', () => {
+    it('relabels Approve to next step name when workflow steps are passed', () => {
+        const ctx = baseCtx({
+            workflow: Workflows.SDD,
+            status: 'specifying',
+            currentStep: WorkflowSteps.SPECIFY,
+            stepHistory: { specify: { startedAt: 'a', completedAt: null } },
+        });
+        const actions = getFooterActions(ctx, WorkflowSteps.SPECIFY, SDD_STEPS);
+        const approve = actions.find(a => a.id === FooterActionIds.APPROVE);
+        expect(approve).toBeDefined();
+        expect(approve!.label).toBe('Plan');
+    });
+
+    it('keeps default "Approve" label when no workflow steps are passed', () => {
+        const ctx = baseCtx({
+            workflow: Workflows.SDD,
+            status: 'specifying',
+            currentStep: WorkflowSteps.SPECIFY,
+            stepHistory: { specify: { startedAt: 'a', completedAt: null } },
+        });
+        const actions = getFooterActions(ctx, WorkflowSteps.SPECIFY);
+        const approve = actions.find(a => a.id === FooterActionIds.APPROVE);
+        expect(approve!.label).toBe('Approve');
     });
 });

--- a/tests/unit/specs/specContext.spec.ts
+++ b/tests/unit/specs/specContext.spec.ts
@@ -88,6 +88,29 @@ describe('normalizeSpecContext (US3 — legacy shape migration)', () => {
         const out = normalizeSpecContext({ status: 'active' });
         expect(out.status).toBe('implementing');
     });
+
+    it('accepts the new "implemented" status as canonical', () => {
+        const out = normalizeSpecContext({ status: 'implemented' });
+        expect(out.status).toBe('implemented');
+    });
+});
+
+describe('status state machine — implement → implemented (final approval gate)', () => {
+    it('completing the implement step lands on `implemented`, not `completed`', () => {
+        // The final terminal `completed` is reserved for the user's
+        // explicit Mark-Completed click. The AI marking the implement
+        // step done only takes the spec to `implemented`.
+        const ctx = setStepStarted(fresh(), 'implement', 'extension');
+        expect(ctx.status).toBe('implementing');
+        const next = setStepCompleted(ctx, 'implement', 'extension');
+        expect(next.status).toBe('implemented');
+    });
+
+    it('non-implement steps preserve their existing completed-status mapping', () => {
+        // Sanity-check that the new wiring didn't disturb other phases.
+        const specify = setStepCompleted(setStepStarted(fresh(), 'specify', 'extension'), 'specify', 'extension');
+        expect(specify.status).toBe('specified');
+    });
 });
 
 describe('substep helpers (US4)', () => {

--- a/webview/src/spec-editor/CreateSpecMock.tsx
+++ b/webview/src/spec-editor/CreateSpecMock.tsx
@@ -1,0 +1,211 @@
+/**
+ * Static Preact mock of the Create New Spec form.
+ *
+ * The real spec editor at `src/features/spec-editor/specEditorProvider.ts`
+ * is a vanilla-DOM webview, so this mock exists only to give Storybook a
+ * faithful visual reference of the layout. Used by:
+ *   - SpecEditor/CreateSpec stories (standalone view).
+ *   - Viewer/Transitions/CreateSpec (the lifecycle "phase zero" entry).
+ *
+ * Auto Mode lives here, next to Submit — by design it is the canonical
+ * first-time entry point for the SDD pipeline, NOT a viewer-footer button.
+ */
+
+export interface CreateSpecMockProps {
+    initialContent?: string;
+    submitting?: boolean;
+}
+
+export function CreateSpecMock({ initialContent = '', submitting = false }: CreateSpecMockProps) {
+    const placeholder =
+        'Describe your feature or task in detail...\n\n' +
+        'Example:\n' +
+        '- What is the feature about?\n' +
+        '- What problem does it solve?\n' +
+        '- Who are the target users?\n' +
+        '- What are the key requirements?\n' +
+        '- Are there any constraints or dependencies?';
+
+    const charCount = initialContent.length;
+    const maxChars = 50_000;
+
+    return (
+        <div
+            style={`
+                background: var(--vscode-editor-background, #0a0512);
+                color: var(--vscode-foreground, #c8c8c8);
+                font-family: var(--vscode-font-family, system-ui, -apple-system, sans-serif);
+                padding: 32px;
+                min-height: 100vh;
+                box-sizing: border-box;
+                max-width: 760px;
+                margin: 0 auto;
+            `}
+        >
+            <header style="margin-bottom: 28px;">
+                <h1 style="font-size: 28px; font-weight: 700; margin: 0 0 6px; color: var(--vscode-foreground, #fff);">
+                    Create New Spec
+                </h1>
+                <p style="font-size: 13px; opacity: 0.7; margin: 0;">
+                    Write a detailed specification for your feature or task
+                </p>
+            </header>
+
+            <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 24px;">
+                <button
+                    type="button"
+                    style="
+                        background: var(--vscode-button-secondaryBackground, #1f1828);
+                        color: var(--vscode-button-secondaryForeground, #ddd);
+                        border: 1px solid var(--vscode-widget-border, #303030);
+                        padding: 8px 14px;
+                        border-radius: 4px;
+                        font-size: 13px;
+                        cursor: pointer;
+                        display: inline-flex;
+                        align-items: center;
+                        gap: 8px;
+                    "
+                >
+                    <span style="opacity: 0.7;">📄</span>
+                    Load Template
+                </button>
+                <div style="display: flex; align-items: center; gap: 12px; font-size: 13px;">
+                    <span style="opacity: 0.7;">Workflow</span>
+                    <button
+                        type="button"
+                        style="
+                            background: var(--vscode-button-secondaryBackground, #1f1828);
+                            color: var(--vscode-button-secondaryForeground, #ddd);
+                            border: 1px solid var(--vscode-widget-border, #303030);
+                            padding: 8px 14px;
+                            border-radius: 4px;
+                            font-size: 13px;
+                            cursor: pointer;
+                            display: inline-flex;
+                            align-items: center;
+                            gap: 8px;
+                            min-width: 120px;
+                            justify-content: space-between;
+                        "
+                    >
+                        SDD
+                        <span style="opacity: 0.5;">▾</span>
+                    </button>
+                </div>
+            </div>
+
+            <section style="margin-bottom: 20px;">
+                <h2 style="font-size: 14px; font-weight: 600; margin: 0 0 10px;">
+                    Specification
+                </h2>
+                <div
+                    style={`
+                        background: var(--vscode-input-background, #0c0814);
+                        border: 1px solid var(--vscode-widget-border, #2a2a2a);
+                        border-radius: 6px;
+                        padding: 16px;
+                        font-family: var(--vscode-editor-font-family, monospace);
+                        font-size: 13px;
+                        line-height: 1.6;
+                        min-height: 320px;
+                        white-space: pre-wrap;
+                        color: ${initialContent ? 'var(--vscode-input-foreground, #ddd)' : 'rgba(190, 175, 230, 0.7)'};
+                    `}
+                >
+                    {initialContent || placeholder}
+                </div>
+                <div style="text-align: right; margin-top: 6px; font-size: 12px; opacity: 0.6;">
+                    {charCount.toLocaleString()} / {maxChars.toLocaleString()}
+                </div>
+            </section>
+
+            <section style="border-top: 1px solid var(--vscode-widget-border, #2a2a2a); padding-top: 16px; margin-bottom: 24px;">
+                <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 8px;">
+                    <h2 style="font-size: 14px; font-weight: 600; margin: 0;">Attachments</h2>
+                    <button
+                        type="button"
+                        style="
+                            background: transparent;
+                            color: var(--vscode-foreground, #ddd);
+                            border: none;
+                            padding: 4px 0;
+                            font-size: 13px;
+                            cursor: pointer;
+                            display: inline-flex;
+                            align-items: center;
+                            gap: 8px;
+                        "
+                    >
+                        <span style="opacity: 0.7;">🖼</span>
+                        Attach Image
+                    </button>
+                </div>
+                <p style="font-size: 12px; opacity: 0.55; margin: 0; font-style: italic;">
+                    Use the button above or paste (Ctrl+V / Cmd+V) to attach images
+                </p>
+            </section>
+
+            <footer style="border-top: 1px solid var(--vscode-widget-border, #2a2a2a); padding-top: 16px; display: flex; justify-content: space-between; align-items: center; gap: 12px;">
+                <button
+                    type="button"
+                    style="
+                        background: transparent;
+                        color: var(--vscode-foreground, #ddd);
+                        border: 1px solid var(--vscode-widget-border, #303030);
+                        padding: 8px 18px;
+                        border-radius: 4px;
+                        font-size: 13px;
+                        cursor: pointer;
+                    "
+                >
+                    Cancel
+                </button>
+                <div style="display: flex; gap: 10px;">
+                    <button
+                        type="button"
+                        title="Run the full SDD pipeline automatically (specify → plan → tasks → implement)"
+                        style="
+                            background: var(--vscode-button-secondaryBackground, #1f1828);
+                            color: var(--vscode-button-secondaryForeground, #ddd);
+                            border: 1px solid var(--vscode-widget-border, #303030);
+                            padding: 8px 18px;
+                            border-radius: 4px;
+                            font-size: 13px;
+                            cursor: pointer;
+                            font-weight: 500;
+                        "
+                    >
+                        Auto Mode
+                    </button>
+                    <button
+                        type="button"
+                        disabled={submitting}
+                        style={`
+                            background: ${submitting ? 'var(--vscode-button-secondaryBackground, #2a2a2a)' : 'var(--vscode-button-background, #3c3c3c)'};
+                            color: var(--vscode-button-foreground, #fff);
+                            border: 1px solid var(--vscode-widget-border, #303030);
+                            padding: 8px 22px;
+                            border-radius: 4px;
+                            font-size: 13px;
+                            font-weight: 600;
+                            cursor: ${submitting ? 'wait' : 'pointer'};
+                            opacity: ${submitting ? 0.6 : 1};
+                        `}
+                    >
+                        {submitting ? 'Submitting…' : 'Submit'}
+                    </button>
+                </div>
+            </footer>
+
+            <p style="margin-top: 14px; font-size: 11px; opacity: 0.55; text-align: left;">
+                <kbd style="background: var(--vscode-keybindingLabel-background, #2a2a2a); padding: 1px 6px; border-radius: 3px; border: 1px solid var(--vscode-widget-border, #303030);">Ctrl</kbd>
+                {' + '}
+                <kbd style="background: var(--vscode-keybindingLabel-background, #2a2a2a); padding: 1px 6px; border-radius: 3px; border: 1px solid var(--vscode-widget-border, #303030);">Enter</kbd>
+                {' to submit · '}
+                <kbd style="background: var(--vscode-keybindingLabel-background, #2a2a2a); padding: 1px 6px; border-radius: 3px; border: 1px solid var(--vscode-widget-border, #303030);">Esc</kbd>
+                {' to cancel'}
+            </p>
+        </div>
+    );
+}

--- a/webview/src/spec-editor/__stories__/CreateSpec.stories.tsx
+++ b/webview/src/spec-editor/__stories__/CreateSpec.stories.tsx
@@ -1,0 +1,59 @@
+/**
+ * Storybook stories for the Create New Spec form.
+ *
+ * The mock component lives in `../CreateSpecMock.tsx` so it can be
+ * reused by the Viewer/Transitions/CreateSpec lifecycle entry.
+ */
+
+import type { Meta, StoryObj } from '@storybook/preact';
+import { CreateSpecMock } from '../CreateSpecMock';
+
+const meta: Meta = {
+    title: 'SpecEditor/CreateSpec',
+    parameters: {
+        layout: 'fullscreen',
+        docs: {
+            description: {
+                component:
+                    'The Create New Spec form (a separate webview) is what the user sees before any spec exists. ' +
+                    'Auto Mode is invoked here — the spec viewer never opens at status=draft.',
+            },
+        },
+    },
+};
+export default meta;
+
+type Story = StoryObj;
+
+export const Empty: Story = {
+    name: 'Empty',
+    render: () => <CreateSpecMock />,
+};
+
+export const WithDraft: Story = {
+    name: 'With Draft',
+    render: () => (
+        <CreateSpecMock
+            initialContent={
+                'Add a quiet-footer mode to the spec viewer.\n\n' +
+                'Goal: hide premature lifecycle actions while a step is mid-generation, ' +
+                'and rename the generic Approve button to the next workflow step’s label.\n\n' +
+                'Constraint: extension code only — user .vscode/settings.json should not need ' +
+                'to change. Verify by reproducing the screenshot from ngx-dev-toolbar.'
+            }
+        />
+    ),
+};
+
+export const Submitting: Story = {
+    name: 'Submitting',
+    render: () => (
+        <CreateSpecMock
+            initialContent={
+                'Add a quiet-footer mode to the spec viewer.\n\n' +
+                'Goal: hide premature lifecycle actions while a step is mid-generation.'
+            }
+            submitting
+        />
+    ),
+};

--- a/webview/src/spec-viewer/components/FooterActions.stories.tsx
+++ b/webview/src/spec-viewer/components/FooterActions.stories.tsx
@@ -1,3 +1,16 @@
+/**
+ * Storybook coverage for the spec-viewer footer.
+ *
+ * Two sections:
+ *   - Legacy stories — drive the old navState.footerState code path
+ *     (status='active' / 'tasks-done'). Kept for backward compat.
+ *   - Per-status stories — drive the catalog code path
+ *     (viewerState.footer[]) with one entry per canonical status.
+ *
+ * Story names use the visible status label only; no parens, no
+ * extra annotations.
+ */
+
 import type { Meta, StoryObj } from '@storybook/preact';
 import { navState, viewerState } from '../signals';
 import { FooterActions } from './FooterActions';
@@ -10,6 +23,8 @@ const meta: Meta<typeof FooterActions> = {
 export default meta;
 
 type Story = StoryObj<typeof FooterActions>;
+
+// ── Legacy code path (driven by navState.footerState) ──────
 
 export const Active: Story = {
     render: () => {
@@ -43,35 +58,19 @@ export const TasksDone: Story = {
     },
 };
 
-export const Completed: Story = {
-    render: () => {
-        navState.value = mockNavState({
-            footerState: { showApproveButton: false, approveText: '', enhancementButtons: [], specStatus: 'completed' },
-        });
-        return <FooterActions initialSpecStatus="completed" />;
-    },
-};
+// ── Catalog code path (driven by viewerState.footer) ───────
+// One entry per canonical spec status, in lifecycle order.
 
-export const Archived: Story = {
-    render: () => {
-        navState.value = mockNavState({
-            footerState: { showApproveButton: false, approveText: '', enhancementButtons: [], specStatus: 'archived' },
-        });
-        return <FooterActions initialSpecStatus="archived" />;
-    },
-};
+interface FooterEntry {
+    id: string;
+    label: string;
+    scope: 'spec' | 'step';
+    tooltip: string;
+}
 
-// ── Catalog path (driven by viewerState.footer) ─────────────
-// FooterActions.tsx has two render paths: the legacy one (above) driven by
-// navState.footerState, and a newer catalog-driven one that fires when
-// viewerState.footer is populated. The catalog path is what the extension
-// produces for every spec-context spec via getFooterActions(ctx, step).
-// These stories cover the catalog path's lifecycle states so we have visual
-// coverage of the action filtering done in src/features/spec-viewer/footerActions.ts.
-
-const baseViewerState = (status: string, footer: { id: string; label: string; scope: 'spec' | 'step'; tooltip: string }[]) => ({
+const baseViewerState = (status: string, activeStep: string, footer: FooterEntry[]) => ({
     status,
-    activeStep: 'tasks',
+    activeStep,
     steps: {},
     pulse: null,
     highlights: [],
@@ -79,26 +78,154 @@ const baseViewerState = (status: string, footer: { id: string; label: string; sc
     footer,
 });
 
-export const CatalogActiveTasks: Story = {
+const pauseFooter = (forwardLabel: string): FooterEntry[] => [
+    { id: 'regenerate', label: 'Regenerate', scope: 'step', tooltip: 'Re-run only the current step' },
+    { id: 'approve', label: forwardLabel, scope: 'step', tooltip: 'Approve this step and continue' },
+];
+
+const finalApprovalFooter: FooterEntry[] = [
+    { id: 'archive', label: 'Archive', scope: 'spec', tooltip: 'Archive this spec' },
+    { id: 'complete', label: 'Mark Completed', scope: 'spec', tooltip: 'Mark this spec as completed' },
+    { id: 'regenerate', label: 'Regenerate', scope: 'step', tooltip: 'Re-run only the current step' },
+];
+
+const REFINE_ACTION: FooterEntry = {
+    id: 'refine',
+    label: '✨ Refine (2)',
+    scope: 'spec',
+    tooltip: 'Submit 2 line comments for refinement',
+};
+
+const withRefine = (footer: FooterEntry[]): FooterEntry[] => [REFINE_ACTION, ...footer];
+
+// Helper to mark a story as in-flight on a given step. Sets the
+// stepHistory entry so the renderer's isRunning check fires and
+// hides the footer buttons (the catalog still emits them; the
+// hide is at the render layer).
+const inFlightNavState = (specStatus: string, step: string) =>
+    mockNavState({
+        specStatus,
+        activeStep: step,
+        stepHistory: { [step]: { startedAt: '2026-05-08T00:00:00Z', completedAt: null } },
+    });
+
+export const Specifying: Story = {
+    name: 'Specifying',
     render: () => {
-        navState.value = mockNavState({ specStatus: 'active' });
-        viewerState.value = baseViewerState('active', [
-            { id: 'archive', label: 'Archive', scope: 'spec', tooltip: 'Archive this spec' },
-            { id: 'regenerate', label: 'Regenerate', scope: 'step', tooltip: 'Re-run only the current step' },
-            { id: 'approve', label: 'Approve', scope: 'step', tooltip: 'Approve this step and continue' },
-        ]);
-        return <FooterActions initialSpecStatus="active" />;
+        // In-flight: renderer hides all buttons because isRunning=true.
+        navState.value = inFlightNavState('specifying', 'specify');
+        viewerState.value = baseViewerState('specifying', 'specify', pauseFooter('Plan'));
+        return <FooterActions initialSpecStatus="specifying" />;
     },
 };
 
-// Regression coverage: the user reported seeing Archive + Reactivate + Regenerate
-// + Approve on a completed spec. The fix in footerActions.ts:46-74 hides
-// step-scoped actions (start, regenerate, approve) when status is terminal.
-// This story asserts the catalog path now produces just Archive + Reactivate.
-export const CatalogCompleted: Story = {
+export const Specified: Story = {
+    name: 'Specified',
+    render: () => {
+        navState.value = mockNavState({ specStatus: 'specified' });
+        viewerState.value = baseViewerState('specified', 'specify', pauseFooter('Plan'));
+        return <FooterActions initialSpecStatus="specified" />;
+    },
+};
+
+export const SpecifiedWithRefine: Story = {
+    name: 'Specified With Refine',
+    render: () => {
+        navState.value = mockNavState({ specStatus: 'specified' });
+        viewerState.value = baseViewerState('specified', 'specify', withRefine(pauseFooter('Plan')));
+        return <FooterActions initialSpecStatus="specified" />;
+    },
+};
+
+export const Planning: Story = {
+    name: 'Planning',
+    render: () => {
+        navState.value = inFlightNavState('planning', 'plan');
+        viewerState.value = baseViewerState('planning', 'plan', pauseFooter('Tasks'));
+        return <FooterActions initialSpecStatus="planning" />;
+    },
+};
+
+export const Planned: Story = {
+    name: 'Planned',
+    render: () => {
+        navState.value = mockNavState({ specStatus: 'planned' });
+        viewerState.value = baseViewerState('planned', 'plan', pauseFooter('Tasks'));
+        return <FooterActions initialSpecStatus="planned" />;
+    },
+};
+
+export const PlannedWithRefine: Story = {
+    name: 'Planned With Refine',
+    render: () => {
+        navState.value = mockNavState({ specStatus: 'planned' });
+        viewerState.value = baseViewerState('planned', 'plan', withRefine(pauseFooter('Tasks')));
+        return <FooterActions initialSpecStatus="planned" />;
+    },
+};
+
+export const CreatingTasks: Story = {
+    name: 'Creating Tasks',
+    render: () => {
+        navState.value = inFlightNavState('tasking', 'tasks');
+        viewerState.value = baseViewerState('tasking', 'tasks', pauseFooter('Implement'));
+        return <FooterActions initialSpecStatus="tasking" />;
+    },
+};
+
+export const TasksCreated: Story = {
+    name: 'Tasks Created',
+    render: () => {
+        navState.value = mockNavState({ specStatus: 'ready-to-implement' });
+        viewerState.value = baseViewerState(
+            'ready-to-implement',
+            'tasks',
+            pauseFooter('Implement')
+        );
+        return <FooterActions initialSpecStatus="ready-to-implement" />;
+    },
+};
+
+export const TasksCreatedWithRefine: Story = {
+    name: 'Tasks Created With Refine',
+    render: () => {
+        navState.value = mockNavState({ specStatus: 'ready-to-implement' });
+        viewerState.value = baseViewerState(
+            'ready-to-implement',
+            'tasks',
+            withRefine(pauseFooter('Implement'))
+        );
+        return <FooterActions initialSpecStatus="ready-to-implement" />;
+    },
+};
+
+export const Implementing: Story = {
+    name: 'Implementing',
+    render: () => {
+        navState.value = inFlightNavState('implementing', 'implement');
+        viewerState.value = baseViewerState(
+            'implementing',
+            'implement',
+            pauseFooter('Complete')
+        );
+        return <FooterActions initialSpecStatus="implementing" />;
+    },
+};
+
+export const Implemented: Story = {
+    name: 'Implemented',
+    render: () => {
+        navState.value = mockNavState({ specStatus: 'implemented' });
+        viewerState.value = baseViewerState('implemented', 'implement', finalApprovalFooter);
+        return <FooterActions initialSpecStatus="implemented" />;
+    },
+};
+
+export const Completed: Story = {
+    name: 'Completed',
     render: () => {
         navState.value = mockNavState({ specStatus: 'completed' });
-        viewerState.value = baseViewerState('completed', [
+        viewerState.value = baseViewerState('completed', 'implement', [
             { id: 'archive', label: 'Archive', scope: 'spec', tooltip: 'Archive this spec' },
             { id: 'reactivate', label: 'Reactivate', scope: 'spec', tooltip: 'Reactivate archived spec' },
         ]);
@@ -106,24 +233,13 @@ export const CatalogCompleted: Story = {
     },
 };
 
-export const CatalogArchived: Story = {
+export const Archived: Story = {
+    name: 'Archived',
     render: () => {
         navState.value = mockNavState({ specStatus: 'archived' });
-        viewerState.value = baseViewerState('archived', [
+        viewerState.value = baseViewerState('archived', 'implement', [
             { id: 'reactivate', label: 'Reactivate', scope: 'spec', tooltip: 'Reactivate archived spec' },
         ]);
         return <FooterActions initialSpecStatus="archived" />;
-    },
-};
-
-export const CatalogTasksDone: Story = {
-    render: () => {
-        navState.value = mockNavState({ specStatus: 'tasks-done' });
-        viewerState.value = baseViewerState('tasks-done', [
-            { id: 'archive', label: 'Archive', scope: 'spec', tooltip: 'Archive this spec' },
-            { id: 'complete', label: 'Mark Completed', scope: 'spec', tooltip: 'Mark this spec as completed' },
-            { id: 'regenerate', label: 'Regenerate', scope: 'step', tooltip: 'Re-run only the current step' },
-        ]);
-        return <FooterActions initialSpecStatus="tasks-done" />;
     },
 };

--- a/webview/src/spec-viewer/components/FooterActions.tsx
+++ b/webview/src/spec-viewer/components/FooterActions.tsx
@@ -30,11 +30,13 @@ export function FooterActions({ initialSpecStatus }: FooterActionsProps) {
 
     const send = (msg: ViewerToExtensionMessage) => () => vscode.postMessage(msg);
 
-    // A step is "running" when activeStep is set but its stepHistory entry has no completedAt.
+    // A step is "running" when activeStep is set AND its stepHistory entry
+    // has startedAt with no completedAt. Requiring startedAt prevents
+    // false positives on terminal-archived specs where the entry is
+    // missing entirely (which previously disabled Reactivate).
     const runningStep = ns.activeStep ?? null;
-    const isRunning = !!(runningStep && !ns.stepHistory?.[runningStep]?.completedAt);
-    const runLockSuffix = isRunning ? ` (disabled while ${runningStep} is running)` : '';
-    const withLock = (label: string) => `${label}${runLockSuffix}`;
+    const runningEntry = runningStep ? ns.stepHistory?.[runningStep] : null;
+    const isRunning = !!(runningEntry?.startedAt && !runningEntry.completedAt);
 
     // R024/R030: Regenerate queues behind a 5s undo toast. Never shown
     // while another step is already running (the button stays disabled).
@@ -73,16 +75,48 @@ export function FooterActions({ initialSpecStatus }: FooterActionsProps) {
     if (vs && Array.isArray(vs.footer) && vs.footer.length > 0) {
         const sendFooter = (id: string) => () =>
             vscode.postMessage({ type: 'footerAction', id });
+
+        // Hide instead of disable while the AI is mid-step. The sidebar's
+        // per-row Archive remains as an escape hatch.
+        const visible = isRunning ? [] : vs.footer;
+
+        // Route each action to the left or right region:
+        //   Left  = Regenerate only — outlined "redo this step" tool.
+        //   Right = lifecycle + forward motion (Refine, Approve, Reactivate,
+        //           Archive, Mark Completed). Closure controls live on the
+        //           right next to the next-step button so the user's eye
+        //           lands on "what do I do next" in one place.
+        const LEFT_IDS = new Set(['regenerate']);
+        const RIGHT_IDS = new Set([
+            'refine',
+            'approve',
+            'reactivate',
+            'archive',
+            'complete',
+            'start',
+        ]);
+        const leftActions = visible.filter(a => LEFT_IDS.has(a.id));
+        const rightActions = visible.filter(a => RIGHT_IDS.has(a.id));
+
+        const renderAction = (a: typeof vs.footer[number]) => {
+            const isPrimary = a.id === 'approve' || a.id === 'complete' || a.id === 'reactivate';
+            const isRefine = a.id === 'refine';
+            const baseTitle = withScopeSuffix(a);
+            return (
+                <Button
+                    key={a.id}
+                    label={a.label}
+                    variant={isRefine ? 'enhancement' : (isPrimary ? 'primary' : 'secondary')}
+                    title={baseTitle}
+                    onClick={sendFooter(a.id)}
+                />
+            );
+        };
+
         return (
             <footer class="actions">
                 <Toast id="action-toast" />
                 <div class="actions-left">
-                    <Button
-                        label="Edit Source"
-                        variant="secondary"
-                        title="Open the raw markdown in an editor"
-                        onClick={send({ type: 'editSource' })}
-                    />
                     {isActive && enhancementButtons.map((btn) => (
                         <Button
                             key={btn.command}
@@ -93,47 +127,25 @@ export function FooterActions({ initialSpecStatus }: FooterActionsProps) {
                             onClick={send({ type: 'clarify', command: btn.command })}
                         />
                     ))}
+                    {leftActions.map(renderAction)}
                 </div>
                 <div class="actions-right">
-                    {vs.footer.map((a) => {
-                        const isPrimary = a.id === 'approve' || a.id === 'complete' || a.id === 'reactivate';
-                        const isRegenerate = a.id === 'regenerate';
-                        const disabled = isRunning && (isPrimary || isRegenerate);
-                        const baseTitle = withScopeSuffix(a);
-                        return (
-                            <Button
-                                key={a.id}
-                                label={a.label}
-                                variant={isPrimary ? 'primary' : 'secondary'}
-                                title={disabled ? withLock(baseTitle) : baseTitle}
-                                disabled={disabled}
-                                onClick={sendFooter(a.id)}
-                            />
-                        );
-                    })}
+                    {rightActions.map(renderAction)}
                 </div>
             </footer>
         );
     }
 
-    const regenerateTitle = isRunning
-        ? withLock('Regenerate the current step from scratch')
-        : 'Regenerate the current step from scratch';
-    const approveTitle = isRunning
-        ? withLock('Approve and advance to the next step')
-        : 'Approve and advance to the next step';
+    // Legacy fallback: only show Archive once the spec is at a closure-eligible
+    // stage (tasks-done / completed / archived). Mirrors the catalog path's
+    // isSpecDone gate in src/features/spec-viewer/footerActions.ts.
+    const isLegacyDone = isTasksDone || isCompleted || isArchived;
 
     return (
         <footer class="actions">
             <Toast id="action-toast" />
             <div class="actions-left">
-                <Button
-                    label="Edit Source"
-                    variant="secondary"
-                    title="Open the raw markdown in an editor"
-                    onClick={send({ type: 'editSource' })}
-                />
-                {!isArchived && (
+                {isLegacyDone && !isArchived && !isRunning && (
                     <Button
                         label={archiveConfirm.label ?? 'Archive'}
                         variant="secondary"
@@ -153,46 +165,42 @@ export function FooterActions({ initialSpecStatus }: FooterActionsProps) {
                 ))}
             </div>
             <div class="actions-right">
+                {/* Hide all step/closure controls during an in-flight step.
+                    Reactivate stays visible on terminal states because
+                    isRunning is now correctly false there. */}
                 {isArchived || isCompleted ? (
                     <Button
                         label={reactivateConfirm.label ?? 'Reactivate'}
                         variant="primary"
-                        title={isRunning
-                            ? withLock('Reactivate this spec')
-                            : (reactivateConfirm.armed ? 'Click again to confirm reactivate' : 'Reactivate this spec')}
-                        disabled={isRunning}
+                        title={reactivateConfirm.armed ? 'Click again to confirm reactivate' : 'Reactivate this spec'}
                         onClick={reactivateConfirm.onClick}
                     />
-                ) : isTasksDone ? (
+                ) : isTasksDone && !isRunning ? (
                     <Button
                         label={completeConfirm.label ?? 'Complete'}
                         variant="primary"
-                        title={isRunning
-                            ? withLock('Mark this spec complete')
-                            : (completeConfirm.armed ? 'Click again to confirm complete' : 'Mark this spec complete')}
-                        disabled={isRunning}
+                        title={completeConfirm.armed ? 'Click again to confirm complete' : 'Mark this spec complete'}
                         onClick={completeConfirm.onClick}
                     />
-                ) : (
+                ) : !isRunning ? (
                     <>
                         <Button
                             label="Regenerate"
                             variant="secondary"
-                            title={regenerateTitle}
-                            disabled={isRunning || regenerateToastActive}
+                            title="Regenerate the current step from scratch"
+                            disabled={regenerateToastActive}
                             onClick={onRegenerateClick}
                         />
                         {ns.footerState?.showApproveButton && (
                             <Button
                                 label={ns.footerState.approveText}
                                 variant="primary"
-                                title={approveTitle}
-                                disabled={isRunning}
+                                title="Approve and advance to the next step"
                                 onClick={send({ type: 'approve' })}
                             />
                         )}
                     </>
-                )}
+                ) : null}
             </div>
             {regenerateToastActive && (
                 <UndoToast

--- a/webview/src/spec-viewer/components/SpecHeader.stories.tsx
+++ b/webview/src/spec-viewer/components/SpecHeader.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/preact';
-import { navState } from '../signals';
+import { navState, viewerState as vs } from '../signals';
 import { SpecHeader } from './SpecHeader';
 import { mockNavState } from './__stories__/mockData';
 
@@ -125,6 +125,73 @@ export const StatusTasksDone: Story = {
             specContextName: 'All Tasks Complete',
             docTypeLabel: 'Tasks',
         });
+        return <SpecHeader />;
+    },
+};
+
+// ── Renamed status labels (spec 094, second pass) ─────────
+// These show the friendlier visible labels for status keys
+// whose default hyphen-split capitalization isn't great.
+
+export const StatusCreatingTasks: Story = {
+    name: 'Creating Tasks',
+    decorators: [withStatus('tasking')],
+    render: () => {
+        navState.value = mockNavState({
+            specContextName: 'Tasking In Progress',
+            docTypeLabel: 'Tasks',
+        });
+        vs.value = {
+            status: 'tasking',
+            activeStep: 'tasks',
+            steps: {},
+            pulse: null,
+            highlights: [],
+            activeSubstep: null,
+            footer: [],
+        };
+        return <SpecHeader />;
+    },
+};
+
+export const StatusTasksCreated: Story = {
+    name: 'Tasks Created',
+    decorators: [withStatus('ready-to-implement')],
+    render: () => {
+        navState.value = mockNavState({
+            specContextName: 'Ready For Build',
+            docTypeLabel: 'Tasks',
+        });
+        vs.value = {
+            status: 'ready-to-implement',
+            activeStep: 'tasks',
+            steps: {},
+            pulse: null,
+            highlights: [],
+            activeSubstep: null,
+            footer: [],
+        };
+        return <SpecHeader />;
+    },
+};
+
+export const StatusImplemented: Story = {
+    name: 'Implemented',
+    decorators: [withStatus('implemented')],
+    render: () => {
+        navState.value = mockNavState({
+            specContextName: 'Build Done — Awaiting Approval',
+            docTypeLabel: 'Tasks',
+        });
+        vs.value = {
+            status: 'implemented',
+            activeStep: 'implement',
+            steps: {},
+            pulse: null,
+            highlights: [],
+            activeSubstep: null,
+            footer: [],
+        };
         return <SpecHeader />;
     },
 };

--- a/webview/src/spec-viewer/components/SpecHeader.tsx
+++ b/webview/src/spec-viewer/components/SpecHeader.tsx
@@ -1,6 +1,15 @@
 import { navState, viewerState } from '../signals';
 
+// Visible-label overrides for canonical status keys whose default
+// hyphen-split capitalization isn't the friendliest reading. Keeps
+// on-disk `.spec-context.json` keys unchanged.
+const STATUS_LABEL_OVERRIDES: Record<string, string> = {
+    tasking: 'Creating Tasks',
+    'ready-to-implement': 'Tasks Created',
+};
+
 function formatStatusLabel(status: string): string {
+    if (STATUS_LABEL_OVERRIDES[status]) return STATUS_LABEL_OVERRIDES[status];
     return status
         .split('-')
         .map(w => w.charAt(0).toUpperCase() + w.slice(1))

--- a/webview/src/spec-viewer/components/StepTab.tsx
+++ b/webview/src/spec-viewer/components/StepTab.tsx
@@ -45,7 +45,12 @@ export function StepTab(props: StepTabProps) {
     const isLastStep = index === totalSteps - 1;
     const inProgress = isLastStep && currentStep === 'implement' && taskCompletionPercent < 100;
     const isStale = stalenessMap?.[phase]?.isStale ?? false;
-    const isWorking = activeStep === phase && !stepHistory?.[phase]?.completedAt;
+
+    const stepName = DOC_TO_STEP[phase] ?? phase;
+    // `activeStep` and `stepHistory` are keyed by step name (e.g. 'specify'),
+    // not doc type (e.g. 'spec'). Compare against the mapped name so the
+    // in-flight visual fires correctly during specifying / planning / etc.
+    const isWorking = activeStep === stepName && !stepHistory?.[stepName]?.completedAt;
     const isLocked = runningStepIndex != null
         && index > runningStepIndex
         && !isViewing
@@ -53,7 +58,6 @@ export function StepTab(props: StepTabProps) {
     const isClickable = (exists || index === 0) && !isLocked;
 
     const vs = viewerState.value;
-    const stepName = DOC_TO_STEP[phase] ?? phase;
     // R003: checkmark only when completed AND the step's document exists.
     const vsCompleted = (vs?.highlights?.includes(stepName) ?? false) && stepDocExists;
     const vsSubstep = vs?.activeSubstep?.step === stepName ? vs.activeSubstep.name : null;
@@ -90,7 +94,9 @@ export function StepTab(props: StepTabProps) {
 
     // Only show the elapsed ticker for a live dispatch run — not for the
     // last-step `inProgress` case, which is driven by task-completion percent.
-    const runEntry = stepHistory?.[phase];
+    // Use the mapped stepName (matches activeStep / stepHistory keys),
+    // not the doc-type phase.
+    const runEntry = stepHistory?.[stepName];
     const runningStartedAt = canonicalState === 'in-flight'
         && runEntry?.startedAt
         && !runEntry.completedAt

--- a/webview/src/spec-viewer/components/__stories__/ViewerTransitions.stories.tsx
+++ b/webview/src/spec-viewer/components/__stories__/ViewerTransitions.stories.tsx
@@ -1,0 +1,425 @@
+/**
+ * Combined Storybook stories that show the full viewer chrome
+ * (header + step tabs + footer) at each canonical spec status.
+ *
+ * Storybook order follows the lifecycle:
+ *   Create Spec → Specifying → Specified → Planning → Planned →
+ *   Creating Tasks → Tasks Created → Implementing → Implemented →
+ *   Completed → Archived
+ *
+ * Story names use the visible status label only — no parens, no
+ * phase numbers.
+ *
+ * For per-component stories see:
+ *   - Viewer/SpecHeader        (header badge variants)
+ *   - Viewer/NavigationBar     (step tabs + sub-doc rail)
+ *   - Viewer/StepTab           (single-tab visual states)
+ *   - Viewer/FooterActions     (footer button visibility per status)
+ *   - Viewer/Activity/PhasesCard (timeline)
+ */
+
+import type { Meta, StoryObj } from '@storybook/preact';
+import { navState, viewerState } from '../../signals';
+import type { ViewerState, SerializedFooterAction } from '../../types';
+import { SpecHeader } from '../SpecHeader';
+import { NavigationBar } from '../NavigationBar';
+import { FooterActions } from '../FooterActions';
+import { CreateSpecMock } from '../../../spec-editor/CreateSpecMock';
+import { mockDoc, mockNavState } from './mockData';
+
+const meta: Meta = {
+    title: 'Viewer/Transitions',
+    parameters: {
+        layout: 'fullscreen',
+        docs: {
+            description: {
+                component:
+                    'Combined header + stepper + footer at each canonical spec status. ' +
+                    'Walk top-to-bottom in the sidebar to step through the lifecycle one status at a time.',
+            },
+        },
+    },
+};
+export default meta;
+
+type Story = StoryObj;
+
+const NOW = Date.now();
+const iso = (offsetMs: number) => new Date(NOW - offsetMs).toISOString();
+
+interface Frame {
+    status: string;
+    badgeText: string;
+    activeDoc: string;
+    workflowPhase: string;
+    activeStep: string;
+    /** Spec's `currentStep` from .spec-context.json. Drives the
+     *  last-step in-progress percent (only fires when currentStep
+     *  is `'implement'`). */
+    currentStep?: string;
+    /** Mock task-completion percent shown on the last navigable
+     *  tab while currentStep is `'implement'`. */
+    taskCompletionPercent?: number;
+    stepHistory: ViewerState['stepHistory'];
+    footer: SerializedFooterAction[];
+    note: string;
+}
+
+// Footer-array shorthands.
+//
+// Pause states (between phases) show the dynamic next-step button + Regenerate.
+// Closure-eligible pauses also show Archive + Mark Completed.
+// In-flight stories pass an empty array — the renderer hides the buttons
+// rather than disabling them while the AI is mid-step.
+
+const pauseFooter = (forwardLabel: string): SerializedFooterAction[] => [
+    { id: 'regenerate', label: 'Regenerate', scope: 'step', tooltip: 'Re-run only the current step' },
+    { id: 'approve', label: forwardLabel, scope: 'step', tooltip: 'Approve this step and continue' },
+];
+
+const finalApprovalFooter: SerializedFooterAction[] = [
+    { id: 'archive', label: 'Archive', scope: 'spec', tooltip: 'Archive this spec' },
+    { id: 'complete', label: 'Mark Completed', scope: 'spec', tooltip: 'Mark this spec as completed' },
+    { id: 'regenerate', label: 'Regenerate', scope: 'step', tooltip: 'Re-run only the current step' },
+];
+
+const completedFooter: SerializedFooterAction[] = [
+    { id: 'archive', label: 'Archive', scope: 'spec', tooltip: 'Archive this spec' },
+    { id: 'reactivate', label: 'Reactivate', scope: 'spec', tooltip: 'Reactivate archived spec' },
+];
+
+const archivedFooter: SerializedFooterAction[] = [
+    { id: 'reactivate', label: 'Reactivate', scope: 'spec', tooltip: 'Reactivate archived spec' },
+];
+
+// Refine variants: prepend a synthetic refine action to an existing
+// footer. The id 'refine' is recognized by FooterActions.tsx and gets
+// the enhancement (sparkle) variant.
+const REFINE_ACTION: SerializedFooterAction = {
+    id: 'refine',
+    label: '✨ Refine (2)',
+    scope: 'spec',
+    tooltip: 'Submit 2 line comments for refinement',
+};
+
+const withRefine = (footer: SerializedFooterAction[]): SerializedFooterAction[] =>
+    [REFINE_ACTION, ...footer];
+
+function renderFrame(frame: Frame) {
+    navState.value = mockNavState({
+        coreDocs: [
+            mockDoc('spec', true, 'Specification'),
+            mockDoc('plan', frame.workflowPhase !== 'spec', 'Plan'),
+            mockDoc('tasks', ['tasks', 'implement'].includes(frame.workflowPhase), 'Tasks'),
+        ],
+        currentDoc: frame.activeDoc,
+        workflowPhase: frame.workflowPhase,
+        activeStep: frame.activeStep,
+        ...(frame.currentStep !== undefined ? { currentStep: frame.currentStep } : {}),
+        ...(frame.taskCompletionPercent !== undefined
+            ? { taskCompletionPercent: frame.taskCompletionPercent }
+            : {}),
+        stepHistory: frame.stepHistory,
+        specStatus: frame.status,
+        badgeText: frame.badgeText,
+        specContextName: 'Quiet Footer Demo',
+        branch: 'feat/094-viewer-state-machine',
+        createdDate: 'May 8, 2026',
+    });
+    viewerState.value = {
+        status: frame.status,
+        activeStep: frame.activeStep,
+        steps: {},
+        pulse: null,
+        highlights: [],
+        activeSubstep: null,
+        footer: frame.footer,
+        transitions: [],
+        stepHistory: frame.stepHistory,
+    };
+
+    return (
+        <div style="background: var(--vscode-editor-background, #1e1e1e); color: var(--vscode-foreground, #ccc); padding: 24px; min-height: 100vh; font-family: var(--vscode-font-family, system-ui);">
+            <p style="opacity: 0.65; font-size: 12px; margin: 0 0 16px;">{frame.note}</p>
+            <div style="border: 1px solid var(--vscode-widget-border, #303030); border-radius: 6px; overflow: hidden;">
+                <SpecHeader />
+                <nav class="compact-nav">
+                    <NavigationBar />
+                </nav>
+                <div style="padding: 64px 24px; opacity: 0.4; font-size: 12px;">
+                    <em>(spec content body — omitted in this story)</em>
+                </div>
+                <FooterActions initialSpecStatus={frame.status} />
+            </div>
+        </div>
+    );
+}
+
+// ── Create Spec — pre-viewer entry point ───────────────────
+// Embeds the actual Create New Spec mock so reviewers can see the
+// "phase zero" UI (where Auto Mode lives) without leaving the
+// transition walk-through.
+
+export const CreateSpec: Story = {
+    name: 'Create Spec',
+    render: () => <CreateSpecMock />,
+};
+
+// ── Specifying — specify in flight ─────────────────────────
+// Footer is empty during in-flight states. The header badge + the
+// active step's pulse are the "AI is working" cues; rendering greyed
+// buttons would be noise. The sidebar's per-row Archive remains
+// available if the user wants to bail mid-step.
+
+export const Specifying: Story = {
+    name: 'Specifying',
+    render: () => renderFrame({
+        status: 'specifying',
+        badgeText: 'SPECIFYING',
+        activeDoc: 'spec',
+        workflowPhase: 'spec',
+        activeStep: 'specify',
+        stepHistory: {
+            specify: { startedAt: iso(45_000), completedAt: null },
+        },
+        footer: [],
+        note: 'AI is writing spec.md. Footer is empty until the step completes.',
+    }),
+};
+
+// ── Specified — specify done, plan not started ─────────────
+
+export const Specified: Story = {
+    name: 'Specified',
+    render: () => renderFrame({
+        status: 'specified',
+        badgeText: 'SPECIFIED',
+        activeDoc: 'spec',
+        workflowPhase: 'spec',
+        activeStep: 'specify',
+        stepHistory: {
+            specify: { startedAt: iso(700_000), completedAt: iso(120_000) },
+        },
+        footer: pauseFooter('Plan'),
+        note: 'specify.md is done. The user reviews and clicks "Plan" to dispatch the next phase.',
+    }),
+};
+
+export const SpecifiedWithRefine: Story = {
+    name: 'Specified With Refine',
+    render: () => renderFrame({
+        status: 'specified',
+        badgeText: 'SPECIFIED',
+        activeDoc: 'spec',
+        workflowPhase: 'spec',
+        activeStep: 'specify',
+        stepHistory: {
+            specify: { startedAt: iso(700_000), completedAt: iso(120_000) },
+        },
+        footer: withRefine(pauseFooter('Plan')),
+        note: 'User added 2 inline comments on spec.md. The ✨ Refine button surfaces alongside the next-step button.',
+    }),
+};
+
+// ── Planning — plan in flight ──────────────────────────────
+
+export const Planning: Story = {
+    name: 'Planning',
+    render: () => renderFrame({
+        status: 'planning',
+        badgeText: 'PLANNING',
+        activeDoc: 'plan',
+        workflowPhase: 'plan',
+        activeStep: 'plan',
+        stepHistory: {
+            specify: { startedAt: iso(900_000), completedAt: iso(700_000) },
+            plan: { startedAt: iso(120_000), completedAt: null },
+        },
+        footer: [],
+        note: 'AI is writing plan.md. Specify shows the green check; Plan tab is in flight.',
+    }),
+};
+
+// ── Planned — plan done, tasks not started ────────────────
+
+export const Planned: Story = {
+    name: 'Planned',
+    render: () => renderFrame({
+        status: 'planned',
+        badgeText: 'PLANNED',
+        activeDoc: 'plan',
+        workflowPhase: 'plan',
+        activeStep: 'plan',
+        stepHistory: {
+            specify: { startedAt: iso(1_400_000), completedAt: iso(1_200_000) },
+            plan: { startedAt: iso(1_200_000), completedAt: iso(120_000) },
+        },
+        footer: pauseFooter('Tasks'),
+        note: 'plan.md is done. The user reviews and clicks "Tasks" to dispatch task generation.',
+    }),
+};
+
+export const PlannedWithRefine: Story = {
+    name: 'Planned With Refine',
+    render: () => renderFrame({
+        status: 'planned',
+        badgeText: 'PLANNED',
+        activeDoc: 'plan',
+        workflowPhase: 'plan',
+        activeStep: 'plan',
+        stepHistory: {
+            specify: { startedAt: iso(1_400_000), completedAt: iso(1_200_000) },
+            plan: { startedAt: iso(1_200_000), completedAt: iso(120_000) },
+        },
+        footer: withRefine(pauseFooter('Tasks')),
+        note: 'User added 2 inline comments on plan.md. ✨ Refine + the next-step button.',
+    }),
+};
+
+// ── Creating Tasks — tasks in flight ──────────────────────
+// Status key on disk: `tasking`. Visible label: "Creating Tasks".
+
+export const CreatingTasks: Story = {
+    name: 'Creating Tasks',
+    render: () => renderFrame({
+        status: 'tasking',
+        badgeText: 'CREATING TASKS',
+        activeDoc: 'tasks',
+        workflowPhase: 'tasks',
+        activeStep: 'tasks',
+        stepHistory: {
+            specify: { startedAt: iso(1_800_000), completedAt: iso(1_600_000) },
+            plan: { startedAt: iso(1_600_000), completedAt: iso(1_200_000) },
+            tasks: { startedAt: iso(180_000), completedAt: null },
+        },
+        footer: [],
+        note: 'AI is writing tasks.md. Footer empty until the step completes.',
+    }),
+};
+
+// ── Tasks Created — tasks done, implement not started ─────
+// Status key on disk: `ready-to-implement`. Visible label: "Tasks Created".
+// Archive + Mark Completed are HIDDEN here — the user is meant to
+// move forward to Implement, not to terminate. Closure controls
+// surface only at `implemented` (final approval gate).
+
+export const TasksCreated: Story = {
+    name: 'Tasks Created',
+    render: () => renderFrame({
+        status: 'ready-to-implement',
+        badgeText: 'TASKS CREATED',
+        activeDoc: 'tasks',
+        workflowPhase: 'tasks',
+        activeStep: 'tasks',
+        stepHistory: {
+            specify: { startedAt: iso(2_400_000), completedAt: iso(2_200_000) },
+            plan: { startedAt: iso(2_200_000), completedAt: iso(1_800_000) },
+            tasks: { startedAt: iso(1_800_000), completedAt: iso(120_000) },
+        },
+        footer: pauseFooter('Implement'),
+        note: 'tasks.md is done. Footer focuses on the forward action. Archive / Mark Completed wait until Implemented.',
+    }),
+};
+
+export const TasksCreatedWithRefine: Story = {
+    name: 'Tasks Created With Refine',
+    render: () => renderFrame({
+        status: 'ready-to-implement',
+        badgeText: 'TASKS CREATED',
+        activeDoc: 'tasks',
+        workflowPhase: 'tasks',
+        activeStep: 'tasks',
+        stepHistory: {
+            specify: { startedAt: iso(2_400_000), completedAt: iso(2_200_000) },
+            plan: { startedAt: iso(2_200_000), completedAt: iso(1_800_000) },
+            tasks: { startedAt: iso(1_800_000), completedAt: iso(120_000) },
+        },
+        footer: withRefine(pauseFooter('Implement')),
+        note: 'User added 2 inline comments on tasks.md. ✨ Refine + the forward "Implement" button.',
+    }),
+};
+
+// ── Implementing — implement in flight ────────────────────
+
+export const Implementing: Story = {
+    name: 'Implementing',
+    render: () => renderFrame({
+        status: 'implementing',
+        badgeText: 'IMPLEMENTING',
+        activeDoc: 'tasks',
+        workflowPhase: 'implement',
+        activeStep: 'implement',
+        // currentStep + taskCompletionPercent drive the last-tab in-flight
+        // pill so the Tasks tab shows e.g. "45%" while the AI builds.
+        currentStep: 'implement',
+        taskCompletionPercent: 45,
+        stepHistory: {
+            specify: { startedAt: iso(3_600_000), completedAt: iso(3_300_000) },
+            plan: { startedAt: iso(3_300_000), completedAt: iso(2_700_000) },
+            tasks: { startedAt: iso(2_700_000), completedAt: iso(2_400_000) },
+            implement: { startedAt: iso(900_000), completedAt: null },
+        },
+        footer: [],
+        note: 'AI is building the feature. The Tasks tab shows the task-completion percent. Footer empty during the build — sidebar Archive is available if you need to bail.',
+    }),
+};
+
+// ── Implemented — implement done, awaiting Mark Completed ──
+
+export const Implemented: Story = {
+    name: 'Implemented',
+    render: () => renderFrame({
+        status: 'implemented',
+        badgeText: 'IMPLEMENTED',
+        activeDoc: 'tasks',
+        workflowPhase: 'implement',
+        activeStep: 'implement',
+        stepHistory: {
+            specify: { startedAt: iso(7_200_000), completedAt: iso(6_900_000) },
+            plan: { startedAt: iso(6_900_000), completedAt: iso(6_300_000) },
+            tasks: { startedAt: iso(6_300_000), completedAt: iso(6_000_000) },
+            implement: { startedAt: iso(6_000_000), completedAt: iso(120_000) },
+        },
+        footer: finalApprovalFooter,
+        note: 'AI finished the build. The Approve button is hidden (no later step). User clicks Mark Completed to mark the spec terminally complete.',
+    }),
+};
+
+// ── Completed — terminal ──────────────────────────────────
+
+export const Completed: Story = {
+    name: 'Completed',
+    render: () => renderFrame({
+        status: 'completed',
+        badgeText: 'COMPLETED',
+        activeDoc: 'tasks',
+        workflowPhase: 'implement',
+        activeStep: 'implement',
+        stepHistory: {
+            specify: { startedAt: iso(7_200_000), completedAt: iso(6_900_000) },
+            plan: { startedAt: iso(6_900_000), completedAt: iso(6_300_000) },
+            tasks: { startedAt: iso(6_300_000), completedAt: iso(6_000_000) },
+            implement: { startedAt: iso(6_000_000), completedAt: iso(60_000) },
+        },
+        footer: completedFooter,
+        note: 'Terminal state. Stepper shows all green checks. Footer shows Archive and Reactivate.',
+    }),
+};
+
+// ── Archived — terminal ──────────────────────────────────
+
+export const Archived: Story = {
+    name: 'Archived',
+    render: () => renderFrame({
+        status: 'archived',
+        badgeText: 'ARCHIVED',
+        activeDoc: 'tasks',
+        workflowPhase: 'implement',
+        activeStep: 'implement',
+        stepHistory: {
+            specify: { startedAt: iso(86_400_000), completedAt: iso(86_000_000) },
+        },
+        footer: archivedFooter,
+        note: 'Terminal state. The spec is shelved. Only Reactivate is available to bring it back.',
+    }),
+};

--- a/webview/src/spec-viewer/components/cards/PhasesCard.stories.tsx
+++ b/webview/src/spec-viewer/components/cards/PhasesCard.stories.tsx
@@ -1,0 +1,156 @@
+import type { Meta, StoryObj } from '@storybook/preact';
+import { PhasesCard } from './PhasesCard';
+import type { ViewerState } from '../../types';
+
+const meta: Meta<typeof PhasesCard> = {
+    title: 'Viewer/Activity/PhasesCard',
+    component: PhasesCard,
+    decorators: [
+        (Story) => (
+            <div style="max-width: 640px; padding: 16px; background: var(--vscode-editor-background, #1e1e1e); color: var(--vscode-foreground, #cccccc);">
+                <Story />
+            </div>
+        ),
+    ],
+};
+export default meta;
+
+type Story = StoryObj<typeof PhasesCard>;
+
+const NOW = Date.now();
+const iso = (offsetMs: number) => new Date(NOW - offsetMs).toISOString();
+
+const baseState = (overrides: Partial<ViewerState>): ViewerState => ({
+    status: 'specifying',
+    activeStep: 'specify',
+    steps: {},
+    pulse: null,
+    highlights: [],
+    activeSubstep: null,
+    footer: [],
+    transitions: [],
+    stepHistory: {},
+    ...overrides,
+});
+
+// ── Specify just started, in flight ──────────────────────────
+// Mirrors the ngx-dev-toolbar screenshot moment: /sdd:specify is
+// running; specify has startedAt, no completedAt; substeps are
+// streaming in. Duration shows "so far" because the step is live.
+
+export const SpecifyInFlight: Story = {
+    name: 'Specify in flight (just started)',
+    render: () => (
+        <PhasesCard
+            state={baseState({
+                status: 'specifying',
+                activeStep: 'specify',
+                stepHistory: {
+                    specify: { startedAt: iso(45_000), completedAt: null },
+                },
+                transitions: [
+                    { step: 'specify', substep: 'parsing', from: null, by: 'sdd', at: iso(44_000) },
+                    { step: 'specify', substep: 'exploring', from: { step: 'specify', substep: 'parsing' }, by: 'sdd', at: iso(40_000) },
+                    { step: 'specify', substep: 'writing-spec', from: { step: 'specify', substep: 'exploring' }, by: 'sdd', at: iso(15_000) },
+                ],
+            })}
+        />
+    ),
+};
+
+// ── Specify completed, plan in flight ────────────────────────
+// User clicked the "Plan" forward button; specify got a
+// completedAt; plan has startedAt and is now the in-flight phase.
+// Specify's row reads "duration" with no "so far" suffix.
+
+export const PlanInFlight: Story = {
+    name: 'Plan in flight (specify completed)',
+    render: () => (
+        <PhasesCard
+            state={baseState({
+                status: 'planning',
+                activeStep: 'plan',
+                stepHistory: {
+                    specify: { startedAt: iso(900_000), completedAt: iso(720_000) },
+                    plan: { startedAt: iso(120_000), completedAt: null },
+                },
+                transitions: [
+                    { step: 'specify', substep: 'writing-spec', from: null, by: 'sdd', at: iso(800_000) },
+                    { step: 'plan', substep: 'research', from: { step: 'specify', substep: null }, by: 'sdd', at: iso(110_000) },
+                    { step: 'plan', substep: 'design', from: { step: 'plan', substep: 'research' }, by: 'sdd', at: iso(60_000) },
+                ],
+            })}
+        />
+    ),
+};
+
+// ── All four phases recorded, implement in flight ───────────
+// Final state of the pipeline — specify, plan, tasks all have
+// completedAt; implement is live. The card shows a full vertical
+// timeline of every phase with extension-stamped step durations.
+
+export const FullPipelineImplementInFlight: Story = {
+    name: 'All four phases — implement in flight',
+    render: () => (
+        <PhasesCard
+            state={baseState({
+                status: 'implementing',
+                activeStep: 'implement',
+                stepHistory: {
+                    specify: { startedAt: iso(3_600_000), completedAt: iso(3_300_000) },
+                    plan: { startedAt: iso(3_300_000), completedAt: iso(2_700_000) },
+                    tasks: { startedAt: iso(2_700_000), completedAt: iso(2_400_000) },
+                    implement: { startedAt: iso(900_000), completedAt: null },
+                },
+                transitions: [
+                    { step: 'specify', substep: 'writing-spec', from: null, by: 'sdd', at: iso(3_500_000) },
+                    { step: 'plan', substep: 'design', from: { step: 'specify', substep: null }, by: 'sdd', at: iso(3_000_000) },
+                    { step: 'tasks', substep: null, from: { step: 'plan', substep: null }, by: 'sdd', at: iso(2_600_000) },
+                    { step: 'implement', substep: 'phase1', from: { step: 'tasks', substep: null }, by: 'sdd', at: iso(800_000) },
+                    { step: 'implement', substep: 'code-review', from: { step: 'implement', substep: 'phase1' }, by: 'sdd', at: iso(300_000) },
+                ],
+            })}
+        />
+    ),
+};
+
+// ── Completed spec ───────────────────────────────────────────
+// Terminal state — every step has a completedAt. No "so far"
+// suffix anywhere; durations are final.
+
+export const Completed: Story = {
+    name: 'Completed (terminal state)',
+    render: () => (
+        <PhasesCard
+            state={baseState({
+                status: 'completed',
+                activeStep: 'implement',
+                stepHistory: {
+                    specify: { startedAt: iso(7_200_000), completedAt: iso(6_900_000) },
+                    plan: { startedAt: iso(6_900_000), completedAt: iso(6_300_000) },
+                    tasks: { startedAt: iso(6_300_000), completedAt: iso(6_000_000) },
+                    implement: { startedAt: iso(6_000_000), completedAt: iso(60_000) },
+                },
+                transitions: [],
+            })}
+        />
+    ),
+};
+
+// ── No history yet ───────────────────────────────────────────
+// Pure draft — the card returns null and does not render. This
+// story exists so reviewers can confirm the empty-state behavior
+// (the activity panel is supposed to collapse when nothing has
+// happened).
+
+export const PureDraftHidden: Story = {
+    name: 'Pure draft (renders nothing)',
+    render: () => (
+        <div>
+            <p style="opacity: 0.6; font-style: italic;">
+                Card returns null when stepHistory is empty — nothing renders below this line:
+            </p>
+            <PhasesCard state={baseState({ status: 'draft', stepHistory: {}, transitions: [] })} />
+        </div>
+    ),
+};

--- a/webview/styles/spec-viewer/_animations.css
+++ b/webview/styles/spec-viewer/_animations.css
@@ -85,13 +85,14 @@
     }
 }
 
-/* Pulsing glow for active working step (green = active progress) */
+/* Pulsing glow for active working step (purple = active progress, distinct
+   from the green completed checkmark). */
 @keyframes working-pulse {
     0%, 100% {
-        box-shadow: 0 0 0 2px var(--bg-secondary), 0 0 0 4px var(--success), 0 0 8px var(--success);
+        box-shadow: 0 0 0 2px var(--bg-secondary), 0 0 0 4px var(--purple), 0 0 8px var(--purple);
     }
     50% {
-        box-shadow: 0 0 0 3px var(--bg-secondary), 0 0 0 5px var(--success), 0 0 16px var(--success);
+        box-shadow: 0 0 0 3px var(--bg-secondary), 0 0 0 5px var(--purple), 0 0 16px var(--purple);
     }
 }
 

--- a/webview/styles/spec-viewer/_navigation.css
+++ b/webview/styles/spec-viewer/_navigation.css
@@ -35,7 +35,7 @@
     position: relative;
     display: flex;
     align-items: center;
-    gap: 6px;
+    gap: 10px;
     padding: 8px 14px;
     border: none;
     background: transparent;
@@ -99,26 +99,34 @@
     font-weight: 700;
 }
 
-/* In-flight (canonical): success-colored % pill + matching working-pulse glow.
-   Pill background matches the green pulse (--success) so the pill and its ring
-   read as one "work in progress" state — using --accent here clashed with the
-   green pulse on themes where --vscode-focusBorder is purple. */
+/* In-flight (canonical): purple badge + working-pulse glow.
+   Distinct from done-green so the active step is unmistakable.
+   Default size matches the completed checkmark (16×16); only the
+   implement-step % pill widens via :not(:empty) below. */
 .step-tab.in-flight .step-status {
-    background: var(--success);
-    border-color: var(--success);
+    background: var(--purple);
+    border-color: var(--purple);
     color: white;
     font-size: 11px;
     font-weight: 700;
+    animation: working-pulse 2s ease-in-out infinite;
+}
+
+/* The pill grows wider only when there's a percent string to show
+   (the implement-step inProgress case). Empty in-flight steps keep
+   the default 16×16 circle defined on .step-status — same size as
+   the completed checkmark, just pulsing. */
+.step-tab.in-flight .step-status:not(:empty) {
     width: auto;
     min-width: 32px;
     padding: 0 6px;
     border-radius: 10px;
-    animation: working-pulse 2s ease-in-out infinite;
 }
 
-/* Extra left padding so the pill's ~16px working-pulse glow doesn't crash
-   into the preceding connector line. */
-.step-tab.in-flight {
+/* Extra left padding when the pill is widened, so the working-pulse
+   glow doesn't crash into the preceding connector line. The default
+   16×16 in-flight badge needs no extra padding. */
+.step-tab.in-flight:has(.step-status:not(:empty)) {
     padding-left: 20px;
 }
 


### PR DESCRIPTION
## Summary

- Reshape the spec viewer footer to match the actual workflow state: hide noisy controls while a step is in flight, add an `implemented` status as the final approval gate, and dynamically label the forward button (Plan / Tasks / Implement / Complete) per workflow step.
- Split the footer into two regions: **left** holds Regenerate only (secondary tool); **right** holds forward-motion + closure controls (Refine, Approve, Reactivate, Archive, Mark Completed).
- Add comprehensive per-status Storybook coverage (`ViewerTransitions`, `FooterActions`, `PhasesCard`, `CreateSpec`) walking the full lifecycle plus Refine variants.

## Changes

- `footerActions.ts`: `isSpecDone` gated to `{implemented, completed}`; `shouldShowApprove` handles the "step done / next step not started" pauses; `getApproveLabel(currentStep, workflowSteps)` resolves the next-step label; START and SDD_AUTO removed (Auto now lives in the Create Spec form).
- `FooterActions.tsx`: tightened `isRunning` predicate (requires `startedAt`); hide-during-in-flight (instead of disable); Edit Source removed (sidebar has equivalent).
- `specContext.ts` / `specContextWriter.ts`: add `implemented` status; `deriveCompletedStatus('implement')` returns `implemented`, not `completed`.
- `StepTab.tsx` + `_navigation.css` + `_animations.css`: fix `isWorking` phase→step mapping; in-flight pill turns purple and widens to show running text.
- `SpecHeader.tsx`: status label overrides — `tasking` → "Creating Tasks", `ready-to-implement` → "Tasks Created".
- `CreateSpecMock.tsx` (new shared module) drives the CreateSpec story.
- `docs/viewer-states.md` rewritten as the source of truth for lifecycle, footer matrix, and step-tab visuals.
- Tests: 508 pass (+11 footer cases for the new gates).

## Test plan

- [ ] `npm test` — all 508 tests green
- [ ] `npm run build-storybook` — clean build
- [ ] Storybook → `Viewer/Transitions` walks the full lifecycle with expected layout per status (in-flight = empty footer, pause states = Regenerate left + forward button right, Implemented = Regenerate left + Archive·Mark Completed right, Completed/Archived right-aligned)
- [ ] Storybook → `Viewer/FooterActions` per-status catalog stories match the transitions
- [ ] Reload extension in a real workspace; trigger a spec through specify → plan → tasks → implement and confirm the footer matches the design at each pause

🤖 Generated with [Claude Code](https://claude.com/claude-code)