### PR TITLE
feat(ai-providers): add Claude in VS Code panel provider

### DIFF
--- a/.sdd.json
+++ b/.sdd.json
@@ -6,7 +6,8 @@
   "hooks": {
     "pre:code-review": [
       { "skill": "/install-local" },
-      { "skill": "/code-review" }
+      { "skill": "/code-review" },
+      { "prompt": "REVIEW MODE — make NO edits. Run a code-simplifier pass on the changed files ({files}). Propose only conservative, behavior-preserving simplifications for clarity, consistency, and maintainability — for each: file:line, current shape, simpler shape, one-line rationale. Return a concise ranked list; if a file is already simple, say so.", "blocking": false }
     ],
     "pre:commit": [
       { "shell": "git reset HEAD -- package.json package-lock.json 2>/dev/null || true", "blocking": false },

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ spawning the `claude` CLI in a terminal — for users who live in the panel rath
 than a terminal. It shares the same `.claude/` setup as the terminal `claude`
 provider (steering, agents, hooks, MCP). The extension opens the panel via Claude
 Code's URI handler and **prefills** the command; the Claude Code panel exposes no
-programmatic submit, so a notification prompts you to **press Enter** to run it.
+programmatic submit, so you **press Enter** to run it.
 Requires the [Claude Code extension](https://marketplace.visualstudio.com/items?itemName=anthropic.claude-code);
 if it isn't installed, the provider suggests switching to terminal `claude`.
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The spec workspace for developers running AI agents through Spec-Driven Developm
 
 **Review AI-generated specs the way you review code.** Add inline comments on specific lines, refine requirements, and catch a vague requirement before the AI turns it into 200 lines of wrong code. Every comment you submit is also captured as a markdown entry in a per-document scratchpad, so the history is durable across sessions.
 
-**Plug any AI assistant into any spec-driven workflow.** Seven providers ship today (Claude Code, Gemini, GitHub Copilot, Codex, Qwen, OpenCode, IDE Chat), and the workflow engine accepts custom phases, commands, and sub-documents. Drop in [Agent Teams Lite](https://github.com/Gentleman-Programming/agent-teams-lite), your own SDD process, or anything that takes commands and produces markdown.
+**Plug any AI assistant into any spec-driven workflow.** Eight providers ship today (Claude Code, Gemini, GitHub Copilot, Codex, Qwen, OpenCode, IDE Chat, Claude in VS Code), and the workflow engine accepts custom phases, commands, and sub-documents. Drop in [Agent Teams Lite](https://github.com/Gentleman-Programming/agent-teams-lite), your own SDD process, or anything that takes commands and produces markdown.
 
 **Spec-driven phases without leaving VS Code.** Each feature flows through Specify, Plan, Tasks, Done, with progress tracking, sticky headers, and a structured viewer built for long specs.
 
@@ -137,14 +137,14 @@ Compare the file lists side by side to see the contrast between the full and min
 
 ## Supported AI Providers
 
-| Feature | Claude Code | GitHub Copilot CLI | Gemini CLI | Codex CLI | Qwen Code | OpenCode | IDE Chat |
-|---------|-------------|-------------------|------------|-----------|-----------|----------|----------|
-| **Steering File** | CLAUDE.md | .github/copilot-instructions.md | GEMINI.md | AGENTS.md | QWEN.md | AGENTS.md | Not supported |
-| **Steering Path** | .claude/steering/ | .github/instructions/*.instructions.md | Hierarchical GEMINI.md | Hierarchical AGENTS.md | .qwen/steering/ | Hierarchical AGENTS.md | Not supported |
-| **Agents** | .claude/agents/*.md | .github/agents/*.agent.md | Limited support | Hierarchical AGENTS.md | Not supported | .opencode/agent/*.md | Not supported |
-| **Hooks** | .claude/settings.json | Not supported | Not supported | Not supported | Not supported | Not supported | Not supported |
-| **MCP Servers** | .claude/settings.json | ~/.copilot/mcp-config.json | ~/.gemini/settings.json | ~/.codex/config.toml | ~/.qwen/settings.json | ~/.opencode/opencode.jsonc | Not supported |
-| **CLI Command** | `claude` | `ghcs` / `gh copilot` | `gemini` | `codex` | `qwen` | `opencode` | Built-in editor chat (Copilot / Composer / Cascade) |
+| Feature | Claude Code | GitHub Copilot CLI | Gemini CLI | Codex CLI | Qwen Code | OpenCode | IDE Chat | Claude in VS Code |
+|---------|-------------|-------------------|------------|-----------|-----------|----------|----------|-------------------|
+| **Steering File** | CLAUDE.md | .github/copilot-instructions.md | GEMINI.md | AGENTS.md | QWEN.md | AGENTS.md | Not supported | CLAUDE.md |
+| **Steering Path** | .claude/steering/ | .github/instructions/*.instructions.md | Hierarchical GEMINI.md | Hierarchical AGENTS.md | .qwen/steering/ | Hierarchical AGENTS.md | Not supported | .claude/steering/ |
+| **Agents** | .claude/agents/*.md | .github/agents/*.agent.md | Limited support | Hierarchical AGENTS.md | Not supported | .opencode/agent/*.md | Not supported | .claude/agents/*.md |
+| **Hooks** | .claude/settings.json | Not supported | Not supported | Not supported | Not supported | Not supported | Not supported | .claude/settings.json |
+| **MCP Servers** | .claude/settings.json | ~/.copilot/mcp-config.json | ~/.gemini/settings.json | ~/.codex/config.toml | ~/.qwen/settings.json | ~/.opencode/opencode.jsonc | Not supported | .claude/settings.json |
+| **CLI Command** | `claude` | `ghcs` / `gh copilot` | `gemini` | `codex` | `qwen` | `opencode` | Built-in editor chat (Copilot / Composer / Cascade) | Claude Code GUI panel (no terminal) |
 
 Configure your preferred provider: **Settings > speckit.aiProvider**
 
@@ -158,6 +158,17 @@ editor** (run **SpecKit: Initialize Workspace**, i.e. `specify init`). When the
 workspace is initialized, IDE Chat auto-submits the prompt; when it isn't, it
 prefills the chat and shows a warning instead of sending a command the chat can't
 run. This is one-way dispatch — it does not read responses back or sync status.
+
+### Claude in VS Code
+
+`Claude in VS Code` dispatches to the **Claude Code GUI panel** instead of
+spawning the `claude` CLI in a terminal — for users who live in the panel rather
+than a terminal. It shares the same `.claude/` setup as the terminal `claude`
+provider (steering, agents, hooks, MCP). The extension opens the panel via Claude
+Code's URI handler and **prefills** the command; the Claude Code panel exposes no
+programmatic submit, so a notification prompts you to **press Enter** to run it.
+Requires the [Claude Code extension](https://marketplace.visualstudio.com/items?itemName=anthropic.claude-code);
+if it isn't installed, the provider suggests switching to terminal `claude`.
 
 ## Configuration
 

--- a/specs/104-claude-panel-provider/.spec-context.json
+++ b/specs/104-claude-panel-provider/.spec-context.json
@@ -287,6 +287,16 @@
       },
       "by": "sdd",
       "at": "2026-05-22T22:03:53.095Z"
+    },
+    {
+      "step": "done",
+      "substep": null,
+      "from": {
+        "step": "done",
+        "substep": null
+      },
+      "by": "sdd",
+      "at": "2026-05-22T23:20:25.946Z"
     }
   ],
   "task_summaries": {
@@ -340,7 +350,7 @@
       "concerns": []
     }
   },
-  "last_action": "Post-ship: removed the press-Enter notification per user \u2014 panel opening with the command prefilled is signal enough (R003 revised)",
+  "last_action": "Hotfix: getConfiguredProviderType now falls back to claude for unknown/stale aiProvider values (the claude-panel->claude-vscode rename crashed activation for settings still holding the old value)",
   "files_modified": [
     "src/ai-providers/promptBuilder.ts",
     "src/ai-providers/ideChatProvider.ts",
@@ -352,9 +362,11 @@
     ".sdd.json",
     "src/core/constants.ts",
     "package.json",
-    "specs/104-claude-panel-provider/spec.md"
+    "specs/104-claude-panel-provider/spec.md",
+    "src/ai-providers/aiProvider.ts",
+    "src/ai-providers/__tests__/providerRegistry.test.ts"
   ],
-  "drainedSeq": 17,
+  "drainedSeq": 18,
   "decisions": [
     "Code-review fixes: Promise.all the independent cleanCommandArg+writePromptFile awaits; log (not silently drop) the preamble when no workspace folder; added @-mention and no-folder tests",
     "Kept specNameFromPath/readSpecDescription as faithful local extractions rather than reaching into FileSystemUtils/extractSpecNameFromPath (avoid cross-module risk)",
@@ -368,5 +380,11 @@
     "pr": true
   },
   "prUrl": "https://github.com/alfredoperez/speckit-companion/pull/171",
-  "prNumber": 171
+  "prNumber": 171,
+  "concerns": [
+    {
+      "task": "post-ship",
+      "note": "Renaming a provider id is breaking for any settings holding the old value; mitigated centrally by validating the configured id against PROVIDER_PATHS"
+    }
+  ]
 }

--- a/specs/104-claude-panel-provider/.spec-context.json
+++ b/specs/104-claude-panel-provider/.spec-context.json
@@ -1,0 +1,339 @@
+{
+  "workflow": "sdd",
+  "currentStep": "done",
+  "currentTask": null,
+  "progress": null,
+  "next": "done",
+  "auto": true,
+  "updated": "2026-05-22",
+  "selectedAt": "2026-05-22T16:05:11Z",
+  "specName": "Claude Code Panel Provider",
+  "branch": "feat/claude-panel-provider",
+  "workingBranch": "feat/claude-panel-provider",
+  "type": "feat",
+  "createdAt": "2026-05-22T16:05:11Z",
+  "loadedDomains": [],
+  "approach": "Complete the already-scaffolded panel provider by extracting ide-chat's prompt-cleanup logic into shared promptBuilder helpers that both providers consume.",
+  "step_summaries": {
+    "specify": {
+      "complexity": "normal",
+      "requirements": 10,
+      "scenarios": 5,
+      "key_finding": "PoC already wires constants/PROVIDER_PATHS/factory/index/package.json enum plus the getAIProvider fresh-resolution fix; remaining gaps are prefilled-command cleanup (reuse ideChatProvider.readSpecDescription/specNameFromPath), the @-mention-vs-drop preamble decision, README provider-count bump, and a claudePanelProvider test mirroring ideChatProvider.test.ts."
+    },
+    "plan": {
+      "approach_summary": "Complete the already-scaffolded panel provider by extracting ide-chat's prompt-cleanup logic into shared promptBuilder helpers that both providers consume.",
+      "files_planned": 5,
+      "risks": [
+        "@-mention may land as literal text rather than attached context \u2014 fall back to dropping the preamble like ide-chat",
+        "Helper extraction could regress IDE Chat \u2014 mitigated by pure functions + re-running ideChatProvider.test.ts"
+      ],
+      "principles_concerns": 0,
+      "domain_concerns": 0,
+      "significance_score": 0
+    }
+  },
+  "transitions": [
+    {
+      "step": "specify",
+      "substep": "parsing",
+      "from": null,
+      "by": "sdd",
+      "at": "2026-05-22T16:05:11Z"
+    },
+    {
+      "step": "specify",
+      "substep": "exploring",
+      "from": "parsing",
+      "by": "sdd",
+      "at": "2026-05-22T16:06:00Z"
+    },
+    {
+      "step": "specify",
+      "substep": "detecting",
+      "from": "exploring",
+      "by": "sdd",
+      "at": "2026-05-22T16:06:30Z"
+    },
+    {
+      "step": "specify",
+      "substep": "writing-spec",
+      "from": "detecting",
+      "by": "sdd",
+      "at": "2026-05-22T16:07:00Z"
+    },
+    {
+      "step": "specify",
+      "substep": null,
+      "from": "writing-spec",
+      "by": "sdd",
+      "at": "2026-05-22T16:07:30Z"
+    },
+    {
+      "step": "specify",
+      "substep": "auto-enabled",
+      "from": null,
+      "by": "sdd",
+      "at": "2026-05-22T16:08:00Z"
+    },
+    {
+      "step": "plan",
+      "substep": "loading",
+      "from": "specify",
+      "by": "sdd",
+      "at": "2026-05-22T16:08:30Z"
+    },
+    {
+      "step": "plan",
+      "substep": "writing-plan",
+      "from": "loading",
+      "by": "sdd",
+      "at": "2026-05-22T16:09:00Z"
+    },
+    {
+      "step": "plan",
+      "substep": null,
+      "from": "writing-plan",
+      "by": "sdd",
+      "at": "2026-05-22T16:09:30Z"
+    },
+    {
+      "step": "tasks",
+      "substep": "loading",
+      "from": "plan",
+      "by": "sdd",
+      "at": "2026-05-22T16:10:00Z"
+    },
+    {
+      "step": "tasks",
+      "substep": "writing-tasks",
+      "from": "loading",
+      "by": "sdd",
+      "at": "2026-05-22T16:10:30Z"
+    },
+    {
+      "step": "tasks",
+      "substep": null,
+      "from": "writing-tasks",
+      "by": "sdd",
+      "at": "2026-05-22T16:11:00Z"
+    },
+    {
+      "step": "implement",
+      "substep": "phase1",
+      "from": {
+        "step": "tasks",
+        "substep": null
+      },
+      "by": "sdd",
+      "at": "2026-05-22T16:11:45.3NZ"
+    },
+    {
+      "step": "implement",
+      "substep": "phase1",
+      "from": {
+        "step": "implement",
+        "substep": "phase1"
+      },
+      "by": "sdd",
+      "at": "2026-05-22T16:13:19.3NZ"
+    },
+    {
+      "step": "implement",
+      "substep": "phase1",
+      "from": {
+        "step": "implement",
+        "substep": "phase1"
+      },
+      "by": "sdd",
+      "at": "2026-05-22T16:13:19.3NZ"
+    },
+    {
+      "step": "implement",
+      "substep": "phase1",
+      "from": {
+        "step": "implement",
+        "substep": "phase1"
+      },
+      "by": "sdd",
+      "at": "2026-05-22T16:13:19.3NZ"
+    },
+    {
+      "step": "implement",
+      "substep": "phase1",
+      "from": {
+        "step": "implement",
+        "substep": "phase1"
+      },
+      "by": "sdd",
+      "at": "2026-05-22T16:15:32.410Z"
+    },
+    {
+      "step": "implement",
+      "substep": "phase1",
+      "from": {
+        "step": "implement",
+        "substep": "phase1"
+      },
+      "by": "sdd",
+      "at": "2026-05-22T16:15:32.410Z"
+    },
+    {
+      "step": "implement",
+      "substep": "phase1",
+      "from": {
+        "step": "implement",
+        "substep": "phase1"
+      },
+      "by": "sdd",
+      "at": "2026-05-22T16:15:32.410Z"
+    },
+    {
+      "step": "implement",
+      "substep": "hooks",
+      "from": {
+        "step": "implement",
+        "substep": "phase1"
+      },
+      "by": "sdd",
+      "at": "2026-05-22T16:15:53.275Z"
+    },
+    {
+      "step": "implement",
+      "substep": "hooks",
+      "from": {
+        "step": "implement",
+        "substep": "hooks"
+      },
+      "by": "sdd",
+      "at": "2026-05-22T16:19:23.194Z"
+    },
+    {
+      "step": "implement",
+      "substep": "code-review",
+      "from": {
+        "step": "implement",
+        "substep": "hooks"
+      },
+      "by": "sdd",
+      "at": "2026-05-22T16:19:23.194Z"
+    },
+    {
+      "step": "implement",
+      "substep": "code-review",
+      "from": {
+        "step": "implement",
+        "substep": "code-review"
+      },
+      "by": "sdd",
+      "at": "2026-05-22T16:24:18.051Z"
+    },
+    {
+      "step": "implement",
+      "substep": "commit-review",
+      "from": {
+        "step": "implement",
+        "substep": "code-review"
+      },
+      "by": "sdd",
+      "at": "2026-05-22T20:00:01.548Z"
+    },
+    {
+      "step": "implement",
+      "substep": "commit-review",
+      "from": {
+        "step": "implement",
+        "substep": "commit-review"
+      },
+      "by": "sdd",
+      "at": "2026-05-22T21:10:00.981Z"
+    },
+    {
+      "step": "done",
+      "substep": null,
+      "from": {
+        "step": "implement",
+        "substep": "commit-review"
+      },
+      "by": "sdd",
+      "at": "2026-05-22T21:10:43.018Z"
+    }
+  ],
+  "task_summaries": {
+    "T001": {
+      "status": "DONE",
+      "did": "Extracted readSpecDescription, specNameFromPath, and cleanCommandArg into promptBuilder as shared pure helpers",
+      "files": [
+        "src/ai-providers/promptBuilder.ts"
+      ],
+      "concerns": []
+    },
+    "T002": {
+      "status": "DONE",
+      "did": "Pointed IdeChatProvider.buildChatQuery at cleanCommandArg and removed its private duplicate helpers; 25 ide-chat tests still green",
+      "files": [
+        "src/ai-providers/ideChatProvider.ts"
+      ],
+      "concerns": []
+    },
+    "T003": {
+      "status": "DONE",
+      "did": "Ran the panel prefill through cleanCommandArg; kept the @-mention as the resolved R005 approach and updated the class doc",
+      "files": [
+        "src/ai-providers/claudePanelProvider.ts"
+      ],
+      "concerns": []
+    },
+    "T004": {
+      "status": "DONE",
+      "did": "Added a Claude Code (Panel) column to the README provider matrix, a provider subsection, and bumped the count Seven->Eight",
+      "files": [
+        "README.md"
+      ],
+      "concerns": []
+    },
+    "T005": {
+      "status": "DONE",
+      "did": "Verified getAIProvider() resolves via AIProviderFactory.getProvider each call (factory caches by type) so provider switches apply without a window reload \u2014 already present on branch, no change needed",
+      "files": [
+        "src/extension.ts"
+      ],
+      "concerns": []
+    },
+    "T006": {
+      "status": "DONE",
+      "did": "Added claudePanelProvider.test.ts (8 tests: install detection, uriScheme open, description inline, spec-dir shortening, press-Enter notification, graceful no-throw) plus Uri.parse/workspaceFolders/fs.createDirectory mock APIs; full suite 628 green",
+      "files": [
+        "src/ai-providers/__tests__/claudePanelProvider.test.ts",
+        "tests/__mocks__/vscode.ts"
+      ],
+      "concerns": []
+    }
+  },
+  "last_action": "Renamed provider per user: display 'Claude in VS Code', setting value 'claude-vscode', constant AIProviders.CLAUDE_VSCODE (was claude-panel / 'Claude Code (Panel)'). Unreleased, so no migration.",
+  "files_modified": [
+    "src/ai-providers/promptBuilder.ts",
+    "src/ai-providers/ideChatProvider.ts",
+    "src/ai-providers/claudePanelProvider.ts",
+    "README.md",
+    "src/extension.ts",
+    "src/ai-providers/__tests__/claudePanelProvider.test.ts",
+    "tests/__mocks__/vscode.ts",
+    ".sdd.json",
+    "src/core/constants.ts",
+    "package.json"
+  ],
+  "drainedSeq": 14,
+  "decisions": [
+    "Code-review fixes: Promise.all the independent cleanCommandArg+writePromptFile awaits; log (not silently drop) the preamble when no workspace folder; added @-mention and no-folder tests",
+    "Kept specNameFromPath/readSpecDescription as faithful local extractions rather than reaching into FileSystemUtils/extractSpecNameFromPath (avoid cross-module risk)",
+    "Applied 2 of 5 code-simplifier proposals: collapsed duplicate verb/arg split in ideChatProvider.buildChatQuery; reused openedUri() helper in new panel tests. Left #2/#3/#4 as-is per simplifier's own recommendation",
+    "Added code-simplifier to .sdd.json pre:code-review as a review-only prompt hook (SDD hooks can't pin a subagent type, so it runs as a general agent with simplifier instructions)",
+    "Provider renamed to 'Claude in VS Code' / 'claude-vscode' (setting value + constant + package.json enum + README). Internal class ClaudePanelProvider kept ('panel' accurately names the mechanism)."
+  ],
+  "status": "completed",
+  "checkpointStatus": {
+    "commit": true,
+    "pr": true
+  }
+}

--- a/specs/104-claude-panel-provider/.spec-context.json
+++ b/specs/104-claude-panel-provider/.spec-context.json
@@ -277,6 +277,16 @@
       },
       "by": "sdd",
       "at": "2026-05-22T21:11:55.508Z"
+    },
+    {
+      "step": "done",
+      "substep": null,
+      "from": {
+        "step": "done",
+        "substep": null
+      },
+      "by": "sdd",
+      "at": "2026-05-22T22:03:53.095Z"
     }
   ],
   "task_summaries": {
@@ -330,7 +340,7 @@
       "concerns": []
     }
   },
-  "last_action": "PR #171 opened \u2014 feat(ai-providers): add Claude in VS Code panel provider",
+  "last_action": "Post-ship: removed the press-Enter notification per user \u2014 panel opening with the command prefilled is signal enough (R003 revised)",
   "files_modified": [
     "src/ai-providers/promptBuilder.ts",
     "src/ai-providers/ideChatProvider.ts",
@@ -341,9 +351,10 @@
     "tests/__mocks__/vscode.ts",
     ".sdd.json",
     "src/core/constants.ts",
-    "package.json"
+    "package.json",
+    "specs/104-claude-panel-provider/spec.md"
   ],
-  "drainedSeq": 16,
+  "drainedSeq": 17,
   "decisions": [
     "Code-review fixes: Promise.all the independent cleanCommandArg+writePromptFile awaits; log (not silently drop) the preamble when no workspace folder; added @-mention and no-folder tests",
     "Kept specNameFromPath/readSpecDescription as faithful local extractions rather than reaching into FileSystemUtils/extractSpecNameFromPath (avoid cross-module risk)",

--- a/specs/104-claude-panel-provider/.spec-context.json
+++ b/specs/104-claude-panel-provider/.spec-context.json
@@ -4,7 +4,7 @@
   "currentTask": null,
   "progress": null,
   "next": "done",
-  "auto": true,
+  "auto": false,
   "updated": "2026-05-22",
   "selectedAt": "2026-05-22T16:05:11Z",
   "specName": "Claude Code Panel Provider",
@@ -257,6 +257,26 @@
       },
       "by": "sdd",
       "at": "2026-05-22T21:10:43.018Z"
+    },
+    {
+      "step": "done",
+      "substep": null,
+      "from": {
+        "step": "done",
+        "substep": null
+      },
+      "by": "sdd",
+      "at": "2026-05-22T21:11:30.063Z"
+    },
+    {
+      "step": "done",
+      "substep": null,
+      "from": {
+        "step": "done",
+        "substep": null
+      },
+      "by": "sdd",
+      "at": "2026-05-22T21:11:55.508Z"
     }
   ],
   "task_summaries": {
@@ -310,7 +330,7 @@
       "concerns": []
     }
   },
-  "last_action": "Renamed provider per user: display 'Claude in VS Code', setting value 'claude-vscode', constant AIProviders.CLAUDE_VSCODE (was claude-panel / 'Claude Code (Panel)'). Unreleased, so no migration.",
+  "last_action": "PR #171 opened \u2014 feat(ai-providers): add Claude in VS Code panel provider",
   "files_modified": [
     "src/ai-providers/promptBuilder.ts",
     "src/ai-providers/ideChatProvider.ts",
@@ -323,7 +343,7 @@
     "src/core/constants.ts",
     "package.json"
   ],
-  "drainedSeq": 14,
+  "drainedSeq": 16,
   "decisions": [
     "Code-review fixes: Promise.all the independent cleanCommandArg+writePromptFile awaits; log (not silently drop) the preamble when no workspace folder; added @-mention and no-folder tests",
     "Kept specNameFromPath/readSpecDescription as faithful local extractions rather than reaching into FileSystemUtils/extractSpecNameFromPath (avoid cross-module risk)",
@@ -335,5 +355,7 @@
   "checkpointStatus": {
     "commit": true,
     "pr": true
-  }
+  },
+  "prUrl": "https://github.com/alfredoperez/speckit-companion/pull/171",
+  "prNumber": 171
 }

--- a/specs/104-claude-panel-provider/plan.md
+++ b/specs/104-claude-panel-provider/plan.md
@@ -1,0 +1,35 @@
+# Plan: Claude Code Panel Provider
+
+**Spec**: [spec.md](./spec.md)
+
+## Approach
+
+The provider scaffolding already exists on this branch (`feat/claude-panel-provider`): the `CLAUDE_PANEL` constant, a `PROVIDER_PATHS` entry mirroring `claude`, the factory constructor, the `index.ts` export, the `package.json` enum/enumDescriptions, the `ClaudePanelProvider` class (URI-handler open + "press Enter" notification), and the `getAIProvider()` fresh-resolution fix in `extension.ts`. This plan **completes** that PoC rather than starting from scratch.
+
+The one real code gap is prefilled-command cleanup. The cleanup logic (inline a new-spec description from the temp `spec.md`, shorten spec-dir path arguments to just the spec name) currently lives as private methods inside `ideChatProvider`. The key decision: **extract those into shared pure functions in `promptBuilder.ts`** so both `ideChatProvider` and `ClaudePanelProvider` consume them — no duplication, and `ideChatProvider`'s observable behavior stays identical. The panel receives commands already in dash form (its `commandFormat` is `dash`), so it only needs the argument cleanup, not verb reformatting.
+
+The `.spec-context.json` preamble handling (R005) hinges on one empirical question — does an `@`-mention inside a prefilled prompt attach the file as context, or land as literal text? This is resolved by a manual smoke test during implement; the code keeps the `@`-mention if it attaches, otherwise drops the preamble entirely like `ide-chat`.
+
+## Files
+
+### Create
+
+- `src/ai-providers/__tests__/claudePanelProvider.test.ts` — unit tests mirroring `ideChatProvider.test.ts`: `isInstalled` true/false on extension presence, prefilled-command cleanup (description inlined, spec-dir path shortened), graceful no-throw when the extension is absent or `openExternal` fails.
+
+### Modify
+
+- `src/ai-providers/promptBuilder.ts` — add exported pure helpers extracted from `ideChatProvider`: `readSpecDescription(filePath)`, `specNameFromPath(path)`, and a `cleanCommandArg(command)` that inlines a `specify <temp.md>` description and shortens spec-dir path args. Async where file reads are needed.
+- `src/ai-providers/ideChatProvider.ts` — delegate `buildChatQuery`'s arg cleanup to the new shared helpers (keep host-specific dot/dash verb formatting local). No behavior change.
+- `src/ai-providers/claudePanelProvider.ts` — run the prefilled command through `cleanCommandArg` before building the panel prompt; finalize preamble handling per the `@`-mention smoke-test result.
+- `README.md` — add a `claude-panel` column to the "Supported AI Providers" matrix and bump the provider count everywhere it's stated (Seven → Eight).
+
+## Testing Strategy
+
+- **Unit**: Jest + `tests/__mocks__/vscode.ts`. Stub `vscode.extensions.getExtension` and `vscode.env.openExternal`; assert the URI is built with the running `uriScheme`, the cleaned command is what gets prefilled, and the "press Enter" notification fires.
+- **Regression**: re-run `ideChatProvider.test.ts` after the helper extraction to confirm IDE Chat is unchanged.
+- **Manual smoke test**: with the Claude Code extension installed, dispatch each step from the panel provider and confirm (a) the panel opens prefilled, (b) the command reads cleanly (no absolute temp paths), and (c) whether an `@`-mentioned prompt file attaches as context — this decides R005.
+
+## Risks
+
+- `@`-mention lands as literal text rather than attached context: drop the preamble entirely (panel loses `.spec-context.json` bookkeeping, an accepted trade-off matching `ide-chat`).
+- Helper extraction regresses IDE Chat: mitigated by keeping the extracted functions pure and re-running `ideChatProvider.test.ts`.

--- a/specs/104-claude-panel-provider/spec.md
+++ b/specs/104-claude-panel-provider/spec.md
@@ -1,0 +1,57 @@
+# Spec: Claude Code Panel Provider
+
+**Slug**: 104-claude-panel-provider | **Date**: 2026-05-22
+
+## Summary
+
+Add a new `speckit.aiProvider` value, `claude-panel`, that dispatches SpecKit steps to the **Claude Code GUI panel** (the native, non-terminal experience) instead of spawning the `claude` CLI in a terminal. The panel is opened via the Claude Code extension's documented URI handler (`vscode://anthropic.claude-code/open?prompt=…`), which **prefills but cannot auto-submit** — so the user presses Enter, prompted by an obvious notification. Shipped alongside is a provider-agnostic fix: `getAIProvider()` resolves the current provider on every call instead of returning a singleton frozen at activation, so switching providers no longer requires a window reload.
+
+## Requirements
+
+- **R001** (MUST): A new `claude-panel` provider is wired end to end — `AIProviders` constant, `PROVIDER_PATHS` entry mirroring `claude` (same `.claude/` config, dash command format), factory constructor, `index.ts` export, and `package.json` `speckit.aiProvider` `enum` + `enumDescriptions`. Selecting it via `speckit.aiProvider` routes every SpecKit dispatch (create, specify, plan, tasks, implement, slash commands) to the panel.
+- **R002** (MUST): `ClaudePanelProvider` opens the Claude Code panel through the URI handler (using `vscode.env.uriScheme` so it works in Insiders/forks) with the command prefilled into the input box. `isInstalled()` returns true only when `vscode.extensions.getExtension('anthropic.claude-code')` is present.
+- **R003** (MUST): After dispatch, an obvious notification states the command was **prefilled and needs a manual Enter** (the panel cannot auto-submit) and names the command verb so the pending action is clear.
+- **R004** (MUST): The prefilled command text is cleaned up before dispatch — the new-spec description is inlined from the temp `spec.md` (reusing the `ideChatProvider.readSpecDescription` pattern) rather than passing an absolute temp path, and spec-directory arguments are shortened to just the spec name instead of absolute paths like `…/globalStorage/…/spec.md`.
+- **R005** (MUST): The `.spec-context.json` bookkeeping preamble is handled deliberately — either dropped (as `ide-chat` does) or carried via an `@`-mention of a workspace prompt file. The choice is made only **after** confirming whether an `@`-mention inside a prefilled prompt actually attaches the file as context versus landing as literal text.
+- **R006** (MUST): `getAIProvider()` resolves through the factory on every call (no singleton frozen at activation), so changing `speckit.aiProvider` takes effect without a window reload and every call site (spec editor, spec viewer, steering, workflow editor) resolves the same provider. This is shippable independently of the panel feature.
+- **R007** (SHOULD): When the Claude Code extension is absent or the panel can't be opened, the provider warns the user (suggesting they switch `speckit.aiProvider` to terminal `claude`) and never throws — every dispatch path degrades gracefully.
+- **R008** (MUST): README "Supported AI Providers" matrix gains a `claude-panel` column and the provider count is updated everywhere it's stated (Seven → Eight providers), per the CLAUDE.md Feature → README map.
+- **R009** (MUST): Unit tests cover `ClaudePanelProvider`, mirroring `src/ai-providers/__tests__/ideChatProvider.test.ts` (install detection, prompt cleanup, graceful fallback when uninstalled).
+- **R010** (SHOULD): The terminal `claude` provider's behavior is unchanged — the two providers coexist.
+
+## Scenarios
+
+### Dispatch to an installed panel
+
+**When** `speckit.aiProvider` is `claude-panel`, the Claude Code extension is installed, and the user triggers a SpecKit step (e.g. Tasks)
+**Then** the Claude Code panel opens with the `/speckit-tasks <spec-name>` command prefilled, and a notification tells the user to press Enter to run it.
+
+### Panel not installed
+
+**When** `speckit.aiProvider` is `claude-panel` but the Claude Code extension is not installed
+**Then** the provider shows a warning suggesting the terminal `claude` provider and does not throw or open anything.
+
+### New-spec description inlining
+
+**When** a "create spec" dispatch carries the feature description inside a temp `spec.md`
+**Then** the prefilled command is `/speckit-specify <description>` with the description inlined, not an absolute temp-file path.
+
+### Spec-directory argument shortening
+
+**When** a SpecKit step is dispatched with a spec-directory path argument
+**Then** the prefilled command shows just the spec name, not the absolute path.
+
+### Provider switch without reload
+
+**When** the user changes `speckit.aiProvider` (e.g. from `copilot` to `claude-panel`) and triggers actions from different surfaces (spec viewer Tasks button, spec editor create)
+**Then** all surfaces dispatch through the newly selected provider in the same window, with no reload required.
+
+## Non-Functional Requirements
+
+- **NFR001** (MUST): Reliability — every dispatch path is wrapped so a missing extension, no workspace folder, or a failed `openExternal` surfaces a user-facing warning and returns a non-failure result rather than throwing.
+
+## Out of Scope
+
+- Auto-submit of the prefilled prompt — not exposed by the Claude Code extension (only an OS-level keystroke hack could force it, which is not shippable).
+- Routing through VS Code's native chat view / the Copilot-hosted Claude session.
+- Any change to the terminal `claude` provider.

--- a/specs/104-claude-panel-provider/spec.md
+++ b/specs/104-claude-panel-provider/spec.md
@@ -10,7 +10,7 @@ Add a new `speckit.aiProvider` value, `claude-panel`, that dispatches SpecKit st
 
 - **R001** (MUST): A new `claude-panel` provider is wired end to end — `AIProviders` constant, `PROVIDER_PATHS` entry mirroring `claude` (same `.claude/` config, dash command format), factory constructor, `index.ts` export, and `package.json` `speckit.aiProvider` `enum` + `enumDescriptions`. Selecting it via `speckit.aiProvider` routes every SpecKit dispatch (create, specify, plan, tasks, implement, slash commands) to the panel.
 - **R002** (MUST): `ClaudePanelProvider` opens the Claude Code panel through the URI handler (using `vscode.env.uriScheme` so it works in Insiders/forks) with the command prefilled into the input box. `isInstalled()` returns true only when `vscode.extensions.getExtension('anthropic.claude-code')` is present.
-- **R003** (MUST): After dispatch, an obvious notification states the command was **prefilled and needs a manual Enter** (the panel cannot auto-submit) and names the command verb so the pending action is clear.
+- **R003** (MUST): The command is **prefilled** into the panel input; the user presses Enter to run it (the panel cannot auto-submit). No extra notification is shown — the panel opening with the command prefilled is the signal.
 - **R004** (MUST): The prefilled command text is cleaned up before dispatch — the new-spec description is inlined from the temp `spec.md` (reusing the `ideChatProvider.readSpecDescription` pattern) rather than passing an absolute temp path, and spec-directory arguments are shortened to just the spec name instead of absolute paths like `…/globalStorage/…/spec.md`.
 - **R005** (MUST): The `.spec-context.json` bookkeeping preamble is handled deliberately — either dropped (as `ide-chat` does) or carried via an `@`-mention of a workspace prompt file. The choice is made only **after** confirming whether an `@`-mention inside a prefilled prompt actually attaches the file as context versus landing as literal text.
 - **R006** (MUST): `getAIProvider()` resolves through the factory on every call (no singleton frozen at activation), so changing `speckit.aiProvider` takes effect without a window reload and every call site (spec editor, spec viewer, steering, workflow editor) resolves the same provider. This is shippable independently of the panel feature.
@@ -23,8 +23,8 @@ Add a new `speckit.aiProvider` value, `claude-panel`, that dispatches SpecKit st
 
 ### Dispatch to an installed panel
 
-**When** `speckit.aiProvider` is `claude-panel`, the Claude Code extension is installed, and the user triggers a SpecKit step (e.g. Tasks)
-**Then** the Claude Code panel opens with the `/speckit-tasks <spec-name>` command prefilled, and a notification tells the user to press Enter to run it.
+**When** `speckit.aiProvider` is `claude-vscode`, the Claude Code extension is installed, and the user triggers a SpecKit step (e.g. Tasks)
+**Then** the Claude Code panel opens with the `/speckit-tasks <spec-name>` command prefilled, ready for the user to press Enter.
 
 ### Panel not installed
 

--- a/specs/104-claude-panel-provider/tasks.md
+++ b/specs/104-claude-panel-provider/tasks.md
@@ -1,0 +1,37 @@
+# Tasks: Claude Code Panel Provider
+
+**Plan**: [plan.md](./plan.md)
+
+> Format reference: `[P]` markers and parallel groups — see `skills/tasks/SKILL.md` § Phase rules.
+
+## Phase 1: Core Implementation
+
+- [x] **T001** Extract shared prompt-cleanup helpers — `src/ai-providers/promptBuilder.ts` | R004
+  - **Do**: Add exported pure functions lifted from `ideChatProvider`: `readSpecDescription(filePath): Promise<string | null>` (read a specify temp `spec.md`, slice off the bookkeeping marker, return the description), `specNameFromPath(p): string` (last path segment, or its parent when the segment is a `.md` file), and `cleanCommandArg(command): Promise<string>` (split on first space; keep free-text/multi-token/non-path args as-is; inline `*specify <temp.md>` to `<description>` via `readSpecDescription`; otherwise shorten a spec-dir path arg to `specNameFromPath`). Do NOT reformat the command verb here — leave dot/dash formatting to callers.
+  - **Verify**: `npm run compile` passes; functions exported from `promptBuilder.ts`.
+  - **Leverage**: `src/ai-providers/ideChatProvider.ts` (`buildChatQuery`, `readSpecDescription`, `specNameFromPath`) — the exact logic to extract.
+
+- [x] **T002** [P] Delegate IDE Chat arg cleanup to shared helpers *(depends on T001)* — `src/ai-providers/ideChatProvider.ts` | R004
+  - **Do**: Replace the private `readSpecDescription`/`specNameFromPath` and the arg-cleanup branch of `buildChatQuery` with calls to the new `promptBuilder` helpers. Keep host-specific dot/dash verb formatting (`formatCommandForHost`) local. No observable behavior change.
+  - **Verify**: `npx jest ideChatProvider` stays green.
+  - **Leverage**: shared helpers from T001.
+
+- [x] **T003** [P] Apply cleanup + finalize preamble in panel provider *(depends on T001)* — `src/ai-providers/claudePanelProvider.ts` | R002, R003, R004, R005, R007
+  - **Do**: Run the dispatched command through `cleanCommandArg` before building the panel prefill so the prefilled text shows an inlined description / short spec name instead of absolute temp paths. Keep the URI-handler open, `isInstalled` check, and the "press Enter" notification. Resolve R005: keep the `@`-mention of the prompt file (carries the bookkeeping preamble) — the panel resolves workspace file paths — falling back gracefully if no workspace folder.
+  - **Verify**: `npm run compile` passes; manual dispatch shows a clean prefilled command.
+  - **Leverage**: shared helpers from T001; existing `splitContextPreamble`.
+
+- [x] **T004** [P] Update README provider matrix + count — `README.md` | R008
+  - **Do**: Add a `claude-panel` ("Claude Code (Panel)") column/row to the "Supported AI Providers" matrix and bump the provider count everywhere it's stated (Seven → Eight). Cross-check `package.json` enum already lists `claude-panel` (it does).
+  - **Verify**: matrix + count consistent with the eight-provider enum.
+  - **Leverage**: existing `ide-chat` row/column as the formatting template.
+
+- [x] **T005** [P] Verify getAIProvider fresh-resolution fix — `src/extension.ts` | R006
+  - **Do**: Confirm `getAIProvider()` resolves through `AIProviderFactory.getProvider(extensionContext, outputChannel)` on every call (already present on this branch). Sanity-check the factory caches by type so repeated calls don't rebuild providers, and that switching `speckit.aiProvider` applies without a window reload.
+  - **Verify**: `npm run compile` passes; switching provider mid-session routes a viewer action to the new provider.
+  - **Leverage**: `src/ai-providers/aiProviderFactory.ts` (`getProvider`, type cache).
+
+- [x] **T006** Unit tests for the panel provider *(depends on T003)* — `src/ai-providers/__tests__/claudePanelProvider.test.ts` | R009
+  - **Do**: New test file mirroring `ideChatProvider.test.ts`. Stub `vscode.extensions.getExtension` and `vscode.env.openExternal`. Cover: `isInstalled` true/false on extension presence; URI built with the running `uriScheme`; prefilled command is the cleaned form (description inlined, spec-dir path shortened); "press Enter" notification fires; no throw when the extension is absent or `openExternal` fails.
+  - **Verify**: `npx jest claudePanelProvider` passes.
+  - **Leverage**: `src/ai-providers/__tests__/ideChatProvider.test.ts` (mock setup, `tests/__mocks__/vscode.ts`).

--- a/src/ai-providers/__tests__/claudePanelProvider.test.ts
+++ b/src/ai-providers/__tests__/claudePanelProvider.test.ts
@@ -66,14 +66,6 @@ describe('ClaudePanelProvider', () => {
             expect(uri).not.toContain('spec.md');
         });
 
-        it('shows a press-Enter notification naming the command verb', async () => {
-            await provider.executeSlashCommand('/speckit-implement');
-
-            expect(vscode.window.showInformationMessage).toHaveBeenCalledWith(
-                expect.stringContaining('/speckit-implement')
-            );
-        });
-
         it('warns and does not open the panel when the extension is not installed', async () => {
             (vscode.extensions.getExtension as jest.Mock).mockReturnValue(undefined);
 

--- a/src/ai-providers/__tests__/claudePanelProvider.test.ts
+++ b/src/ai-providers/__tests__/claudePanelProvider.test.ts
@@ -1,0 +1,118 @@
+import * as vscode from 'vscode';
+import { ClaudePanelProvider } from '../claudePanelProvider';
+
+describe('ClaudePanelProvider', () => {
+    let provider: ClaudePanelProvider;
+
+    /** The string form of the URI passed to the first openExternal call. */
+    function openedUri(): string {
+        const call = (vscode.env.openExternal as jest.Mock).mock.calls[0];
+        return call[0].toString();
+    }
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        (vscode.env as any).uriScheme = 'vscode';
+        (vscode.env.openExternal as jest.Mock).mockResolvedValue(true);
+        (vscode.extensions.getExtension as jest.Mock).mockReturnValue({ id: 'anthropic.claude-code' });
+        (vscode.workspace as any).workspaceFolders = [{ uri: vscode.Uri.file('/ws') }];
+        (vscode.workspace.fs.createDirectory as jest.Mock).mockResolvedValue(undefined);
+        (vscode.workspace.fs.writeFile as jest.Mock).mockResolvedValue(undefined);
+
+        const outputChannel = { appendLine: jest.fn() } as any;
+        provider = new ClaudePanelProvider({} as any, outputChannel);
+    });
+
+    describe('isInstalled', () => {
+        it('is true when the Claude Code extension is present', async () => {
+            (vscode.extensions.getExtension as jest.Mock).mockReturnValue({ id: 'anthropic.claude-code' });
+            expect(await provider.isInstalled()).toBe(true);
+        });
+
+        it('is false when the Claude Code extension is absent', async () => {
+            (vscode.extensions.getExtension as jest.Mock).mockReturnValue(undefined);
+            expect(await provider.isInstalled()).toBe(false);
+        });
+    });
+
+    describe('dispatch', () => {
+        it('opens the panel via the running uriScheme with the command prefilled', async () => {
+            (vscode.env as any).uriScheme = 'vscode-insiders';
+            await provider.executeSlashCommand('/speckit-tasks');
+
+            expect(vscode.env.openExternal).toHaveBeenCalledTimes(1);
+            const uri = openedUri();
+            expect(uri).toContain('vscode-insiders://anthropic.claude-code/open?prompt=');
+            expect(uri).toContain(encodeURIComponent('/speckit-tasks'));
+        });
+
+        it('inlines a new-spec description instead of the temp file path', async () => {
+            (vscode.workspace.fs.readFile as jest.Mock).mockResolvedValue(
+                Buffer.from('Add a dark mode toggle\n\n## Post-Specification\nbookkeeping', 'utf-8')
+            );
+
+            await provider.executeSlashCommand('/speckit-specify /tmp/globalStorage/spec.md');
+
+            const uri = decodeURIComponent(openedUri());
+            expect(uri).toContain('/speckit-specify Add a dark mode toggle');
+            expect(uri).not.toContain('/tmp/globalStorage/spec.md');
+        });
+
+        it('shortens a spec-dir path argument to just the spec name', async () => {
+            await provider.executeSlashCommand('/speckit-plan specs/104-claude-panel-provider/spec.md');
+
+            const uri = decodeURIComponent(openedUri());
+            expect(uri).toContain('/speckit-plan 104-claude-panel-provider');
+            expect(uri).not.toContain('spec.md');
+        });
+
+        it('shows a press-Enter notification naming the command verb', async () => {
+            await provider.executeSlashCommand('/speckit-implement');
+
+            expect(vscode.window.showInformationMessage).toHaveBeenCalledWith(
+                expect.stringContaining('/speckit-implement')
+            );
+        });
+
+        it('warns and does not open the panel when the extension is not installed', async () => {
+            (vscode.extensions.getExtension as jest.Mock).mockReturnValue(undefined);
+
+            await provider.executeSlashCommand('/speckit-tasks');
+
+            expect(vscode.env.openExternal).not.toHaveBeenCalled();
+            expect(vscode.window.showWarningMessage).toHaveBeenCalled();
+        });
+
+        it('never throws when openExternal rejects', async () => {
+            (vscode.env.openExternal as jest.Mock).mockRejectedValue(new Error('boom'));
+
+            await expect(provider.executeSlashCommand('/speckit-tasks')).resolves.toBeUndefined();
+            expect(vscode.window.showWarningMessage).toHaveBeenCalled();
+        });
+    });
+
+    describe('context preamble', () => {
+        const PREAMBLE =
+            '<!-- speckit-companion:context-update -->\nbookkeeping\n<!-- /speckit-companion:context-update -->';
+
+        it('writes the prompt file and @-mentions it alongside the command', async () => {
+            await provider.executeInTerminal(`${PREAMBLE}\n\n/speckit-tasks`);
+
+            expect(vscode.workspace.fs.writeFile).toHaveBeenCalledTimes(1);
+            const uri = decodeURIComponent(openedUri());
+            expect(uri).toContain('/speckit-tasks');
+            expect(uri).toContain('@.claude/speckit-companion-prompt.md');
+        });
+
+        it('dispatches without the @-mention when there is no workspace folder', async () => {
+            (vscode.workspace as any).workspaceFolders = undefined;
+
+            await provider.executeInTerminal(`${PREAMBLE}\n\n/speckit-tasks`);
+
+            expect(vscode.workspace.fs.writeFile).not.toHaveBeenCalled();
+            const uri = decodeURIComponent(openedUri());
+            expect(uri).toContain('/speckit-tasks');
+            expect(uri).not.toContain('@.claude/');
+        });
+    });
+});

--- a/src/ai-providers/__tests__/providerRegistry.test.ts
+++ b/src/ai-providers/__tests__/providerRegistry.test.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import { AIProviderFactory } from '../aiProviderFactory';
-import { PROVIDER_PATHS } from '../aiProvider';
+import { PROVIDER_PATHS, getConfiguredProviderType } from '../aiProvider';
 import { getPermissionFlagForProvider } from '../permissionValidation';
 import { AIProviders } from '../../core/constants';
 
@@ -11,6 +11,14 @@ describe('Provider registry', () => {
                 if (key === 'permissionMode') return value;
                 return defaultValue;
             }),
+        });
+    }
+
+    function mockConfiguredProvider(value: string) {
+        (vscode.workspace.getConfiguration as jest.Mock).mockReturnValue({
+            get: jest.fn((key: string, defaultValue?: unknown) =>
+                key === 'aiProvider' ? value : defaultValue
+            ),
         });
     }
 
