### PR TITLE
chore: prefix demo testing specs (_00/_01/_02) + fix 099 status

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,9 @@ storybook-static/
 # Local-only demo spec dirs (underscore-prefixed under specs/)
 specs/_*/
 
+# Committed demo testing fixtures (one per viewer state) — tracked at a fixed
+# baseline so the viewer can be opened against known states. See CLAUDE.md.
+!specs/_00_demo-specified/
+!specs/_01_demo-planned/
+!specs/_02_demo-tasked/
+

--- a/specs/099-step-button-loading-state/.spec-context.json
+++ b/specs/099-step-button-loading-state/.spec-context.json
@@ -326,7 +326,6 @@
       "at": "2026-05-21T13:10:30Z"
     }
   ],
-  "status": "draft",
   "stepHistory": {
     "specify": {
       "startedAt": "2026-05-21T12:42:11.649Z",

--- a/specs/_00_demo-specified/.spec-context.json
+++ b/specs/_00_demo-specified/.spec-context.json
@@ -1,0 +1,15 @@
+{
+  "workflow": "speckit",
+  "specName": "Demo — Specified",
+  "branch": "demo/specified",
+  "selectedAt": "2026-05-20T20:00:00.000Z",
+  "currentStep": "specify",
+  "status": "specified",
+  "stepHistory": {
+    "specify": {
+      "startedAt": "2026-05-20T20:00:00.000Z",
+      "completedAt": "2026-05-20T20:05:00.000Z"
+    }
+  },
+  "transitions": []
+}

--- a/specs/_00_demo-specified/spec.md
+++ b/specs/_00_demo-specified/spec.md
@@ -1,0 +1,22 @@
+# Spec: Demo — Dark Mode Toggle
+
+> Canonical testing fixture in the **specified** state (spec only, no plan/tasks).
+> Committed at a fixed baseline — do NOT commit local edits (see CLAUDE.md).
+
+## Summary
+
+Add a dark-mode toggle to the app header so users can switch themes without
+opening settings.
+
+## Requirements
+
+- **R001** (MUST): A toggle in the header switches between light and dark themes.
+- **R002** (MUST): The chosen theme persists across reloads.
+- **R003** (SHOULD): The toggle reflects the OS theme on first load.
+
+## Scenarios
+
+### Toggle the theme
+
+**When** the user clicks the header toggle
+**Then** the app switches theme immediately and remembers the choice on reload

--- a/specs/_01_demo-planned/.spec-context.json
+++ b/specs/_01_demo-planned/.spec-context.json
@@ -1,0 +1,19 @@
+{
+  "workflow": "speckit",
+  "specName": "Demo — Planned",
+  "branch": "demo/planned",
+  "selectedAt": "2026-05-20T20:00:00.000Z",
+  "currentStep": "plan",
+  "status": "planned",
+  "stepHistory": {
+    "specify": {
+      "startedAt": "2026-05-20T20:00:00.000Z",
+      "completedAt": "2026-05-20T20:05:00.000Z"
+    },
+    "plan": {
+      "startedAt": "2026-05-20T20:05:00.000Z",
+      "completedAt": "2026-05-20T20:10:00.000Z"
+    }
+  },
+  "transitions": []
+}

--- a/specs/_01_demo-planned/plan.md
+++ b/specs/_01_demo-planned/plan.md
@@ -1,0 +1,13 @@
+# Plan: Demo — CSV Export
+
+**Spec**: [spec.md](./spec.md)
+
+## Approach
+
+Serialize the already-materialized table view-model (post filter/sort) to CSV in
+the browser and trigger a download via a Blob URL — no backend round-trip.
+
+## Files
+
+- `table/exportCsv.ts` — view-model → CSV string (escaping, header row).
+- `table/TableToolbar.tsx` — add the "Export CSV" button wired to the download.

--- a/specs/_01_demo-planned/spec.md
+++ b/specs/_01_demo-planned/spec.md
@@ -1,0 +1,21 @@
+# Spec: Demo — CSV Export
+
+> Canonical testing fixture in the **planned** state (spec + plan, no tasks).
+> Committed at a fixed baseline — do NOT commit local edits (see CLAUDE.md).
+
+## Summary
+
+Let users export the current table view to a CSV file.
+
+## Requirements
+
+- **R001** (MUST): An "Export CSV" action downloads the current rows as `.csv`.
+- **R002** (MUST): The export respects the active filter and sort.
+- **R003** (SHOULD): Column headers match the visible table headers.
+
+## Scenarios
+
+### Export the current view
+
+**When** the user clicks "Export CSV" with a filter applied
+**Then** a CSV of the filtered, sorted rows downloads with matching headers

--- a/specs/_02_demo-tasked/.spec-context.json
+++ b/specs/_02_demo-tasked/.spec-context.json
@@ -1,0 +1,23 @@
+{
+  "workflow": "speckit",
+  "specName": "Demo — Tasked",
+  "branch": "demo/tasked",
+  "selectedAt": "2026-05-20T20:00:00.000Z",
+  "currentStep": "tasks",
+  "status": "ready-to-implement",
+  "stepHistory": {
+    "specify": {
+      "startedAt": "2026-05-20T20:00:00.000Z",
+      "completedAt": "2026-05-20T20:05:00.000Z"
+    },
+    "plan": {
+      "startedAt": "2026-05-20T20:05:00.000Z",
+      "completedAt": "2026-05-20T20:10:00.000Z"
+    },
+    "tasks": {
+      "startedAt": "2026-05-20T20:10:00.000Z",
+      "completedAt": "2026-05-20T20:15:00.000Z"
+    }
+  },
+  "transitions": []
+}

--- a/specs/_02_demo-tasked/plan.md
+++ b/specs/_02_demo-tasked/plan.md
@@ -1,0 +1,14 @@
+# Plan: Demo — Command Palette Quick-Open
+
+**Spec**: [spec.md](./spec.md)
+
+## Approach
+
+A modal overlay backed by a small fuzzy matcher over an in-memory item index.
+Recent items come from a capped MRU list in local storage.
+
+## Files
+
+- `palette/fuzzy.ts` — ranking/scoring for the query.
+- `palette/CommandPalette.tsx` — modal, input, result list, keyboard nav.
+- `palette/useRecentItems.ts` — MRU list persisted to local storage.

--- a/specs/_02_demo-tasked/spec.md
+++ b/specs/_02_demo-tasked/spec.md
@@ -1,0 +1,22 @@
+# Spec: Demo — Command Palette Quick-Open
+
+> Canonical testing fixture in the **tasked-out** state (spec + plan + tasks,
+> ready to implement). Committed at a fixed baseline — do NOT commit local edits
+> (see CLAUDE.md).
+
+## Summary
+
+Add a keyboard-driven quick-open palette so users can jump to any item by name.
+
+## Requirements
+
+- **R001** (MUST): A shortcut opens a fuzzy-search palette over all items.
+- **R002** (MUST): Selecting a result navigates to that item.
+- **R003** (SHOULD): The palette shows recent items when the query is empty.
+
+## Scenarios
+
+### Jump to an item
+
+**When** the user presses the shortcut and types part of an item's name
+**Then** matching items rank by relevance and Enter navigates to the top match

--- a/specs/_02_demo-tasked/tasks.md
+++ b/specs/_02_demo-tasked/tasks.md
@@ -1,0 +1,10 @@
+# Tasks: Demo — Command Palette Quick-Open
+
+**Plan**: [plan.md](./plan.md)
+
+## Phase 1: Core Implementation
+
+- [ ] **T001** Fuzzy matcher — `palette/fuzzy.ts` | R001
+- [ ] **T002** [P] Recent-items MRU hook — `palette/useRecentItems.ts` | R003
+- [ ] **T003** Palette modal + keyboard nav — `palette/CommandPalette.tsx` *(depends on T001)* | R001, R002
+- [ ] **T004** Wire the open shortcut and navigation — `palette/CommandPalette.tsx` *(depends on T003)* | R002


### PR DESCRIPTION
## What

- **Rename the committed demo testing fixtures** to sequential prefixes so they sort in workflow order:
  - `_demo-specified` → `_00_demo-specified`
  - `_demo-planned` → `_01_demo-planned`
  - `_demo-tasked` → `_02_demo-tasked`
  - Adds matching `.gitignore` negation exceptions (base rule is `specs/_*/`) so the fixtures stay tracked.
- **Fix spec 099's status** — removed a stray duplicate `"status": "draft"` after the `transitions` array in `specs/099-step-button-loading-state/.spec-context.json`. JSON keeps the last key, so the duplicate was overriding the correct top-level `"status": "completed"` and the spec showed under **Active** instead of **Completed**.

## Why

The demo fixtures are manual-testing specs (one per viewer state); a numeric prefix makes them sort predictably. The 099 duplicate was a data glitch making a shipped spec look active.

## Notes

- **Data + gitignore only — no `src/`/`webview/` changes.**
- No version bump.
- The `feat/100-ide-chat-provider` branch (PR #165) still carries these fixtures under the old `_demo-*` names; they'll reconcile to the `_0N_` prefix when that PR merges.

## Testing

- `git show --stat` contains only the 099 `.spec-context.json` edit + the three `_0N_demo-*` dirs + `.gitignore`.
- Sidebar: 099 appears under Completed; demos render as `_00 / _01 / _02` in workflow order.