### PR TITLE
feat(spec-viewer): restructure inline comment composer as a single card

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/096-scratchpad-extras"
+  "feature_directory": "specs/097-inline-comment-composer"
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -225,5 +225,5 @@ npm run test:watch    # Watch mode
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan:
-`specs/096-scratchpad-extras/plan.md`
+`specs/097-inline-comment-composer/plan.md`
 <!-- SPECKIT END -->

--- a/specs/094-viewer-state-machine/.spec-context.json
+++ b/specs/094-viewer-state-machine/.spec-context.json
@@ -1,10 +1,10 @@
 {
   "workflow": "sdd",
-  "currentStep": "implement",
+  "currentStep": "plan",
   "currentTask": "T008",
   "progress": null,
   "next": "done",
-  "status": "implementing",
+  "status": "completed",
   "updated": "2026-05-08",
   "selectedAt": "2026-05-08T17:00:00Z",
   "specName": "Viewer State Machine",
@@ -27,13 +27,17 @@
     "T001": {
       "status": "DONE",
       "did": "Added isAwaitingApproval predicate; tightened Archive, Mark Completed, and SDD Auto visibleWhen rules.",
-      "files": ["src/features/spec-viewer/footerActions.ts"],
+      "files": [
+        "src/features/spec-viewer/footerActions.ts"
+      ],
       "concerns": []
     },
     "T002": {
       "status": "DONE",
       "did": "Added getApproveLabel helper; getFooterActions now rewrites the visible Approve action's label using workflow steps.",
-      "files": ["src/features/spec-viewer/footerActions.ts"],
+      "files": [
+        "src/features/spec-viewer/footerActions.ts"
+      ],
       "concerns": []
     },
     "T003": {
@@ -48,25 +52,33 @@
     "T004": {
       "status": "DONE",
       "did": "Added Awaiting-approval suppression test cases (4 scenarios).",
-      "files": ["tests/unit/spec-viewer/footerActions.spec.ts"],
+      "files": [
+        "tests/unit/spec-viewer/footerActions.spec.ts"
+      ],
       "concerns": []
     },
     "T005": {
       "status": "DONE",
       "did": "Added getApproveLabel cases (5) and dynamic Approve label cases in getFooterActions (2).",
-      "files": ["tests/unit/spec-viewer/footerActions.spec.ts"],
+      "files": [
+        "tests/unit/spec-viewer/footerActions.spec.ts"
+      ],
       "concerns": []
     },
     "T006": {
       "status": "DONE",
       "did": "Documented awaiting-approval suppression, draft-only Auto rule, dynamic Approve label, and overflow-menu future-proofing note.",
-      "files": ["docs/viewer-states.md"],
+      "files": [
+        "docs/viewer-states.md"
+      ],
       "concerns": []
     },
     "T007": {
       "status": "DONE",
       "did": "Added Reading Specs bullet for the quiet awaiting-approval footer; updated lifecycle-writes paragraph to reflect dynamic next-step button name.",
-      "files": ["README.md"],
+      "files": [
+        "README.md"
+      ],
       "concerns": []
     },
     "T008": {
@@ -107,33 +119,72 @@
     {
       "step": "plan",
       "substep": null,
-      "from": { "step": "specify", "substep": null },
+      "from": {
+        "step": "specify",
+        "substep": null
+      },
       "by": "extension",
       "at": "2026-05-08T17:05:00Z"
     },
     {
       "step": "tasks",
       "substep": null,
-      "from": { "step": "plan", "substep": null },
+      "from": {
+        "step": "plan",
+        "substep": null
+      },
       "by": "extension",
       "at": "2026-05-08T17:08:00Z"
     },
     {
       "step": "implement",
       "substep": null,
-      "from": { "step": "tasks", "substep": null },
+      "from": {
+        "step": "tasks",
+        "substep": null
+      },
       "by": "extension",
       "at": "2026-05-08T17:10:00Z"
+    },
+    {
+      "step": "specify",
+      "substep": null,
+      "from": {
+        "step": "specify",
+        "substep": null
+      },
+      "by": "extension",
+      "at": "2026-05-21T02:04:04.376Z"
+    },
+    {
+      "step": "plan",
+      "substep": null,
+      "from": {
+        "step": "implement",
+        "substep": null
+      },
+      "by": "extension",
+      "at": "2026-05-21T02:04:04.377Z"
+    },
+    {
+      "step": "plan",
+      "substep": null,
+      "from": {
+        "step": "plan",
+        "substep": null
+      },
+      "by": "extension",
+      "at": "2026-05-21T02:04:11.173Z"
     }
   ],
   "stepHistory": {
     "specify": {
       "startedAt": "2026-05-08T17:00:00Z",
-      "completedAt": "2026-05-08T17:05:00Z"
+      "completedAt": "2026-05-21T02:04:04.376Z"
     },
     "plan": {
-      "startedAt": "2026-05-08T17:05:00Z",
-      "completedAt": "2026-05-08T17:08:00Z"
+      "startedAt": "2026-05-21T02:04:04.377Z",
+      "completedAt": null
     },
     "tasks": {
       "startedAt": "2026-05-08T17:08:00Z",

--- a/specs/097-inline-comment-composer/.spec-context.json
+++ b/specs/097-inline-comment-composer/.spec-context.json
@@ -1,0 +1,238 @@
+{
+  "workflow": "speckit",
+  "selectedAt": "2026-05-21T01:32:35Z",
+  "currentStep": "implement",
+  "status": "completed",
+  "specName": "Inline Comment Composer",
+  "branch": "main",
+  "stepHistory": {
+    "specify": {
+      "startedAt": "2026-05-21T01:32:35Z",
+      "completedAt": "2026-05-21T01:38:28.814Z"
+    },
+    "plan": {
+      "startedAt": "2026-05-21T01:38:28.816Z",
+      "completedAt": "2026-05-21T01:44:24.920Z"
+    },
+    "tasks": {
+      "startedAt": "2026-05-21T01:44:24.754Z",
+      "completedAt": "2026-05-21T01:47:54.335Z"
+    },
+    "implement": {
+      "startedAt": "2026-05-21T01:47:54.337Z",
+      "completedAt": "2026-05-21T01:52:06Z"
+    }
+  },
+  "transitions": [
+    {
+      "step": "specify",
+      "substep": null,
+      "from": {
+        "step": "specify",
+        "substep": null
+      },
+      "by": "extension",
+      "at": "2026-05-21T01:38:28.814Z"
+    },
+    {
+      "step": "plan",
+      "substep": null,
+      "from": {
+        "step": "specify",
+        "substep": null
+      },
+      "by": "extension",
+      "at": "2026-05-21T01:38:28.816Z"
+    },
+    {
+      "step": "plan",
+      "substep": null,
+      "from": {
+        "step": "specify",
+        "substep": null
+      },
+      "by": "ai",
+      "at": "2026-05-21T01:42:32Z"
+    },
+    {
+      "step": "plan",
+      "substep": "research",
+      "from": {
+        "step": "plan",
+        "substep": null
+      },
+      "by": "ai",
+      "at": "2026-05-21T01:42:39Z"
+    },
+    {
+      "step": "plan",
+      "substep": "design",
+      "from": {
+        "step": "plan",
+        "substep": "research"
+      },
+      "by": "ai",
+      "at": "2026-05-21T01:43:08Z"
+    },
+    {
+      "step": "tasks",
+      "substep": null,
+      "from": {
+        "step": "plan",
+        "substep": null
+      },
+      "by": "extension",
+      "at": "2026-05-21T01:44:24.754Z"
+    },
+    {
+      "step": "tasks",
+      "substep": null,
+      "from": {
+        "step": "plan",
+        "substep": null
+      },
+      "by": "ai",
+      "at": "2026-05-21T01:45:08Z"
+    },
+    {
+      "step": "tasks",
+      "substep": "generate",
+      "from": {
+        "step": "tasks",
+        "substep": null
+      },
+      "by": "ai",
+      "at": "2026-05-21T01:45:21Z"
+    },
+    {
+      "step": "tasks",
+      "substep": null,
+      "from": {
+        "step": "tasks",
+        "substep": null
+      },
+      "by": "extension",
+      "at": "2026-05-21T01:47:54.335Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "from": {
+        "step": "tasks",
+        "substep": null
+      },
+      "by": "extension",
+      "at": "2026-05-21T01:47:54.337Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "from": {
+        "step": "implement",
+        "substep": null
+      },
+      "by": "ai",
+      "at": "2026-05-21T01:48:07Z"
+    },
+    {
+      "step": "implement",
+      "substep": "run-tests",
+      "from": {
+        "step": "implement",
+        "substep": null
+      },
+      "by": "ai",
+      "at": "2026-05-21T01:52:06Z"
+    }
+  ],
+  "task_summaries": {
+    "T003": {
+      "status": "DONE",
+      "did": "Moved the card border/radius/background onto the outer .inline-editor wrapper so the composer renders as one bordered card.",
+      "files": ["webview/styles/spec-viewer/_editor.css"]
+    },
+    "T004": {
+      "status": "DONE",
+      "did": "Restructured InlineEditor JSX into a single .inline-editor card with stacked header/body/footer regions, keeping all props and callbacks wired identically.",
+      "files": ["webview/src/spec-viewer/components/InlineEditor.tsx"]
+    },
+    "T005": {
+      "status": "DONE",
+      "did": "Styled the header/body/footer regions so they sit flush within the single card boundary with no internal separators.",
+      "files": ["webview/styles/spec-viewer/_editor.css"]
+    },
+    "T006": {
+      "status": "DONE",
+      "did": "Updated the LineMode story to render the single-card paragraph layout via shared args.",
+      "files": ["webview/src/spec-viewer/components/InlineEditor.stories.tsx"]
+    },
+    "T007": {
+      "status": "DONE",
+      "did": "Removed the standalone .editor-actions block and rendered getContextActions buttons in the footer left group with unchanged data-action/onClick wiring.",
+      "files": ["webview/src/spec-viewer/components/InlineEditor.tsx"]
+    },
+    "T008": {
+      "status": "DONE",
+      "did": "Made the footer a flex row with justify-content space-between so secondary actions sit left and primary actions right, with flex-wrap for the multi-action task case.",
+      "files": ["webview/styles/spec-viewer/_editor.css"]
+    },
+    "T009": {
+      "status": "DONE",
+      "did": "Added TaskMode, SectionMode, and UserStoryMode stories covering the distinct secondary-action sets.",
+      "files": ["webview/src/spec-viewer/components/InlineEditor.stories.tsx"]
+    },
+    "T010": {
+      "status": "DONE",
+      "did": "Rendered the card header: line mode shows a target label, row mode folds the scenario context (label + text) into the header region.",
+      "files": ["webview/src/spec-viewer/components/InlineEditor.tsx"]
+    },
+    "T011": {
+      "status": "DONE",
+      "did": "Styled the header with overflow-wrap so long context wraps gracefully and kept primary footer actions right-aligned and non-shrinking.",
+      "files": ["webview/styles/spec-viewer/_editor.css"]
+    },
+    "T012": {
+      "status": "DONE",
+      "did": "Kept row mode returning the tr/td wrapper with the new header/body/footer card inside the cell and no secondary action.",
+      "files": ["webview/src/spec-viewer/components/InlineEditor.tsx"]
+    },
+    "T013": {
+      "status": "DONE",
+      "did": "Updated the RowMode story so the scenario shows in the card header with right-aligned primary actions.",
+      "files": ["webview/src/spec-viewer/components/InlineEditor.stories.tsx"]
+    },
+    "T014": {
+      "status": "DONE",
+      "did": "Removed dead .editor-actions and inner .editor-comment-area/.editor-comment-section CSS left behind by the relocation, preserving context-action/textarea/button styling.",
+      "files": ["webview/styles/spec-viewer/_editor.css"]
+    },
+    "T017": {
+      "status": "DONE",
+      "did": "Ran npm run compile and npm run compile-web; both the extension (tsc) and the webview (webpack) build with no errors.",
+      "files": []
+    },
+    "T001": {
+      "status": "DONE",
+      "did": "Confirmed the extension + webview compile cleanly before/after changes via npm run compile and npm run compile-web.",
+      "files": []
+    },
+    "T002": {
+      "status": "DONE_WITH_CONCERNS",
+      "did": "Skipped the manual Storybook baseline capture — requires a human-driven Storybook session.",
+      "files": [],
+      "concerns": ["Storybook visual baseline (T002) is a manual step and was not run by the AI."]
+    },
+    "T015": {
+      "status": "DONE_WITH_CONCERNS",
+      "did": "Left the live Extension Development Host behavior-regression checklist for a human; cannot drive the F5 viewer interactively.",
+      "files": [],
+      "concerns": ["Behavior regression (Cmd/Ctrl+Enter persist, Escape, auto-focus, empty-submit, lifecycle gating) needs a manual viewer pass."]
+    },
+    "T016": {
+      "status": "DONE_WITH_CONCERNS",
+      "did": "Left live-viewer verification of each relocated secondary action (Remove*/Toggle outcomes) for a human; logic in lineActions.ts is untouched.",
+      "files": [],
+      "concerns": ["Per-line-type secondary action outcomes need a manual viewer pass to confirm no behavior regression."]
+    }
+  }
+}

--- a/specs/097-inline-comment-composer/checklists/requirements.md
+++ b/specs/097-inline-comment-composer/checklists/requirements.md
@@ -1,0 +1,35 @@
+# Specification Quality Checklist: Inline Comment Composer Card
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-21
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Items marked incomplete require spec updates before `/speckit.clarify` or `/speckit.plan`
+- This is a visual restructure of an existing composer; behavior preservation is captured in FR-007/FR-008 and SC-003.

--- a/specs/097-inline-comment-composer/data-model.md
+++ b/specs/097-inline-comment-composer/data-model.md
@@ -1,0 +1,70 @@
+# Data Model: Inline Comment Composer Card
+
+**Feature**: 097-inline-comment-composer
+**Date**: 2026-05-21
+
+This feature introduces **no new data entities and no schema changes**. It
+is a visual restructure of an existing component. The model below documents
+the existing types the composer consumes so the restructure stays
+behavior-preserving (FR-007/FR-008/FR-009).
+
+## Existing types (unchanged)
+
+### `EditorMode`
+`'line' | 'row'` — selects the line composer vs the acceptance-scenario
+row composer. Both must render as a cohesive card (FR-006).
+
+### `InlineEditorProps`
+Props of `InlineEditor` (`webview/src/spec-viewer/components/InlineEditor.tsx`).
+The restructure keeps every field and callback identical:
+
+| Field | Type | Role | Changed? |
+|-------|------|------|----------|
+| `mode` | `EditorMode` | line vs row | no |
+| `lineNum` | `number` | anchor line / scenario number | no |
+| `lineType` | `LineType` | drives secondary action set | no |
+| `scenarioContent` | `string?` | row-mode header context text | no (now shown in card header) |
+| `onSubmit` | `(comment: string) => void` | add comment | no |
+| `onCancel` | `() => void` | close composer | no |
+| `onContextAction` | `(action: string) => void` | secondary action | no |
+
+### `LineType`
+`'user-story' | 'acceptance' | 'task' | 'section' | 'paragraph'` — detected
+by `detectLineType()` in `lineActions.ts`. Unchanged.
+
+### `ContextAction`
+`{ action: string; label: string }` — the secondary action(s) per line
+type, from `getContextActions(lineType)`:
+
+| LineType | Secondary actions (footer, left-aligned) |
+|----------|------------------------------------------|
+| `user-story` | Remove Story |
+| `acceptance` | Remove Scenario |
+| `task` | Toggle, Remove Task |
+| `section` | Remove Section |
+| `paragraph` | Remove Line |
+
+The data and the `handleContextAction` outcomes (add removal refinement /
+toggle checkbox) are unchanged — only where the buttons render moves.
+
+### `Refinement` (persistence — unchanged)
+Created by `addRefinement()` and batched by `submitAllRefinements()` into a
+`submitRefinements` message; the extension appends to the per-doc scratchpad
+(`<docType>-extra.md`). No change to shape or flow.
+
+## View structure (presentation only — not persisted)
+
+The card's regions are layout, not data. For reference:
+
+```text
+.inline-editor (single bordered card)
+├── header   → line: target label ("line N" / type) ; row: scenario text
+├── body     → existing <textarea>
+└── footer   → [secondary actions ··· left]  [Cancel] [Add Comment ··· right]
+```
+
+## State transitions
+
+None. The composer has no new state. Open/close, submit, cancel, and
+context-action flows are identical to today; the lifecycle gate (disabled
+when spec is completed/archived) is unchanged.

--- a/specs/097-inline-comment-composer/plan.md
+++ b/specs/097-inline-comment-composer/plan.md
@@ -1,0 +1,96 @@
+# Implementation Plan: Inline Comment Composer Card
+
+**Branch**: `097-inline-comment-composer` | **Date**: 2026-05-21 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/097-inline-comment-composer/spec.md`
+
+## Summary
+
+Restructure the spec-viewer's inline comment composer so it reads as one
+cohesive, GitHub-style review-comment card instead of a textarea with a
+secondary "Remove Line" button floating above it. The card gains a header
+(what's being commented on), a body (the existing textarea), and a single
+footer row with the secondary line action(s) left-aligned and the primary
+Cancel / Add Comment actions right-aligned. This is a visual restructure
+only — markup placement and CSS change; all composer behavior (anchoring,
+submission, scratchpad persistence, keyboard shortcuts, auto-focus,
+empty-submit cancels, context-action outcomes) is preserved unchanged.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.3+ (ES2022 target, strict mode)
+**Primary Dependencies**: VS Code Extension API (`@types/vscode ^1.84.0`), Preact (webview), Webpack 5
+**Storage**: File-based — refinement comments persist to `<docType>-extra.md` scratchpad (unchanged by this feature)
+**Testing**: Jest (`describe`/`it` BDD) for extension side; Storybook for webview component visual review
+**Target Platform**: VS Code webview (browser context) inside the desktop editor
+**Project Type**: Single project (VS Code extension with bundled webview UI)
+**Performance Goals**: N/A (static layout change; composer is already instant)
+**Constraints**: Visual restructure only — no behavior change, no new comment capabilities (FR-009); must remain themable via VS Code CSS variables
+**Scale/Scope**: One Preact component (`InlineEditor.tsx`), one CSS partial (`_editor.css`), plus Storybook stories. ~6 line types/modes to verify.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- **I. Extensibility and Configuration** — PASS. No provider or
+  configuration surface touched; the action-set data in `lineActions.ts`
+  stays the single source of truth for per-line-type actions.
+- **II. Spec-Driven Workflow** — PASS. Composer is part of the viewer
+  that supports the Specify→Plan→Tasks→Implement pipeline; lifecycle
+  gating (composer disabled when completed/archived) is preserved.
+- **III. Visual and Interactive** — PASS (and directly served). This is a
+  pure UI/UX improvement to a visual, interactive component.
+- **IV. Modular Architecture for Complex Features** — PASS. Change stays
+  within the established modular structure: webview component +
+  CSS partial + Storybook story; no new cross-cutting modules.
+
+No violations. Complexity Tracking not required.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/097-inline-comment-composer/
+├── plan.md              # This file (/speckit.plan command output)
+├── research.md          # Phase 0 output (/speckit.plan command)
+├── data-model.md        # Phase 1 output (/speckit.plan command)
+├── quickstart.md        # Phase 1 output (/speckit.plan command)
+├── checklists/          # Pre-existing checklist artifacts
+└── tasks.md             # Phase 2 output (/speckit.tasks command - NOT created here)
+```
+
+No `contracts/` directory: the composer is a purely internal webview
+component with no external interface (no public API, CLI command, or
+network endpoint). Contracts are not applicable.
+
+### Source Code (repository root)
+
+```text
+webview/
+├── src/spec-viewer/
+│   ├── components/
+│   │   ├── InlineEditor.tsx          # PRIMARY edit: header/body/footer card markup
+│   │   ├── InlineEditor.stories.tsx  # Update + add stories per line type
+│   │   └── InlineComment.tsx         # Persisted-comment card (unchanged)
+│   └── editor/
+│       ├── lineActions.ts            # Action data + handlers (unchanged)
+│       ├── inlineEditor.ts           # Mounting/anchoring (unchanged)
+│       └── refinements.ts            # Add/submit/persist (unchanged)
+└── styles/spec-viewer/
+    └── _editor.css                   # PRIMARY edit: single-card border, footer split
+
+src/features/spec-viewer/
+└── messageHandlers.ts                # Scratchpad persistence (unchanged)
+```
+
+**Structure Decision**: Single-project VS Code extension with a bundled
+Preact webview. The change is confined to the webview component
+`InlineEditor.tsx`, its CSS partial `_editor.css`, and its Storybook
+stories. No extension-side (`src/`) logic changes. This honors the
+extension-isolation rule (no edits to `.claude/**` or `.specify/**`) and
+the "keep the inline-comment UX, layer onto it" guidance — the existing
+mounting, action data, and persistence paths are untouched.
+
+## Complexity Tracking
+
+> No constitution violations; no entries required.

--- a/specs/097-inline-comment-composer/quickstart.md
+++ b/specs/097-inline-comment-composer/quickstart.md
@@ -1,0 +1,85 @@
+# Quickstart: Inline Comment Composer Card
+
+**Feature**: 097-inline-comment-composer
+**Date**: 2026-05-21
+
+How to build, view, and verify the restructured composer.
+
+## Build / run
+
+```bash
+npm install            # if needed
+npm run watch          # auto-compile webview + extension on change
+# Press F5 in VS Code to launch the Extension Development Host
+```
+
+For isolated component review:
+
+```bash
+npm run storybook      # open the Viewer/InlineEditor stories
+```
+
+> Project note: VS Code won't pick up changes without a version bump for a
+> packaged install. For dev, use the Extension Development Host (F5) /
+> `/install-local`. Do **not** commit a version bump into the feature PR.
+
+## Visual acceptance (US1 — single cohesive card)
+
+1. Open a spec in the viewer (editable spec — not completed/archived).
+2. Hover a plain paragraph line; click the "+".
+3. Confirm: the composer is **one bordered card**. No button floats above
+   or outside the border. Header, textarea, and footer are all inside the
+   same boundary. *(SC-001: zero detached controls.)*
+
+## Secondary action placement (US2 — actions inside the card)
+
+For each line type, open the composer and confirm the secondary action(s)
+render **inside the card footer**, left-aligned, never above the textarea:
+
+| Line type | Expected footer secondary action(s) |
+|-----------|-------------------------------------|
+| Paragraph | Remove Line |
+| Section heading | Remove Section |
+| User story header | Remove Story |
+| Task item | Toggle, Remove Task (both fit on one row) |
+| Acceptance scenario (row) | none — header shows scenario only |
+
+Then verify behavior is unchanged (SC-003 / FR-008):
+
+- Click **Remove Line** → adds a "🗑️ Remove this line" refinement comment
+  and closes the composer (same as before).
+- On a task, click **Toggle** → the task checkbox flips; click
+  **Remove Task** → adds a removal refinement.
+
+## GitHub-style header + footer (US3)
+
+1. On a line composer: confirm a **header** indicates the comment target,
+   and **Cancel / Add Comment** are **right-aligned** in the footer.
+2. On an acceptance-scenario row composer: confirm the **scenario context**
+   shows in the header and primary actions are right-aligned. *(SC-005.)*
+
+## Behavior regression checks (FR-007 / SC-003)
+
+- Type a comment, press **Cmd/Ctrl+Enter** → submits and persists.
+- Press **Escape** → composer closes (cancel).
+- Click "+" → textarea is **auto-focused**.
+- Submit with **empty** text → composer just closes (no comment added).
+- Submit a real comment → it persists to the per-doc scratchpad
+  (`<docType>-extra.md`) as before.
+- Open on a **completed/archived** spec → composer remains
+  disabled/unavailable.
+
+## Edge cases (from spec)
+
+- **Task (multi-action)**: Toggle + Remove Task both fit without breaking
+  the single-card layout.
+- **Long scenario text**: header wraps/truncates gracefully; footer
+  controls stay inside the card.
+- **Narrow viewer width**: card and right-aligned footer remain readable
+  and contained.
+
+## Done when
+
+All three user stories pass their independent tests, every behavior in the
+regression list works unchanged, and Storybook shows a single-card layout
+for each line type and the row mode.

--- a/specs/097-inline-comment-composer/research.md
+++ b/specs/097-inline-comment-composer/research.md
@@ -1,0 +1,121 @@
+# Research: Inline Comment Composer Card
+
+**Feature**: 097-inline-comment-composer
+**Date**: 2026-05-21
+
+This is a visual restructure of an existing webview component. No new
+technology is introduced, so research focuses on (a) the current
+implementation's shape, (b) the GitHub layout we're matching, and (c)
+how to relocate controls without breaking any behavior.
+
+## Decision 1: Restructure in-place in `InlineEditor.tsx`, do not rebuild
+
+- **Decision**: Modify the existing `InlineEditor` Preact component
+  (`webview/src/spec-viewer/components/InlineEditor.tsx`) and its styles
+  (`webview/styles/spec-viewer/_editor.css`). Keep the same props,
+  callbacks, mounting code (`editor/inlineEditor.ts`), action data
+  (`editor/lineActions.ts`), and persistence path.
+- **Rationale**: The request is purely a layout fix ("the top button
+  looks weird"). The component already unifies line-mode and row-mode
+  and already wires submit/cancel/context-action callbacks. A rebuild
+  would risk regressing the keyboard shortcuts, auto-focus, anchoring,
+  and scratchpad persistence that FR-007/FR-008 require to stay intact.
+  Project memory also says: keep the existing line-hover "+" /
+  comment-card / dialog system — layer onto it, don't delete it.
+- **Alternatives considered**:
+  - *New `CommentCard` component*: more code, more surface for
+    regression, no user-visible benefit over editing in place.
+  - *CSS-only fix*: rejected. The floating button is a separate DOM
+    block (`.editor-actions`) rendered before the textarea card; making
+    it read as "inside" the card requires moving it in the markup, not
+    just restyling.
+
+## Decision 2: Card anatomy — header / body / footer
+
+- **Decision**: The composer becomes one bordered card with three
+  stacked regions:
+  1. **Header**: context of what's being commented on. Row mode shows
+     the scenario text (today's `.editor-context`). Line mode shows a
+     short target label (e.g. "Commenting on line N" / the line type).
+  2. **Body**: the existing textarea.
+  3. **Footer**: a single row. Secondary line action(s) (Remove*/Toggle)
+     left-aligned; primary actions (Cancel, Add Comment) right-aligned.
+- **Rationale**: This matches the GitHub review-comment card mental model
+  (SC-002) and satisfies FR-001 (single bordered card), FR-003/FR-004
+  (secondary actions inside, primary right-aligned), and FR-005 (header
+  shows target). A left/right split in one flex footer keeps everything
+  on one line and contained (edge case: task has Toggle + Remove Task —
+  both fit on the left).
+- **Alternatives considered**:
+  - *Actions in the header row*: spec allows header OR footer. Footer
+    keeps secondary and primary actions visually grouped as "controls,"
+    which reads more like GitHub and avoids a crowded header when the
+    context text is long.
+  - *Keep `.editor-actions` block but move it below the textarea*: still
+    a separate block; cleaner to fold into the footer.
+
+## Decision 3: The card border moves to the outer `.inline-editor`
+
+- **Decision**: Apply the card border/radius/padding to the outer
+  `.inline-editor` wrapper. Remove the inner `.editor-comment-area`
+  border (or collapse it) so there is exactly one border. The textarea
+  keeps its own input border (it's an input field, not a detached
+  control — consistent with GitHub).
+- **Rationale**: Today `.inline-editor` is transparent/borderless and the
+  border lives on the inner `.editor-comment-area`, which is why the
+  `.editor-actions` button sits visually *outside* the bordered area.
+  Moving the border out makes the header, textarea, and footer all live
+  inside one boundary (FR-001, SC-001).
+- **Alternatives considered**: keeping the border on the inner area and
+  pulling the actions inside it — works too, but moving the border to the
+  wrapper is the cleaner expression of "everything is one card,"
+  especially for row mode where the card lives inside a `<td>`.
+
+## Decision 4: Row mode keeps the `<tr>/<td>` wrapper; card lives in the cell
+
+- **Decision**: Row mode (`mode === 'row'`) still returns
+  `<tr class="inline-editor-row"><td colSpan={4}>…</td></tr>`; the card
+  markup inside the cell uses the same header/body/footer structure, with
+  no secondary action (acceptance-scenario row has none) and the scenario
+  text as the header.
+- **Rationale**: FR-006 requires both modes to be cohesive cards. The
+  table structure must be preserved so the editor row aligns under the
+  scenario row. Only the inner card layout changes.
+- **Alternatives considered**: unifying line/row into one return shape —
+  out of scope and risks table layout regressions.
+
+## Decision 5: Behavior is untouched; only markup + CSS change
+
+- **Decision**: Do not change `lineActions.ts` action data/handlers,
+  `inlineEditor.ts` mounting/anchoring, `refinements.ts`
+  add/submit/persist logic, the keyboard handlers, auto-focus, or
+  empty-submit-cancels. The `onContextAction`, `onSubmit`, `onCancel`
+  props and their wiring stay identical; the buttons just render in a new
+  location.
+- **Rationale**: FR-007, FR-008, FR-009, SC-003 — visual restructure
+  only, zero behavior change. Keeping the callbacks and data layer
+  constant is the safest way to guarantee no regression.
+- **Alternatives considered**: none — changing behavior is explicitly out
+  of scope.
+
+## Decision 6: Verification via Storybook + manual viewer check
+
+- **Decision**: Update the two existing stories
+  (`InlineEditor.stories.tsx` LineMode/RowMode) so the card renders in
+  isolation, and add stories for the line types that have distinct
+  action sets (task = Toggle + Remove Task; section; user-story). Verify
+  the live composer in the spec viewer for each line type and the
+  acceptance-scenario row.
+- **Rationale**: Storybook is the established visual-review surface for
+  these components (existing stories prove the convention). It lets us
+  confirm the single-card layout and footer alignment per line type
+  (US2 independent test) without spinning up a full spec. Manual viewer
+  check covers anchoring + real behavior (SC-003).
+- **Alternatives considered**: automated DOM/snapshot tests — overkill
+  for a layout change; the value is visual and is better judged in
+  Storybook and the live viewer.
+
+## Open questions
+
+None. All FRs map to concrete edits in `InlineEditor.tsx` and
+`_editor.css`; no NEEDS CLARIFICATION remain.

--- a/specs/097-inline-comment-composer/spec.md
+++ b/specs/097-inline-comment-composer/spec.md
@@ -1,0 +1,96 @@
+# Feature Specification: Inline Comment Composer Card
+
+**Feature Branch**: `097-inline-comment-composer`  
+**Created**: 2026-05-21  
+**Status**: Draft  
+**Input**: User description: "The add comment dialog top button looks weird — restructure the inline comment composer to mimic GitHub's review-comment UI (a single contained card with header, textarea, and right-aligned footer actions) so the affordance feels intentional instead of stacked."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Comment composer reads as one cohesive card (Priority: P1)
+
+When a reviewer hovers a line in the spec viewer and opens the inline comment composer, they see a single bordered card that contains everything needed to comment: the context of what they are commenting on, the text input, and the action buttons. No control floats above or outside the card.
+
+**Why this priority**: This is the core of the request. Today a secondary button ("Remove Line") floats above the textarea card and reads as a disconnected control, breaking the visual unit. Fixing the composition is the whole point of the feature and delivers value on its own.
+
+**Independent Test**: Open the composer on a plain paragraph line and confirm the composer is a single bordered card with no detached button stacked above it.
+
+**Acceptance Scenarios**:
+
+1. **Given** a spec is open in the viewer and the spec is editable, **When** the reviewer opens the inline comment composer on a line, **Then** the composer appears as one bordered card with no control rendered outside that border.
+2. **Given** the composer is open, **When** the reviewer looks at the card, **Then** the comment input and the action buttons are visually contained within the same card boundary.
+
+---
+
+### User Story 2 - Secondary line action lives inside the card (Priority: P2)
+
+The context-specific action for the line (e.g., "Remove Line", "Remove Story", "Remove Section", "Remove Scenario", "Remove Task", "Toggle") is presented inside the card — in a header row or in the footer — aligned with the other card controls, instead of floating above the input.
+
+**Why this priority**: Relocating the floating action is what removes the "stacked / disconnected" feel. It depends on the card structure from US1 but is the specific behavior the screenshot calls out.
+
+**Independent Test**: Open the composer on each line type (paragraph, user story, section, acceptance scenario, task) and confirm each line type's action(s) render inside the card, aligned with the card's other controls — never above the card.
+
+**Acceptance Scenarios**:
+
+1. **Given** the composer is open on a paragraph line, **When** the reviewer views the card, **Then** the "Remove Line" action appears within the card (header or footer), not floating above the input.
+2. **Given** the composer is open on a task line that has multiple actions ("Toggle", "Remove Task"), **When** the reviewer views the card, **Then** all actions are grouped inside the card and aligned with the other controls.
+3. **Given** the reviewer activates the relocated secondary action, **When** it is triggered, **Then** it performs exactly the same outcome it did before the restructure (e.g., adds the removal refinement, toggles the task).
+
+---
+
+### User Story 3 - Familiar GitHub-style header and footer layout (Priority: P3)
+
+The card shows a header indicating what is being commented on (the target line or scenario), and the primary actions (Cancel, Add Comment) are right-aligned in the footer — matching the layout reviewers already know from GitHub PR review.
+
+**Why this priority**: This is polish that completes the GitHub mental-model match. The composer is already usable after US1/US2; this makes it feel intentional and familiar.
+
+**Independent Test**: Open the composer on a line and on an acceptance-scenario row and confirm both show a context header and right-aligned primary actions.
+
+**Acceptance Scenarios**:
+
+1. **Given** the composer is open on a line, **When** the reviewer views the card, **Then** a header indicates the comment target (the line) and the primary actions are right-aligned in the footer.
+2. **Given** the composer is open on an acceptance-scenario row, **When** the reviewer views the card, **Then** the scenario context is shown in the header and the primary actions are right-aligned in the footer.
+
+---
+
+### Edge Cases
+
+- **Line type with multiple secondary actions** (task = Toggle + Remove Task): all actions fit inside the card without breaking the single-card layout.
+- **Row (acceptance scenario) composer**: has no secondary line action — the header shows only the scenario context; the layout stays a cohesive card.
+- **Long context text** in the header (e.g., a long scenario sentence): the header wraps or truncates gracefully without pushing controls outside the card.
+- **Empty comment submission**: submitting with no text cancels/closes the composer (existing behavior preserved).
+- **Spec is completed or archived**: the composer remains disabled/unavailable, as it is today.
+- **Narrow viewer width**: the card and its right-aligned footer actions remain readable and contained.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The inline comment composer MUST render as a single bordered card; no control may appear outside that card's border.
+- **FR-002**: The floating action button currently rendered above the comment input MUST be removed and its action relocated into the card (header row or footer).
+- **FR-003**: Context-specific line actions (Remove Line, Remove Story, Remove Section, Remove Scenario, Remove Task, Toggle) MUST be presented inside the card, visually aligned with the card's other controls.
+- **FR-004**: The primary footer actions (Cancel and Add Comment) MUST be right-aligned within the card footer.
+- **FR-005**: The card MUST display a header that indicates what is being commented on (the target line or the acceptance scenario).
+- **FR-006**: The restructure MUST apply to both the line-mode composer and the row-mode (acceptance-scenario) composer, each presented as a cohesive card.
+- **FR-007**: All existing composer behavior MUST be preserved unchanged: line/row anchoring, comment submission, refinement persistence via the scratchpad, the Escape-to-cancel and Cmd/Ctrl+Enter-to-submit shortcuts, auto-focus of the input, and empty-submission cancelling the composer.
+- **FR-008**: Activating a relocated secondary action MUST produce the same outcome it produced before the restructure (e.g., adding the removal refinement comment, toggling the task checkbox).
+- **FR-009**: This change MUST be a visual restructure only — no new comment capabilities are added.
+
+### Out of Scope
+
+- Write/Preview tabs.
+- Formatting toolbar.
+- File attachments.
+- Comment threading and replies.
+- "Start a review" batching of comments.
+- Mentions / autocomplete.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: The composer reads as a single visual unit — on inspection, zero controls appear detached or floating outside the card border (today there is one).
+- **SC-002**: A reviewer familiar with GitHub PR review can locate the comment input, the secondary action, and the submit/cancel actions without instruction.
+- **SC-003**: 100% of existing composer behaviors (add comment, cancel, each remove/toggle action, scratchpad persistence, keyboard shortcuts, auto-focus) continue to work after the restructure — no regressions.
+- **SC-004**: Commenting on a line takes the same number of clicks as before the change (the restructure adds no extra steps).
+- **SC-005**: Both the line composer and the acceptance-scenario row composer present a context header and right-aligned primary actions.

--- a/specs/097-inline-comment-composer/tasks.md
+++ b/specs/097-inline-comment-composer/tasks.md
@@ -1,0 +1,178 @@
+---
+description: "Task list for Inline Comment Composer Card"
+---
+
+# Tasks: Inline Comment Composer Card
+
+**Input**: Design documents from `/specs/097-inline-comment-composer/`
+**Prerequisites**: plan.md (required), spec.md (required), research.md, data-model.md, quickstart.md
+
+**Tests**: No automated test tasks. Per research Decision 6, verification is via
+Storybook (visual review) and a manual viewer pass — automated DOM/snapshot
+tests are explicitly out of scope for this layout change.
+
+**Organization**: Tasks are grouped by user story to enable independent
+implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (US1, US2, US3)
+- Include exact file paths in descriptions
+
+## Path Conventions
+
+Single-project VS Code extension with a bundled Preact webview. All changes
+live under `webview/src/spec-viewer/` and `webview/styles/spec-viewer/`. No
+extension-side (`src/`) changes (plan: Structure Decision).
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Confirm the build/preview toolchain works before touching the composer.
+
+- [X] T001 Run `npm install` (if needed) then `npm run watch` from repo root to confirm the webview + extension compile cleanly before changes (per quickstart.md "Build / run")
+- [ ] T002 Launch `npm run storybook` and open `Viewer/InlineEditor` (LineMode, RowMode) to capture the current "floating button above textarea" baseline in `webview/src/spec-viewer/components/InlineEditor.stories.tsx` *(manual visual baseline — not run by AI)*
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: The single structural change that every user story builds on — the card must become one bordered container before actions/header can be placed inside it.
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete
+
+- [X] T003 In `webview/styles/spec-viewer/_editor.css`, move the card border/radius/padding/background from `.editor-comment-area` onto the outer `.inline-editor` wrapper (border, `var(--radius-md)`, padding, `var(--bg-*)`); collapse the inner `.editor-comment-area` border so exactly one card boundary remains (research Decision 3; FR-001, SC-001). Keep the `.editor-textarea` input border intact.
+
+**Checkpoint**: The composer renders as a single bordered card (textarea inside one border). User story implementation can now begin.
+
+---
+
+## Phase 3: User Story 1 - Comment composer reads as one cohesive card (Priority: P1) 🎯 MVP
+
+**Goal**: The composer is a single bordered card containing the input and actions — no control rendered outside the card border.
+
+**Independent Test**: Open the composer on a plain paragraph line; confirm it is one bordered card with no detached button stacked above it (quickstart "Visual acceptance").
+
+### Implementation for User Story 1
+
+- [X] T004 [US1] In `webview/src/spec-viewer/components/InlineEditor.tsx`, restructure the `editorBody` JSX into a single `.inline-editor` card with three stacked regions — header, body (existing `<textarea>`), footer — so all markup is nested inside one wrapper (research Decision 2; FR-001, FR-006). Keep `mode`/`onSubmit`/`onCancel`/`onContextAction` wiring identical (data-model: props unchanged).
+- [X] T005 [US1] In `webview/styles/spec-viewer/_editor.css`, style the new `.inline-editor` header / body / footer regions so the header, textarea, and footer sit flush within the single card boundary with no internal separator lines (FR-001; existing "no visual separators" rule preserved).
+- [X] T006 [P] [US1] In `webview/src/spec-viewer/components/InlineEditor.stories.tsx`, update the `LineMode` story (paragraph) so it renders the single-card layout; visually confirm in Storybook that no control floats outside the border (SC-001).
+
+**Checkpoint**: Paragraph-line composer is a single cohesive card — US1 independently testable.
+
+---
+
+## Phase 4: User Story 2 - Secondary line action lives inside the card (Priority: P2)
+
+**Goal**: Each line type's secondary action(s) (Remove Line / Remove Story / Remove Section / Remove Scenario / Toggle + Remove Task) render inside the card footer, left-aligned, never above the textarea — and behave exactly as before.
+
+**Independent Test**: Open the composer on each line type (paragraph, user story, section, acceptance scenario, task) and confirm each line type's action(s) render inside the card footer aligned with other controls; activate each and confirm the same outcome as before (quickstart "Secondary action placement").
+
+### Implementation for User Story 2
+
+- [X] T007 [US2] In `webview/src/spec-viewer/components/InlineEditor.tsx`, remove the standalone `.editor-actions` block rendered before the textarea and render the `getContextActions(lineType)` buttons inside the footer, left-aligned, keeping each button's `data-action`, `key`, and `onClick={() => onContextAction(action)}` exactly as today (FR-002, FR-003, FR-008; data-model: action data/handlers unchanged).
+- [X] T008 [US2] In `webview/styles/spec-viewer/_editor.css`, make the footer a single flex row with secondary actions left-aligned and primary actions right-aligned (`justify-content: space-between` or a left/right group split); ensure the task case (Toggle + Remove Task) fits on one row without breaking the card (FR-003; edge case "multi-action task"). Preserve existing `.context-action` ghost/hover styling.
+- [X] T009 [P] [US2] In `webview/src/spec-viewer/components/InlineEditor.stories.tsx`, add stories for the distinct action sets — `TaskMode` (Toggle + Remove Task), `SectionMode` (Remove Section), and `UserStoryMode` (Remove Story) — and verify in Storybook each renders its action(s) inside the footer (US2 independent test; research Decision 6).
+
+**Checkpoint**: All line types show their secondary action(s) inside the card footer with unchanged behavior — US1 + US2 work independently.
+
+---
+
+## Phase 5: User Story 3 - Familiar GitHub-style header and footer layout (Priority: P3)
+
+**Goal**: The card shows a header indicating the comment target, and the primary actions (Cancel, Add Comment) are right-aligned in the footer — for both line mode and acceptance-scenario row mode.
+
+**Independent Test**: Open the composer on a line and on an acceptance-scenario row; confirm both show a context header and right-aligned primary actions (quickstart "GitHub-style header + footer").
+
+### Implementation for User Story 3
+
+- [X] T010 [US3] In `webview/src/spec-viewer/components/InlineEditor.tsx`, render the card header: line mode shows a short target label (e.g. "Commenting on line {lineNum}" / line type); row mode shows the existing scenario context (`Scenario {lineNum}:` + `scenarioContent`) folded into the header region instead of the separate `.editor-context` block (FR-005, FR-006; data-model: `scenarioContent` now shown in header).
+- [X] T011 [US3] In `webview/styles/spec-viewer/_editor.css`, style the header (target/scenario label + text) so long context text wraps or truncates gracefully without pushing controls outside the card, and keep the footer primary actions (`.editor-buttons`) right-aligned (FR-004, FR-005; edge cases "long context text", "narrow viewer width").
+- [X] T012 [US3] In `webview/src/spec-viewer/components/InlineEditor.tsx`, ensure row mode still returns `<tr class="inline-editor-row"><td colSpan={4} class="editor-cell">{card}</td></tr>` with the new header/body/footer card inside the cell and no secondary action (research Decision 4; FR-006).
+- [X] T013 [P] [US3] In `webview/src/spec-viewer/components/InlineEditor.stories.tsx`, update the `RowMode` story so the scenario shows in the card header with right-aligned primary actions; confirm in Storybook (SC-005).
+
+**Checkpoint**: Both line and row composers present a context header with right-aligned primary actions — all three stories independently functional.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Behavior-regression verification and cleanup across all stories.
+
+- [X] T014 Remove any now-dead CSS in `webview/styles/spec-viewer/_editor.css` left behind by the relocation (e.g. obsolete `.editor-actions` margin/`margin-bottom` rules, redundant `.editor-comment-area` border rules) without changing `.context-action`, `.editor-textarea`, `.editor-cancel`, `.editor-add` appearance.
+- [ ] T015 Run the full behavior-regression checklist from quickstart.md in the Extension Development Host (F5): Cmd/Ctrl+Enter submits & persists to `<docType>-extra.md`, Escape cancels, "+" auto-focuses the textarea, empty submit just closes, and the composer stays disabled on a completed/archived spec (FR-007, SC-003). *(manual live-viewer pass — not run by AI)*
+- [ ] T016 Verify each relocated secondary action in the live viewer produces its prior outcome: Remove Line/Story/Section/Scenario/Task each add the removal refinement comment, and Toggle flips the task checkbox (FR-008, SC-003). *(manual live-viewer pass — not run by AI)*
+- [X] T017 Run `npm run compile` (and lint if configured) from repo root to confirm the webview builds with no TypeScript errors after the restructure.
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies — can start immediately.
+- **Foundational (Phase 2)**: Depends on Setup. T003 (single border on `.inline-editor`) BLOCKS all user stories — every story renders content inside this card.
+- **User Stories (Phase 3–5)**: All depend on Phase 2. Because US1, US2, US3 all edit the same two files (`InlineEditor.tsx`, `_editor.css`), run them sequentially in priority order (P1 → P2 → P3) to avoid same-file conflicts; the `.stories.tsx` tasks (T006, T009, T013) are the parallel-safe exceptions.
+- **Polish (Phase 6)**: Depends on all desired user stories being complete.
+
+### User Story Dependencies
+
+- **US1 (P1)**: Starts after Phase 2 — no dependency on other stories. MVP.
+- **US2 (P2)**: Builds on the US1 card structure (footer must exist) — implement after US1.
+- **US3 (P3)**: Builds on the US1 card structure (header region) and shares the footer with US2 — implement after US2.
+
+### Within Each User Story
+
+- `.tsx` markup change before `_editor.css` styling that targets it.
+- Storybook story update last (verifies the result) — and is `[P]` because it touches only `.stories.tsx`.
+
+### Parallel Opportunities
+
+- T001 and T002 (Setup) are sequential (watch then storybook), but independent of everything else.
+- Within a story, the `[P]` Storybook task (T006 / T009 / T013) can be written in parallel with the next story's planning since it only touches `InlineEditor.stories.tsx`.
+- T015 and T016 (Polish, live-viewer checks) can be done together in one Extension Development Host session.
+- Cross-story parallelism is NOT available: US1/US2/US3 all edit `InlineEditor.tsx` and `_editor.css`.
+
+---
+
+## Parallel Example: Storybook stories (after their story's markup lands)
+
+```bash
+# These only touch InlineEditor.stories.tsx and can be batched once the
+# corresponding markup (T004 / T007 / T010-T012) is in place:
+Task: "T006 Update LineMode story for single-card layout"
+Task: "T009 Add TaskMode / SectionMode / UserStoryMode stories"
+Task: "T013 Update RowMode story for header + right-aligned actions"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Phase 1: Setup (confirm build + capture baseline).
+2. Phase 2: Foundational (T003 — single card border). CRITICAL, blocks all stories.
+3. Phase 3: User Story 1 (one cohesive card on a paragraph line).
+4. **STOP and VALIDATE**: Open the composer on a paragraph line — one bordered card, nothing floating (SC-001).
+5. Demo if ready.
+
+### Incremental Delivery
+
+1. Setup + Foundational → single-card boundary exists.
+2. US1 → cohesive card → validate → demo (MVP!).
+3. US2 → secondary actions inside footer → validate per line type → demo.
+4. US3 → header + right-aligned primary actions, row mode → validate → demo.
+5. Polish → run full regression + behavior checks (SC-003) → compile.
+
+### Notes
+
+- [P] tasks = different file (`.stories.tsx`), no dependency on incomplete tasks.
+- This is a visual restructure only (FR-009): keep all props, callbacks, action
+  data (`lineActions.ts`), mounting (`inlineEditor.ts`), and persistence
+  (`refinements.ts`) untouched — buttons only change location.
+- Do NOT commit a version bump into the feature PR (quickstart project note).
+- Commit after each story or logical group; stop at any checkpoint to validate.

--- a/webview/src/spec-viewer/components/InlineEditor.stories.tsx
+++ b/webview/src/spec-viewer/components/InlineEditor.stories.tsx
@@ -9,17 +9,54 @@ export default meta;
 
 type Story = StoryObj<typeof InlineEditor>;
 
+const lineArgs = {
+    onSubmit: (comment: string) => console.log('submit', comment),
+    onCancel: () => console.log('cancel'),
+    onContextAction: (action: string) => console.log('action', action),
+};
+
+// Single-card layout on a plain paragraph line: footer shows "Remove Line".
 export const LineMode: Story = {
     args: {
         mode: 'line',
         lineNum: 12,
         lineType: 'paragraph',
-        onSubmit: (comment: string) => console.log('submit', comment),
-        onCancel: () => console.log('cancel'),
-        onContextAction: (action: string) => console.log('action', action),
+        ...lineArgs,
     },
 };
 
+// Task line: footer carries two secondary actions (Toggle + Remove Task).
+export const TaskMode: Story = {
+    args: {
+        mode: 'line',
+        lineNum: 24,
+        lineType: 'task',
+        ...lineArgs,
+    },
+};
+
+// Section heading line: footer shows "Remove Section".
+export const SectionMode: Story = {
+    args: {
+        mode: 'line',
+        lineNum: 5,
+        lineType: 'section',
+        ...lineArgs,
+    },
+};
+
+// User story header line: footer shows "Remove Story".
+export const UserStoryMode: Story = {
+    args: {
+        mode: 'line',
+        lineNum: 8,
+        lineType: 'user-story',
+        ...lineArgs,
+    },
+};
+
+// Acceptance-scenario row: scenario context shows in the card header,
+// primary actions right-aligned, no secondary action.
 export const RowMode: Story = {
     decorators: [(Story) => <table><tbody><Story /></tbody></table>],
     args: {
@@ -27,8 +64,6 @@ export const RowMode: Story = {
         lineNum: 3,
         lineType: 'acceptance',
         scenarioContent: 'Given a user with valid credentials, When they submit the login form, Then they are redirected to the dashboard',
-        onSubmit: (comment: string) => console.log('submit', comment),
-        onCancel: () => console.log('cancel'),
-        onContextAction: (action: string) => console.log('action', action),
+        ...lineArgs,
     },
 };

--- a/webview/src/spec-viewer/components/InlineEditor.tsx
+++ b/webview/src/spec-viewer/components/InlineEditor.tsx
@@ -38,10 +38,28 @@ export function InlineEditor(props: InlineEditorProps) {
 
     const contextActions = mode === 'line' ? getContextActions(lineType) : [];
 
-    const editorBody = (
+    const card = (
         <div class="inline-editor">
-            {mode === 'line' && contextActions.length > 0 && (
-                <div class="editor-actions">
+            <div class="editor-header">
+                {mode === 'row' && scenarioContent ? (
+                    <>
+                        <span class="editor-context-label">Scenario {lineNum}:</span>
+                        <span class="editor-context-text">{scenarioContent}</span>
+                    </>
+                ) : (
+                    <span class="editor-header-target">Commenting on line {lineNum}</span>
+                )}
+            </div>
+            <div class="editor-body">
+                <textarea
+                    ref={textareaRef}
+                    class="editor-textarea"
+                    placeholder="Add a comment or refinement instruction..."
+                    onKeyDown={handleKeydown}
+                />
+            </div>
+            <div class="editor-footer">
+                <div class="editor-footer-actions">
                     {contextActions.map(({ action, label }) => (
                         <button
                             key={action}
@@ -53,20 +71,6 @@ export function InlineEditor(props: InlineEditorProps) {
                         </button>
                     ))}
                 </div>
-            )}
-            {mode === 'row' && scenarioContent && (
-                <div class="editor-context">
-                    <span class="editor-context-label">Scenario {lineNum}:</span>
-                    <span class="editor-context-text">{scenarioContent}</span>
-                </div>
-            )}
-            <div class="editor-comment-section editor-comment-area">
-                <textarea
-                    ref={textareaRef}
-                    class="editor-textarea"
-                    placeholder="Add a comment or refinement instruction..."
-                    onKeyDown={handleKeydown}
-                />
                 <div class="editor-buttons">
                     <button class="editor-cancel" onClick={onCancel}>Cancel</button>
                     <button class="editor-add" onClick={handleAdd}>Add Comment</button>
@@ -78,10 +82,10 @@ export function InlineEditor(props: InlineEditorProps) {
     if (mode === 'row') {
         return (
             <tr class="inline-editor-row">
-                <td colSpan={4} class="editor-cell">{editorBody}</td>
+                <td colSpan={4} class="editor-cell">{card}</td>
             </tr>
         );
     }
 
-    return editorBody;
+    return card;
 }

--- a/webview/src/spec-viewer/components/InlineEditor.tsx
+++ b/webview/src/spec-viewer/components/InlineEditor.tsx
@@ -41,11 +41,13 @@ export function InlineEditor(props: InlineEditorProps) {
     const card = (
         <div class="inline-editor">
             <div class="editor-header">
-                {mode === 'row' && scenarioContent ? (
-                    <>
-                        <span class="editor-context-label">Scenario {lineNum}:</span>
-                        <span class="editor-context-text">{scenarioContent}</span>
-                    </>
+                {mode === 'row' ? (
+                    scenarioContent && (
+                        <>
+                            <span class="editor-context-label">Scenario {lineNum}:</span>
+                            <span class="editor-context-text">{scenarioContent}</span>
+                        </>
+                    )
                 ) : (
                     <span class="editor-header-target">Commenting on line {lineNum}</span>
                 )}

--- a/webview/styles/spec-viewer/_editor.css
+++ b/webview/styles/spec-viewer/_editor.css
@@ -31,6 +31,17 @@
     color: var(--text-secondary);
 }
 
+/* Row-mode scenario context shown in the header */
+.editor-context-label {
+    font-weight: 600;
+    color: var(--text-secondary);
+    margin-right: 8px;
+}
+
+.editor-context-text {
+    font-style: italic;
+}
+
 /* Body - the existing textarea */
 .editor-body {
     padding: var(--space-2) var(--space-3);

--- a/webview/styles/spec-viewer/_editor.css
+++ b/webview/styles/spec-viewer/_editor.css
@@ -1,27 +1,85 @@
 /**
  * SpecKit Companion - Inline Editor Styles
- * GitHub-style inline editor
+ * GitHub-style inline comment composer card
  */
 
 /* ============================================
-   Inline Editor (GitHub-style)
+   Inline Editor Card (GitHub-style)
    ============================================ */
 
+/* Single bordered card: header, body, footer all live inside one boundary */
 .inline-editor {
     margin: 8px 0 4px 0;
-    padding: 8px 0;
-    background: transparent;
-    border: none;
-    border-radius: 0;
+    background: var(--bg-secondary);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-md);
     box-shadow: none;
+    overflow: hidden;
     animation: slideDown var(--transition-fast) ease-out;
 }
 
-.editor-actions {
+/* Header - what's being commented on */
+.editor-header {
+    padding: var(--space-2) var(--space-3) 0;
+    font-size: var(--text-sm);
+    color: var(--text-muted);
+    overflow-wrap: anywhere;
+}
+
+.editor-header-target {
+    font-weight: 500;
+    color: var(--text-secondary);
+}
+
+/* Body - the existing textarea */
+.editor-body {
+    padding: var(--space-2) var(--space-3);
+}
+
+.editor-textarea {
+    width: 100%;
+    min-height: 60px;
+    padding: 10px 12px;
+    background: var(--bg-primary);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    color: var(--text-primary);
+    font-size: 13px;
+    font-family: var(--font-family);
+    line-height: 1.5;
+    resize: vertical;
+    outline: none;
+    transition: border-color var(--transition-fast);
+}
+
+.editor-textarea:focus {
+    border-color: var(--accent);
+}
+
+.editor-textarea::placeholder {
+    color: var(--text-muted);
+}
+
+/* Footer - secondary actions left, primary actions right */
+.editor-footer {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+    padding: 0 var(--space-3) var(--space-2);
+}
+
+.editor-footer-actions {
     display: flex;
     gap: 8px;
     flex-wrap: wrap;
-    margin-bottom: 8px;
+}
+
+.editor-buttons {
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+    flex-shrink: 0;
 }
 
 /* Context action buttons - ghost style */
@@ -74,57 +132,7 @@
     color: var(--success);
 }
 
-/* Editor divider removed per FR-011 */
-
-/* Ensure no visual separators between editor sections */
-.editor-actions {
-    border-bottom: none;
-}
-
-.editor-comment-section {
-    display: flex;
-    flex-direction: column;
-    gap: 8px;
-    border-top: none;
-}
-
-.editor-comment-area {
-    border: 1px solid var(--border);
-    border-radius: var(--radius-md);
-    padding: var(--space-3);
-    margin-top: var(--space-2);
-}
-
-.editor-textarea {
-    width: 100%;
-    min-height: 60px;
-    padding: 10px 12px;
-    background: var(--bg-primary);
-    border: 1px solid var(--border);
-    border-radius: var(--radius-sm);
-    color: var(--text-primary);
-    font-size: 13px;
-    font-family: var(--font-family);
-    line-height: 1.5;
-    resize: vertical;
-    outline: none;
-    transition: border-color var(--transition-fast);
-}
-
-.editor-textarea:focus {
-    border-color: var(--accent);
-}
-
-.editor-textarea::placeholder {
-    color: var(--text-muted);
-}
-
-.editor-buttons {
-    display: flex;
-    justify-content: flex-end;
-    gap: 8px;
-}
-
+/* Primary actions */
 .editor-cancel,
 .editor-add {
     padding: 6px 14px;

--- a/webview/styles/spec-viewer/_tables.css
+++ b/webview/styles/spec-viewer/_tables.css
@@ -343,23 +343,6 @@
     border-left: 3px solid var(--accent);
 }
 
-/* Editor context showing the scenario content */
-.editor-context {
-    font-size: var(--text-sm);
-    color: var(--text-muted);
-    padding-bottom: 8px;
-}
-
-.editor-context-label {
-    font-weight: 600;
-    color: var(--text-secondary);
-    margin-right: 8px;
-}
-
-.editor-context-text {
-    font-style: italic;
-}
-
 /* Comment row for scenario table */
 .comment-row {
     background: transparent;


### PR DESCRIPTION
## Summary

- Restructure the spec-viewer inline comment composer into one cohesive, GitHub-style review-comment card: **header** (what's being commented on) → **body** (textarea) → **footer** (secondary line actions left, Cancel / Add Comment right).
- Move the card border onto the outer `.inline-editor` wrapper so the header, textarea, and footer all sit inside a single boundary — no control floats above the textarea anymore.
- Visual restructure only: props, callbacks, action data (`lineActions.ts`), mounting (`inlineEditor.ts`), and scratchpad persistence (`refinements.ts`) are untouched — buttons only changed location.
- Add Storybook stories for the distinct per-line-type action sets (`TaskMode`, `SectionMode`, `UserStoryMode`) and refresh `LineMode` / `RowMode`.

Spec: `specs/097-inline-comment-composer/`

## Test plan

- [x] `npm run compile` (tsc) passes
- [x] `npm run compile-web` (webpack) bundles cleanly
- [ ] Storybook: confirm single-card layout for each line type + row mode (manual visual)
- [ ] Live viewer (F5): single bordered card on a paragraph line, secondary actions inside the footer per line type, header + right-aligned primary actions in line and row modes
- [ ] Behavior regression: Cmd/Ctrl+Enter persists, Escape cancels, "+" auto-focuses, empty submit just closes, composer disabled on completed/archived specs
- [ ] Each relocated action produces its prior outcome (Remove* adds a refinement; Toggle flips the task checkbox)

🤖 Generated with [Claude Code](https://claude.com/claude-code)