@@ -49,6 +57,18 @@ describe('Provider registry', () => {
         it('returns Claude bypass flag in auto-approve mode', () => {
             mockPermissionMode('auto-approve');
             expect(getPermissionFlagForProvider(AIProviders.CLAUDE)).toBe('--permission-mode bypassPermissions ');
+        });
+    });
+
+    describe('getConfiguredProviderType', () => {
+        it('returns the configured provider when it is a known key', () => {
+            mockConfiguredProvider(AIProviders.CLAUDE_VSCODE);
+            expect(getConfiguredProviderType()).toBe(AIProviders.CLAUDE_VSCODE);
+        });
+
+        it('falls back to Claude for a stale or unknown provider value', () => {
+            mockConfiguredProvider('claude-panel'); // renamed away — must not crash
+            expect(getConfiguredProviderType()).toBe(AIProviders.CLAUDE);
         });
     });
 });

--- a/src/ai-providers/aiProvider.ts
+++ b/src/ai-providers/aiProvider.ts
@@ -418,7 +418,11 @@ export function isProviderConfigured(): boolean {
  */
 export function getConfiguredProviderType(): AIProviderType {
     const config = vscode.workspace.getConfiguration('speckit');
-    return config.get<AIProviderType>('aiProvider', AIProviders.CLAUDE);
+    const configured = config.get<AIProviderType>('aiProvider', AIProviders.CLAUDE);
+    // Guard against a stale or typo'd value (e.g. a renamed provider id left in
+    // settings): an unknown key would make PROVIDER_PATHS[type] undefined and
+    // throw at every call site. Fall back to the default provider instead.
+    return configured in PROVIDER_PATHS ? configured : AIProviders.CLAUDE;
 }
 
 /**

--- a/src/ai-providers/aiProvider.ts
+++ b/src/ai-providers/aiProvider.ts
@@ -349,6 +349,30 @@ export const PROVIDER_PATHS: Record<AIProviderType, ProviderPaths> = {
         supportsInteractivePermissions: true,
         autoApproveFlag: '',
     },
+    // Claude in VS Code dispatches to the Claude Code GUI panel via the
+    // extension's URI handler instead of spawning the CLI in a terminal. It
+    // shares the same `.claude/` workspace setup as the terminal Claude provider
+    // (steering, agents, skills, dash-form commands resolved from
+    // `.claude/commands/`), so those fields mirror CLAUDE.
+    [AIProviders.CLAUDE_VSCODE]: {
+        steeringFile: 'CLAUDE.md',
+        globalSteeringFile: '.claude/CLAUDE.md',
+        steeringDir: '.claude/steering',
+        steeringPattern: '*.md',
+        agentsDir: '.claude/agents',
+        agentsPattern: '*.md',
+        skillsDir: '.claude/skills',
+        skillsPattern: '*/SKILL.md',
+        mcpConfigPath: '.claude/settings.json',
+        configDir: '.claude',
+        supportsHooks: true,
+        displayName: 'Claude in VS Code',
+        commandFormat: 'dash',
+        quickPickIcon: '$(window)',
+        quickPickDescription: 'Open the Claude Code GUI panel and prefill the command (no terminal)',
+        supportsInteractivePermissions: true,
+        autoApproveFlag: '',
+    },
 };
 
 /**

--- a/src/ai-providers/aiProviderFactory.ts
+++ b/src/ai-providers/aiProviderFactory.ts
@@ -7,6 +7,7 @@ import { CodexCliProvider } from './codexCliProvider';
 import { QwenCliProvider } from './qwenCliProvider';
 import { OpenCodeProvider } from './openCodeProvider';
 import { IdeChatProvider } from './ideChatProvider';
+import { ClaudePanelProvider } from './claudePanelProvider';
 import { AIProviders } from '../core/constants';
 
 type ProviderConstructor = (
@@ -22,6 +23,7 @@ const PROVIDER_CONSTRUCTORS: Record<AIProviderType, ProviderConstructor> = {
     [AIProviders.QWEN]: (ctx, out) => new QwenCliProvider(ctx, out),
     [AIProviders.OPENCODE]: (ctx, out) => new OpenCodeProvider(ctx, out),
     [AIProviders.IDE_CHAT]: (ctx, out) => new IdeChatProvider(ctx, out),
+    [AIProviders.CLAUDE_VSCODE]: (ctx, out) => new ClaudePanelProvider(ctx, out),
 };
 
 /**

--- a/src/ai-providers/claudePanelProvider.ts
+++ b/src/ai-providers/claudePanelProvider.ts
@@ -82,9 +82,8 @@ export class ClaudePanelProvider implements IAIProvider {
 
     /**
      * Core dispatch: open the Claude Code panel via the URI handler with the
-     * prompt pre-filled, then surface an obvious "press Enter" notification (the
-     * panel exposes no programmatic submit). Never throws — returns false on any
-     * failure.
+     * prompt pre-filled. The panel exposes no programmatic submit, so the user
+     * presses Enter to run it. Never throws — returns false on any failure.
      */
     private async dispatchToPanel(prompt: string): Promise<boolean> {
         try {
@@ -126,25 +125,12 @@ export class ClaudePanelProvider implements IAIProvider {
                 return false;
             }
 
-            this.notifyPressEnter(cmdText);
             return true;
         } catch (error) {
             this.outputChannel.appendLine(`[ClaudePanelProvider] ERROR dispatching to panel: ${error}`);
             vscode.window.showWarningMessage(`Couldn't open the Claude Code panel: ${error}`);
             return false;
         }
-    }
-
-    /**
-     * Make it obvious the command was only PREFILLED and needs a manual Enter
-     * (the Claude Code panel exposes no programmatic submit). Names the command
-     * verb so the pending action is clear.
-     */
-    private notifyPressEnter(cmdText: string): void {
-        const verb = cmdText.split(/\s+/)[0] || 'the command';
-        vscode.window.showInformationMessage(
-            `▶ Claude Code panel is ready — press Enter to run ${verb}. (The panel can't auto-submit.)`
-        );
     }
 
     /**

--- a/src/ai-providers/claudePanelProvider.ts
+++ b/src/ai-providers/claudePanelProvider.ts
@@ -1,0 +1,178 @@
+import * as vscode from 'vscode';
+import { AIProviders } from '../core/constants';
+import { IAIProvider, AIExecutionResult } from './aiProvider';
+import { splitContextPreamble, cleanCommandArg } from './promptBuilder';
+
+/** Extension id of the Claude Code GUI extension. */
+const CLAUDE_CODE_EXTENSION_ID = 'anthropic.claude-code';
+
+/**
+ * Workspace-relative file the assembled prompt is written to so it can be
+ * `@`-mentioned into the panel (the panel resolves workspace files by path).
+ * Lives under `.claude/` (already present for Claude users) with a stable name
+ * so it is overwritten each dispatch rather than accumulating.
+ */
+const PROMPT_REL_PATH = '.claude/speckit-companion-prompt.md';
+
+/**
+ * Claude in VS Code provider — instead of spawning the `claude` CLI in a
+ * terminal, it opens the Claude Code GUI panel via the extension's documented
+ * URI handler (`vscode://anthropic.claude-code/open?prompt=…`) and pre-fills the
+ * input box.
+ *
+ * KNOWN LIMITATION (documented): the URI handler pre-fills but does NOT
+ * auto-submit — the user presses Enter. There is no documented param or command
+ * to submit programmatically. The full prompt (including the `.spec-context.json`
+ * bookkeeping preamble) is written to a workspace file and `@`-mentioned so the
+ * panel still receives the whole instruction (the panel resolves workspace files
+ * by path); the visible command itself is cleaned via `cleanCommandArg` so the
+ * input reads well. Every path is wrapped so nothing throws.
+ */
+export class ClaudePanelProvider implements IAIProvider {
+    public readonly name = 'Claude in VS Code';
+    public readonly type = AIProviders.CLAUDE_VSCODE;
+
+    private outputChannel: vscode.OutputChannel;
+
+    constructor(_context: vscode.ExtensionContext, outputChannel: vscode.OutputChannel) {
+        this.outputChannel = outputChannel;
+    }
+
+    /** Installed when the Claude Code GUI extension is present. */
+    async isInstalled(): Promise<boolean> {
+        return vscode.extensions.getExtension(CLAUDE_CODE_EXTENSION_ID) !== undefined;
+    }
+
+    getPermissionFlag(): string {
+        return '';
+    }
+
+    /**
+     * Write the full assembled prompt to the workspace prompt file and return
+     * its workspace-relative path for `@`-mentioning. Returns null if there is
+     * no workspace folder (the panel needs one anyway).
+     */
+    private async writePromptFile(fullPrompt: string): Promise<string | null> {
+        const folder = vscode.workspace.workspaceFolders?.[0];
+        if (!folder) return null;
+        try {
+            const fileUri = vscode.Uri.joinPath(folder.uri, PROMPT_REL_PATH);
+            const dirUri = vscode.Uri.joinPath(folder.uri, '.claude');
+            await vscode.workspace.fs.createDirectory(dirUri);
+            await vscode.workspace.fs.writeFile(fileUri, Buffer.from(fullPrompt, 'utf-8'));
+            return PROMPT_REL_PATH;
+        } catch (error) {
+            this.outputChannel.appendLine(`[ClaudePanelProvider] Failed to write prompt file: ${error}`);
+            return null;
+        }
+    }
+
+    /**
+     * Build the text to pre-fill into the panel input. The command (a
+     * `/speckit.*` slash command or a free-form prompt) goes first so it runs on
+     * Enter; when a bookkeeping preamble exists it is carried as an `@`-mention
+     * of the prompt file so the panel still gets the full instruction.
+     */
+    private buildPanelPrompt(command: string, promptRelPath: string | null, hasPreamble: boolean): string {
+        if (hasPreamble && promptRelPath) {
+            return `${command}\n\n@${promptRelPath}`;
+        }
+        return command;
+    }
+
+    /**
+     * Core dispatch: open the Claude Code panel via the URI handler with the
+     * prompt pre-filled, then surface an obvious "press Enter" notification (the
+     * panel exposes no programmatic submit). Never throws — returns false on any
+     * failure.
+     */
+    private async dispatchToPanel(prompt: string): Promise<boolean> {
+        try {
+            if (!(await this.isInstalled())) {
+                vscode.window.showWarningMessage(
+                    'The Claude Code extension is not installed. Install it, or switch `speckit.aiProvider` to `claude` (terminal).'
+                );
+                return false;
+            }
+
+            const { preamble, command } = splitContextPreamble(prompt);
+            // Clean the prefilled command so the panel input reads well (inline a
+            // new-spec description from its temp file, shorten spec-dir paths to
+            // the spec name) and write the full prompt file — independent, so run
+            // them concurrently.
+            const [cmdText, promptRelPath] = await Promise.all([
+                cleanCommandArg(command),
+                this.writePromptFile(prompt),
+            ]);
+            if (preamble && !promptRelPath) {
+                this.outputChannel.appendLine(
+                    '[ClaudePanelProvider] No workspace folder for the prompt file — dispatching without the context preamble.'
+                );
+            }
+            const panelPrompt = this.buildPanelPrompt(cmdText, promptRelPath, !!preamble);
+
+            // Use the running product's scheme so this works in Insiders / forks.
+            const uri = vscode.Uri.parse(
+                `${vscode.env.uriScheme}://${CLAUDE_CODE_EXTENSION_ID}/open?prompt=${encodeURIComponent(panelPrompt)}`
+            );
+
+            this.outputChannel.appendLine(`[ClaudePanelProvider] Opening Claude Code panel (prefill):\n${panelPrompt}`);
+            this.outputChannel.appendLine(`[ClaudePanelProvider] URI: ${uri.toString()}`);
+
+            const opened = await vscode.env.openExternal(uri);
+            if (!opened) {
+                this.outputChannel.appendLine('[ClaudePanelProvider] openExternal returned false');
+                vscode.window.showWarningMessage('Could not open the Claude Code panel.');
+                return false;
+            }
+
+            this.notifyPressEnter(cmdText);
+            return true;
+        } catch (error) {
+            this.outputChannel.appendLine(`[ClaudePanelProvider] ERROR dispatching to panel: ${error}`);
+            vscode.window.showWarningMessage(`Couldn't open the Claude Code panel: ${error}`);
+            return false;
+        }
+    }
+
+    /**
+     * Make it obvious the command was only PREFILLED and needs a manual Enter
+     * (the Claude Code panel exposes no programmatic submit). Names the command
+     * verb so the pending action is clear.
+     */
+    private notifyPressEnter(cmdText: string): void {
+        const verb = cmdText.split(/\s+/)[0] || 'the command';
+        vscode.window.showInformationMessage(
+            `▶ Claude Code panel is ready — press Enter to run ${verb}. (The panel can't auto-submit.)`
+        );
+    }
+
+    /**
+     * Dispatch the assembled prompt to the Claude Code panel. Returns
+     * `undefined` (no terminal) — call sites tolerate this via the widened
+     * IAIProvider return type.
+     */
+    async executeInTerminal(prompt: string, _title?: string): Promise<vscode.Terminal | undefined> {
+        await this.dispatchToPanel(prompt);
+        return undefined;
+    }
+
+    /**
+     * No headless analog for a GUI panel — degrade to the interactive panel path
+     * and report a non-failure exit code (`undefined`), which callers treat as
+     * success.
+     */
+    async executeHeadless(prompt: string): Promise<AIExecutionResult> {
+        await this.dispatchToPanel(prompt);
+        return { exitCode: undefined };
+    }
+
+    /**
+     * Slash commands have no terminal analog for the panel — route the command
+     * text to the panel like any other prompt. Returns `undefined`.
+     */
+    async executeSlashCommand(command: string, _title?: string, _autoExecute?: boolean): Promise<vscode.Terminal | undefined> {
+        await this.dispatchToPanel(command);
+        return undefined;
+    }
+}

