### PR TITLE
feat(spec-viewer): persist inline review comments to a per-doc scratchpad

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,0 +1,3 @@
+{
+  "feature_directory": "specs/096-scratchpad-extras"
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,12 @@ All notable changes to this project will be documented in this file.
 
 ### New Features
 
-- **Per-Document Scratchpads**: Each core document (spec/plan/tasks) gains an optional scratchpad sub-tab — a plain markdown file (`spec-extra.md`, `plan-extra.md`, `tasks-extra.md`) for freeform refinement notes, questions, deferred concerns, or AI instructions. Scratchpads are lazily created from an empty state (single **Create `<doc>-extra.md`** action), styled distinctly in the children rail, and carry a "has notes" dot when non-empty. Their **Refine** button reads the scratchpad and dispatches a direct, in-place AI edit of the matching source document (never a template regeneration, never a slash command); empty scratchpads are guarded. Scratchpads are non-core: they never gate phase transitions, never count toward task completion, and are committable to source control.
-- **Inline comments now persist to the scratchpad**: When the existing batch **Refine** button on a source tab submits collected line comments to the AI, those same comments are also appended to the matching scratchpad file as a timestamped history block. The hover-to-add comment workflow (`+` button on each line, the comment-entry dialog, the comment cards) is unchanged — the scratchpad just becomes a durable record of every batch you've sent.
+- **Inline review comments now persist to a per-document scratchpad**: When you submit a batch of inline comments via the source-tab **Refine** button, the AI gets the direct-edit prompt as before *and* the same batch is appended to a matching `<doc>-extra.md` history file (`spec-extra.md`, `plan-extra.md`, `tasks-extra.md`). Each entry records the exact source line, the nearest preceding heading, and the full source block (paragraph or list item, walked from the actual source markdown) so the trail stays meaningful even after the source file is edited and line numbers shift. Entries render as a labeled `## Refinement batch · TIMESTAMP` → `### Line N · Section` → **Original** quote → **Comment** layout, newest batch on top, with `---` rules between batches. The scratchpad sub-tab appears in the children rail only once the file exists (no manual create path) and is a read-only history with only an Edit affordance for manual cleanup. Scratchpads are non-core: never gate phase transitions, never count toward task completion, committable to source control.
+
+### Bug Fixes
+
+- **Multi-line blockquotes render as one card**: The viewer's markdown renderer now groups consecutive `>` lines into a single `<blockquote>` element instead of fragmenting them into one card per line.
+- **Sidebar green check no longer contradicts "not created"**: The pass icon on Spec / Plan / Tasks sub-items in the explorer tree is now gated on the file actually existing on disk, so a hand-crafted or out-of-sync `.spec-context.json` can't show "completed" next to a missing document.
 
 ## [0.16.0] - 2026-05-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### New Features
+
+- **Per-Document Scratchpads**: Each core document (spec/plan/tasks) gains an optional scratchpad sub-tab — a plain markdown file (`spec-extra.md`, `plan-extra.md`, `tasks-extra.md`) for freeform refinement notes, questions, deferred concerns, or AI instructions. Scratchpads are lazily created from an empty state (single **Create `<doc>-extra.md`** action), styled distinctly in the children rail, and carry a "has notes" dot when non-empty. Their **Refine** button reads the scratchpad and dispatches a direct, in-place AI edit of the matching source document (never a template regeneration, never a slash command); empty scratchpads are guarded. Scratchpads are non-core: they never gate phase transitions, never count toward task completion, and are committable to source control.
+- **Inline comments now persist to the scratchpad**: When the existing batch **Refine** button on a source tab submits collected line comments to the AI, those same comments are also appended to the matching scratchpad file as a timestamped history block. The hover-to-add comment workflow (`+` button on each line, the comment-entry dialog, the comment cards) is unchanged — the scratchpad just becomes a durable record of every batch you've sent.
+
 ## [0.16.0] - 2026-05-12
 
 ### New Features

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -224,5 +224,6 @@ npm run test:watch    # Watch mode
 
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
-shell commands, and other important information, read the current plan
+shell commands, and other important information, read the current plan:
+`specs/096-scratchpad-extras/plan.md`
 <!-- SPECKIT END -->

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The spec workspace for developers running AI agents through Spec-Driven Developm
 
 ## Why it exists
 
-**Review AI-generated specs the way you review code.** Add inline comments on specific lines, refine requirements, and catch a vague requirement before the AI turns it into 200 lines of wrong code.
+**Review AI-generated specs the way you review code.** Add inline comments on specific lines, refine requirements, and catch a vague requirement before the AI turns it into 200 lines of wrong code. Every comment you submit is also captured as a markdown entry in a per-document scratchpad, so the history is durable across sessions.
 
 **Plug any AI assistant into any spec-driven workflow.** Six providers ship today (Claude Code, Gemini, GitHub Copilot, Codex, Qwen, OpenCode), and the workflow engine accepts custom phases, commands, and sub-documents. Drop in [Agent Teams Lite](https://github.com/Gentleman-Programming/agent-teams-lite), your own SDD process, or anything that takes commands and produces markdown.
 
@@ -35,10 +35,18 @@ Guide your features through structured phases with a dedicated editor that rende
 
 ### Inline Review Comments
 
-Review spec documents with inline comments. Add feedback directly on specific lines, refine requirements, and collaborate on specs before implementation begins.
+Review spec documents with inline comments. Add feedback directly on specific lines, refine requirements, and collaborate on specs before implementation begins. Every batch you submit via the **Refine** button is dispatched to the AI for a direct, in-place edit of the source document — and is also appended to the matching per-document scratchpad so you have a permanent, committable record.
 
 ![Inline Comments](https://raw.githubusercontent.com/alfredoperez/speckit-companion/main/docs/screenshots/inline-comment-dialog.png)
 *Inline review comments. Catch a vague requirement on line 12 before the AI turns it into 200 lines of wrong code.*
+
+### Per-Document Scratchpads
+
+Each core document (spec, plan, tasks) gets an optional scratchpad sub-tab — a plain markdown file (`spec-extra.md`, `plan-extra.md`, `tasks-extra.md`) for freeform refinement notes, questions, deferred concerns, or AI instructions. Two ways content lands here:
+1. Submitting line comments via the source-tab **Refine** button appends a timestamped batch entry automatically.
+2. You can also type free-form notes directly into the file (via the empty-state **Create** button or **Edit** affordance).
+
+Scratchpads are lazily created, committable, and never count toward phase gating or task completion. The scratchpad-tab **Refine** button re-applies the file to the matching source — handy after manual edits.
 
 ### Create Specs Visually
 
@@ -73,6 +81,7 @@ The spec viewer is built for fast scanning of long-form specs:
 - **Title-leading header**: the spec name dominates above a compact `[STATUS] [⌥ branch] · date` cluster, so the page anchor is the first thing your eye lands on.
 - **Sticky chrome**: step tabs (Specification / Plan / Tasks) and header stay pinned at the top while you scroll.
 - **Children rail**: when a step has sub-files (e.g., Plan's `data-model.md`, `quickstart.md`, `research.md`), they render as chips directly under the active step tab, with the parent step itself as the first chip so any sub-doc has a one-click path back to the overview.
+- **Scratchpad sub-tabs**: each core document (spec/plan/tasks) carries a `… Notes` scratchpad chip in the children rail, styled distinctly (dashed, italic) so it never reads as the authoritative artifact. Opening one whose file doesn't exist yet shows a single **Create `<doc>-extra.md`** action; once it has content a small dot marks the chip. The scratchpad footer offers **Edit** (open in the editor) and **Refine** (apply the notes to the source doc as a direct in-place edit). The **Refine** button appears only on a scratchpad tab, never on a source-document tab.
 - **Table of contents**: sticky outline column on the left of the content area. Defaults to h2-only (so phase-heavy `tasks.md` reads as a clean ~7-entry list); a small `+` toggle expands h3 subsections when needed. Auto-hides on narrow panes.
 - **Quiet content**: when the structured header has the metadata, in-content duplicates (the `Input:` block, repeated branch chips, literal `Slug:`/`Date:` paragraphs) are suppressed so the body is just the spec content.
 - **Diagrams**: wide mermaid diagrams scroll horizontally inside the prose column instead of bleeding past it. Each diagram has its own `−` / Reset / `+` zoom controls.

--- a/README.md
+++ b/README.md
@@ -42,11 +42,9 @@ Review spec documents with inline comments. Add feedback directly on specific li
 
 ### Per-Document Scratchpads
 
-Each core document (spec, plan, tasks) gets an optional scratchpad sub-tab — a plain markdown file (`spec-extra.md`, `plan-extra.md`, `tasks-extra.md`) for freeform refinement notes, questions, deferred concerns, or AI instructions. Two ways content lands here:
-1. Submitting line comments via the source-tab **Refine** button appends a timestamped batch entry automatically.
-2. You can also type free-form notes directly into the file (via the empty-state **Create** button or **Edit** affordance).
+Each core document (spec, plan, tasks) gets a per-doc scratchpad file (`spec-extra.md`, `plan-extra.md`, `tasks-extra.md`) that records every inline-comment batch you submit. Submitting line comments via the source-tab **Refine** button dispatches them to the AI *and* appends them to the matching scratchpad as a labeled history block (`## Refinement batch · TIMESTAMP` → `### Line N · Section` → **Original** quote → **Comment** note), newest batch on top, with `---` rules between batches.
 
-Scratchpads are lazily created, committable, and never count toward phase gating or task completion. The scratchpad-tab **Refine** button re-applies the file to the matching source — handy after manual edits.
+The scratchpad sub-tab appears in the children rail only once the file exists — there is no manual create flow. The sub-tab is a read-only history with only an **Edit** affordance for manual cleanup; it's not a freeform notes file. Scratchpads are committable, never count toward phase gating or task completion, and exist purely so your review trail survives across sessions.
 
 ### Create Specs Visually
 
@@ -81,7 +79,7 @@ The spec viewer is built for fast scanning of long-form specs:
 - **Title-leading header**: the spec name dominates above a compact `[STATUS] [⌥ branch] · date` cluster, so the page anchor is the first thing your eye lands on.
 - **Sticky chrome**: step tabs (Specification / Plan / Tasks) and header stay pinned at the top while you scroll.
 - **Children rail**: when a step has sub-files (e.g., Plan's `data-model.md`, `quickstart.md`, `research.md`), they render as chips directly under the active step tab, with the parent step itself as the first chip so any sub-doc has a one-click path back to the overview.
-- **Scratchpad sub-tabs**: each core document (spec/plan/tasks) carries a `… Notes` scratchpad chip in the children rail, styled distinctly (dashed, italic) so it never reads as the authoritative artifact. Opening one whose file doesn't exist yet shows a single **Create `<doc>-extra.md`** action; once it has content a small dot marks the chip. The scratchpad footer offers **Edit** (open in the editor) and **Refine** (apply the notes to the source doc as a direct in-place edit). The **Refine** button appears only on a scratchpad tab, never on a source-document tab.
+- **Scratchpad sub-tabs**: each core document (spec/plan/tasks) gets a `… Notes` chip in the children rail once an inline-comment batch has been submitted against it — styled distinctly (dashed, italic) so it never reads as the authoritative artifact. The chip is hidden until the `<doc>-extra.md` file exists; there is no manual create flow. Opening the chip shows the read-only refinement history (latest batch on top); the footer offers only **Edit** to open the file in VS Code's editor for manual cleanup.
 - **Table of contents**: sticky outline column on the left of the content area. Defaults to h2-only (so phase-heavy `tasks.md` reads as a clean ~7-entry list); a small `+` toggle expands h3 subsections when needed. Auto-hides on narrow panes.
 - **Quiet content**: when the structured header has the metadata, in-content duplicates (the `Input:` block, repeated branch chips, literal `Slug:`/`Date:` paragraphs) are suppressed so the body is just the spec content.
 - **Diagrams**: wide mermaid diagrams scroll horizontally inside the prose column instead of bleeding past it. Each diagram has its own `−` / Reset / `+` zoom controls.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -40,6 +40,9 @@ src/
 │   │                           # specEditorCommands.ts, tempFileManager.ts, types.ts, index.ts
 │   ├── spec-viewer/            # specViewerProvider.ts, specViewerCommands.ts,
 │   │                           # messageHandlers.ts, documentScanner.ts,
+│   │                           # extractBlock.ts (walks source markdown for
+│   │                           #   the block + section anchoring inline-
+│   │                           #   comment batches into the scratchpad),
 │   │                           # phaseCalculation.ts, staleness.ts,
 │   │                           # stateDerivation.ts (060: ctx → ViewerState),
 │   │                           # footerActions.ts (060: scope + visibility),
@@ -75,6 +78,9 @@ webview/
 │   │   ├── highlighting.ts
 │   │   ├── modal.ts
 │   │   ├── navigation.ts
+│   │   ├── scratchpad.ts       # Pure helper: which doc is currently active
+│   │   │                       # in nav state? Used by FooterActions to
+│   │   │                       # branch to the scratchpad-tab footer.
 │   │   ├── state.ts
 │   │   ├── toc.ts              # Builds a sticky table-of-contents sidebar from rendered H2/H3 headings;
 │   │   │                       # tracks the active heading via IntersectionObserver and toggles a

--- a/docs/sidebar.md
+++ b/docs/sidebar.md
@@ -79,7 +79,7 @@ Every canonical status is mapped to a distinct color treatment so badges read at
 
 - Green beaker icon — completed spec
 - Blue beaker icon — spec with an active workflow step
-- Green check — completed step
+- Green check — completed step (requires the step's file to exist on disk; a hand-crafted or out-of-sync `.spec-context.json` that claims completion without the file shows the default empty icon instead)
 - Green pulsing glow — step actively being worked on
 - Blue dot — current step
 

--- a/docs/viewer-states.md
+++ b/docs/viewer-states.md
@@ -217,25 +217,21 @@ batch to the matching scratchpad file as a timestamped history block.
 ### Scratchpad footer (overrides the matrix above)
 
 When the active document is a **scratchpad** (`*-extra.md`, `isScratchpad: true`)
-the footer is replaced by a dedicated, scratchpad-only set — gated entirely on
-the active doc, independent of spec status:
+the footer is replaced by a dedicated, read-only set — gated entirely on the
+active doc, independent of spec status:
 
 | Active doc | Left side | Right side |
 |------------|-----------|------------|
-| scratchpad (file exists) | — | Edit, **Refine** |
-| scratchpad (file absent) | — | — (the create action lives in the empty-state body) |
+| scratchpad (file exists) | — | Edit |
 
 - **Edit** reuses the standard `editDocument` affordance to open the scratchpad
-  in the editor.
-- **Refine** posts `applyScratchpad`: the extension reads the scratchpad and
-  dispatches a **direct, in-place edit** of the matching source document. It is
-  never routed through the generic `footerAction` catalog and never invokes a
-  `/speckit-*` slash command (those re-run setup scripts that overwrite the
-  source from a template). An empty scratchpad is guarded — Refine dispatches
-  nothing and shows a "Nothing to apply" toast.
-- Refine on the scratchpad tab is useful for re-applying after manual edits to
-  the scratchpad file; the source-tab batch Refine remains the primary path
-  for ad-hoc line comments collected via hover.
+  in VS Code's text editor for manual cleanup.
+- A scratchpad chip only appears in the children rail once its `*-extra.md`
+  file exists on disk — there is no manual create flow, and therefore no
+  "file absent" state to render here. The file is created as a side effect of
+  the source-tab batch Refine when it appends the first batch.
+- There is no scratchpad-tab Refine button or `applyScratchpad` message; the
+  AI dispatch path is exclusively the source-tab batch Refine described above.
 
 ---
 

--- a/docs/viewer-states.md
+++ b/docs/viewer-states.md
@@ -209,7 +209,33 @@ The "Next Step" button shows only when:
 - The next core document doesn't exist yet
 - Label shows the next step name: "Plan", "Tasks", or "Implement"
 
-The **Refine** button (`✨ Refine (N)`) appears dynamically when inline comments are pending.
+The source-tab **Refine** button (`✨ Refine (N)`) still appears dynamically
+when pending inline comments are collected. Submitting it (a) dispatches a
+direct-edit prompt to the AI for the source document and (b) appends the same
+batch to the matching scratchpad file as a timestamped history block.
+
+### Scratchpad footer (overrides the matrix above)
+
+When the active document is a **scratchpad** (`*-extra.md`, `isScratchpad: true`)
+the footer is replaced by a dedicated, scratchpad-only set — gated entirely on
+the active doc, independent of spec status:
+
+| Active doc | Left side | Right side |
+|------------|-----------|------------|
+| scratchpad (file exists) | — | Edit, **Refine** |
+| scratchpad (file absent) | — | — (the create action lives in the empty-state body) |
+
+- **Edit** reuses the standard `editDocument` affordance to open the scratchpad
+  in the editor.
+- **Refine** posts `applyScratchpad`: the extension reads the scratchpad and
+  dispatches a **direct, in-place edit** of the matching source document. It is
+  never routed through the generic `footerAction` catalog and never invokes a
+  `/speckit-*` slash command (those re-run setup scripts that overwrite the
+  source from a template). An empty scratchpad is guarded — Refine dispatches
+  nothing and shows a "Nothing to apply" toast.
+- Refine on the scratchpad tab is useful for re-applying after manual edits to
+  the scratchpad file; the source-tab batch Refine remains the primary path
+  for ad-hoc line comments collected via hover.
 
 ---
 

--- a/specs/096-scratchpad-extras/.spec-context.json
+++ b/specs/096-scratchpad-extras/.spec-context.json
@@ -1,0 +1,206 @@
+{
+  "workflow": "speckit",
+  "selectedAt": "2026-05-20T19:47:47Z",
+  "currentStep": "implement",
+  "status": "completed",
+  "specName": "Scratchpad Extras",
+  "branch": "main",
+  "stepHistory": {
+    "specify": {
+      "startedAt": "2026-05-20T19:47:47Z",
+      "completedAt": "2026-05-20T19:49:24.649Z"
+    },
+    "plan": {
+      "startedAt": "2026-05-20T19:49:24.653Z",
+      "completedAt": "2026-05-20T20:03:55.431Z"
+    },
+    "tasks": {
+      "startedAt": "2026-05-20T20:03:55.264Z",
+      "completedAt": "2026-05-20T20:09:06.772Z"
+    },
+    "implement": {
+      "startedAt": "2026-05-20T20:09:06.774Z",
+      "completedAt": null
+    }
+  },
+  "transitions": [
+    {
+      "step": "specify",
+      "substep": null,
+      "from": {
+        "step": "specify",
+        "substep": null
+      },
+      "by": "extension",
+      "at": "2026-05-20T19:49:24.649Z"
+    },
+    {
+      "step": "plan",
+      "substep": null,
+      "from": {
+        "step": "specify",
+        "substep": null
+      },
+      "by": "extension",
+      "at": "2026-05-20T19:49:24.653Z"
+    },
+    {
+      "step": "plan",
+      "substep": null,
+      "from": {
+        "step": "plan",
+        "substep": null
+      },
+      "by": "ai",
+      "at": "2026-05-20T19:50:29Z"
+    },
+    {
+      "step": "plan",
+      "substep": "research",
+      "from": {
+        "step": "plan",
+        "substep": null
+      },
+      "by": "ai",
+      "at": "2026-05-20T19:50:45Z"
+    },
+    {
+      "step": "plan",
+      "substep": "design",
+      "from": {
+        "step": "plan",
+        "substep": "research"
+      },
+      "by": "ai",
+      "at": "2026-05-20T19:56:33Z"
+    },
+    {
+      "step": "plan",
+      "substep": null,
+      "from": {
+        "step": "plan",
+        "substep": "design"
+      },
+      "by": "ai",
+      "at": "2026-05-20T19:59:04Z"
+    },
+    {
+      "step": "tasks",
+      "substep": null,
+      "from": {
+        "step": "plan",
+        "substep": null
+      },
+      "by": "extension",
+      "at": "2026-05-20T20:03:55.264Z"
+    },
+    {
+      "step": "tasks",
+      "substep": null,
+      "from": {
+        "step": "plan",
+        "substep": null
+      },
+      "by": "ai",
+      "at": "2026-05-20T20:04:31Z"
+    },
+    {
+      "step": "tasks",
+      "substep": "generate",
+      "from": {
+        "step": "tasks",
+        "substep": null
+      },
+      "by": "ai",
+      "at": "2026-05-20T20:04:41Z"
+    },
+    {
+      "step": "tasks",
+      "substep": null,
+      "from": {
+        "step": "tasks",
+        "substep": null
+      },
+      "by": "extension",
+      "at": "2026-05-20T20:09:06.772Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "from": {
+        "step": "tasks",
+        "substep": null
+      },
+      "by": "extension",
+      "at": "2026-05-20T20:09:06.774Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "from": {
+        "step": "implement",
+        "substep": null
+      },
+      "by": "ai",
+      "at": "2026-05-20T20:09:22Z"
+    },
+    {
+      "step": "implement",
+      "substep": "run-tests",
+      "from": {
+        "step": "implement",
+        "substep": null
+      },
+      "by": "ai",
+      "at": "2026-05-20T20:26:40Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "from": {
+        "step": "implement",
+        "substep": "run-tests"
+      },
+      "by": "ai",
+      "at": "2026-05-20T20:28:49Z"
+    }
+  ],
+  "task_summaries": {
+    "T001": { "status": "DONE", "did": "Added ScratchpadFiles map and SCRATCHPAD_SUFFIX constants.", "files": ["src/core/constants.ts"] },
+    "T002": { "status": "DONE", "did": "Added isScratchpad/scratchpadFor/hasContent to SpecDocument and extended DocumentType (extension).", "files": ["src/features/spec-viewer/types.ts"] },
+    "T003": { "status": "DONE", "did": "Mirrored SpecDocument fields and DocumentType extension in the webview.", "files": ["webview/src/spec-viewer/types.ts"] },
+    "T004": { "status": "DONE", "did": "Synthesized one scratchpad doc per existing core source doc with exists/hasContent and de-duped on-disk *-extra.md.", "files": ["src/features/spec-viewer/documentScanner.ts"] },
+    "T005": { "status": "DONE", "did": "Scratchpad fields ride through NavState.relatedDocs automatically (category 'related'); verified, no code change needed.", "files": ["src/features/spec-viewer/specViewerProvider.ts"] },
+    "T006": { "status": "DONE", "did": "Added .step-child--scratchpad distinction styling.", "files": ["webview/styles/spec-viewer/_navigation.css"] },
+    "T007": { "status": "DONE", "did": "Applied scratchpad/has-notes class hooks in the children rail.", "files": ["webview/src/spec-viewer/components/NavigationBar.tsx"] },
+    "T008": { "status": "DONE", "did": "Unit-tested scanner synthesis (per-source, source-absent, de-dupe, hasContent).", "files": ["tests/unit/spec-viewer/documentScanner.spec.ts", "tests/__mocks__/vscode.ts"] },
+    "T009": { "status": "DONE", "did": "Unit-tested handleCreateScratchpad (create/no-op/switch/toast).", "files": ["tests/unit/spec-viewer/scratchpadHandlers.spec.ts"] },
+    "T010": { "status": "DONE", "did": "Added createScratchpad message to both unions.", "files": ["webview/src/spec-viewer/types.ts", "src/features/spec-viewer/types.ts"] },
+    "T011": { "status": "DONE", "did": "Implemented and routed handleCreateScratchpad (empty write + re-scan + switch + failure toast).", "files": ["src/features/spec-viewer/messageHandlers.ts", "src/features/spec-viewer/specViewerProvider.ts"] },
+    "T012": { "status": "DONE", "did": "Created ScratchpadEmptyState with a single labeled create action.", "files": ["webview/src/spec-viewer/components/ScratchpadEmptyState.tsx"] },
+    "T013": { "status": "DONE", "did": "Added Storybook coverage for the empty state.", "files": ["webview/src/spec-viewer/components/ScratchpadEmptyState.stories.tsx"] },
+    "T014": { "status": "DONE", "did": "Rendered the empty state when the active doc is a non-existent scratchpad.", "files": ["webview/src/spec-viewer/App.tsx"] },
+    "T015": { "status": "DONE", "did": "Added the Edit control on the scratchpad footer reusing editDocument.", "files": ["webview/src/spec-viewer/components/FooterActions.tsx"] },
+    "T016": { "status": "DONE", "did": "Unit-tested handleApplyScratchpad (empty guard, single direct-edit prompt, no slash command, tasks mapping).", "files": ["tests/unit/spec-viewer/scratchpadHandlers.spec.ts"] },
+    "T017": { "status": "DONE", "did": "Extended footerActions.spec.ts to assert Refine gating via the isScratchpadActive helper.", "files": ["tests/unit/spec-viewer/footerActions.spec.ts", "webview/src/spec-viewer/scratchpad.ts"] },
+    "T018": { "status": "DONE", "did": "Added applyScratchpad message to both unions.", "files": ["webview/src/spec-viewer/types.ts", "src/features/spec-viewer/types.ts"] },
+    "T019": { "status": "DONE", "did": "Implemented and routed handleApplyScratchpad (read, empty guard, direct-edit prompt to source path, never a slash command).", "files": ["src/features/spec-viewer/messageHandlers.ts"] },
+    "T020": { "status": "DONE", "did": "Added the scratchpad-gated Refine button (not via the footerAction catalog).", "files": ["webview/src/spec-viewer/components/FooterActions.tsx"] },
+    "T021": { "status": "DONE", "did": "Rendered the has-notes dot class when doc.hasContent.", "files": ["webview/src/spec-viewer/components/NavigationBar.tsx"] },
+    "T022": { "status": "DONE", "did": "Added has-notes dot CSS on .step-child--scratchpad.", "files": ["webview/styles/spec-viewer/_navigation.css"] },
+    "T023": { "status": "DONE", "did": "Added NavigationBar stories for has-notes vs empty scratchpad.", "files": ["webview/src/spec-viewer/components/NavigationBar.stories.tsx"] },
+    "T024": { "status": "DONE", "did": "Deleted InlineComment/InlineEditor components and their stories; updated components/index.ts.", "files": ["webview/src/spec-viewer/components/index.ts"] },
+    "T025": { "status": "DONE", "did": "Deleted editor modules (refinements/inlineEditor/lineActions/index), modal.ts and the now-dead elements.ts.", "files": ["webview/src/spec-viewer/index.tsx"] },
+    "T026": { "status": "DONE", "did": "Removed refinement signals and the Refinement import.", "files": ["webview/src/spec-viewer/signals.ts"] },
+    "T027": { "status": "DONE", "did": "Removed line-action wrapping in the renderer (kept li.line for task grouping) and the comment-button injection in scenarios.", "files": ["webview/src/spec-viewer/markdown/renderer.ts", "webview/src/spec-viewer/markdown/scenarios.ts"] },
+    "T028": { "status": "DONE", "did": "Dropped setupLineActions/setupRefineModal wiring and imports from index.tsx.", "files": ["webview/src/spec-viewer/index.tsx"] },
+    "T029": { "status": "DONE", "did": "Deleted _refinements/_editor/_modal CSS, trimmed _line-actions and _tables, updated index.css imports.", "files": ["webview/styles/spec-viewer/index.css", "webview/styles/spec-viewer/_line-actions.css", "webview/styles/spec-viewer/_tables.css"] },
+    "T030": { "status": "DONE", "did": "Removed submitRefinements/refineLine/editLine/removeLine messages+handlers, the Refinement/LineType types, and the server-rendered refine modal HTML; updated affected tests.", "files": ["src/features/spec-viewer/messageHandlers.ts", "src/features/spec-viewer/types.ts", "webview/src/spec-viewer/types.ts", "src/features/spec-viewer/html/generator.ts", "src/features/spec-viewer/__tests__/messageHandlers.test.ts", "src/features/spec-viewer/__tests__/generator.test.ts"] },
+    "T031": { "status": "DONE", "did": "Verified toggleCheckbox is reachable via direct checkbox clicks (actions.ts) and kept it." },
+    "T032": { "status": "DONE", "did": "Documented scratchpad sub-tabs, empty-state create, and scratchpad Refine in README (replaced the inline-comment feature section).", "files": ["README.md"] },
+    "T033": { "status": "DONE", "did": "Updated the footer button matrix in viewer-states.md for the scratchpad footer and removal of the old batch Refine.", "files": ["docs/viewer-states.md"] },
+    "T034": { "status": "DONE", "did": "Added CHANGELOG entries for scratchpads and the inline-comment removal.", "files": ["CHANGELOG.md"] },
+    "T035": { "status": "DONE_WITH_CONCERNS", "did": "Could not run the live Extension Dev Host walkthrough headlessly; validated programmatically via compile, webview build, webview type-check, and the unit suite.", "concerns": ["Manual quickstart.md verification in the Extension Development Host still needs a human run before release."] },
+    "T036": { "status": "DONE", "did": "Ran npm run compile, compile-web, tsc --noEmit (webview), and the full jest suite — 535 tests across 48 suites pass.", "files": [] }
+  }
+}

--- a/specs/096-scratchpad-extras/checklists/requirements.md
+++ b/specs/096-scratchpad-extras/checklists/requirements.md
@@ -1,0 +1,35 @@
+# Specification Quality Checklist: Per-Document Scratchpad Extras
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-20
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Items marked incomplete require spec updates before `/speckit.clarify` or `/speckit.plan`
+- All items pass on first validation; no [NEEDS CLARIFICATION] markers were required (informed defaults documented in Assumptions).

--- a/specs/096-scratchpad-extras/contracts/webview-messages.md
+++ b/specs/096-scratchpad-extras/contracts/webview-messages.md
@@ -1,0 +1,136 @@
+# Contract: Spec-Viewer Message Protocol Changes
+
+**Feature**: 096-scratchpad-extras
+**Date**: 2026-05-20
+
+The spec viewer is a WebviewPanel that communicates with the extension via
+`postMessage`. This contract defines the protocol delta for scratchpads. Message
+unions live in `webview/src/spec-viewer/types.ts` (`ViewerToExtensionMessage`,
+`ExtensionToViewerMessage`) and the extension-side mirror in
+`src/features/spec-viewer/types.ts`; routing is in
+`src/features/spec-viewer/messageHandlers.ts`.
+
+---
+
+## Added — Webview → Extension
+
+### `createScratchpad`
+
+Sent from the empty-state create action (FR-006, FR-007).
+
+```ts
+{ type: 'createScratchpad'; documentType: DocumentType }
+```
+
+- `documentType`: the scratchpad doc type to create (`'spec-extra' | 'plan-extra' | 'tasks-extra'`).
+
+**Handler behavior** (`handleCreateScratchpad`):
+1. Resolve the spec-viewer instance for the spec directory.
+2. Map the scratchpad doc type → file name (`<sourceType>-extra.md`) and absolute
+   path in the spec directory.
+3. If the file does not already exist, create it **empty** via
+   `vscode.workspace.fs.writeFile(uri, new Uint8Array())`.
+4. Re-scan documents and switch the active document to the new scratchpad
+   (content update), so the view lands on the freshly created file.
+
+**Errors**: on write failure, log to the output channel and post an
+`actionToast` describing the failure; do not crash the panel.
+
+### `applyScratchpad`
+
+Sent from the repurposed Refine button, visible only on a scratchpad tab
+(FR-009, FR-010, FR-011, FR-012).
+
+```ts
+{ type: 'applyScratchpad'; documentType: DocumentType }
+```
+
+- `documentType`: the active scratchpad doc type.
+
+**Handler behavior** (`handleApplyScratchpad`):
+1. Resolve the instance and the active scratchpad `SpecDocument`
+   (must be `isScratchpad`); resolve `scratchpadFor` → source file
+   `<sourceType>.md` under `changeRoot || specDirectory`.
+2. Read the scratchpad file contents.
+3. **Empty guard (FR-012)**: if contents are empty/whitespace, do **not**
+   dispatch; post `actionToast` "Nothing to apply — scratchpad is empty" and
+   return.
+4. Otherwise build a direct-edit prompt (reusing the `handleSubmitRefinements`
+   shape, `messageHandlers.ts:594-602`) and dispatch via
+   `deps.executeInTerminal(prompt)`.
+
+**Prompt shape** (built in extension code — the sanctioned prompt surface):
+
+```
+Apply the refinement notes below to <targetPath>/<sourceType>.md.
+Edit that file in place.
+DO NOT regenerate from any template.
+DO NOT run any setup script (e.g. setup-spec.sh, setup-plan.sh, setup-tasks.sh).
+DO NOT replace the file — make targeted edits only.
+Treat the notes as instructions/questions/concerns about the document; apply the
+substantive changes they call for. Do not modify the scratchpad file itself.
+
+Refinement notes (from <sourceType>-extra.md):
+---
+<full scratchpad contents>
+---
+```
+
+**Invariant**: never dispatch a `/speckit-*` slash command for apply — those
+re-run setup scripts that overwrite the source from a template (issue #153 /
+spec 093). 100% of applies must be direct edits (SC-003).
+
+---
+
+## Added — Extension → Webview
+
+### `actionToast` (existing message, new usages)
+
+Already defined: `{ type: 'actionToast'; message: string }`. Reused for:
+- The apply empty guard ("Nothing to apply — scratchpad is empty").
+- Create/apply failure messages.
+
+No new extension→webview message type is required.
+
+---
+
+## Changed — `SpecDocument` payload
+
+`SpecDocument` (carried inside `NavState.relatedDocs` on `contentUpdated` /
+`navStateUpdated`) gains optional `isScratchpad`, `scratchpadFor`, and
+`hasContent` (P2). Backward compatible — older payloads simply omit them.
+
+---
+
+## Removed — Webview → Extension (FR-015 / SC-005)
+
+These messages and their handlers are deleted with the inline-comment system:
+
+| Message | Reason |
+|---------|--------|
+| `submitRefinements` | Batch comment submit — replaced by `applyScratchpad` |
+| `refineLine` | Per-line refine (was unimplemented/TODO) |
+| `editLine` | Inline-editor context action (line-action menu removed) |
+| `removeLine` | Inline-editor context action (line-action menu removed) |
+
+**Retain `toggleCheckbox`** unless implementation proves it is reachable only via
+the removed line-action menu. Default: keep (task-checkbox toggling is an
+independent feature).
+
+Associated types `Refinement` and `LineType` are removed once no longer
+referenced.
+
+---
+
+## Acceptance checks for this contract
+
+- C1: Clicking create on an absent scratchpad creates an empty file and the view
+  switches to it (FR-007).
+- C2: Clicking Refine on a non-empty scratchpad dispatches exactly one
+  direct-edit instruction targeting the matching `<source>.md`, with no slash
+  command and no setup-script invocation (FR-010, FR-011, SC-003).
+- C3: Clicking Refine on an empty scratchpad dispatches nothing and shows the
+  "nothing to apply" toast (FR-012).
+- C4: The Refine control is absent from the message flow while a source-document
+  tab is active (FR-009, SC-004).
+- C5: No removed message type is reachable from the rendered viewer (SC-005).

--- a/specs/096-scratchpad-extras/data-model.md
+++ b/specs/096-scratchpad-extras/data-model.md
@@ -1,0 +1,176 @@
+# Data Model: Per-Document Scratchpad Extras
+
+**Feature**: 096-scratchpad-extras
+**Date**: 2026-05-20
+
+This feature is file-based and adds no persisted schema beyond plain markdown
+files. The "data model" here is (a) the conceptual entities and (b) the
+in-memory TypeScript shapes that flow extension → webview.
+
+---
+
+## Entities
+
+### Scratchpad (Extra) Document
+
+A plain markdown file paired one-to-one with a core source document.
+
+| Attribute | Value |
+|-----------|-------|
+| Identity | `<doctype>-extra.md` in the same spec directory as its source |
+| Doctypes | `spec-extra.md`, `plan-extra.md`, `tasks-extra.md` (exactly three) |
+| Content | Freeform markdown — notes, questions, deferred concerns, AI instructions |
+| Authorship | User only (never AI-generated; not derived from conversation) |
+| Cardinality | At most one per source document |
+| Lifecycle | Optional, lazily created, durable (persists after apply), committable |
+| Workflow role | Non-core — never gates phases, never counted, never triggers lifecycle |
+
+### Source Document
+
+An existing core artifact a scratchpad refines and the target of the apply edit.
+
+| Attribute | Value |
+|-----------|-------|
+| Doctypes | `spec` (`spec.md`), `plan` (`plan.md`), `tasks` (`tasks.md`) |
+| Relationship | One source ↔ at most one scratchpad |
+| Apply target | The scratchpad's contents are applied as a direct in-place edit here |
+
+### Pairing / Naming Map
+
+| Source step | Source file | Scratchpad file | Scratchpad doc type |
+|-------------|-------------|-----------------|---------------------|
+| `spec`  | `spec.md`  | `spec-extra.md`  | `spec-extra`  |
+| `plan`  | `plan.md`  | `plan-extra.md`  | `plan-extra`  |
+| `tasks` | `tasks.md` | `tasks-extra.md` | `tasks-extra` |
+
+Suffix rule: scratchpad base name = `<source-base>-extra`. Only the three core
+source documents participate (custom-workflow steps do not).
+
+---
+
+## TypeScript shape changes
+
+### `SpecDocument` (new optional fields)
+
+Extension: `src/features/spec-viewer/types.ts` (and mirrored in
+`webview/src/spec-viewer/types.ts`).
+
+```ts
+interface SpecDocument {
+  // ...existing fields: type, label, fileName, filePath, exists,
+  //    isCore, category, parentStep ...
+
+  /** True when this entry represents a *-extra.md scratchpad. */
+  isScratchpad?: boolean;
+
+  /** Source doc type this scratchpad pairs with: 'spec' | 'plan' | 'tasks'. */
+  scratchpadFor?: DocumentType;
+
+  /** P2 (FR-016): true when the scratchpad file is non-empty. */
+  hasContent?: boolean;
+}
+```
+
+A scratchpad entry always sets `isCore: false`, `category: 'related'`,
+`parentStep` = its source step (so the existing children rail renders it), and
+`exists` = real on-disk existence.
+
+### `DocumentType`
+
+Extend the document-type union (extension `types.ts:56` `CORE_DOCUMENTS` area and
+webview type) to admit `'spec-extra' | 'plan-extra' | 'tasks-extra'` as valid
+related doc types so `switchDocument`/`currentDocument` round-trips cleanly.
+
+### `NavState` passthrough
+
+`NavState.relatedDocs` already carries `SpecDocument[]`; the new fields ride
+along automatically. No new top-level `NavState` field is required for the core
+loop. (The P2 indicator reads `doc.hasContent` directly off the related doc.)
+
+### Constants
+
+`src/core/constants.ts` — add scratchpad naming, e.g.:
+
+```ts
+export const ScratchpadFiles = {
+  spec:  'spec-extra.md',
+  plan:  'plan-extra.md',
+  tasks: 'tasks-extra.md',
+} as const;
+export const SCRATCHPAD_SUFFIX = '-extra';
+```
+
+---
+
+## Derivation rules (documentScanner)
+
+For each **existing** core source doc whose type ∈ {`spec`, `plan`, `tasks`},
+synthesize one scratchpad `SpecDocument`:
+
+```
+scratchpad = {
+  type: `${sourceType}-extra`,
+  label: `${SourceLabel} Notes`,        // e.g. "Spec Notes" (distinct from source tab)
+  fileName: `${sourceType}-extra.md`,
+  filePath: join(specDirectory, `${sourceType}-extra.md`),
+  exists: <on-disk existence>,
+  hasContent: <exists && file non-empty/whitespace>,   // P2
+  isCore: false,
+  category: 'related',
+  parentStep: sourceType,
+  isScratchpad: true,
+  scratchpadFor: sourceType,
+}
+```
+
+Rules:
+- **Gate on source existence** — do not synthesize a scratchpad when the source
+  doc does not exist (Edge Case: source absent → no scratchpad sub-tab).
+- **Show even when the scratchpad file is absent** — `exists: false` is valid; it
+  drives the empty-state create flow. (This is why synthesis is independent of
+  the recursive related-doc scan, which only emits existing files.)
+- **De-dupe** — add the three `*-extra.md` names to the scanner's skip set so the
+  generic recursive related-doc scan does not also emit them (otherwise a
+  manually-created `spec-extra.md` would appear twice). This also satisfies
+  FR-017: an on-disk `*-extra.md` is surfaced through the synthesized entry with
+  `exists: true`.
+
+---
+
+## Validation rules (from requirements)
+
+| Rule | Source | Enforced where |
+|------|--------|----------------|
+| At most one scratchpad per source | FR-001, Assumptions | Synthesis emits exactly one per source type |
+| Scratchpad lives beside source in spec dir | FR-002 | `filePath` join on `specDirectory` |
+| Never auto-created | FR-003 | Synthesis only models the entry; file written only on explicit `createScratchpad` |
+| Sub-tab next to source, same related-doc pattern | FR-004 | `parentStep` + children rail |
+| Visually distinguished from source tab | FR-005 | `.step-child--scratchpad` keyed off `isScratchpad` |
+| Empty state + single create action when absent | FR-006 | `ScratchpadEmptyState` when `isScratchpad && !exists` |
+| Create writes empty file + switches view | FR-007 | `createScratchpad` handler |
+| Open in standard editor, same affordance | FR-008 | reuse `editDocument` |
+| Refine visible/active only on scratchpad tab | FR-009 | `FooterActions` gates on active doc `isScratchpad` |
+| Apply reads full contents, edits matching source | FR-010 | `applyScratchpad` handler resolves `scratchpadFor` |
+| Direct in-place edit, no template regeneration | FR-011 | direct-edit prompt; never a slash command |
+| No dispatch when empty + indicate nothing to apply | FR-012 | extension empty guard → `actionToast` |
+| Non-core: no gating, no task count, no lifecycle | FR-013 | `isCore: false`; existing guards already exclude |
+| Committable, not ignored | FR-014 | no ignore rules added (no-op) |
+| Remove inline-comment capability fully | FR-015 | deletions per research Decision 6 |
+| Indicate scratchpads with content (P2) | FR-016 | `hasContent` flag + sub-tab dot |
+| Recognize on-disk-created scratchpads | FR-017 | synthesis reads real existence; generic scan skips `*-extra` |
+
+---
+
+## State transitions
+
+Scratchpad file lifecycle (no `.spec-context.json` involvement):
+
+```
+(absent)  --createScratchpad-->  (empty file, exists)
+(exists)  --user edits in editor-->  (has content)
+(has content) --Refine/applyScratchpad--> (unchanged; durable record kept)
+(exists)  --deleted on disk-->  (absent → next view shows empty state)
+```
+
+The apply action never mutates the scratchpad (Assumption: persists as a durable
+handoff record).

--- a/specs/096-scratchpad-extras/plan.md
+++ b/specs/096-scratchpad-extras/plan.md
@@ -1,0 +1,181 @@
+# Implementation Plan: Per-Document Scratchpad Extras
+
+**Branch**: `096-scratchpad-extras` | **Date**: 2026-05-20 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/096-scratchpad-extras/spec.md`
+
+## Summary
+
+Replace the in-viewer inline review-comment system with **per-document
+scratchpad files** (`spec-extra.md`, `plan-extra.md`, `tasks-extra.md`) surfaced
+as sub-tabs next to each core source document. A repurposed **Refine** button —
+visible only while viewing a scratchpad — reads the scratchpad's full contents
+and dispatches a direct, in-place AI edit of the matching source document
+(never a template regeneration). Scratchpads are lazily created from an empty
+state, stored as plain markdown in the spec directory, committable, and
+explicitly excluded from phase gating and task counting. The legacy
+inline-comment infrastructure (hover-to-add control, comment cards/dialog,
+batch-submit, in-memory refinement state, and its message protocol) is removed
+wholesale.
+
+Technical approach: extend `documentScanner` to synthesize a scratchpad
+`SpecDocument` per existing core doc (so the existing related-doc "children
+rail" renders sub-tabs, including before the file exists); add `isScratchpad` /
+`scratchpadFor` to the document model and `NavState`; add webview empty-state +
+create flow and a scratchpad-gated Refine button; add `createScratchpad` and
+`applyScratchpad` messages with extension handlers that do file I/O and build
+the direct-edit prompt (reusing the proven `handleSubmitRefinements` prompt
+shape); delete the inline-comment modules, signals, renderer line-actions, CSS,
+and dead message types.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.3+ (ES2022 target, strict mode)
+**Primary Dependencies**: VS Code Extension API (`@types/vscode ^1.84.0`), Preact + `@preact/signals` (webview), Webpack 5
+**Storage**: File-based — plain markdown scratchpad files in the spec directory; `.spec-context.json` is **not** modified by scratchpads
+**Testing**: Jest + ts-jest (BDD `describe`/`it`, VS Code mock at `tests/__mocks__/vscode.ts`); Storybook for webview components
+**Target Platform**: VS Code extension (desktop), webview UI in browser context
+**Project Type**: single (VS Code extension with a bundled Preact webview)
+**Performance Goals**: No regression in viewer responsiveness; scratchpad existence/has-content checks bounded to ≤3 files per spec, run during the existing scan/content-update pass
+**Constraints**: Extension isolation — all behavior in `src/` and `webview/` only; no edits to `.claude/**` or `.specify/**`. The AI apply instruction must be built as prompt text in extension code. Direct edits only — never invoke a `/speckit-*` slash command for apply
+**Scale/Scope**: 3 scratchpad types × N specs; net code reduction (inline-comment system removed); ~15-20 touched files
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Extensibility & Configuration | PASS | No provider changes; reuses existing provider dispatch (`executeInTerminal`). |
+| II. Spec-Driven Workflow | PASS | Scratchpads are `isCore: false` — never gate Specify→Plan→Tasks→Implement, never counted, never trigger lifecycle. Verified existing guards already exclude non-core files. |
+| III. Visual & Interactive | PASS | Sub-tabs, empty state, create/refine/edit buttons — all GUI surfaces. |
+| IV. Modular Architecture | PASS | Reuses the modular spec-viewer structure (provider / messageHandlers / html / webview components / CSS partials). Net reduction in modules. |
+
+**Initial gate: PASS** — no violations, Complexity Tracking empty.
+**Post-design re-check: PASS** — design introduces two new messages and two
+optional model fields; no architectural deviation.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/096-scratchpad-extras/
+├── plan.md              # This file
+├── research.md          # Phase 0 output (design decisions)
+├── data-model.md        # Phase 1 output (entities + model changes)
+├── quickstart.md        # Phase 1 output (manual verification walkthrough)
+├── contracts/
+│   └── webview-messages.md   # Phase 1 output (message protocol changes)
+├── spec.md
+└── tasks.md             # Phase 2 output (/speckit.tasks — NOT created here)
+```
+
+### Source Code (repository root)
+
+```text
+src/
+├── core/
+│   └── constants.ts                         # Add scratchpad file-name constants + suffix
+└── features/spec-viewer/
+    ├── types.ts                             # SpecDocument: +isScratchpad, +scratchpadFor; DocumentType extends
+    ├── documentScanner.ts                   # Synthesize scratchpad docs per core doc; skip *-extra in generic scan
+    ├── specViewerProvider.ts                # Carry scratchpad fields + hasContent into NavState
+    └── messageHandlers.ts                   # +createScratchpad, +applyScratchpad handlers; remove dead comment handlers
+
+webview/
+├── src/spec-viewer/
+│   ├── types.ts                             # SpecDocument mirror fields; message union edits
+│   ├── signals.ts                           # Remove refinement signals
+│   ├── components/
+│   │   ├── NavigationBar.tsx                # Scratchpad sub-tab styling hook
+│   │   ├── FooterActions.tsx                # Scratchpad-gated Refine + Edit buttons
+│   │   ├── ScratchpadEmptyState.tsx         # NEW — empty state + create action
+│   │   ├── InlineComment.tsx                # DELETE (+ stories)
+│   │   └── InlineEditor.tsx                 # DELETE (+ stories)
+│   ├── editor/                              # DELETE refinements.ts, inlineEditor.ts, lineActions.ts, index.ts
+│   ├── modal.ts                             # DELETE (legacy refine modal)
+│   ├── markdown/
+│   │   ├── renderer.ts                      # Remove line-action wrapping (line-add-btn, line-comment-slot)
+│   │   └── scenarios.ts                     # Remove row-add-btn injection
+│   └── App.tsx / index.tsx                  # Render empty state when active doc is a non-existent scratchpad; drop line-action setup
+└── styles/spec-viewer/
+    ├── index.css                            # Update @imports
+    ├── _refinements.css / _editor.css / _modal.css   # DELETE
+    ├── _navigation.css                      # Add .step-child--scratchpad + has-notes dot
+    ├── _line-actions.css                    # Remove .line-add-btn rules
+    └── _tables.css                          # Remove .row-add-btn / comment-row rules
+
+tests/                                       # Extension-side unit tests (scanner injection, handlers, empty guard)
+```
+
+**Structure Decision**: Single VS Code-extension project. All work lands in the
+existing `src/features/spec-viewer/` (extension side) and
+`webview/src/spec-viewer/` (webview side) modules plus shared `src/core/`
+constants — the modular spec-viewer layout the codebase already uses. No new
+top-level structure.
+
+## Phase 0: Research
+
+Complete — see [research.md](./research.md). No `NEEDS CLARIFICATION` remained.
+Key resolved decisions:
+
+1. Scratchpads surface via synthesized related docs in `documentScanner` so the
+   existing children rail renders them — including before the file exists.
+2. `SpecDocument` gains `isScratchpad` + `scratchpadFor`, carried into `NavState`.
+3. Refine is a scratchpad-gated button in `FooterActions`, posting
+   `applyScratchpad`; the extension builds a direct-edit prompt reusing the
+   `handleSubmitRefinements` shape (no slash command, no setup scripts).
+4. Lazy create via a new `createScratchpad` message + `fs.writeFile`.
+5. Edit reuses the existing `editDocument` handler.
+6. Inline-comment system removed wholesale (components, editor modules, signals,
+   renderer line-actions, CSS, dead messages). `toggleCheckbox` retained unless
+   proven coupled to the removed line-action menu.
+7. Non-core guarantees already enforced by existing guards — no new gating code.
+8. P2 has-notes indicator via a `hasContent` flag on the scratchpad doc.
+9. Scope limited to spec/plan/tasks only.
+
+## Phase 1: Design & Contracts
+
+Complete — artifacts generated:
+
+- [data-model.md](./data-model.md) — Scratchpad/Source document entities, the
+  `SpecDocument` field additions, `NavState` passthrough, naming map, and
+  lifecycle/validation rules.
+- [contracts/webview-messages.md](./contracts/webview-messages.md) — the new
+  `createScratchpad` / `applyScratchpad` messages, the `actionToast` response
+  for the empty guard, and the removed message types.
+- [quickstart.md](./quickstart.md) — end-to-end manual verification covering all
+  three user stories, edge cases, and the removal acceptance (SC-005).
+
+**Agent context update**: `CLAUDE.md` "Active Technologies / Recent Changes"
+already covers TS 5.3 + VS Code API + Preact + file-based storage; this feature
+introduces no new technology, so no agent-context edit is required.
+
+## Phase 2: (Deferred to /speckit.tasks)
+
+Task breakdown will be generated by `/speckit.tasks`. Suggested phasing for the
+task author (P1 first; P2 last):
+
+1. **Model + scanner** (P1, US1/US2 prerequisite): add constants and
+   `SpecDocument` fields; synthesize scratchpad docs in `documentScanner`; skip
+   `*-extra.md` in the generic related scan; carry fields + `hasContent` into
+   `NavState`.
+2. **Create flow** (P1, US2): `createScratchpad` message + handler (empty
+   `fs.writeFile`, re-scan, switch view); `ScratchpadEmptyState` component;
+   render it when the active doc is a non-existent scratchpad.
+3. **Apply flow** (P1, US1): `applyScratchpad` message + handler (read file,
+   resolve `scratchpadFor` → `<source>.md`, empty guard → `actionToast`, else
+   build direct-edit prompt → `executeInTerminal`); scratchpad-gated Refine
+   button in `FooterActions`; Edit affordance reusing `editDocument`.
+4. **Removal** (P1, FR-015/SC-005): delete inline-comment components, editor
+   modules, signals, renderer line-actions, CSS partials/rules, and dead message
+   types/handlers; verify `toggleCheckbox` coupling.
+5. **Visual distinction** (P1, FR-005): `.step-child--scratchpad` styling.
+6. **Activity indicator** (P2, FR-016): has-notes dot on the scratchpad sub-tab.
+7. **Tests + docs**: unit tests (scanner injection incl. source-absent skip and
+   on-disk recognition, apply empty guard, create); update `README.md`
+   ("Reading Specs"), `docs/viewer-states.md` (footer Refine), and `CHANGELOG.md`.
+
+## Complexity Tracking
+
+> No constitution violations — section intentionally empty.

--- a/specs/096-scratchpad-extras/quickstart.md
+++ b/specs/096-scratchpad-extras/quickstart.md
@@ -1,0 +1,99 @@
+# Quickstart: Per-Document Scratchpad Extras
+
+**Feature**: 096-scratchpad-extras
+**Audience**: Developer verifying the implementation in the Extension Dev Host.
+
+## Prerequisites
+
+```bash
+npm install
+npm run compile      # or: npm run watch
+```
+
+Press **F5** in VS Code to launch the Extension Development Host. Open a
+workspace that has a spec with at least a `spec.md` (e.g. `specs/<feature>/`).
+
+---
+
+## Story 1 — Capture notes and apply them (P1)
+
+1. Open a spec in the spec viewer; select the **Spec** tab.
+2. Confirm a **scratchpad sub-tab** appears in the children rail next to Spec
+   (visually distinct from the Spec tab). Click it.
+3. If the file is absent, create it (Story 2), then **Edit** it and type a few
+   refinement notes (e.g. "Tighten FR-003 wording; clarify the empty-state copy").
+4. Back on the scratchpad tab, confirm the **Refine** button is visible/active.
+   Click it.
+5. **Expect**: the AI CLI receives a direct-edit instruction targeting
+   `spec.md` (not a regenerate/template command, no `setup-*.sh`). The scratchpad
+   file is left intact.
+   - ✅ FR-010, FR-011, SC-002, SC-003
+6. Switch to the **Spec** (source) tab. **Expect**: the Refine button is **hidden**.
+   - ✅ FR-009, SC-004
+
+---
+
+## Story 2 — Create a scratchpad on demand (P1)
+
+1. Open a spec where `spec-extra.md` does not exist; click the Spec scratchpad
+   sub-tab.
+2. **Expect**: an empty state with a single create action labeled for the
+   specific file (e.g. **"Create spec-extra.md"**).
+   - ✅ FR-006
+3. Click create. **Expect**: an empty `spec-extra.md` is created in the spec
+   directory and the view switches to it.
+   - ✅ FR-007, SC-001
+4. Use the **Edit** affordance. **Expect**: it opens in the standard VS Code
+   editor (same affordance as other documents).
+   - ✅ FR-008
+
+---
+
+## Story 3 — See which scratchpads have notes (P2)
+
+1. Add content to one scratchpad; leave another empty/absent.
+2. **Expect**: only the scratchpad with content shows the "has notes" indicator
+   (dot on its sub-tab); empty/absent ones do not.
+   - ✅ FR-016 (may ship after the initial release)
+
+---
+
+## Edge cases
+
+| Case | Action | Expect |
+|------|--------|--------|
+| Empty apply | Refine on an existing but empty scratchpad | No dispatch; "Nothing to apply" toast (FR-012) |
+| Deleted on disk | Delete `plan-extra.md` while its tab is open | Sub-tab returns to empty state on next view |
+| Created on disk | Create `tasks-extra.md` directly in the spec dir | Viewer surfaces it as existing, no in-app create needed (FR-017) |
+| Source absent | Open a spec with no `plan.md` | No plan scratchpad sub-tab offered |
+| Mapping | Refine on `tasks-extra` | Edits `tasks.md` only — never `spec.md`/`plan.md` |
+
+---
+
+## Removal acceptance (FR-015 / SC-005)
+
+Confirm none of the old inline-comment controls are reachable:
+
+- [ ] No hover "+" / comment button appears on lines or scenario rows.
+- [ ] No inline comment cards or comment-entry dialog can be opened.
+- [ ] The old batch "Refine (N)" submit button is gone.
+- [ ] Task checkboxes still toggle (independent feature retained).
+
+---
+
+## Non-core guarantees (FR-013, FR-014, SC-006)
+
+- [ ] Adding/editing a `*-extra.md` does **not** change step badges, phase
+      gating, or the task-completion percentage.
+- [ ] Creating `tasks-extra.md` does **not** fire a phase-complete notification.
+- [ ] `*-extra.md` files appear in `git status` (not ignored).
+
+---
+
+## Automated checks
+
+```bash
+npm test         # scanner injection (incl. source-absent skip + on-disk
+                 # recognition), create handler, apply empty guard, apply prompt
+npm run compile  # type-check the message-union and SpecDocument changes
+```

--- a/specs/096-scratchpad-extras/research.md
+++ b/specs/096-scratchpad-extras/research.md
@@ -1,0 +1,231 @@
+# Research: Per-Document Scratchpad Extras
+
+**Feature**: 096-scratchpad-extras
+**Date**: 2026-05-20
+**Input**: `spec.md`, current spec-viewer codebase
+
+This document resolves the technical unknowns for replacing inline review
+comments with per-document scratchpad files. There were no open
+`NEEDS CLARIFICATION` markers in the spec; the items below are the design
+decisions derived from reading the existing implementation.
+
+---
+
+## Decision 1 — How scratchpad sub-tabs are surfaced
+
+**Decision**: Inject scratchpad documents into the `SpecDocument[]` produced by
+`documentScanner.scanDocuments()`, one per existing core source document
+(spec, plan, tasks), with `parentStep` set to the source step so the existing
+"step children" rail renders them automatically.
+
+**Rationale**: The viewer already renders a second-row sub-tab rail in
+`NavigationBar.tsx` (`webview/src/spec-viewer/components/NavigationBar.tsx:119-142`)
+driven entirely by `relatedDocs` whose `parentStep === currentDoc`. Adding the
+scratchpad as a related document with `parentStep: 'spec' | 'plan' | 'tasks'`
+reuses that rail with zero new navigation logic. FR-004 explicitly asks to
+follow "the same pattern used for related documents."
+
+**Critical nuance — show the tab before the file exists**: The recursive
+related-doc scan only adds files that exist on disk
+(`documentScanner.ts:244-252`, `exists: true`). A scratchpad must appear as a
+sub-tab even when its file does not exist yet (FR-006 empty state), so the
+scanner must *synthesize* a scratchpad entry for each existing source doc with
+`exists` reflecting the real on-disk state — independent of the recursive scan.
+The injection must run only when the **source** doc exists (Edge Case: "Source
+document absent → scratchpad sub-tab is not offered").
+
+**Alternatives considered**:
+- *Let the generic recursive scan pick up `*-extra.md`*: rejected — it only
+  surfaces files that already exist, so it cannot render the empty-state create
+  affordance, and it would mis-label them as generic related docs.
+- *A separate sub-tab system parallel to related docs*: rejected — duplicates
+  the rail rendering and violates the "same pattern" requirement.
+
+---
+
+## Decision 2 — Distinguishing scratchpad docs in the model
+
+**Decision**: Add two optional fields to `SpecDocument` (extension
+`src/features/spec-viewer/types.ts:87-111` and the mirrored webview type):
+`isScratchpad?: boolean` and `scratchpadFor?: DocumentType` (the source doc
+type, e.g. `'spec'`). Carry both through `NavState.relatedDocs` to the webview.
+
+**Rationale**: The webview needs to (a) style the sub-tab differently (FR-005),
+(b) render the empty-state / create flow for non-existent scratchpads (FR-006),
+and (c) decide when the Refine button is visible (FR-009). A typed flag is the
+minimal, explicit signal; `scratchpadFor` lets the extension resolve the target
+source file when applying.
+
+**Alternatives considered**:
+- *Infer scratchpad-ness from the `-extra.md` suffix in the webview*: rejected —
+  scatters naming knowledge across layers; the extension already owns naming.
+
+---
+
+## Decision 3 — The repurposed "Refine" (apply) button
+
+**Decision**: Render the Refine button in `FooterActions.tsx`, visible and
+active **only** when the active document is a scratchpad
+(`navState.currentDoc` resolves to a doc with `isScratchpad === true`). Clicking
+posts a new `applyScratchpad` message. The extension handler reads the
+scratchpad file, resolves the source path from `scratchpadFor`
+(`<sourceType>.md`), and dispatches a **direct-edit** prompt via
+`executeInTerminal` — never a slash command.
+
+**Rationale**: The proven direct-edit pattern already exists in
+`handleSubmitRefinements` (`messageHandlers.ts:578-606`): it builds a free-form
+prompt that says "Edit `<path>` in place… DO NOT regenerate from any template…
+DO NOT run any setup script." This is exactly FR-010/FR-011, and it was added
+specifically to fix template-regeneration overwrites (issue #153, spec
+093-fix-refine-overwrite). The new handler reuses this prompt shape with the
+scratchpad's full contents as the instruction body.
+
+**Note on the existing `refine` footer id**: `FooterActions.tsx` already lists
+`'refine'` in `RIGHT_IDS` (line 90-97) and renders it with the `enhancement`
+variant, but the extension never emits a `refine` footer action
+(`getFooterActions` in `footerActions.ts` has no such id; `FooterActionIds` in
+`constants.ts:283` lacks `REFINE`; the `footerAction` switch in
+`messageHandlers.ts:112-135` would hit the "Unknown footerAction id" default).
+So the id is vestigial. The new Refine button is wired as its own conditional
+control in `FooterActions.tsx` keyed off `isScratchpad`, posting a dedicated
+`applyScratchpad` message — not routed through the generic `footerAction`
+catalog. This keeps scratchpad-tab gating in the webview where the active doc is
+known.
+
+**Empty guard (FR-012)**: The extension owns file contents, so emptiness is
+enforced at dispatch: if the scratchpad is empty/whitespace, the handler skips
+`executeInTerminal` and posts an `actionToast` ("Nothing to apply — scratchpad
+is empty"). The button stays visible on scratchpad tabs per FR-009; the guard is
+the source of truth.
+
+**Alternatives considered**:
+- *Route through the `footerAction` catalog + `getFooterActions`*: rejected —
+  footer derivation works from `.spec-context.json` state, which does not know
+  the active tab; scratchpad-vs-source gating is a webview concern.
+- *Send a `/speckit-*` slash command*: rejected — those re-run setup scripts and
+  overwrite the source from a template (the exact bug FR-011 forbids).
+
+---
+
+## Decision 4 — Lazy creation flow
+
+**Decision**: The empty-state create action posts a new `createScratchpad`
+message with the scratchpad doc type. The extension creates an empty file with
+`vscode.workspace.fs.writeFile` in the spec directory, then re-scans and switches
+the view to the new scratchpad (content update). The existing markdown file
+watcher (`**/{specDir}/**/*.md`, `fileWatchers.ts`) also refreshes the viewer.
+
+**Rationale**: FR-003 (lazy, never auto-created), FR-007 (create + switch). All
+file I/O stays on the extension side per the project's isolation rule. No
+template is used — the file is created empty.
+
+**Alternatives considered**:
+- *Create on first edit in the editor*: rejected — FR-006/FR-007 require an
+  explicit in-app create action from the empty state.
+
+---
+
+## Decision 5 — Edit affordance
+
+**Decision**: Reuse the existing `editDocument`/`editSource` message + handler
+(`messageHandlers.ts:166-190`, opens `currentDocument.filePath` in the VS Code
+text editor beside). Surface an explicit "Edit" control on the scratchpad view
+so it uses the same affordance as other documents (FR-008).
+
+**Rationale**: The handler already opens the current document for editing;
+scratchpads are just another document. No new editing machinery needed.
+
+---
+
+## Decision 6 — Removing the inline-comment infrastructure (FR-015)
+
+**Decision**: Delete the inline review comment system wholesale and prune its
+message protocol. Concretely:
+
+- **Webview components**: `components/InlineComment.tsx`, `components/InlineEditor.tsx`
+  (+ their `.stories.tsx`).
+- **Webview editor modules**: `editor/refinements.ts`, `editor/inlineEditor.ts`,
+  `editor/lineActions.ts`, `editor/index.ts`, and legacy `modal.ts`.
+- **Signals** (`signals.ts`): `pendingRefinements`, `activeEditor`,
+  `refineLineNum`, `refineContent`.
+- **Renderer line actions**: the `wrapWithLineActions` / `line-add-btn`
+  injection in `markdown/renderer.ts` and `row-add-btn` in `markdown/scenarios.ts`,
+  plus `.line-comment-slot`.
+- **CSS**: `_refinements.css`, `_editor.css`, `_modal.css`; the `.line-add-btn`
+  rules in `_line-actions.css`; `.row-add-btn`/comment-row rules in `_tables.css`;
+  update `index.css` imports.
+- **Message protocol** (`types.ts` both sides + `messageHandlers.ts`):
+  remove `submitRefinements`, `refineLine`, and the inline-editor context-action
+  messages `editLine` / `removeLine` (only reachable from the removed line-action
+  menu) and their handlers; remove the `Refinement`/`LineType` types once unused.
+
+**Keep**: `toggleCheckbox` (task-checkbox toggling) is independent of inline
+comments — **verify during implementation** whether it is triggered by direct
+checkbox clicks in the rendered markdown (keep) or only via the removed
+line-action menu (remove). Treat "keep unless proven coupled" as the default.
+
+**Rationale**: SC-005 requires none of the removed controls remain reachable.
+All comment state was in-memory only (no persistence), so removal needs no
+migration (Assumption: existing ephemeral comments need no migration).
+
+---
+
+## Decision 7 — Non-core guarantees (FR-013, FR-014)
+
+**Decision**: No new gating code is required. Scratchpads carry `isCore: false`.
+
+**Rationale**: Verified the existing guards already exclude non-core files:
+- Task counting parses **only** `tasks.md`
+  (`phaseCalculation.calculateTaskCompletion`: `if (docType !== TASKS) return 0`).
+- Phase completion checks **only** core docs / step history
+  (`phaseCalculation.calculatePhases`).
+- The tasks watcher pattern is `**/{specDir}/**/tasks.md` — it never matches
+  `tasks-extra.md`.
+- `.spec-context.json` is untouched by scratchpads; lifecycle/status logic does
+  not read scratchpad files.
+
+FR-014 (committable, not ignored): nothing to do — the extension adds no ignore
+rules; plain files in the spec dir are committed by default.
+
+---
+
+## Decision 8 — Activity-surface indication (FR-016, P2)
+
+**Decision**: Surface a lightweight "has notes" indicator on the scratchpad
+sub-tab (and/or the activity panel) when the scratchpad file is non-empty.
+Implement minimally and mark **P2** — it may ship after the core loop.
+
+**Rationale**: FR-016 is `SHOULD` and Priority P2. The scanner already knows
+each scratchpad's existence; computing "has content" requires reading the file
+(cheap, only the 1-3 scratchpads). Pass a `hasContent` flag on the scratchpad
+`SpecDocument` and render a small dot on the sub-tab.
+
+**Alternatives considered**:
+- *Full Activity-panel row per scratchpad*: deferred — heavier than the P2 scope
+  needs for the initial release.
+
+---
+
+## Decision 9 — Scope: only the three core documents
+
+**Decision**: Generate scratchpads only for `spec`, `plan`, `tasks` — never for
+custom-workflow steps or non-core related docs.
+
+**Rationale**: Assumptions + Out of Scope both restrict this version to the
+three core documents. Gate scanner injection to those three known core types
+(not "any core step"), so custom workflows do not sprout scratchpads.
+
+---
+
+## Constitution alignment
+
+- **Extension isolation** (CLAUDE.md): All changes live in `src/` and `webview/`.
+  The apply prompt is built by extension code (the sanctioned "prompt text the
+  extension builds" surface). No edits to `.claude/**` or `.specify/**`.
+- **II. Spec-Driven Workflow**: Scratchpads are explicitly non-core and never
+  gate the Specify→Plan→Tasks→Implement pipeline.
+- **III. Visual & Interactive**: Sub-tabs, empty state, create/refine buttons.
+- **IV. Modular Architecture**: Reuses the existing modular spec-viewer
+  structure; nets a *reduction* in modules (inline-comment system removed).
+
+No violations; Complexity Tracking is empty.

--- a/specs/096-scratchpad-extras/spec.md
+++ b/specs/096-scratchpad-extras/spec.md
@@ -1,0 +1,116 @@
+# Feature Specification: Per-Document Scratchpad Extras
+
+**Feature Branch**: `096-scratchpad-extras`  
+**Created**: 2026-05-20  
+**Status**: Draft  
+**Input**: User description: "Replace inline review comments with per-document scratchpad files (spec-extra.md, plan-extra.md, tasks-extra.md) surfaced as sub-tabs in the spec viewer, with a repurposed Refine button that dispatches the scratchpad contents to the AI to edit the corresponding source doc."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Capture refinement notes and apply them to a source document (Priority: P1)
+
+A user reviewing a spec wants to jot down freeform refinement notes, questions, deferred concerns, or instructions for the AI without altering the source artifact yet. They open the scratchpad that pairs with the document they are reading, write their notes in plain markdown, and later trigger a single action that hands the scratchpad's contents to the AI with instructions to edit the corresponding source document in place.
+
+**Why this priority**: This is the core value of the feature and the direct replacement for the removed inline-comment workflow. Without it, there is no way to collect and act on refinement notes.
+
+**Independent Test**: Open a spec's scratchpad, type notes, trigger the apply action, and confirm the AI edits the matching source document (not a regenerated template) and the scratchpad file remains intact for handoff.
+
+**Acceptance Scenarios**:
+
+1. **Given** a spec with an existing scratchpad containing notes, **When** the user views that scratchpad tab and triggers the apply action, **Then** the full scratchpad contents are sent to the AI with instructions to directly edit the matching source document.
+2. **Given** the user is viewing a source-document tab (not a scratchpad), **When** the user looks for the apply action, **Then** the apply action is hidden because there is nothing to submit.
+3. **Given** a scratchpad for one document type, **When** the apply action runs, **Then** the AI is instructed to edit only the matching source document and never to run a command that regenerates the document from a template.
+
+---
+
+### User Story 2 - Create a scratchpad on demand (Priority: P1)
+
+A user wants to start taking notes for a document that has no scratchpad yet. They open the scratchpad sub-tab, see a clear empty state, create the file with one action, and immediately begin editing it.
+
+**Why this priority**: Scratchpads are lazily created, so a frictionless creation path is required before any notes can be captured. It is a prerequisite for Story 1 on documents that have never been annotated.
+
+**Independent Test**: Open a scratchpad sub-tab for a document with no scratchpad file, confirm an empty state with a single create action appears, click it, and confirm the file is created and the view switches to it.
+
+**Acceptance Scenarios**:
+
+1. **Given** a source document with no paired scratchpad file, **When** the user opens the scratchpad sub-tab, **Then** an empty state with a single create action (labeled for the specific scratchpad, e.g. "Create spec-extra.md") is shown.
+2. **Given** the empty state is shown, **When** the user triggers the create action, **Then** an empty scratchpad file is created in the spec directory and the view switches to the newly created scratchpad.
+3. **Given** a scratchpad file exists, **When** the user chooses to edit it, **Then** it opens in the standard editor using the same affordance as other documents.
+
+---
+
+### User Story 3 - See which scratchpads have pending notes at a glance (Priority: P2)
+
+A user wants to know which of a spec's scratchpads currently contain notes without opening each one, so they can quickly spot outstanding refinement work.
+
+**Why this priority**: A convenience that improves discoverability of pending work but is not required for the core capture-and-apply loop. Explicitly noted as non-blocking for the initial release.
+
+**Independent Test**: Add content to one scratchpad, leave others empty, open the activity surface, and confirm only the scratchpad with content is flagged.
+
+**Acceptance Scenarios**:
+
+1. **Given** a spec where some scratchpads contain notes and others are empty or absent, **When** the user views the activity surface, **Then** scratchpads that contain content are indicated and empty or absent ones are not.
+
+---
+
+### Edge Cases
+
+- **Empty scratchpad apply**: When the user triggers the apply action on a scratchpad that exists but contains no content, the system does not dispatch an empty instruction to the AI and indicates there is nothing to apply.
+- **Scratchpad deleted outside the viewer**: If a scratchpad file is removed from disk while its tab is open, the sub-tab returns to the empty state on next view.
+- **Scratchpad created outside the viewer**: If a user creates a `*-extra.md` file directly in the spec directory, the viewer surfaces it as an existing scratchpad without requiring the in-app create action.
+- **Source document absent**: If the paired source document does not exist, the scratchpad sub-tab is not offered for that document type.
+- **Existing ephemeral inline comments**: Any in-flight inline review comments from the old model are not migrated; the old infrastructure is removed wholesale.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST support up to one optional scratchpad document per core source document, named with an `-extra` suffix on the source document's base name (spec-extra, plan-extra, tasks-extra).
+- **FR-002**: System MUST store each scratchpad as a plain markdown file in the same spec directory as its source document, alongside the existing source artifacts.
+- **FR-003**: System MUST create scratchpad files lazily — only when the user explicitly creates one — and MUST NOT create them automatically when a spec is created.
+- **FR-004**: System MUST surface each existing scratchpad as a sub-tab next to its source document in the spec viewer, following the same pattern used for related documents.
+- **FR-005**: System MUST visually distinguish the scratchpad sub-tab from the source-document tab so the user can tell which is the authoritative artifact and which is the scratchpad.
+- **FR-006**: System MUST show an empty state with a single, clearly labeled create action when the user opens a scratchpad sub-tab whose file does not exist.
+- **FR-007**: System MUST create an empty scratchpad file and switch the view to it when the user triggers the create action from the empty state.
+- **FR-008**: System MUST allow the user to open an existing scratchpad in the standard editor using the same edit affordance available for other documents.
+- **FR-009**: System MUST display the apply ("Refine") action as visible and active only when the user is viewing a scratchpad tab, and MUST hide it when the user is viewing a source-document tab.
+- **FR-010**: System MUST, when the apply action is triggered, read the full contents of the active scratchpad and dispatch an AI instruction to edit the matching source document directly (scratchpad for a given document type maps to that document type's source).
+- **FR-011**: System MUST instruct the AI to perform a direct, in-place edit of the source document and MUST NOT invoke any command that regenerates the source document from a template.
+- **FR-012**: System MUST NOT dispatch an apply instruction when the active scratchpad is empty, and MUST indicate to the user that there is nothing to apply.
+- **FR-013**: System MUST treat scratchpad files as non-core artifacts: they MUST NOT gate phase transitions, MUST NOT count toward task completion, and MUST NOT trigger any workflow-lifecycle behavior.
+- **FR-014**: System MUST leave scratchpad files committable to source control and MUST NOT add them to ignore rules.
+- **FR-015**: System MUST remove the prior inline review comment capability in full, including the hover-to-add control, the comment cards, the comment entry dialog, the batch-submit action's old behavior, and the associated stored comment/refinement state and message protocol.
+- **FR-016**: System SHOULD surface, on the activity surface, an indication of which scratchpads currently contain content (Priority P2; may follow the initial release).
+- **FR-017**: System MUST recognize scratchpad files created directly on disk and surface them in the viewer without requiring the in-app create action.
+
+### Key Entities *(include if feature involves data)*
+
+- **Scratchpad (Extra) Document**: A plain markdown file paired one-to-one with a core source document (spec, plan, or tasks) within a single spec. Holds freeform refinement notes, questions, deferred concerns, or AI instructions authored by the user. Identified by the `<doctype>-extra.md` naming convention. Optional, lazily created, intended for source control, and excluded from core workflow tracking.
+- **Source Document**: An existing core spec artifact (spec, plan, or tasks) that a scratchpad refines. The target of the apply action's direct AI edit.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A user can create a scratchpad for any of the three core documents and begin editing it in a single action from the empty state.
+- **SC-002**: A user can capture notes in a scratchpad and apply them to the matching source document in one action without manually copying content.
+- **SC-003**: 100% of apply actions result in a direct edit of the matching source document, with zero cases of template regeneration.
+- **SC-004**: The apply action is available only while viewing a scratchpad and never while viewing a source document, across all three document types.
+- **SC-005**: After release, none of the removed inline-comment controls or behaviors remain reachable in the spec viewer.
+- **SC-006**: Scratchpad files appear in the user's source-control change set by default (are not ignored) and never affect phase transitions or task-completion counts.
+
+## Assumptions
+
+- The three supported scratchpads correspond exactly to the three core documents (spec, plan, tasks); custom-workflow or non-core steps do not produce their own scratchpads in this version.
+- Each source document supports at most one scratchpad; multiple scratchpads per source are out of scope.
+- The apply action does not clear or modify the scratchpad after a successful dispatch; the scratchpad persists as a durable, committable record for teammate handoff.
+- Cross-document refinement (e.g., a spec scratchpad editing the plan document) is not supported; each scratchpad maps only to its own source document.
+- The AI does not auto-generate scratchpad content from conversation history; scratchpads are authored by the user.
+- Existing ephemeral inline review comments require no migration because they were never persisted.
+
+## Out of Scope
+
+- Multiple scratchpads per source document.
+- Custom workflows producing their own scratchpads for non-core steps.
+- AI auto-generating a scratchpad based on conversation history.
+- Cross-scratchpad refinement (dispatching one document's scratchpad to edit a different source document).

--- a/specs/096-scratchpad-extras/tasks.md
+++ b/specs/096-scratchpad-extras/tasks.md
@@ -1,0 +1,219 @@
+---
+description: "Task list for Per-Document Scratchpad Extras"
+---
+
+# Tasks: Per-Document Scratchpad Extras
+
+**Input**: Design documents from `/specs/096-scratchpad-extras/`
+**Prerequisites**: plan.md (required), spec.md (required), research.md, data-model.md, contracts/webview-messages.md
+
+**Tests**: Included — the plan's Testing section, quickstart "Automated checks", and the suggested phasing all request unit tests (scanner injection, create handler, apply empty guard/prompt). Storybook coverage is included for new/changed webview components per the project's testing conventions.
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (US1, US2, US3)
+- Include exact file paths in descriptions
+
+## Path Conventions
+
+Single VS Code-extension project. Extension code under `src/`, webview UI under
+`webview/src/`, webview CSS under `webview/styles/`, tests under `tests/unit/`.
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Naming constants the scanner, handlers, and webview all key off.
+
+- [X] T001 Add scratchpad naming constants (`ScratchpadFiles` map for `spec`/`plan`/`tasks` → `<type>-extra.md`, and `SCRATCHPAD_SUFFIX = '-extra'`) in `src/core/constants.ts`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: The model fields, scanner synthesis, NavState passthrough, and sub-tab rendering that EVERY user story depends on. The scratchpad sub-tab cannot appear (and nothing else can be built) until this phase is complete.
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete.
+
+- [X] T002 [P] Add optional `isScratchpad`, `scratchpadFor: DocumentType`, and `hasContent` fields to `SpecDocument`, and extend the `DocumentType` union with `'spec-extra' | 'plan-extra' | 'tasks-extra'` in `src/features/spec-viewer/types.ts`
+- [X] T003 [P] Mirror the same `SpecDocument` field additions and `DocumentType` union extension in `webview/src/spec-viewer/types.ts`
+- [X] T004 Synthesize one scratchpad `SpecDocument` per **existing** core source doc (`spec`/`plan`/`tasks` only) in `src/features/spec-viewer/documentScanner.ts` — gate on source existence (skip when source absent), set `type: '<src>-extra'`, distinct `label`, `fileName`/`filePath` in the spec dir, real `exists`, `hasContent` (exists && non-whitespace), `isCore: false`, `category: 'related'`, `parentStep: <src>`, `isScratchpad: true`, `scratchpadFor: <src>`; add the three `*-extra.md` names to the generic related-doc scan skip set so on-disk files are not double-listed (FR-001, FR-004, FR-017; depends on T002)
+- [X] T005 Carry the scratchpad fields (`isScratchpad`, `scratchpadFor`, `hasContent`) through `NavState.relatedDocs` to the webview in `src/features/spec-viewer/specViewerProvider.ts` (depends on T002)
+- [X] T006 [P] Add `.step-child--scratchpad` distinction styling for the scratchpad sub-tab in `webview/styles/spec-viewer/_navigation.css` (FR-005)
+- [X] T007 [P] Apply the `.step-child--scratchpad` class hook keyed off `doc.isScratchpad` when rendering the children rail in `webview/src/spec-viewer/components/NavigationBar.tsx` (FR-005)
+- [X] T008 [P] Unit-test scanner synthesis in `tests/unit/spec-viewer/documentScanner.spec.ts`: one scratchpad per existing source, source-absent → no scratchpad, on-disk `*-extra.md` surfaced once (de-dupe), and `hasContent` reflects file emptiness
+
+**Checkpoint**: Scratchpad sub-tabs render (distinct from source tabs) for each existing core doc, with `exists`/`hasContent` flowing to the webview. User stories can now begin.
+
+---
+
+## Phase 3: User Story 2 - Create a scratchpad on demand (Priority: P1)
+
+**Goal**: Opening a scratchpad sub-tab whose file is absent shows an empty state with a single create action that writes the file and switches the view to it; an existing scratchpad opens in the standard editor.
+
+**Independent Test**: Open a scratchpad sub-tab for a doc with no `*-extra.md`, confirm the empty state with a single labeled create action, click it, confirm an empty file is created and the view switches to it; then use Edit and confirm it opens in the standard VS Code editor.
+
+**Note**: Sequenced before US1 because lazy creation (this story) is the natural prerequisite for capturing notes to apply; both are P1.
+
+### Tests for User Story 2
+
+- [X] T009 [P] [US2] Unit-test `handleCreateScratchpad` in `tests/unit/spec-viewer/scratchpadHandlers.spec.ts`: creates an empty file when absent, no-ops when the file already exists, switches the active doc to the new scratchpad, and posts an `actionToast` on write failure
+
+### Implementation for User Story 2
+
+- [X] T010 [US2] Add the `createScratchpad` message (`{ type: 'createScratchpad'; documentType: DocumentType }`) to the viewer→extension union in `webview/src/spec-viewer/types.ts` and the extension-side mirror in `src/features/spec-viewer/types.ts`
+- [X] T011 [US2] Implement `handleCreateScratchpad` and route it in `src/features/spec-viewer/messageHandlers.ts`: map the scratchpad doc type → `<src>-extra.md` path in the spec dir, create it empty via `vscode.workspace.fs.writeFile(uri, new Uint8Array())` only if absent, re-scan and switch the active doc to it; on failure log + post `actionToast` (FR-003, FR-007; depends on T010)
+- [X] T012 [P] [US2] Create `ScratchpadEmptyState.tsx` (empty-state UI with one create action labeled for the specific file, e.g. "Create spec-extra.md", posting `createScratchpad`) in `webview/src/spec-viewer/components/ScratchpadEmptyState.tsx` (FR-006)
+- [X] T013 [P] [US2] Add Storybook coverage for the empty state in `webview/src/spec-viewer/components/ScratchpadEmptyState.stories.tsx`
+- [X] T014 [US2] Render `ScratchpadEmptyState` when the active doc is a scratchpad with `!exists` (and the normal markdown view otherwise) in `webview/src/spec-viewer/App.tsx` (FR-006; depends on T012)
+- [X] T015 [US2] Add an "Edit" control on the scratchpad view that reuses the existing `editDocument` message/affordance in `webview/src/spec-viewer/components/FooterActions.tsx` (FR-008)
+
+**Checkpoint**: A user can create any of the three scratchpads from its empty state and edit it in the standard editor.
+
+---
+
+## Phase 4: User Story 1 - Capture notes and apply them to a source document (Priority: P1) 🎯 MVP
+
+**Goal**: A scratchpad-gated "Refine" button reads the active scratchpad's full contents and dispatches a direct, in-place AI edit of the matching source document — never a template regeneration — and is hidden on source-document tabs.
+
+**Independent Test**: With an existing non-empty scratchpad (created in US2 or on disk), click Refine and confirm the AI CLI receives a direct-edit instruction targeting the matching `<source>.md` (no slash command, no `setup-*.sh`) and the scratchpad is left intact; switch to the source tab and confirm Refine is hidden.
+
+### Tests for User Story 1
+
+- [X] T016 [P] [US1] Unit-test `handleApplyScratchpad` in `tests/unit/spec-viewer/scratchpadHandlers.spec.ts`: empty/whitespace scratchpad → no dispatch + "Nothing to apply" `actionToast` (FR-012/C3); non-empty → exactly one `executeInTerminal` direct-edit prompt naming the matching `<source>.md`, containing no `/speckit-*` slash command and no `setup-*.sh` (FR-010/FR-011/SC-003/C2); `tasks-extra` maps to `tasks.md` only (mapping)
+- [X] T017 [P] [US1] Extend `tests/unit/spec-viewer/footerActions.spec.ts` to assert the Refine button is rendered/active only when the active doc `isScratchpad` and hidden on source-document tabs (FR-009/SC-004/C4)
+
+### Implementation for User Story 1
+
+- [X] T018 [US1] Add the `applyScratchpad` message (`{ type: 'applyScratchpad'; documentType: DocumentType }`) to the viewer→extension union in `webview/src/spec-viewer/types.ts` and the extension-side mirror in `src/features/spec-viewer/types.ts`
+- [X] T019 [P] [US1] Implement `handleApplyScratchpad` and route it in `src/features/spec-viewer/messageHandlers.ts`: resolve the active scratchpad + `scratchpadFor` → `<src>.md` under `changeRoot || specDirectory`, read contents, empty guard → `actionToast` and return, else build a direct-edit prompt (reusing the `handleSubmitRefinements` shape: edit in place, do not regenerate from template, do not run setup scripts, do not modify the scratchpad) and dispatch via `deps.executeInTerminal(prompt)` — never a slash command (FR-010, FR-011, FR-012, SC-003; depends on T018)
+- [X] T020 [P] [US1] Add the scratchpad-gated Refine button (visible/active only when the active doc `isScratchpad`, posting `applyScratchpad`; not routed through the generic `footerAction` catalog) in `webview/src/spec-viewer/components/FooterActions.tsx` (FR-009; depends on T018)
+
+**Checkpoint**: The full capture-and-apply loop works — create a scratchpad (US2), write notes, Refine to directly edit the matching source. MVP complete.
+
+---
+
+## Phase 5: User Story 3 - See which scratchpads have pending notes at a glance (Priority: P2)
+
+**Goal**: A scratchpad sub-tab that contains content shows a "has notes" indicator; empty or absent ones do not.
+
+**Independent Test**: Add content to one scratchpad, leave another empty/absent, and confirm only the one with content shows the indicator on its sub-tab.
+
+**Note**: Relies on `hasContent` already computed by the scanner (T004); this story only renders it.
+
+### Implementation for User Story 3
+
+- [X] T021 [US3] Render a "has notes" dot on the scratchpad sub-tab when `doc.hasContent` is true in `webview/src/spec-viewer/components/NavigationBar.tsx` (FR-016)
+- [X] T022 [P] [US3] Add the has-notes dot CSS (e.g. `.step-child--scratchpad.has-notes::after`) in `webview/styles/spec-viewer/_navigation.css` (FR-016)
+- [X] T023 [P] [US3] Add/extend Storybook coverage for the sub-tab has-notes indicator (content vs empty) in `webview/src/spec-viewer/components/NavigationBar.stories.tsx`
+
+**Checkpoint**: Scratchpads with pending notes are distinguishable at a glance.
+
+---
+
+## Phase 6: Inline-Comment System Removal (FR-015 / SC-005) — Cross-Cutting, P1
+
+**Purpose**: Remove the prior inline review-comment infrastructure wholesale so none of its controls remain reachable. Sequenced after the new apply flow exists so the Refine capability is never absent.
+
+- [X] T024 [P] Delete inline-comment components `InlineComment.tsx` and `InlineEditor.tsx` plus their `.stories.tsx` in `webview/src/spec-viewer/components/`
+- [X] T025 [P] Delete inline-editor modules `editor/refinements.ts`, `editor/inlineEditor.ts`, `editor/lineActions.ts`, `editor/index.ts`, and legacy `modal.ts` in `webview/src/spec-viewer/`
+- [X] T026 [P] Remove the refinement signals (`pendingRefinements`, `activeEditor`, `refineLineNum`, `refineContent`) in `webview/src/spec-viewer/signals.ts`
+- [X] T027 Remove the line-action wrapping (`wrapWithLineActions` / `line-add-btn` / `line-comment-slot`) in `webview/src/spec-viewer/markdown/renderer.ts` and the `row-add-btn` injection in `webview/src/spec-viewer/markdown/scenarios.ts`
+- [X] T028 Drop line-action setup wiring (and any imports of the deleted editor modules) in `webview/src/spec-viewer/App.tsx` and `webview/src/spec-viewer/index.tsx` (depends on T025, T027)
+- [X] T029 [P] Delete CSS partials `_refinements.css`, `_editor.css`, `_modal.css`; remove `.line-add-btn` rules in `_line-actions.css` and `.row-add-btn`/comment-row rules in `_tables.css`; update `@import`s in `index.css` (all under `webview/styles/spec-viewer/`)
+- [X] T030 Remove the dead messages `submitRefinements`/`refineLine`/`editLine`/`removeLine` and their handlers in `src/features/spec-viewer/messageHandlers.ts`, drop them from the message unions, and delete the now-unused `Refinement`/`LineType` types in `src/features/spec-viewer/types.ts` and `webview/src/spec-viewer/types.ts`
+- [X] T031 Verify `toggleCheckbox` is reachable via direct checkbox clicks in rendered markdown (keep) rather than only via the removed line-action menu; remove it across `webview/src/spec-viewer/` + `src/features/spec-viewer/messageHandlers.ts` only if proven coupled (default: keep)
+
+**Checkpoint**: None of the removed inline-comment controls are reachable; task checkboxes still toggle.
+
+---
+
+## Phase 7: Polish & Cross-Cutting Concerns
+
+**Purpose**: Documentation, manual verification, and a clean type-check/test pass.
+
+- [X] T032 [P] Document scratchpad sub-tabs, the empty-state create action, and the scratchpad-gated Refine in the "Reading Specs" subsection of `README.md`
+- [X] T033 [P] Update the footer button matrix for the scratchpad-gated Refine (and removal of the old batch refine) in `docs/viewer-states.md`
+- [X] T034 [P] Add a CHANGELOG.md entry for per-document scratchpad extras and the inline-comment system removal
+- [ ] T035 Run the `quickstart.md` manual verification in the Extension Dev Host: all three user stories, edge cases (empty apply, deleted/created on disk, source absent, mapping), removal acceptance, and non-core guarantees
+- [X] T036 Run `npm run compile` and `npm test`; resolve any type or test fallout from the message-union, `SpecDocument`, and removal changes
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies — start immediately.
+- **Foundational (Phase 2)**: Depends on Setup — BLOCKS all user stories.
+- **User Stories (Phases 3–5)**: All depend on Foundational. US2 (P1) → US1 (P1) → US3 (P2) in the recommended order; US1 is independently testable against an on-disk scratchpad if run before US2.
+- **Removal (Phase 6)**: Independent files mostly; sequenced after US1 so Refine is never absent. Can otherwise proceed in parallel with the user stories.
+- **Polish (Phase 7)**: Depends on the desired stories + removal being complete.
+
+### User Story Dependencies
+
+- **US2 (P1)**: Needs Foundational only. No dependency on other stories.
+- **US1 (P1)**: Needs Foundational only. Practically pairs with US2 for the full loop, but independently testable via an on-disk `*-extra.md`.
+- **US3 (P2)**: Needs Foundational only (reads `hasContent` from T004). No dependency on US1/US2.
+
+### Within Each Story / Phase
+
+- T004 and T005 depend on T002 (model fields).
+- T011 depends on T010; T014 depends on T012 (US2).
+- T019 and T020 depend on T018 (US1).
+- T028 depends on T025 and T027 (removal).
+- Tests for a story are written to fail first, then implementation makes them pass.
+
+### Parallel Opportunities
+
+- **Foundational**: T002 ∥ T003 (separate type files); T006 ∥ T007 ∥ T008 after T002.
+- **US2**: T012 ∥ T013 ∥ T009 (component, story, test — separate files).
+- **US1**: T016 ∥ T017 (tests); then T019 ∥ T020 after T018.
+- **US3**: T022 ∥ T023.
+- **Removal**: T024 ∥ T025 ∥ T026 ∥ T029 (independent files); T027 then T028; T030/T031 sequential on shared type/handler files.
+- **Polish**: T032 ∥ T033 ∥ T034 (docs).
+
+---
+
+## Parallel Example: Foundational (Phase 2)
+
+```bash
+# After T001 (constants), launch the independent type + style + test tasks:
+Task: "Add SpecDocument scratchpad fields + DocumentType union in src/features/spec-viewer/types.ts"   # T002
+Task: "Mirror the same in webview/src/spec-viewer/types.ts"                                             # T003
+# After T002:
+Task: ".step-child--scratchpad styling in webview/styles/spec-viewer/_navigation.css"                  # T006
+Task: "NavigationBar scratchpad class hook in components/NavigationBar.tsx"                             # T007
+Task: "Scanner synthesis unit tests in tests/unit/spec-viewer/documentScanner.spec.ts"                 # T008
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Stories 2 + 1)
+
+1. Complete Phase 1 (Setup) and Phase 2 (Foundational) — scratchpad sub-tabs render.
+2. Complete Phase 3 (US2) — create a scratchpad from its empty state.
+3. Complete Phase 4 (US1) — Refine applies notes as a direct source edit.
+4. **STOP and VALIDATE**: create → write notes → Refine → confirm direct edit; confirm Refine hidden on source tabs.
+
+### Incremental Delivery
+
+1. Foundational → sub-tabs visible and distinct.
+2. US2 → create-on-demand works (demo).
+3. US1 → capture-and-apply loop works (MVP demo).
+4. US3 → has-notes indicator (P2, may follow initial release).
+5. Removal → old inline-comment system gone (SC-005).
+6. Polish → docs + quickstart validation + clean compile/test.
+
+### Notes
+
+- [P] tasks = different files, no dependencies.
+- [Story] label maps a task to its user story for traceability; Setup/Foundational/Removal/Polish carry no story label.
+- Scratchpads are non-core: no `.spec-context.json` writes, no gating, no task counting (FR-013, verified by existing guards — no new code).
+- Apply is always a direct edit via `executeInTerminal` — never a `/speckit-*` slash command (SC-003).
+- Commit after each task or logical group.

--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -222,6 +222,20 @@ export const FileNames = {
 } as const;
 
 /**
+ * Per-document scratchpad ("extra") file names, keyed by source document base.
+ * A scratchpad pairs one-to-one with its core source doc and holds freeform
+ * refinement notes; its base name is `<source-base>-extra`.
+ */
+export const ScratchpadFiles = {
+    spec: 'spec-extra.md',
+    plan: 'plan-extra.md',
+    tasks: 'tasks-extra.md',
+} as const;
+
+/** Suffix appended to a source document's base name to form its scratchpad. */
+export const SCRATCHPAD_SUFFIX = '-extra';
+
+/**
  * Workflow step identifiers and their config key variants
  */
 export const WorkflowSteps = {

--- a/src/features/spec-viewer/__tests__/messageHandlers.test.ts
+++ b/src/features/spec-viewer/__tests__/messageHandlers.test.ts
@@ -329,14 +329,17 @@ describe('messageHandlers - submitRefinements', () => {
         jest.clearAllMocks();
     });
 
-    function dispatchRefinements(currentDocument: 'spec' | 'plan' | 'tasks') {
+    function dispatchRefinements(
+        currentDocument: 'spec' | 'plan' | 'tasks',
+        availableDocuments: Array<Record<string, unknown>> = [],
+    ) {
         const deps = createMockDeps({
             getInstance: jest.fn().mockReturnValue({
                 state: {
                     specDirectory: SPEC_DIR,
                     specName: 'my-feature',
                     currentDocument,
-                    availableDocuments: [],
+                    availableDocuments,
                 },
                 debounceTimer: undefined,
             }),
@@ -397,5 +400,145 @@ describe('messageHandlers - submitRefinements', () => {
             expect(prompt).toContain(`${SPEC_DIR}/${doc}.md`);
             expect(prompt).toContain('DO NOT regenerate');
         }
+    });
+
+    it('appends the batch to the matching scratchpad file when one exists', async () => {
+        const scratchpad = {
+            type: 'spec-extra',
+            label: 'Spec Notes',
+            fileName: 'spec-extra.md',
+            filePath: `${SPEC_DIR}/spec-extra.md`,
+            exists: false,
+            isCore: false,
+            category: 'related',
+            parentStep: 'spec',
+            isScratchpad: true,
+            scratchpadFor: 'spec',
+        };
+        (vscode.workspace.fs.stat as jest.Mock).mockRejectedValue(new Error('not found'));
+        (vscode.workspace.fs.writeFile as jest.Mock).mockResolvedValue(undefined);
+
+        const { deps, handler, refinements } = dispatchRefinements('spec', [scratchpad]);
+
+        await handler({ type: 'submitRefinements', refinements } as any);
+
+        expect(vscode.workspace.fs.writeFile).toHaveBeenCalledTimes(1);
+        const [, data] = (vscode.workspace.fs.writeFile as jest.Mock).mock.calls[0];
+        const written = new TextDecoder().decode(data as Uint8Array);
+        expect(written).toContain('tighten wording');
+        expect(written).toContain('add detail');
+        // Batch is h2, entries are h3, labels make role unambiguous.
+        expect(written).toContain('## Refinement batch');
+        expect(written).toContain('### Line 5');
+        expect(written).toContain('### Line 12');
+        expect(written).toContain('**Original**');
+        expect(written).toContain('**Comment**');
+
+        // AI dispatch still happens — persistence is layered on, not replacing.
+        expect(deps.executeInTerminal).toHaveBeenCalledTimes(1);
+    });
+
+    it('skips scratchpad append when no matching scratchpad exists in the doc set', async () => {
+        const { deps, handler, refinements } = dispatchRefinements('spec', []);
+
+        await handler({ type: 'submitRefinements', refinements } as any);
+
+        expect(vscode.workspace.fs.writeFile).not.toHaveBeenCalled();
+        // AI dispatch still happens.
+        expect(deps.executeInTerminal).toHaveBeenCalledTimes(1);
+    });
+
+    it('enriches each refinement with its surrounding block + section heading from the source', async () => {
+        // line numbers (1-based):
+        // 1: "# Spec"
+        // 2: ""
+        // 3: "## Requirements"
+        // 4: ""
+        // 5: "Some paragraph text"
+        // 6: "that wraps onto a second line"
+        // 7: "and a third."
+        // 8: ""
+        // 9: "- **FR-001**: System MUST persist"
+        //10: "  the chosen theme across sessions."
+        //11: "- **FR-002**: Honor OS theme."
+        const sourceMd = [
+            '# Spec',
+            '',
+            '## Requirements',
+            '',
+            'Some paragraph text',
+            'that wraps onto a second line',
+            'and a third.',
+            '',
+            '- **FR-001**: System MUST persist',
+            '  the chosen theme across sessions.',
+            '- **FR-002**: Honor OS theme.',
+        ].join('\n');
+
+        const sourceDoc = {
+            type: 'spec',
+            label: 'Spec',
+            fileName: 'spec.md',
+            filePath: `${SPEC_DIR}/spec.md`,
+            exists: true,
+            isCore: true,
+            category: 'core',
+        };
+        const scratchpad = {
+            type: 'spec-extra',
+            label: 'Spec Notes',
+            fileName: 'spec-extra.md',
+            filePath: `${SPEC_DIR}/spec-extra.md`,
+            exists: false,
+            isCore: false,
+            category: 'related',
+            parentStep: 'spec',
+            isScratchpad: true,
+            scratchpadFor: 'spec',
+        };
+
+        (vscode.workspace.fs.stat as jest.Mock).mockImplementation(async (u: any) => {
+            const p = u?.fsPath ?? u?.path ?? '';
+            if (p === `${SPEC_DIR}/spec.md`) return { type: vscode.FileType.File };
+            throw new Error('not found');
+        });
+        (vscode.workspace.fs.readFile as jest.Mock).mockImplementation(async (u: any) => {
+            const p = u?.fsPath ?? u?.path ?? '';
+            if (p === `${SPEC_DIR}/spec.md`) return Buffer.from(sourceMd);
+            return Buffer.from('');
+        });
+        (vscode.workspace.fs.writeFile as jest.Mock).mockResolvedValue(undefined);
+
+        const { deps, handler } = dispatchRefinements('spec', [sourceDoc, scratchpad]);
+        const refinements = [
+            { lineNum: 6, lineContent: 'that wraps onto a second line', comment: 'tighten this paragraph' },
+            { lineNum: 9, lineContent: '- **FR-001**: System MUST persist', comment: 'scope unclear' },
+        ];
+
+        await handler({ type: 'submitRefinements', refinements } as any);
+
+        const prompt = (deps.executeInTerminal as jest.Mock).mock.calls[0][0] as string;
+
+        // Exact line numbers preserved for the AI.
+        expect(prompt).toContain('Line 6');
+        expect(prompt).toContain('Line 9');
+        // Section heading attached.
+        expect(prompt).toContain('Requirements');
+        // Full paragraph block (all three lines) for line 6.
+        expect(prompt).toContain('Some paragraph text');
+        expect(prompt).toContain('and a third.');
+        // FR-001 list item + its continuation captured (but FR-002 NOT).
+        expect(prompt).toContain('the chosen theme across sessions');
+        expect(prompt).not.toMatch(/FR-002/);
+
+        // Scratchpad gets the same enrichment, in the labeled-sections shape.
+        const [, data] = (vscode.workspace.fs.writeFile as jest.Mock).mock.calls[0];
+        const written = new TextDecoder().decode(data as Uint8Array);
+        expect(written).toContain('### Line 6 · Requirements');
+        expect(written).toContain('### Line 9 · Requirements');
+        expect(written).toContain('**Original**');
+        expect(written).toContain('**Comment**');
+        expect(written).toContain('Some paragraph text');
+        expect(written).toContain('the chosen theme across sessions');
     });
 });

--- a/src/features/spec-viewer/documentScanner.ts
+++ b/src/features/spec-viewer/documentScanner.ts
@@ -13,6 +13,20 @@ import {
 } from './types';
 import { fileNameToDocType, fileNameToDisplayName } from './utils';
 import type { WorkflowStepConfig } from '../workflows/types';
+import { ScratchpadFiles, SCRATCHPAD_SUFFIX } from '../../core/constants';
+
+/**
+ * Map a source document file name → its scratchpad base key.
+ * Only the three core source documents participate in scratchpads.
+ */
+const SCRATCHPAD_SOURCE_FILES: Record<string, keyof typeof ScratchpadFiles> = {
+    'spec.md': 'spec',
+    'plan.md': 'plan',
+    'tasks.md': 'tasks',
+};
+
+/** Set of scratchpad file names, used to de-dupe the generic related scan. */
+const SCRATCHPAD_FILE_NAMES: ReadonlySet<string> = new Set(Object.values(ScratchpadFiles));
 
 /**
  * Check if a file exists
@@ -234,6 +248,12 @@ export async function scanDocuments(
                     continue;
                 }
 
+                // Skip scratchpad files — they are synthesized below (gated on
+                // source existence) so an on-disk *-extra.md is not double-listed.
+                if (SCRATCHPAD_FILE_NAMES.has(fileName) && !relativePath.includes('/')) {
+                    continue;
+                }
+
                 // Skip duplicates across dirs
                 if (seenRelativePaths.has(relativePath)) continue;
                 seenRelativePaths.add(relativePath);
@@ -259,6 +279,31 @@ export async function scanDocuments(
     await scanRelatedDocs(specDirectory);
     if (changeRoot && changeRoot !== specDirectory) {
         await scanRelatedDocs(changeRoot);
+    }
+
+    // Synthesize one scratchpad ("extra") doc per existing core source doc
+    // (spec/plan/tasks only). The scratchpad file itself may be absent —
+    // `exists` reflects on-disk state and gates chip visibility downstream.
+    for (const source of documents.filter(d => d.isCore && d.exists)) {
+        const base = SCRATCHPAD_SOURCE_FILES[path.basename(source.fileName)];
+        if (!base) continue;
+
+        const scratchpadFileName = ScratchpadFiles[base];
+        const filePath = path.join(path.dirname(source.filePath), scratchpadFileName);
+        const exists = await fileExists(filePath);
+
+        documents.push({
+            type: `${base}${SCRATCHPAD_SUFFIX}`,
+            label: `${source.label} Notes`,
+            fileName: scratchpadFileName,
+            filePath,
+            exists,
+            isCore: false,
+            category: 'related',
+            parentStep: source.type,
+            isScratchpad: true,
+            scratchpadFor: source.type,
+        });
     }
 
     // Assign parentStep to orphan related docs (no parentStep yet)

--- a/src/features/spec-viewer/extractBlock.ts
+++ b/src/features/spec-viewer/extractBlock.ts
@@ -1,0 +1,77 @@
+export interface ExtractedBlock {
+    /** 1-based first line of the block. */
+    startLine: number;
+    /** 1-based last line of the block. */
+    endLine: number;
+    /** Joined block text (raw source lines). */
+    text: string;
+    /** Nearest preceding heading title, or null if none. */
+    heading: string | null;
+}
+
+/**
+ * Walk the source markdown to find the block (paragraph or list item) that
+ * contains the clicked line, plus the nearest preceding heading. The result
+ * gives the AI stable context even after the source doc has been edited and
+ * line numbers have shifted.
+ */
+export function extractBlock(lines: string[], lineNum: number): ExtractedBlock | null {
+    const idx = lineNum - 1;
+    if (idx < 0 || idx >= lines.length) return null;
+
+    const isBlank = (s: string) => !s.trim();
+    const isHeading = (s: string) => /^#{1,6}\s/.test(s);
+    const isHr = (s: string) => /^[-*_]{3,}\s*$/.test(s.trim());
+    const isListItem = (s: string) => /^\s*([-*+]|\d+\.)\s/.test(s);
+    const isIndentedContinuation = (s: string) => /^\s+\S/.test(s) && !isListItem(s);
+    const isBoundary = (s: string) => isBlank(s) || isHeading(s) || isHr(s);
+
+    const findHeading = (from: number): string | null => {
+        for (let i = from - 1; i >= 0; i--) {
+            const m = lines[i].match(/^#{1,6}\s+(.+)$/);
+            if (m) return m[1].trim();
+        }
+        return null;
+    };
+
+    if (isHeading(lines[idx]) || isHr(lines[idx]) || isBlank(lines[idx])) {
+        return {
+            startLine: lineNum,
+            endLine: lineNum,
+            text: lines[idx],
+            heading: findHeading(idx),
+        };
+    }
+
+    const clickedIsListItem = isListItem(lines[idx]);
+    let start = idx;
+    let end = idx;
+
+    while (start > 0) {
+        const dest = lines[start - 1];
+        if (isBoundary(dest)) break;
+        if (clickedIsListItem) {
+            if (isListItem(dest) || isIndentedContinuation(dest)) break;
+        } else {
+            // For paragraph clicks, a preceding list-item line means the
+            // clicked text is a continuation; pull the bullet into the block.
+            if (isListItem(dest)) { start--; break; }
+        }
+        start--;
+    }
+
+    while (end < lines.length - 1) {
+        const next = lines[end + 1];
+        if (isBoundary(next)) break;
+        if (isListItem(next)) break;
+        if (clickedIsListItem && !isIndentedContinuation(next)) break;
+        end++;
+    }
+
+    return {
+        startLine: start + 1,
+        endLine: end + 1,
+        text: lines.slice(start, end + 1).join('\n'),
+        heading: findHeading(start),
+    };
+}

--- a/src/features/spec-viewer/messageHandlers.ts
+++ b/src/features/spec-viewer/messageHandlers.ts
@@ -11,6 +11,7 @@ import {
     DocumentType,
 } from './types';
 import { SPEC_CONTEXT_FILENAME } from '../specs/specContextReader';
+import { extractBlock } from './extractBlock';
 import { ConfigKeys, SpecStatuses, FooterActionIds } from '../../core/constants';
 import { NotificationUtils } from '../../core/utils/notificationUtils';
 import type { CustomCommandConfig } from '../../core/types/config';
@@ -570,10 +571,11 @@ async function handleOpenFile(
 }
 
 /**
- * Handle submit refinements - dispatch a direct-edit prompt for the current
- * doc. We deliberately avoid invoking any per-step slash command (e.g.
- * /speckit.plan) because some of those commands re-run setup scripts that
- * overwrite the existing file from a template (see issue #153).
+ * Dispatch inline-comment batches as a direct-edit prompt to the AI and
+ * append the same batch to the matching scratchpad file as history.
+ *
+ * Never invoke a per-step slash command (e.g. /speckit.plan) — those re-run
+ * setup scripts that overwrite the source from a template (issue #153).
  */
 async function handleSubmitRefinements(
     specDirectory: string,
@@ -587,9 +589,130 @@ async function handleSubmitRefinements(
     const filename = `${docType}.md`;
     const targetPath = instance.state.changeRoot || specDirectory;
 
-    const refinementText = refinements
-        .map(r => `- Line ${r.lineNum} ("${r.lineContent.slice(0, 50)}${r.lineContent.length > 50 ? '...' : ''}"): ${r.comment}`)
-        .join('\n');
+    // Read the source markdown so each refinement can be enriched with its
+    // surrounding block (paragraph or list item) and nearest preceding heading.
+    // Falls back to the passed-in single line if the source can't be read.
+    const sourceDoc = instance.state.availableDocuments.find(
+        d => d.isCore && d.type === docType,
+    );
+    let sourceLines: string[] | null = null;
+    if (sourceDoc) {
+        try {
+            const data = await vscode.workspace.fs.readFile(vscode.Uri.file(sourceDoc.filePath));
+            sourceLines = Buffer.from(data).toString('utf-8').split('\n');
+        } catch {
+            sourceLines = null;
+        }
+    }
+
+    interface Enriched {
+        lineNum: number;
+        comment: string;
+        heading: string | null;
+        startLine: number;
+        endLine: number;
+        block: string;
+    }
+    const enriched: Enriched[] = refinements.map(r => {
+        if (sourceLines) {
+            const block = extractBlock(sourceLines, r.lineNum);
+            if (block) {
+                return {
+                    lineNum: r.lineNum,
+                    comment: r.comment,
+                    heading: block.heading,
+                    startLine: block.startLine,
+                    endLine: block.endLine,
+                    block: block.text,
+                };
+            }
+        }
+        return {
+            lineNum: r.lineNum,
+            comment: r.comment,
+            heading: null,
+            startLine: r.lineNum,
+            endLine: r.lineNum,
+            block: r.lineContent,
+        };
+    });
+
+    const blockquote = (text: string) =>
+        text.split('\n').map(l => `> ${l}`).join('\n');
+
+    const formatRefinement = (r: Enriched, mode: 'prompt' | 'scratchpad'): string => {
+        if (mode === 'prompt') {
+            const range = r.startLine === r.endLine
+                ? `Line ${r.lineNum}`
+                : `Line ${r.lineNum} (block lines ${r.startLine}–${r.endLine})`;
+            const where = r.heading ? `${range} in section "${r.heading}"` : range;
+            const indented = blockquote(r.block).replace(/^/gm, '  ');
+            return `- ${where}: ${r.comment}\n${indented}`;
+        }
+        const label = r.heading
+            ? `Line ${r.lineNum} · ${r.heading}`
+            : `Line ${r.lineNum}`;
+        return [
+            `### ${label}`,
+            '',
+            '**Original**',
+            '',
+            blockquote(r.block),
+            '',
+            '**Comment**',
+            '',
+            r.comment,
+        ].join('\n');
+    };
+
+    const promptRefinementText = enriched
+        .map(r => formatRefinement(r, 'prompt'))
+        .join('\n\n');
+    const scratchpadRefinementText = enriched
+        .map(r => formatRefinement(r, 'scratchpad'))
+        .join('\n\n');
+
+    // Persist this batch to the matching scratchpad file. Synthesis emits one
+    // scratchpad entry per existing core source doc, so when one matches the
+    // current docType we append; otherwise we skip persistence and just
+    // dispatch the AI prompt.
+    const scratchpad = instance.state.availableDocuments.find(
+        d => d.isScratchpad && d.scratchpadFor === docType,
+    );
+    if (scratchpad) {
+        let existing = '';
+        let wasFirstWrite = false;
+        try {
+            const data = await vscode.workspace.fs.readFile(vscode.Uri.file(scratchpad.filePath));
+            existing = Buffer.from(data).toString('utf-8');
+        } catch {
+            wasFirstWrite = true;
+        }
+        try {
+            const stamp = new Date().toISOString().slice(0, 16).replace('T', ' ');
+            const heading = `## Refinement batch · ${stamp} UTC`;
+            // Newest batch on top — reads like a review feed. Earlier history
+            // sits below a horizontal rule.
+            const trimmedExisting = existing.replace(/^\s+|\s+$/g, '');
+            const next = trimmedExisting
+                ? `${heading}\n\n${scratchpadRefinementText}\n\n---\n\n${trimmedExisting}\n`
+                : `${heading}\n\n${scratchpadRefinementText}\n`;
+            await vscode.workspace.fs.writeFile(
+                vscode.Uri.file(scratchpad.filePath),
+                Buffer.from(next, 'utf-8'),
+            );
+            deps.outputChannel.appendLine(
+                `[SpecViewer] Appended ${refinements.length} refinement(s) to ${scratchpad.fileName}`,
+            );
+            // First write needs an explicit re-scan so the chip appears
+            // without waiting on the file watcher.
+            if (wasFirstWrite) {
+                await deps.updateContent(specDirectory, instance.state.currentDocument);
+            }
+        } catch (error) {
+            deps.outputChannel.appendLine(`[SpecViewer] Error appending to scratchpad: ${error}`);
+        }
+    }
 
     const prompt = [
         `Edit ${targetPath}/${filename} in place to apply ONLY these line-specific refinements.`,
@@ -598,9 +721,10 @@ async function handleSubmitRefinements(
         `DO NOT replace the file — make targeted edits only.`,
         ``,
         `Refinements requested:`,
-        refinementText,
+        promptRefinementText,
     ].join('\n');
 
     deps.outputChannel.appendLine(`[SpecViewer] Submitting ${refinements.length} refinements for ${docType} (direct edit)`);
     await deps.executeInTerminal(prompt);
 }
+

--- a/src/features/spec-viewer/messageHandlers.ts
+++ b/src/features/spec-viewer/messageHandlers.ts
@@ -586,7 +586,6 @@ async function handleSubmitRefinements(
     if (!instance) return;
 
     const docType = instance.state.currentDocument;
-    const filename = `${docType}.md`;
     const targetPath = instance.state.changeRoot || specDirectory;
 
     // Read the source markdown so each refinement can be enriched with its
@@ -595,6 +594,11 @@ async function handleSubmitRefinements(
     const sourceDoc = instance.state.availableDocuments.find(
         d => d.isCore && d.type === docType,
     );
+    // Derive the AI-prompt target filename from the resolved source doc so
+    // workflows with non-matching step / file names (SDD's `specify` step →
+    // `spec.md`) target the correct file. Fall back to `${docType}.md` only
+    // when no source doc could be resolved.
+    const filename = sourceDoc?.fileName ?? `${docType}.md`;
     let sourceLines: string[] | null = null;
     if (sourceDoc) {
         try {

--- a/src/features/spec-viewer/types.ts
+++ b/src/features/spec-viewer/types.ts
@@ -20,10 +20,15 @@ export type CoreDocumentType = 'spec' | 'plan' | 'tasks';
 export type WorkflowDocumentType = string;
 
 /**
+ * Scratchpad ("extra") document types, paired one-to-one with a core source doc.
+ */
+export type ScratchpadDocumentType = 'spec-extra' | 'plan-extra' | 'tasks-extra';
+
+/**
  * Extended to include related and workflow documents
  * Related docs are identified by their filename
  */
-export type DocumentType = CoreDocumentType | WorkflowDocumentType;
+export type DocumentType = CoreDocumentType | ScratchpadDocumentType | WorkflowDocumentType;
 
 // ============================================
 // Phase Types (for stepper)
@@ -108,6 +113,12 @@ export interface SpecDocument {
 
     /** Parent workflow step name (e.g., 'specify') when discovered via subDir */
     parentStep?: string;
+
+    /** True when this entry represents a *-extra.md scratchpad. */
+    isScratchpad?: boolean;
+
+    /** Source doc type this scratchpad pairs with (e.g. 'spec', 'plan', 'tasks'). */
+    scratchpadFor?: DocumentType;
 }
 
 /**

--- a/src/features/specs/specExplorerProvider.ts
+++ b/src/features/specs/specExplorerProvider.ts
@@ -689,7 +689,11 @@ class SpecItem extends vscode.TreeItem {
                 const stepHistory = specContext.stepHistory ?? {};
                 const stepName = documentType as StepName;
                 const cs = (specContext.currentStep ?? 'specify') as StepName;
-                if (STEP_NAMES.includes(stepName) && isStepCompleted(stepName, cs, stepHistory)) {
+                // Gate the green "pass" icon on the file actually existing —
+                // otherwise a hand-crafted .spec-context.json (or a deleted
+                // doc) can show "completed" while the description reads
+                // "not created", which is contradictory.
+                if (status !== 'empty' && STEP_NAMES.includes(stepName) && isStepCompleted(stepName, cs, stepHistory)) {
                     this.iconPath = new vscode.ThemeIcon('pass', new vscode.ThemeColor('testing.iconPassed'));
                 } else if (specContext.currentStep === documentType) {
                     this.iconPath = new vscode.ThemeIcon('circle-filled', new vscode.ThemeColor('charts.blue'));

--- a/tests/__mocks__/vscode.ts
+++ b/tests/__mocks__/vscode.ts
@@ -95,6 +95,8 @@ export const workspace = {
     fs: {
         readDirectory: jest.fn().mockResolvedValue([]),
         stat: jest.fn().mockRejectedValue(new Error('not found')),
+        readFile: jest.fn().mockResolvedValue(new Uint8Array()),
+        writeFile: jest.fn().mockResolvedValue(undefined),
     },
     findFiles: jest.fn().mockResolvedValue([]),
     getConfiguration: jest.fn().mockReturnValue({

--- a/tests/unit/spec-viewer/documentScanner.spec.ts
+++ b/tests/unit/spec-viewer/documentScanner.spec.ts
@@ -1,0 +1,123 @@
+import * as vscode from 'vscode';
+import { scanDocuments } from '../../../src/features/spec-viewer/documentScanner';
+import type { SpecDocument } from '../../../src/features/spec-viewer/types';
+
+const SPEC_DIR = '/specs/096-scratchpad';
+
+function uriPath(u: unknown): string {
+    if (typeof u === 'string') return u;
+    const obj = u as { fsPath?: string; path?: string };
+    return obj.fsPath ?? obj.path ?? '';
+}
+
+interface FakeFs {
+    /** Absolute file/dir paths that exist on disk. */
+    existing: Set<string>;
+    /** Directory path → [name, FileType] entries. */
+    dirEntries: Record<string, Array<[string, number]>>;
+    /** File path → text contents. */
+    contents: Record<string, string>;
+}
+
+function installFs(fake: FakeFs): void {
+    (vscode.workspace.fs.stat as jest.Mock).mockImplementation(async (u: unknown) => {
+        if (fake.existing.has(uriPath(u))) return { type: vscode.FileType.File };
+        throw new Error('not found');
+    });
+    (vscode.workspace.fs.readDirectory as jest.Mock).mockImplementation(async (u: unknown) => {
+        return fake.dirEntries[uriPath(u)] ?? [];
+    });
+    (vscode.workspace.fs.readFile as jest.Mock).mockImplementation(async (u: unknown) => {
+        return Buffer.from(fake.contents[uriPath(u)] ?? '');
+    });
+}
+
+const outputChannel = { appendLine: jest.fn() } as unknown as vscode.OutputChannel;
+
+function scratchpads(docs: SpecDocument[]): SpecDocument[] {
+    return docs.filter(d => d.isScratchpad);
+}
+
+beforeEach(() => {
+    jest.clearAllMocks();
+});
+
+describe('documentScanner scratchpad synthesis', () => {
+    it('synthesizes one scratchpad per existing core source doc', async () => {
+        installFs({
+            existing: new Set([
+                `${SPEC_DIR}/spec.md`,
+                `${SPEC_DIR}/plan.md`,
+                `${SPEC_DIR}/tasks.md`,
+            ]),
+            dirEntries: {
+                [SPEC_DIR]: [
+                    ['spec.md', vscode.FileType.File],
+                    ['plan.md', vscode.FileType.File],
+                    ['tasks.md', vscode.FileType.File],
+                ],
+            },
+            contents: {},
+        });
+
+        const docs = await scanDocuments(SPEC_DIR, outputChannel);
+        const pads = scratchpads(docs);
+
+        expect(pads.map(d => d.type).sort()).toEqual([
+            'plan-extra',
+            'spec-extra',
+            'tasks-extra',
+        ]);
+        const spec = pads.find(d => d.type === 'spec-extra')!;
+        expect(spec).toMatchObject({
+            isScratchpad: true,
+            scratchpadFor: 'spec',
+            parentStep: 'spec',
+            isCore: false,
+            category: 'related',
+            fileName: 'spec-extra.md',
+            exists: false,
+        });
+    });
+
+    it('does not synthesize a scratchpad when the source doc is absent', async () => {
+        installFs({
+            existing: new Set([`${SPEC_DIR}/spec.md`]),
+            dirEntries: {
+                [SPEC_DIR]: [['spec.md', vscode.FileType.File]],
+            },
+            contents: {},
+        });
+
+        const docs = await scanDocuments(SPEC_DIR, outputChannel);
+        const pads = scratchpads(docs);
+
+        expect(pads.map(d => d.type)).toEqual(['spec-extra']);
+    });
+
+    it('surfaces an on-disk *-extra.md exactly once (de-dupe)', async () => {
+        installFs({
+            existing: new Set([
+                `${SPEC_DIR}/spec.md`,
+                `${SPEC_DIR}/spec-extra.md`,
+            ]),
+            dirEntries: {
+                [SPEC_DIR]: [
+                    ['spec.md', vscode.FileType.File],
+                    ['spec-extra.md', vscode.FileType.File],
+                ],
+            },
+            contents: { [`${SPEC_DIR}/spec-extra.md`]: 'some notes' },
+        });
+
+        const docs = await scanDocuments(SPEC_DIR, outputChannel);
+        const extras = docs.filter(d => d.fileName === 'spec-extra.md');
+
+        expect(extras).toHaveLength(1);
+        expect(extras[0]).toMatchObject({
+            type: 'spec-extra',
+            isScratchpad: true,
+            exists: true,
+        });
+    });
+});

--- a/tests/unit/spec-viewer/extractBlock.spec.ts
+++ b/tests/unit/spec-viewer/extractBlock.spec.ts
@@ -1,0 +1,110 @@
+import { extractBlock } from '../../../src/features/spec-viewer/extractBlock';
+
+function lines(...rows: string[]): string[] {
+    return rows;
+}
+
+describe('extractBlock', () => {
+    it('returns null for an out-of-range line number', () => {
+        expect(extractBlock(lines('# H', ''), 0)).toBeNull();
+        expect(extractBlock(lines('# H', ''), 99)).toBeNull();
+    });
+
+    it('treats a heading line as its own block', () => {
+        const src = lines('# Spec', '', 'body');
+        const block = extractBlock(src, 1)!;
+
+        expect(block).toEqual({
+            startLine: 1,
+            endLine: 1,
+            text: '# Spec',
+            heading: null,
+        });
+    });
+
+    it('treats a blank line as its own block', () => {
+        const src = lines('para', '', 'more');
+        const block = extractBlock(src, 2)!;
+
+        expect(block.startLine).toBe(2);
+        expect(block.endLine).toBe(2);
+        expect(block.text).toBe('');
+    });
+
+    it('captures the whole paragraph and the nearest heading', () => {
+        const src = lines(
+            '# Spec',
+            '',
+            '## Summary',
+            '',
+            'first line',
+            'second line',
+            'third line',
+            '',
+            'next paragraph',
+        );
+
+        const block = extractBlock(src, 6)!;
+
+        expect(block.startLine).toBe(5);
+        expect(block.endLine).toBe(7);
+        expect(block.text).toBe('first line\nsecond line\nthird line');
+        expect(block.heading).toBe('Summary');
+    });
+
+    it('captures only the clicked list item, not its siblings', () => {
+        const src = lines(
+            '## Requirements',
+            '',
+            '- first item',
+            '- second item',
+            '- third item',
+        );
+
+        const block = extractBlock(src, 4)!;
+
+        expect(block.text).toBe('- second item');
+        expect(block.startLine).toBe(4);
+        expect(block.endLine).toBe(4);
+        expect(block.heading).toBe('Requirements');
+    });
+
+    it('includes indented continuation lines under the clicked list item', () => {
+        const src = lines(
+            '## Requirements',
+            '',
+            '- first item',
+            '  with a continuation',
+            '  and another',
+            '- second item',
+        );
+
+        const block = extractBlock(src, 3)!;
+
+        expect(block.text).toBe('- first item\n  with a continuation\n  and another');
+        expect(block.startLine).toBe(3);
+        expect(block.endLine).toBe(5);
+    });
+
+    it('pulls the bullet in when clicking on a continuation line', () => {
+        const src = lines(
+            '- first item',
+            '  continuation here',
+            '',
+            '- second item',
+        );
+
+        const block = extractBlock(src, 2)!;
+
+        expect(block.text).toBe('- first item\n  continuation here');
+        expect(block.startLine).toBe(1);
+        expect(block.endLine).toBe(2);
+    });
+
+    it('returns null heading when no preceding heading exists', () => {
+        const src = lines('plain paragraph');
+        const block = extractBlock(src, 1)!;
+
+        expect(block.heading).toBeNull();
+    });
+});

--- a/webview/src/spec-viewer/components/FooterActions.stories.tsx
+++ b/webview/src/spec-viewer/components/FooterActions.stories.tsx
@@ -12,9 +12,10 @@
  */
 
 import type { Meta, StoryObj } from '@storybook/preact';
+import type { SpecDocument } from '../types';
 import { navState, viewerState } from '../signals';
 import { FooterActions } from './FooterActions';
-import { mockNavState } from './__stories__/mockData';
+import { mockDoc, mockNavState } from './__stories__/mockData';
 
 const meta: Meta<typeof FooterActions> = {
     title: 'Viewer/FooterActions',
@@ -241,5 +242,35 @@ export const Archived: Story = {
             { id: 'reactivate', label: 'Reactivate', scope: 'spec', tooltip: 'Reactivate archived spec' },
         ]);
         return <FooterActions initialSpecStatus="archived" />;
+    },
+};
+
+// ── Scratchpad tab ──────────────────────────────────────────
+// When the active doc is a scratchpad (a `<doc>-extra.md` history file),
+// the footer is replaced by a read-only set with only an Edit button.
+
+export const ScratchpadTab: Story = {
+    name: 'Scratchpad tab',
+    render: () => {
+        const specScratch: SpecDocument = {
+            type: 'spec-extra',
+            label: 'Spec Notes',
+            fileName: 'spec-extra.md',
+            filePath: '/workspace/specs/my-feature/spec-extra.md',
+            exists: true,
+            isCore: false,
+            category: 'related',
+            parentStep: 'spec',
+            isScratchpad: true,
+            scratchpadFor: 'spec',
+        };
+        navState.value = mockNavState({
+            coreDocs: [mockDoc('spec', true, 'Specification'), mockDoc('plan', true, 'Plan'), mockDoc('tasks', true, 'Tasks')],
+            relatedDocs: [specScratch],
+            currentDoc: 'spec-extra',
+            isViewingRelatedDoc: true,
+        });
+        viewerState.value = null;
+        return <FooterActions initialSpecStatus="active" />;
     },
 };

--- a/webview/src/spec-viewer/components/FooterActions.tsx
+++ b/webview/src/spec-viewer/components/FooterActions.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'preact/hooks';
 import type { VSCodeApi, ViewerToExtensionMessage, SerializedFooterAction } from '../types';
 import { navState, viewerState } from '../signals';
+import { findActiveDoc } from '../scratchpad';
 import { Button } from '../../shared/components/Button';
 import { Toast } from '../../shared/components/Toast';
 import { UndoToast } from '../../shared/components/UndoToast';
@@ -62,6 +63,28 @@ export function FooterActions({ initialSpecStatus }: FooterActionsProps) {
     const reactivateConfirm = useInlineConfirm(
         () => vscode.postMessage({ type: 'reactivateSpec' })
     );
+
+    // Scratchpad view: read-only history of inline-comment batches. The only
+    // footer affordance is Edit, which opens the file in the standard editor
+    // for manual cleanup. The dispatch path stays on the source-tab batch
+    // Refine — there is no scratchpad-tab Refine.
+    const activeDoc = findActiveDoc(ns);
+    if (activeDoc?.isScratchpad) {
+        return (
+            <footer class="actions">
+                <Toast id="action-toast" />
+                <div class="actions-left"></div>
+                <div class="actions-right">
+                    <Button
+                        label="Edit"
+                        variant="secondary"
+                        title="Open this scratchpad in the editor"
+                        onClick={send({ type: 'editDocument' })}
+                    />
+                </div>
+            </footer>
+        );
+    }
 
     const status = vs?.status || ns.footerState?.specStatus || ns.specStatus || initialSpecStatus;
     const isTasksDone = status === 'tasks-done';

--- a/webview/src/spec-viewer/components/NavigationBar.stories.tsx
+++ b/webview/src/spec-viewer/components/NavigationBar.stories.tsx
@@ -1,7 +1,23 @@
 import type { Meta, StoryObj } from '@storybook/preact';
+import type { SpecDocument } from '../types';
 import { navState } from '../signals';
 import { NavigationBar } from './NavigationBar';
 import { mockDoc, mockNavState, mockRelatedDoc, stalePlan } from './__stories__/mockData';
+
+function scratchpadDoc(base: 'spec' | 'plan' | 'tasks'): SpecDocument {
+    return {
+        type: `${base}-extra`,
+        label: `${base[0].toUpperCase()}${base.slice(1)} Notes`,
+        fileName: `${base}-extra.md`,
+        filePath: `/workspace/specs/my-feature/${base}-extra.md`,
+        exists: true,
+        isCore: false,
+        category: 'related',
+        parentStep: base,
+        isScratchpad: true,
+        scratchpadFor: base,
+    };
+}
 
 const meta: Meta<typeof NavigationBar> = {
     title: 'Viewer/NavigationBar',
@@ -132,6 +148,28 @@ export const SpecWithoutChildren: Story = {
             ],
             currentDoc: 'spec',
             workflowPhase: 'plan',
+        });
+        return <NavigationBar />;
+    },
+};
+
+// ── Scratchpad sub-tab (FR-005 distinction) ───────────────────────────
+// The "Spec Notes" chip is rendered distinct from the source chip (dashed
+// italic). It only appears once `spec-extra.md` exists on disk; the file
+// is created as a side effect of submitting inline-comment batches via
+// the source-tab Refine button.
+
+export const SpecWithScratchpad: Story = {
+    render: () => {
+        navState.value = mockNavState({
+            coreDocs: [
+                mockDoc('spec', true, 'Specification'),
+                mockDoc('plan', true, 'Plan'),
+                mockDoc('tasks', true, 'Tasks'),
+            ],
+            relatedDocs: [scratchpadDoc('spec')],
+            currentDoc: 'spec',
+            workflowPhase: 'spec',
         });
         return <NavigationBar />;
     },

--- a/webview/src/spec-viewer/components/NavigationBar.tsx
+++ b/webview/src/spec-viewer/components/NavigationBar.tsx
@@ -42,12 +42,17 @@ export function NavigationBar() {
     // Related tabs for the current step — rendered in a right-aligned slot
     // inside .nav-primary (R010, R011). The Overview tab is removed since
     // the parent step-tab itself routes to the overview.
+    // Scratchpads are hidden until the *-extra.md file exists on disk — the
+    // file is created as a side effect of submitting inline-comment batches,
+    // there's no manual create path.
+    const isVisible = (d: typeof relatedDocs[number]) =>
+        !d.isScratchpad || d.exists;
     const relevantRelatedDocs = relatedDocs.filter(d =>
-        d.parentStep === currentDoc
+        d.parentStep === currentDoc && isVisible(d)
     );
     const displayRelatedDocs = isViewingRelatedDoc
         ? relatedDocs.filter(d => {
-            return !d.parentStep || d.parentStep === viewingRelatedDoc?.parentStep;
+            return (!d.parentStep || d.parentStep === viewingRelatedDoc?.parentStep) && isVisible(d);
         })
         : relevantRelatedDocs;
 
@@ -130,7 +135,7 @@ export function NavigationBar() {
                         {displayRelatedDocs.map(doc => (
                             <button
                                 key={doc.type}
-                                class={`step-child ${doc.type === currentDoc ? 'active' : ''}`}
+                                class={`step-child ${doc.isScratchpad ? 'step-child--scratchpad' : ''} ${doc.type === currentDoc ? 'active' : ''}`}
                                 data-doc={doc.type}
                                 onClick={() => handleRelatedClick(doc.type)}
                             >

--- a/webview/src/spec-viewer/markdown/renderer.ts
+++ b/webview/src/spec-viewer/markdown/renderer.ts
@@ -211,10 +211,12 @@ export function renderMarkdown(markdown: string): string {
             if (!inBlockquote) {
                 if (inList) {
                     html += listType === 'ul' ? '</ul>\n' : '</ol>\n';
-                    lastClosedListType = listType;
-                    lastClosedListCount = listItemCount;
                     inList = false;
                 }
+                // A blockquote breaks ordered-list continuation: the next
+                // ordered list must restart numbering rather than resume.
+                lastClosedListType = null;
+                lastClosedListCount = 0;
                 inBlockquote = true;
                 blockquoteStartLine = sourceLineNum;
             }

--- a/webview/src/spec-viewer/markdown/renderer.ts
+++ b/webview/src/spec-viewer/markdown/renderer.ts
@@ -141,6 +141,23 @@ export function renderMarkdown(markdown: string): string {
     let lastClosedListCount = 0;
     let inTable = false;
     let tableRows: string[] = [];
+    let inBlockquote = false;
+    let blockquoteLines: string[] = [];
+    let blockquoteStartLine = 0;
+
+    const flushBlockquote = () => {
+        if (!inBlockquote) return;
+        const inner = blockquoteLines
+            .map(l => parseInline(l) || '&nbsp;')
+            .join('<br>\n');
+        html += wrapWithLineActions(
+            `<blockquote><p>${inner}</p></blockquote>`,
+            blockquoteStartLine,
+        );
+        inBlockquote = false;
+        blockquoteLines = [];
+        blockquoteStartLine = 0;
+    };
 
     for (let i = 0; i < lines.length; i++) {
         const line = lines[i];
@@ -185,6 +202,27 @@ export function renderMarkdown(markdown: string): string {
         if (inCodeBlock) {
             codeContent.push(line);
             continue;
+        }
+
+        // Blockquote (group consecutive '>' lines into one <blockquote>).
+        // Must come before list/empty handling so we accumulate first and
+        // flush on the first non-quoted line.
+        if (line.startsWith('>')) {
+            if (!inBlockquote) {
+                if (inList) {
+                    html += listType === 'ul' ? '</ul>\n' : '</ol>\n';
+                    lastClosedListType = listType;
+                    lastClosedListCount = listItemCount;
+                    inList = false;
+                }
+                inBlockquote = true;
+                blockquoteStartLine = sourceLineNum;
+            }
+            // Trim a single leading "> " (preserve any further leading space).
+            blockquoteLines.push(line.replace(/^>\s?/, ''));
+            continue;
+        } else if (inBlockquote) {
+            flushBlockquote();
         }
 
         // Tables
@@ -251,15 +289,6 @@ export function renderMarkdown(markdown: string): string {
             lastClosedListType = null;
             lastClosedListCount = 0;
             html += '<hr>\n';
-            continue;
-        }
-
-        // Blockquote - wrap with line actions for commenting
-        if (line.startsWith('>')) {
-            lastClosedListType = null;
-            lastClosedListCount = 0;
-            const content = parseInline(line.slice(1).trim());
-            html += wrapWithLineActions(`<blockquote><p>${content}</p></blockquote>`, sourceLineNum);
             continue;
         }
 
@@ -381,6 +410,9 @@ export function renderMarkdown(markdown: string): string {
     }
 
     // Close any open elements
+    if (inBlockquote) {
+        flushBlockquote();
+    }
     if (inList) {
         html += listType === 'ul' ? '</ul>\n' : '</ol>\n';
     }

--- a/webview/src/spec-viewer/scratchpad.ts
+++ b/webview/src/spec-viewer/scratchpad.ts
@@ -1,0 +1,9 @@
+import type { NavState, SpecDocument } from './types';
+
+/** Resolve the currently-active document from nav state. */
+export function findActiveDoc(ns: NavState | null | undefined): SpecDocument | undefined {
+    if (!ns) return undefined;
+    return [...(ns.coreDocs ?? []), ...(ns.relatedDocs ?? [])].find(
+        d => d.type === ns.currentDoc
+    );
+}

--- a/webview/src/spec-viewer/types.ts
+++ b/webview/src/spec-viewer/types.ts
@@ -17,7 +17,8 @@ export interface VSCodeApi {
 // ============================================
 
 export type CoreDocumentType = 'spec' | 'plan' | 'tasks';
-export type DocumentType = CoreDocumentType | string;
+export type ScratchpadDocumentType = 'spec-extra' | 'plan-extra' | 'tasks-extra';
+export type DocumentType = CoreDocumentType | ScratchpadDocumentType | string;
 
 export interface SpecDocument {
     type: DocumentType;
@@ -28,6 +29,10 @@ export interface SpecDocument {
     isCore: boolean;
     category?: 'core' | 'related';
     parentStep?: string;
+    /** True when this entry represents a *-extra.md scratchpad. */
+    isScratchpad?: boolean;
+    /** Source doc type this scratchpad pairs with. */
+    scratchpadFor?: DocumentType;
 }
 
 /**

--- a/webview/styles/spec-viewer/_navigation.css
+++ b/webview/styles/spec-viewer/_navigation.css
@@ -240,3 +240,17 @@
     font-weight: 600;
     box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--accent, #4a9eff) 35%, transparent);
 }
+
+/* Scratchpad ("Notes") sub-tab: dashed underline + muted italic so the user
+   reads it as a working surface, not an authoritative artifact (FR-005). */
+.step-child--scratchpad {
+    font-style: italic;
+    color: var(--text-muted);
+    text-decoration: underline dashed color-mix(in srgb, var(--text-muted) 60%, transparent);
+    text-underline-offset: 3px;
+}
+
+.step-child--scratchpad.active {
+    font-style: italic;
+}
+


### PR DESCRIPTION
## Summary

- Add a per-document scratchpad (`<doc>-extra.md`) that records every inline-comment batch submitted via the source-tab Refine button. Each entry shows the exact source line, nearest preceding heading, and the full source block (paragraph or list item, walked from the actual source markdown) as labeled **Original** + **Comment** sections so it stays unambiguous on read-back.
- Renderer fix: multi-line blockquotes now group into one `<blockquote>` element instead of fragmenting into one card per line.
- Sidebar fix: the green ✓ on Spec / Plan / Tasks sub-items is now gated on file existence so it can't contradict a "not created" label.

## Divergence from spec 096

The original spec called for a freeform scratchpad replacing the inline-comment system entirely (FR-015 / SC-005). After implementing that and seeing it in use, the direction reversed: the hover-to-comment UX is good and stays; the scratchpad becomes a history layer instead of a replacement. The spec files are included for context but `tasks.md` still shows the removal tasks checked off from before the pivot — leaving as-is rather than back-editing.

## Test plan

- [ ] `npm run compile` + webview `tsc --noEmit` clean
- [ ] `npm test` — 541 passing across 48 suites (new: `extractBlock.spec.ts`, `documentScanner.spec.ts`; updated: `messageHandlers.test.ts` for persistence + enrichment)
- [ ] In the Extension Dev Host with a fresh spec: hover a line → \`+\` → comment → submit batch Refine → AI prompt fires AND \`<doc>-extra.md\` is written; chip appears immediately in the children rail; opening it shows \`## Refinement batch · TIMESTAMP\` / \`### Line N · Section\` / \`**Original**\` + \`**Comment**\`
- [ ] Second batch lands above the first, separated by \`---\`
- [ ] Scratchpad tab footer shows only Edit
- [ ] Spec whose \`tasks.md\` is deleted no longer shows the spurious green ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)