### PR TITLE
fix(spec-viewer): handle CRLF and strip spec-kit boilerplate

### DIFF
--- a/specs/103-fix-spec-doc-rendering/.spec-context.json
+++ b/specs/103-fix-spec-doc-rendering/.spec-context.json
@@ -7,6 +7,8 @@
   "next": "done",
   "status": "completed",
   "checkpointStatus": { "commit": true, "pr": true },
+  "prUrl": "https://github.com/alfredoperez/speckit-companion/pull/170",
+  "prNumber": 170,
   "updated": "2026-05-22",
   "selectedAt": "2026-05-22T12:05:53.442Z",
   "specName": "Fix Spec Document Rendering (CRLF + Frontmatter)",
@@ -16,7 +18,7 @@
   "createdAt": "2026-05-22T12:05:53.442Z",
   "loadedDomains": [],
   "approach": "Normalize CRLF/CR to LF and strip leading YAML frontmatter at the top of renderMarkdown, before the preprocessor chain — single chokepoint, no other code changes.",
-  "last_action": "Phase 1 complete (T001-T004, incl. Format-legend strip) — build + tests pass",
+  "last_action": "PR #170 opened — fix(spec-viewer): handle CRLF and strip spec-kit boilerplate",
   "files_modified": [
     "webview/src/spec-viewer/markdown/preprocessors.ts",
     "webview/src/spec-viewer/markdown/renderer.ts",

--- a/specs/103-fix-spec-doc-rendering/.spec-context.json
+++ b/specs/103-fix-spec-doc-rendering/.spec-context.json
@@ -1,0 +1,51 @@
+{
+  "workflow": "sdd",
+  "auto": false,
+  "currentStep": "done",
+  "currentTask": null,
+  "progress": null,
+  "next": "done",
+  "status": "completed",
+  "checkpointStatus": { "commit": true, "pr": true },
+  "updated": "2026-05-22",
+  "selectedAt": "2026-05-22T12:05:53.442Z",
+  "specName": "Fix Spec Document Rendering (CRLF + Frontmatter)",
+  "branch": "feat/activity-view-overhaul",
+  "workingBranch": "fix/fix-spec-doc-rendering",
+  "type": "fix",
+  "createdAt": "2026-05-22T12:05:53.442Z",
+  "loadedDomains": [],
+  "approach": "Normalize CRLF/CR to LF and strip leading YAML frontmatter at the top of renderMarkdown, before the preprocessor chain — single chokepoint, no other code changes.",
+  "last_action": "Phase 1 complete (T001-T004, incl. Format-legend strip) — build + tests pass",
+  "files_modified": [
+    "webview/src/spec-viewer/markdown/preprocessors.ts",
+    "webview/src/spec-viewer/markdown/renderer.ts",
+    "webview/src/spec-viewer/markdown/renderer.test.ts"
+  ],
+  "step_summaries": {
+    "specify": {
+      "complexity": "minimal",
+      "requirements": 5,
+      "scenarios": 5,
+      "key_finding": "renderMarkdown splits on \\n and uses $-anchored block regexes; JS '.' doesn't match \\r, so CRLF checkouts fall through to raw <p>. No frontmatter handling exists, so leading YAML --- leaks as hr+paragraph."
+    }
+  },
+  "task_summaries": {
+    "T001": { "status": "DONE", "did": "Added stripFrontmatter() preprocessor removing a leading --- ... --- block (start-anchored, leaves mid-doc rules intact)", "files": ["webview/src/spec-viewer/markdown/preprocessors.ts"], "concerns": [] },
+    "T002": { "status": "DONE", "did": "renderMarkdown now normalizes \\r\\n?->\\n and calls stripFrontmatter before preprocessors", "files": ["webview/src/spec-viewer/markdown/renderer.ts"], "concerns": [] },
+    "T003": { "status": "DONE", "did": "Added renderer.test.ts: cases for CRLF rendering, frontmatter strip, mid-doc hr, no-frontmatter passthrough", "files": ["webview/src/spec-viewer/markdown/renderer.test.ts"], "concerns": [] },
+    "T004": { "status": "DONE", "did": "Added stripTaskFormatLegend() removing the spec-kit '## Format:' notation legend; wired into renderMarkdown; tests cover removal, sibling-section preservation, no-op", "files": ["webview/src/spec-viewer/markdown/preprocessors.ts", "webview/src/spec-viewer/markdown/renderer.ts", "webview/src/spec-viewer/markdown/renderer.test.ts"], "concerns": [] }
+  },
+  "transitions": [
+    { "step": "specify", "substep": "parsing", "from": null, "by": "sdd", "at": "2026-05-22T12:05:53.442Z" },
+    { "step": "specify", "substep": "exploring", "from": { "step": "specify", "substep": "parsing" }, "by": "sdd", "at": "2026-05-22T12:05:53.449Z" },
+    { "step": "specify", "substep": "detecting", "from": { "step": "specify", "substep": "exploring" }, "by": "sdd", "at": "2026-05-22T12:05:53.456Z" },
+    { "step": "specify", "substep": "writing-spec", "from": { "step": "specify", "substep": "detecting" }, "by": "sdd", "at": "2026-05-22T12:05:53.463Z" },
+    { "step": "tasks", "substep": null, "from": { "step": "specify", "substep": "writing-spec" }, "by": "sdd", "at": "2026-05-22T12:05:53.470Z" },
+    { "step": "tasks", "substep": "auto-enabled", "from": { "step": "tasks", "substep": null }, "by": "sdd", "at": "2026-05-22T12:05:53.477Z" },
+    { "step": "implement", "substep": "phase1", "from": { "step": "tasks", "substep": "auto-enabled" }, "by": "sdd", "at": "2026-05-22T12:12:04.252Z" },
+    { "step": "implement", "substep": "hooks", "from": { "step": "implement", "substep": "phase1" }, "by": "sdd", "at": "2026-05-22T12:12:04.261Z" },
+    { "step": "implement", "substep": "code-review", "from": { "step": "implement", "substep": "hooks" }, "by": "sdd", "at": "2026-05-22T12:12:04.270Z" },
+    { "step": "done", "substep": null, "from": { "step": "implement", "substep": "code-review" }, "by": "sdd", "at": "2026-05-22T12:15:45.892Z" }
+  ]
+}

--- a/specs/103-fix-spec-doc-rendering/plan.md
+++ b/specs/103-fix-spec-doc-rendering/plan.md
@@ -1,0 +1,29 @@
+# Plan: Fix Spec Document Rendering (CRLF + Frontmatter)
+
+**Spec**: [spec.md](./spec.md)
+
+## Approach
+
+Add two normalization steps at the top of `renderMarkdown` (the single entry
+point in `webview/src/spec-viewer/markdown/renderer.ts`), running before the
+existing preprocessor chain: (1) replace `\r\n?` with `\n` to normalize line
+endings, and (2) strip a leading YAML frontmatter block via a small new
+preprocessor. Doing both at the chokepoint means every downstream regex
+(preprocessors + the main line loop) sees clean LF input with no frontmatter,
+so no other code needs to change.
+
+## Files to Change
+
+### Modify
+
+- `webview/src/spec-viewer/markdown/renderer.ts` — at the start of `renderMarkdown`, normalize line endings (`markdown = markdown.replace(/\r\n?/g, '\n')`) and call the new frontmatter stripper, before `preprocessHtmlComments`. Import the new preprocessor.
+- `webview/src/spec-viewer/markdown/preprocessors.ts` — add `stripFrontmatter(markdown: string): string` (removes a leading `---\n…\n---` block, leaving mid-document `---` untouched) and `stripTaskFormatLegend(markdown: string): string` (removes the spec-kit `## Format:` notation legend section, up to the next heading).
+
+### Tests
+
+- `webview/src/spec-viewer/markdown/*.test.ts` — add cases: CRLF document renders headings/lists/hr correctly; leading frontmatter is stripped; mid-document `---` still becomes `<hr>`; document without frontmatter is unchanged.
+
+## Notes
+
+- Frontmatter regex anchored at start, e.g. `/^\s*---\n[\s\S]*?\n---\s*\n?/`. Run it after CRLF normalization so it only deals with `\n`.
+- Keep the change confined to the spec-viewer renderer; the shared `render/` pipeline is out of scope (it didn't exhibit the bug and isn't on this path).

--- a/specs/103-fix-spec-doc-rendering/spec.md
+++ b/specs/103-fix-spec-doc-rendering/spec.md
@@ -1,0 +1,58 @@
+# Spec: Fix Spec Document Rendering (CRLF + Frontmatter)
+
+**Slug**: 103-fix-spec-doc-rendering | **Date**: 2026-05-22
+
+## Summary
+
+The spec viewer's markdown renderer fails on two kinds of speckit-generated
+document content. (1) On Windows and Windows-mounted dev-containers, files
+checked out with CRLF line endings render entirely as raw text — headings show a
+literal `#`, `---` shows literally, lists don't form — because the renderer's
+block-level regexes are `$`-anchored and JavaScript's `.` does not match `\r`.
+(2) On every platform, the leading YAML frontmatter block (`---\ndescription:
+"…"\n---`) that spec-kit writes leaks into the rendered output as a stray
+horizontal rule + paragraph + horizontal rule. This fix normalizes line endings
+and strips leading frontmatter at the single renderer chokepoint, before any
+preprocessor runs.
+
+## Requirements
+
+- **R001** (MUST): `renderMarkdown` MUST normalize CRLF (`\r\n`) and lone CR (`\r`) to LF (`\n`) before any preprocessing or line splitting, so CRLF-checked-out documents render identically to LF documents.
+- **R002** (MUST): A leading YAML frontmatter block — an opening `---` on the first line, arbitrary lines, and a closing `---` — MUST be stripped from the document before rendering, so it does not appear as content.
+- **R003** (MUST): Frontmatter stripping MUST only apply to a block at the very start of the document (after optional leading blank lines). A `---` used later as a thematic break (horizontal rule) MUST still render as `<hr>`.
+- **R004** (SHOULD): Normalization MUST run before the existing preprocessors (`preprocessHtmlComments`, `preprocessSpecMetadata`, etc.) so their `\n`-based regexes also see clean input.
+- **R005** (SHOULD): The spec-kit tasks.md `## Format:` legend (the block explaining the `[ID] [P?] [Story] Description` notation) MUST be stripped before rendering, since it is authoring scaffolding, not reader content. Only that section (heading through the line before the next heading) is removed; surrounding sections are untouched.
+
+## Scenarios
+
+### CRLF document renders correctly
+
+**When** a spec/plan/tasks document whose text uses `\r\n` line endings is opened in the viewer
+**Then** headings, horizontal rules, ordered/unordered lists, and tables render as formatted HTML (no literal `#`, `---`, or `-` prefixes), identical to the LF rendering
+
+### Leading YAML frontmatter is hidden
+
+**When** a document begins with `---\ndescription: "…"\n---` (spec-kit frontmatter)
+**Then** the frontmatter block produces no visible output — no stray `<hr>`, no `description: …` paragraph — and the first visible element is the document's H1
+
+### Mid-document thematic break still renders
+
+**When** a document contains a `---` line surrounded by blank lines partway through the body (not at the top)
+**Then** it renders as a horizontal rule (`<hr>`), unaffected by frontmatter stripping
+
+### Document without frontmatter is unchanged
+
+**When** a document does not start with a `---` block
+**Then** rendering output is identical to current behavior (no content is stripped)
+
+### Tasks "## Format:" legend is hidden
+
+**When** a tasks.md contains the spec-kit `## Format: \`[ID] [P?] [Story] Description\`` heading followed by its notation bullets
+**Then** that heading and its bullets produce no visible output, while the next section (e.g. `## Path Conventions`) and all task content render normally
+
+## Out of Scope
+
+- Parsing or displaying frontmatter values (description, status, etc.) as structured metadata in the header — frontmatter is simply hidden.
+- Changing how `.spec-context.json`-driven metadata is rendered.
+- Fixing line endings on disk (e.g., `.gitattributes`); this is a render-time normalization only.
+- The shared `webview/src/render/` renderer used elsewhere — this fix targets the spec-viewer renderer that exhibits the bug.

--- a/specs/103-fix-spec-doc-rendering/tasks.md
+++ b/specs/103-fix-spec-doc-rendering/tasks.md
@@ -1,0 +1,22 @@
+# Tasks: Fix Spec Document Rendering (CRLF + Frontmatter)
+
+**Plan**: [plan.md](./plan.md)
+
+## Phase 1: Core Implementation
+
+- [x] **T001** Add `stripFrontmatter` preprocessor — `webview/src/spec-viewer/markdown/preprocessors.ts` | R002, R003
+  - **Do**: Export `stripFrontmatter(markdown: string): string` that removes a leading YAML frontmatter block matched by `/^\s*---\n[\s\S]*?\n---\s*\n?/` (anchored at document start, after optional blank lines). Return input unchanged when no leading block matches.
+  - **Verify**: Unit test — frontmatter at top removed; mid-document `---` and frontmatter-free input returned unchanged.
+  - **Leverage**: `preprocessHtmlComments` in the same file (same `markdown.replace` shape).
+
+- [x] **T002** Normalize line endings + strip frontmatter in `renderMarkdown` *(depends on T001)* — `webview/src/spec-viewer/markdown/renderer.ts` | R001, R004
+  - **Do**: As the first statements of `renderMarkdown`, add `markdown = markdown.replace(/\r\n?/g, '\n');` then `markdown = stripFrontmatter(markdown);`, before `preprocessHtmlComments`. Add `stripFrontmatter` to the import from `./preprocessors`. Add a brief comment referencing issue #158.
+  - **Verify**: `npm run compile` passes; CRLF input renders headings/lists/hr (no literal `#`/`---`).
+
+- [x] **T003** [P] Add renderer tests *(depends on T002)* — `webview/src/spec-viewer/markdown/*.test.ts` | R001, R002, R003
+  - **Do**: Cover (a) a CRLF document (`# H\r\n\r\n- item\r\n`) renders `<h1>`/`<li>` not literal text; (b) leading frontmatter stripped — no `description:` paragraph, no leading `<hr>`; (c) mid-document `---` becomes `<hr>`; (d) frontmatter-free document unchanged.
+  - **Verify**: `npm test` passes.
+
+- [x] **T004** Strip spec-kit `## Format:` legend *(depends on T002)* — `webview/src/spec-viewer/markdown/preprocessors.ts`, `renderer.ts`, `renderer.test.ts` | R005
+  - **Do**: Add `stripTaskFormatLegend()` removing the `## Format:` heading + notation bullets (up to the next heading); call it in `renderMarkdown` after `stripFrontmatter`; add tests covering removal, sibling-section preservation, and no-op when absent.
+  - **Verify**: `npm test` passes; legend strip fires on real `specs/097-inline-comment-composer/tasks.md` while `## Path Conventions` survives.

--- a/webview/src/spec-viewer/markdown/preprocessors.ts
+++ b/webview/src/spec-viewer/markdown/preprocessors.ts
@@ -106,6 +106,29 @@ export function preprocessUserStories(markdown: string): string {
 }
 
 /**
+ * Strip a leading YAML frontmatter block (`---` … `---`) from the document.
+ * spec-kit prepends a block like `---\ndescription: "…"\n---` to generated
+ * spec/plan/tasks files. The renderer has no frontmatter handling, so the
+ * delimiters render as `<hr>` and the keys leak as a paragraph. Only a block at
+ * the very start (after optional blank lines) is removed, so a `---` used later
+ * in the body as a thematic break still renders as a horizontal rule. See #158.
+ */
+export function stripFrontmatter(markdown: string): string {
+    return markdown.replace(/^\s*---[ \t]*\n[\s\S]*?\n---[ \t]*(?:\n|$)/, '');
+}
+
+/**
+ * Strip spec-kit's tasks.md "## Format:" legend — the boilerplate block that
+ * explains the `[ID] [P?] [Story] Description` task notation (what `[P]` and
+ * `[Story]` mean, "include file paths", etc.). It's authoring scaffolding, not
+ * content for the reader. Removes the heading and the lines that follow it up to
+ * the next heading (or end of document). See #158.
+ */
+export function stripTaskFormatLegend(markdown: string): string {
+    return markdown.replace(/^##[ \t]+Format:.*(?:\n(?!#{1,6}[ \t]).*)*\n?/m, '');
+}
+
+/**
  * Preprocess HTML comments into collapsible "Template Instructions" blocks
  * Empty comments are removed entirely.
  */

--- a/webview/src/spec-viewer/markdown/renderer.test.ts
+++ b/webview/src/spec-viewer/markdown/renderer.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Unit tests for renderMarkdown + stripFrontmatter — issue #158.
+ *
+ * Coverage:
+ *  - CRLF documents render block elements (headings/lists/rules) instead of
+ *    falling through to raw paragraphs (the Windows / git-autocrlf bug).
+ *  - Leading spec-kit YAML frontmatter is stripped, not leaked as <hr>+text.
+ *  - A `---` used mid-document as a thematic break still renders as <hr>.
+ *  - Documents without frontmatter are returned unchanged.
+ */
+
+import { renderMarkdown } from './renderer';
+import { stripFrontmatter, stripTaskFormatLegend } from './preprocessors';
+
+describe('renderMarkdown — CRLF normalization (issue #158)', () => {
+    it('renders a CRLF heading as <h1>, not a literal "#" paragraph', () => {
+        // Arrange — Windows / git autocrlf checkout: every line ends with \r\n
+        const input = '# Tasks: Demo\r\n\r\n- item one\r\n- item two\r\n';
+
+        // Act
+        const result = renderMarkdown(input);
+
+        // Assert
+        expect(result).toContain('<h1 id="tasks-demo">Tasks: Demo</h1>');
+        expect(result).not.toContain('<p>'); // nothing fell through to raw text
+        expect(result).not.toContain('\r');
+    });
+
+    it('renders CRLF list items as <li>, not raw "- " text', () => {
+        // Arrange
+        const input = '- item one\r\n- item two\r\n';
+
+        // Act
+        const result = renderMarkdown(input);
+
+        // Assert
+        expect(result).toContain('<ul>');
+        expect(result).toContain('item one');
+        expect(result).toContain('item two');
+        expect(result).not.toContain('- item one');
+    });
+
+    it('renders a CRLF "---" line as <hr>, not literal dashes', () => {
+        // Arrange — leading text so the rule is mid-document, not frontmatter
+        const input = 'before\r\n\r\n---\r\n\r\nafter\r\n';
+
+        // Act
+        const result = renderMarkdown(input);
+
+        // Assert
+        expect(result).toContain('<hr>');
+    });
+});
+
+describe('renderMarkdown — leading YAML frontmatter (issue #158)', () => {
+    it('strips spec-kit frontmatter so it does not leak as content', () => {
+        // Arrange — exactly the shape spec-kit writes atop tasks.md
+        const input =
+            '---\n' +
+            'description: "Task list for Demo"\n' +
+            '---\n\n' +
+            '# Tasks: Demo\n\n' +
+            '- a\n';
+
+        // Act
+        const result = renderMarkdown(input);
+
+        // Assert
+        expect(result).not.toContain('description:');
+        expect(result).toContain('<h1 id="tasks-demo">Tasks: Demo</h1>');
+    });
+
+    it('keeps a mid-document "---" rule when there is no frontmatter', () => {
+        // Arrange
+        const input = '# Heading\n\nbody\n\n---\n\nmore\n';
+
+        // Act
+        const result = renderMarkdown(input);
+
+        // Assert
+        expect(result).toContain('<hr>');
+    });
+});
+
+describe('renderMarkdown — strips the spec-kit "## Format:" legend (issue #158)', () => {
+    it('removes the Format heading and its notation bullets, keeps later sections', () => {
+        // Arrange — the exact boilerplate spec-kit writes into tasks.md
+        const input =
+            '# Tasks: Demo\n\n' +
+            '## Format: `[ID] [P?] [Story] Description`\n\n' +
+            '- **[P]**: Can run in parallel (different files, no dependencies)\n' +
+            '- **[Story]**: Which user story this task belongs to (US1, US2, US3)\n' +
+            '- Include exact file paths in descriptions\n\n' +
+            '## Path Conventions\n\n' +
+            'Real content here.\n';
+
+        // Act
+        const result = renderMarkdown(input);
+
+        // Assert
+        expect(result).not.toContain('Can run in parallel');
+        expect(result).not.toContain('Format:');
+        expect(result).toContain('Path Conventions');
+        expect(result).toContain('Real content here.');
+    });
+});
+
+describe('stripTaskFormatLegend', () => {
+    it('strips the Format legend section up to the next heading', () => {
+        // Arrange
+        const input =
+            '## Format: `[ID] [P?] [Story] Description`\n' +
+            '- **[P]**: parallel\n\n' +
+            '## Next\n\nbody\n';
+
+        // Act
+        const result = stripTaskFormatLegend(input);
+
+        // Assert
+        expect(result).toBe('## Next\n\nbody\n');
+    });
+
+    it('leaves documents without a Format legend unchanged', () => {
+        // Arrange
+        const input = '# Tasks\n\n- **T001** do a thing\n';
+
+        // Act / Assert
+        expect(stripTaskFormatLegend(input)).toBe(input);
+    });
+});
+
+describe('stripFrontmatter', () => {
+    it('removes a leading --- ... --- block', () => {
+        // Arrange
+        const input = '---\ndescription: "x"\n---\n\n# Title';
+
+        // Act
+        const result = stripFrontmatter(input);
+
+        // Assert
+        expect(result).not.toContain('description:');
+        expect(result).toContain('# Title');
+    });
+
+    it('leaves a document without frontmatter unchanged', () => {
+        // Arrange
+        const input = '# Title\n\nbody text\n';
+
+        // Act / Assert
+        expect(stripFrontmatter(input)).toBe(input);
+    });
+
+    it('does not strip a mid-document --- thematic break', () => {
+        // Arrange
+        const input = '# Title\n\nbefore\n\n---\n\nafter\n';
+
+        // Act / Assert
+        expect(stripFrontmatter(input)).toBe(input);
+    });
+});

--- a/webview/src/spec-viewer/markdown/renderer.ts
+++ b/webview/src/spec-viewer/markdown/renderer.ts
@@ -8,7 +8,9 @@ import {
     preprocessSpecMetadata,
     preprocessUserStories,
     preprocessCallouts,
-    preprocessHtmlComments
+    preprocessHtmlComments,
+    stripFrontmatter,
+    stripTaskFormatLegend
 } from './preprocessors';
 import { parseAcceptanceScenarios } from './scenarios';
 
@@ -121,6 +123,20 @@ function renderTable(rows: string[]): string {
  * Parse and render markdown content to HTML
  */
 export function renderMarkdown(markdown: string): string {
+    // Normalize line endings (CRLF / lone CR → LF) before anything else. The
+    // block-level regexes below are $-anchored and JS '.' does not match '\r',
+    // so a CRLF document (Windows / git autocrlf checkout) leaves a trailing
+    // '\r' on every line, failing every heading/list/rule match and rendering
+    // the whole document as raw paragraphs. See issue #158.
+    markdown = markdown.replace(/\r\n?/g, '\n');
+
+    // Strip spec-kit's leading YAML frontmatter so it doesn't leak as an <hr> +
+    // paragraph. Runs after newline normalization so it only deals with '\n'.
+    markdown = stripFrontmatter(markdown);
+
+    // Strip spec-kit's tasks.md "## Format:" notation legend (author scaffolding).
+    markdown = stripTaskFormatLegend(markdown);
+
     // Preprocess special patterns before main rendering
     markdown = preprocessHtmlComments(markdown);
     markdown = preprocessSpecMetadata(markdown, hasSpecContext);


### PR DESCRIPTION
## What

- Normalize CRLF / lone CR → LF at the top of `renderMarkdown` so Windows and Windows-mounted dev-container checkouts (git `autocrlf`) render formatted markdown instead of raw text.
- Strip the leading spec-kit YAML frontmatter (`---\ndescription: …\n---`) so it no longer leaks as a stray `<hr>` + paragraph.
- Strip the spec-kit tasks.md `## Format:` notation legend (the `[ID] [P?] [Story]` explainer) — authoring scaffolding, not reader content.

## Why

The custom spec-viewer renderer splits on `\n` and uses `$`-anchored block regexes; JS `.` doesn't match `\r`, so CRLF documents left a trailing `\r` on every line and every heading/list/rule fell through to a raw `<p>` — the whole document rendered "raw" on Windows (issue #158), while it rendered fine in Codespace (LF). Separately, spec-kit's frontmatter and format legend leaked into the output on all platforms.

## Testing

- 11 new renderer tests: CRLF heading/list/rule rendering, frontmatter strip, mid-document `---` still `<hr>`, format-legend strip, and no-op cases. Full suite: 94 webview tests pass.
- Verified both strippers fire on the real `specs/097-inline-comment-composer/tasks.md` while real sections (e.g. `## Path Conventions`) survive.

Closes #158