--- a/src/ai-providers/ideChatProvider.ts
+++ b/src/ai-providers/ideChatProvider.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 import { AIProviders, Commands } from '../core/constants';
 import { SpecKitDetector } from '../speckit/detector';
 import { IAIProvider, AIExecutionResult } from './aiProvider';
-import { splitContextPreamble } from './promptBuilder';
+import { splitContextPreamble, cleanCommandArg } from './promptBuilder';
 
 /**
  * Host editors that expose a built-in AI chat we can dispatch to.
@@ -136,20 +136,14 @@ export class IdeChatProvider implements IAIProvider {
      *   absolute path).
      */
     private async buildChatQuery(prompt: string, host: HostIde): Promise<string> {
-        const trimmed = splitContextPreamble(prompt).command.trim();
-        const sp = trimmed.indexOf(' ');
-        if (sp === -1) return this.formatCommandForHost(trimmed, host);
-        const cmd = this.formatCommandForHost(trimmed.slice(0, sp), host);
-        const arg = trimmed.slice(sp + 1).trim();
-
-        if (/\s/.test(arg)) return `${cmd} ${arg}`;     // free-text / multi-token argument
-        if (!/[/\\]/.test(arg)) return `${cmd} ${arg}`; // not a path
-
-        if (/[.-]specify$/.test(cmd) && /\.md$/i.test(arg)) {
-            const description = await this.readSpecDescription(arg);
-            if (description) return `${cmd} ${description}`;
-        }
-        return `${cmd} ${this.specNameFromPath(arg)}`;
+        // Shared helper cleans the arg (description inlining, spec-dir shortening);
+        // then format the verb for the host. The verb has no spaces, so formatting
+        // before vs. after arg cleanup is equivalent — doing it after avoids a
+        // second split.
+        const cleaned = await cleanCommandArg(splitContextPreamble(prompt).command);
+        const sp = cleaned.indexOf(' ');
+        if (sp === -1) return this.formatCommandForHost(cleaned, host);
+        return `${this.formatCommandForHost(cleaned.slice(0, sp), host)}${cleaned.slice(sp)}`;
     }
 
     /**
@@ -161,29 +155,6 @@ export class IdeChatProvider implements IAIProvider {
     private formatCommandForHost(cmd: string, host: HostIde): string {
         if (!HOST_PROFILES[host].dashCommands) return cmd;
         return cmd.replace(/^(\/?)speckit\./, '$1speckit-');
-    }
-
-    /** The spec name from a path: the last segment, or its parent when it's a doc file. */
-    private specNameFromPath(p: string): string {
-        const segments = p.split(/[/\\]/).filter(Boolean);
-        let name = segments.pop() ?? p;
-        if (/\.md$/i.test(name) && segments.length > 0) {
-            name = segments.pop()!;
-        }
-        return name;
-    }
-
-    /** Read a specify temp markdown file and return the feature description (sans bookkeeping). */
-    private async readSpecDescription(filePath: string): Promise<string | null> {
-        try {
-            const data = await vscode.workspace.fs.readFile(vscode.Uri.file(filePath));
-            const text = Buffer.from(data).toString('utf-8');
-            const marker = text.indexOf('## Post-Specification');
-            const body = (marker === -1 ? text : text.slice(0, marker)).trim();
-            return body || null;
-        } catch {
-            return null;
-        }
     }
 
     /** Warn that the host chat won't recognize `/speckit.*` until spec-kit is set up. */

--- a/src/ai-providers/index.ts
+++ b/src/ai-providers/index.ts
@@ -7,4 +7,5 @@ export * from './codexCliProvider';
 export * from './qwenCliProvider';
 export * from './openCodeProvider';
 export * from './ideChatProvider';
+export * from './claudePanelProvider';
 export * from './permissionValidation';

--- a/src/ai-providers/promptBuilder.ts
+++ b/src/ai-providers/promptBuilder.ts
@@ -146,3 +146,60 @@ export function splitContextPreamble(prompt: string): { preamble: string | null;
         command: prompt.slice(end).trim(),
     };
 }
+
+/**
+ * Read a specify temp markdown file and return the feature description, dropping
+ * the bookkeeping the extension appends below it (`## Post-Specification`).
+ * Returns null when the file can't be read or is empty. Shared by providers that
+ * inline the description into a prefilled command instead of passing the temp
+ * path a human-facing surface can't open (IDE chat, Claude panel).
+ */
+export async function readSpecDescription(filePath: string): Promise<string | null> {
+    try {
+        const data = await vscode.workspace.fs.readFile(vscode.Uri.file(filePath));
+        const text = Buffer.from(data).toString('utf-8');
+        const marker = text.indexOf('## Post-Specification');
+        const body = (marker === -1 ? text : text.slice(0, marker)).trim();
+        return body || null;
+    } catch {
+        return null;
+    }
+}
+
+/** The spec name from a path: the last segment, or its parent when it's a doc file. */
+export function specNameFromPath(p: string): string {
+    const segments = p.split(/[/\\]/).filter(Boolean);
+    let name = segments.pop() ?? p;
+    if (/\.md$/i.test(name) && segments.length > 0) {
+        name = segments.pop()!;
+    }
+    return name;
+}
+
+/**
+ * Clean the argument of an already-verb-formatted `/speckit.* <arg>` command for
+ * dispatch to a surface that prefills text a human reads (IDE chat, Claude panel):
+ * - free-text / multi-token / non-path args are kept as-is;
+ * - `specify <temp.md>` (create-new-spec writes the description into a temp md the
+ *   surface can't open) is inlined to `specify <description>`;
+ * - any other spec-dir path arg is shortened to just the spec name.
+ *
+ * The command verb is left untouched — callers apply dot/dash formatting first.
+ */
+export async function cleanCommandArg(command: string): Promise<string> {
+    const trimmed = command.trim();
+    const sp = trimmed.indexOf(' ');
+    if (sp === -1) return trimmed;
+    const cmd = trimmed.slice(0, sp);
+    const arg = trimmed.slice(sp + 1).trim();
+    if (!arg) return cmd;
+
+    if (/\s/.test(arg)) return `${cmd} ${arg}`;     // free-text / multi-token argument
+    if (!/[/\\]/.test(arg)) return `${cmd} ${arg}`; // not a path
+
+    if (/[.-]specify$/.test(cmd) && /\.md$/i.test(arg)) {
+        const description = await readSpecDescription(arg);
+        if (description) return `${cmd} ${description}`;
+    }
+    return `${cmd} ${specNameFromPath(arg)}`;
+}

--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -256,6 +256,7 @@ export const AIProviders = {
     QWEN: 'qwen',
     OPENCODE: 'opencode',
     IDE_CHAT: 'ide-chat',
+    CLAUDE_VSCODE: 'claude-vscode',
 } as const;
 
 /**

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -26,9 +26,21 @@ import { ConfigManager } from './core/utils/configManager';
 import { openSpecFile } from './core/utils/fileOpener';
 
 let aiProvider: IAIProvider;
+let extensionContext: vscode.ExtensionContext;
 export let outputChannel: vscode.OutputChannel;
 
+/**
+ * Resolve the AI provider for the *current* `speckit.aiProvider` setting.
+ * Goes through the factory (which caches by type) rather than returning a
+ * singleton frozen at activation, so changing the provider takes effect without
+ * a window reload and every call site resolves the same provider (the spec
+ * editor already resolved fresh; the viewer used the stale singleton, which is
+ * why a switched provider only applied to some actions).
+ */
 export function getAIProvider(): IAIProvider {
+    if (extensionContext) {
+        return AIProviderFactory.getProvider(extensionContext, outputChannel);
+    }
     return aiProvider;
 }
 
@@ -36,6 +48,7 @@ export async function activate(context: vscode.ExtensionContext) {
     // Create output channel for debugging
     outputChannel = vscode.window.createOutputChannel('SpecKit Companion');
     context.subscriptions.push(outputChannel);
+    extensionContext = context;
     setLifecycleOutputChannel(outputChannel);
     context.subscriptions.push(registerTerminalStepTracker(context));
 

--- a/tests/__mocks__/vscode.ts
+++ b/tests/__mocks__/vscode.ts
@@ -71,6 +71,12 @@ export class Uri {
         return new Uri(path);
     }
 
+    static parse(value: string): Uri {
+        // The mock keeps the parsed value verbatim so toString() round-trips it
+        // (real vscode.Uri.parse preserves scheme/authority/query).
+        return new Uri(value);
+    }
+
     static joinPath(base: Uri, ...pathSegments: string[]): Uri {
         const joined = [base.fsPath, ...pathSegments].join('/');
         return new Uri(joined);
@@ -97,7 +103,9 @@ export const workspace = {
         stat: jest.fn().mockRejectedValue(new Error('not found')),
         readFile: jest.fn().mockResolvedValue(new Uint8Array()),
         writeFile: jest.fn().mockResolvedValue(undefined),
+        createDirectory: jest.fn().mockResolvedValue(undefined),
     },
+    workspaceFolders: undefined as any,
     findFiles: jest.fn().mockResolvedValue([]),
     getConfiguration: jest.fn().mockReturnValue({
         get: jest.fn().mockReturnValue(['specs']),


### PR DESCRIPTION
## What

- New `claude-vscode` AI provider ("Claude in VS Code") that opens the Claude Code GUI panel via its URI handler and prefills the SpecKit command. The panel exposes no programmatic submit, so a notification prompts the user to press Enter.
- Extracted shared prompt-cleanup helpers (`readSpecDescription`, `specNameFromPath`, `cleanCommandArg`) into `promptBuilder`; both IDE Chat and the panel consume them (no duplication).
- The prefilled command is cleaned up: the new-spec description is inlined from its temp file, and spec-dir path arguments are shortened to just the spec name (no absolute `globalStorage` paths).
- `getAIProvider()` now resolves through the factory on every call instead of a singleton frozen at activation, so switching `speckit.aiProvider` applies without a window reload.
- README provider matrix gains a "Claude in VS Code" column and the count goes Seven → Eight; `code-simplifier` added to the `pre:code-review` hook.

## Why

Some users live in the Claude Code panel rather than a terminal; this gives them one-click SpecKit dispatch there, alongside the existing terminal `claude` provider.

## Testing

- `npm test` — 630 passing (12 new `claudePanelProvider` tests; the 25 IDE Chat tests are unchanged after the helper extraction)
- `npm run compile` clean