### PR TITLE
feat(workflows): hide workflows unsupported by the active AI provider

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,6 +11,7 @@
       "name": "sdd",
       "displayName": "SDD",
       "description": "Streamlined Spec-Driven Development Workflow",
+      "supportedAiProviders": ["claude", "claude-vscode"],
       "steps": [
         {
           "name": "specify",

--- a/README.md
+++ b/README.md
@@ -359,6 +359,33 @@ Workflows can define `commands`: extra action buttons that appear next to the pr
 
 Commands with `step: "specify"` appear as secondary buttons next to Submit in the spec creation dialog. Multiple commands per step are supported.
 
+#### Provider Compatibility
+
+A workflow can declare which AI providers it supports with `supportedAiProviders`. When set, the workflow is **hidden entirely** unless the active `speckit.aiProvider` is in the list — it disappears from the workflow picker, the spec editor, and every step/footer action. Omit the field (or use an empty array) to support all providers.
+
+```json
+{
+  "speckit.customWorkflows": [
+    {
+      "name": "sdd",
+      "displayName": "SDD Workflow",
+      "supportedAiProviders": ["claude"],
+      "steps": [
+        { "name": "specify", "label": "Specify", "command": "sdd.specify", "file": "spec.md" }
+      ]
+    }
+  ]
+}
+```
+
+The SDD workflow is implemented as Claude Code skills (`/sdd:*`), so declaring it `["claude"]` keeps it from appearing — as a dead, unrunnable path — under GitHub Copilot, Gemini, Qwen, or Codex.
+
+| Property | Required | Description |
+|----------|----------|-------------|
+| `supportedAiProviders` | No | Array of provider ids the workflow supports: `claude`, `gemini`, `copilot`, `codex`, `qwen`, `opencode`, `ide-chat`, `claude-vscode`. Omit or leave empty for all providers. An unknown id matches no real provider, hiding the workflow everywhere. |
+
+The built-in default workflow has no declaration and is always available, so at least one workflow is always selectable regardless of provider.
+
 #### Steps with sub-files
 
 Steps can declare child documents that appear as expandable items in the sidebar:

--- a/package.json
+++ b/package.json
@@ -983,6 +983,23 @@
                     },
                     "additionalProperties": false
                   }
+                },
+                "supportedAiProviders": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "enum": [
+                      "claude",
+                      "gemini",
+                      "copilot",
+                      "codex",
+                      "qwen",
+                      "opencode",
+                      "ide-chat",
+                      "claude-vscode"
+                    ]
+                  },
+                  "description": "AI provider ids this workflow supports. Omit or leave empty to support all providers. When set, the workflow is hidden unless the active speckit.aiProvider is in this list (e.g. [\"claude\"] for a Claude-only workflow like SDD)."
                 }
               },
               "additionalProperties": false

--- a/specs/105-workflow-provider-filter/.spec-context.json
+++ b/specs/105-workflow-provider-filter/.spec-context.json
@@ -10,7 +10,7 @@
   "branch": "feat/claude-panel-provider",
   "workingBranch": "feat/105-workflow-provider-filter",
   "type": "feat",
-  "auto": true,
+  "auto": false,
   "createdAt": "2026-05-23T12:47:35.625Z",
   "loadedDomains": [],
   "approach": "Add an optional supportedAiProviders field to WorkflowConfig and a shared isWorkflowSupportedForProvider predicate that both workflow-listing paths use to filter custom workflows by the active provider; the default speckit workflow is never filtered.",
@@ -259,6 +259,26 @@
       },
       "by": "sdd",
       "at": "2026-05-23T13:14:53.780Z"
+    },
+    {
+      "step": "done",
+      "substep": null,
+      "from": {
+        "step": "done",
+        "substep": null
+      },
+      "by": "sdd",
+      "at": "2026-05-23T13:26:00.923Z"
+    },
+    {
+      "step": "done",
+      "substep": null,
+      "from": {
+        "step": "done",
+        "substep": null
+      },
+      "by": "sdd",
+      "at": "2026-05-23T13:26:35.185Z"
     }
   ],
   "status": "completed",
@@ -333,7 +353,7 @@
       "concerns": []
     }
   },
-  "last_action": "T006 done \u2014 18/18 tests pass",
+  "last_action": "PR #172 opened \u2014 feat(workflows): hide workflows unsupported by the active AI provider",
   "files_modified": [
     "src/features/workflows/types.ts",
     "src/features/workflows/workflowManager.ts",
@@ -349,9 +369,11 @@
       "note": "package.json working tree has a version bump and spec-104 claude-vscode enum leftover; stage only the schema addition at commit"
     }
   ],
-  "drainedSeq": 11,
+  "drainedSeq": 12,
   "checkpointStatus": {
     "commit": true,
     "pr": true
-  }
+  },
+  "prUrl": "https://github.com/alfredoperez/speckit-companion/pull/172",
+  "prNumber": 172
 }

--- a/specs/105-workflow-provider-filter/.spec-context.json
+++ b/specs/105-workflow-provider-filter/.spec-context.json
@@ -1,0 +1,357 @@
+{
+  "workflow": "sdd",
+  "currentStep": "done",
+  "currentTask": null,
+  "progress": null,
+  "next": "done",
+  "updated": "2026-05-23",
+  "selectedAt": "2026-05-23T12:47:35.625Z",
+  "specName": "Provider-Aware Workflow Filtering",
+  "branch": "feat/claude-panel-provider",
+  "workingBranch": "feat/105-workflow-provider-filter",
+  "type": "feat",
+  "auto": true,
+  "createdAt": "2026-05-23T12:47:35.625Z",
+  "loadedDomains": [],
+  "approach": "Add an optional supportedAiProviders field to WorkflowConfig and a shared isWorkflowSupportedForProvider predicate that both workflow-listing paths use to filter custom workflows by the active provider; the default speckit workflow is never filtered.",
+  "step_summaries": {
+    "specify": {
+      "complexity": "normal",
+      "requirements": 7,
+      "scenarios": 5,
+      "key_finding": "Workflows are surfaced by two independent getWorkflows() functions (workflowManager.ts + specEditorProvider.ts), both reading speckit.customWorkflows; SDD is a user-installed custom workflow, not a code-level built-in, so the filter must live in both paths against getConfiguredProviderType()."
+    },
+    "plan": {
+      "approach_summary": "Add an optional supportedAiProviders field to WorkflowConfig and a shared isWorkflowSupportedForProvider predicate that both workflow-listing paths use to filter custom workflows by the active provider; the default speckit workflow is never filtered.",
+      "files_planned": 6,
+      "risks": [
+        "Importing getConfiguredProviderType into workflowManager.ts could create a circular import; aiProvider.ts imports only constants so it should be safe, otherwise read the config inline."
+      ],
+      "principles_concerns": 0,
+      "domain_concerns": 0,
+      "significance_score": 0
+    }
+  },
+  "transitions": [
+    {
+      "step": "specify",
+      "substep": "parsing",
+      "from": null,
+      "by": "sdd",
+      "at": "2026-05-23T12:47:35.625Z"
+    },
+    {
+      "step": "specify",
+      "substep": "exploring",
+      "from": {
+        "step": "specify",
+        "substep": "parsing"
+      },
+      "by": "sdd",
+      "at": "2026-05-23T12:47:35.640Z"
+    },
+    {
+      "step": "specify",
+      "substep": "detecting",
+      "from": {
+        "step": "specify",
+        "substep": "exploring"
+      },
+      "by": "sdd",
+      "at": "2026-05-23T12:47:35.655Z"
+    },
+    {
+      "step": "specify",
+      "substep": "writing-spec",
+      "from": {
+        "step": "specify",
+        "substep": "detecting"
+      },
+      "by": "sdd",
+      "at": "2026-05-23T12:47:35.670Z"
+    },
+    {
+      "step": "specify",
+      "substep": null,
+      "from": {
+        "step": "specify",
+        "substep": "writing-spec"
+      },
+      "by": "sdd",
+      "at": "2026-05-23T12:47:35.684Z"
+    },
+    {
+      "step": "specify",
+      "substep": null,
+      "from": {
+        "step": "specify",
+        "substep": null
+      },
+      "by": "sdd",
+      "at": "2026-05-23T12:48:21.015Z"
+    },
+    {
+      "step": "plan",
+      "substep": "loading",
+      "from": {
+        "step": "specify",
+        "substep": null
+      },
+      "by": "sdd",
+      "at": "2026-05-23T12:49:54.653Z"
+    },
+    {
+      "step": "plan",
+      "substep": "writing-plan",
+      "from": {
+        "step": "plan",
+        "substep": "loading"
+      },
+      "by": "sdd",
+      "at": "2026-05-23T12:49:54.667Z"
+    },
+    {
+      "step": "plan",
+      "substep": null,
+      "from": {
+        "step": "plan",
+        "substep": "writing-plan"
+      },
+      "by": "sdd",
+      "at": "2026-05-23T12:49:54.683Z"
+    },
+    {
+      "step": "tasks",
+      "substep": "loading",
+      "from": {
+        "step": "plan",
+        "substep": null
+      },
+      "by": "sdd",
+      "at": "2026-05-23T12:50:18.851Z"
+    },
+    {
+      "step": "tasks",
+      "substep": "writing-tasks",
+      "from": {
+        "step": "tasks",
+        "substep": "loading"
+      },
+      "by": "sdd",
+      "at": "2026-05-23T12:50:18.865Z"
+    },
+    {
+      "step": "tasks",
+      "substep": null,
+      "from": {
+        "step": "tasks",
+        "substep": "writing-tasks"
+      },
+      "by": "sdd",
+      "at": "2026-05-23T12:50:18.881Z"
+    },
+    {
+      "step": "implement",
+      "substep": "phase1",
+      "from": {
+        "step": "tasks",
+        "substep": null
+      },
+      "by": "sdd",
+      "at": "2026-05-23T12:53:21.552Z"
+    },
+    {
+      "step": "implement",
+      "substep": "phase1",
+      "from": {
+        "step": "implement",
+        "substep": "phase1"
+      },
+      "by": "sdd",
+      "at": "2026-05-23T12:59:24.484Z"
+    },
+    {
+      "step": "implement",
+      "substep": "phase1",
+      "from": {
+        "step": "implement",
+        "substep": "phase1"
+      },
+      "by": "sdd",
+      "at": "2026-05-23T12:59:24.528Z"
+    },
+    {
+      "step": "implement",
+      "substep": "phase1",
+      "from": {
+        "step": "implement",
+        "substep": "phase1"
+      },
+      "by": "sdd",
+      "at": "2026-05-23T12:59:24.571Z"
+    },
+    {
+      "step": "implement",
+      "substep": "phase1",
+      "from": {
+        "step": "implement",
+        "substep": "phase1"
+      },
+      "by": "sdd",
+      "at": "2026-05-23T12:59:24.612Z"
+    },
+    {
+      "step": "implement",
+      "substep": "phase1",
+      "from": {
+        "step": "implement",
+        "substep": "phase1"
+      },
+      "by": "sdd",
+      "at": "2026-05-23T12:59:24.653Z"
+    },
+    {
+      "step": "implement",
+      "substep": "phase1",
+      "from": {
+        "step": "implement",
+        "substep": "phase1"
+      },
+      "by": "sdd",
+      "at": "2026-05-23T12:59:24.695Z"
+    },
+    {
+      "step": "implement",
+      "substep": "hooks",
+      "from": {
+        "step": "implement",
+        "substep": "phase1"
+      },
+      "by": "sdd",
+      "at": "2026-05-23T13:00:27.419Z"
+    },
+    {
+      "step": "implement",
+      "substep": "code-review",
+      "from": {
+        "step": "implement",
+        "substep": "hooks"
+      },
+      "by": "sdd",
+      "at": "2026-05-23T13:07:54.248Z"
+    },
+    {
+      "step": "implement",
+      "substep": "commit-review",
+      "from": {
+        "step": "implement",
+        "substep": "code-review"
+      },
+      "by": "sdd",
+      "at": "2026-05-23T13:14:23.500Z"
+    },
+    {
+      "step": "done",
+      "substep": null,
+      "from": {
+        "step": "implement",
+        "substep": "commit-review"
+      },
+      "by": "sdd",
+      "at": "2026-05-23T13:14:53.780Z"
+    }
+  ],
+  "status": "completed",
+  "stepHistory": {
+    "specify": {
+      "startedAt": "2026-05-23T12:50:18.881Z",
+      "completedAt": "2026-05-23T12:50:18.881Z"
+    },
+    "plan": {
+      "startedAt": "2026-05-23T12:50:18.881Z",
+      "completedAt": "2026-05-23T12:50:18.881Z"
+    },
+    "tasks": {
+      "startedAt": "2026-05-23T12:50:18.881Z",
+      "completedAt": "2026-05-23T12:59:24.695Z"
+    },
+    "implement": {
+      "startedAt": "2026-05-23T12:59:24.695Z",
+      "completedAt": null
+    }
+  },
+  "task_summaries": {
+    "T001": {
+      "status": "DONE",
+      "did": "Added optional supportedAiProviders field to WorkflowConfig",
+      "files": [
+        "src/features/workflows/types.ts"
+      ],
+      "concerns": []
+    },
+    "T002": {
+      "status": "DONE",
+      "did": "Added isWorkflowSupportedForProvider predicate, provider filter in getWorkflows, and validation; compile confirms no circular import",
+      "files": [
+        "src/features/workflows/workflowManager.ts"
+      ],
+      "concerns": []
+    },
+    "T003": {
+      "status": "DONE",
+      "did": "Added supportedAiProviders to customWorkflows settings schema (additionalProperties:false required it)",
+      "files": [
+        "package.json"
+      ],
+      "concerns": [
+        "package.json also carries an unrelated version bump (0.18.8) and an orphaned claude-vscode enum line from spec 104 \u2014 must not be committed under this PR"
+      ]
+    },
+    "T004": {
+      "status": "DONE",
+      "did": "Documented supportedAiProviders in README Custom Workflows (new Provider Compatibility subsection + property table + behavior note)",
+      "files": [
+        "README.md"
+      ],
+      "concerns": []
+    },
+    "T005": {
+      "status": "DONE",
+      "did": "Filtered spec-editor webview workflow list by active provider (inline type + isWorkflowSupportedForProvider); also added barrel export",
+      "files": [
+        "src/features/spec-editor/specEditorProvider.ts",
+        "src/features/workflows/index.ts"
+      ],
+      "concerns": []
+    },
+    "T006": {
+      "status": "DONE",
+      "did": "Added 14 tests (predicate, provider-aware getWorkflows, validation); all 18 pass",
+      "files": [
+        "src/features/workflows/__tests__/workflowManager.test.ts"
+      ],
+      "concerns": []
+    }
+  },
+  "last_action": "T006 done \u2014 18/18 tests pass",
+  "files_modified": [
+    "src/features/workflows/types.ts",
+    "src/features/workflows/workflowManager.ts",
+    "package.json",
+    "README.md",
+    "src/features/spec-editor/specEditorProvider.ts",
+    "src/features/workflows/index.ts",
+    "src/features/workflows/__tests__/workflowManager.test.ts"
+  ],
+  "concerns": [
+    {
+      "task": "T003",
+      "note": "package.json working tree has a version bump and spec-104 claude-vscode enum leftover; stage only the schema addition at commit"
+    }
+  ],
+  "drainedSeq": 11,
+  "checkpointStatus": {
+    "commit": true,
+    "pr": true
+  }
+}

--- a/specs/105-workflow-provider-filter/plan.md
+++ b/specs/105-workflow-provider-filter/plan.md
@@ -1,0 +1,64 @@
+# Plan: Provider-Aware Workflow Filtering
+
+**Spec**: [spec.md](./spec.md)
+
+## Approach
+
+Add an optional `supportedAiProviders?: string[]` field to `WorkflowConfig` and
+introduce a single shared predicate, `isWorkflowSupportedForProvider(workflow,
+providerType)`, in [workflowManager.ts](../../src/features/workflows/workflowManager.ts).
+Both workflow-listing paths — `getWorkflows()` in `workflowManager.ts` (selector,
+viewer, `getWorkflow`) and the private `getWorkflows()` in
+[specEditorProvider.ts](../../src/features/spec-editor/specEditorProvider.ts)
+(editor webview picker) — filter their custom-workflow loop through that predicate
+against the active provider from `getConfiguredProviderType()`. The default
+`speckit` workflow is never run through the filter, so a workflow is always
+available. Empty/omitted list = supported everywhere, preserving today's behavior.
+
+## Files
+
+### Modify
+
+- `src/features/workflows/types.ts` — add `supportedAiProviders?: string[]` to
+  `WorkflowConfig` with a doc comment (omitted/empty = all providers).
+- `src/features/workflows/workflowManager.ts` — (1) export
+  `isWorkflowSupportedForProvider(workflow, providerType)`: returns `true` when
+  `supportedAiProviders` is absent/empty, else `true` only if `providerType` is in
+  the list; (2) in `getWorkflows()`, after the duplicate check, skip any custom
+  workflow the active provider doesn't support (read provider via
+  `getConfiguredProviderType()`); `DEFAULT_WORKFLOW` is pushed unconditionally;
+  (3) extend `validateWorkflow()` to error when `supportedAiProviders` is present
+  and not an array of strings, and warn (non-blocking) on a provider id not in
+  `AIProviders`.
+- `src/features/spec-editor/specEditorProvider.ts` — add `supportedAiProviders?:
+  string[]` to the inline `customWorkflows` type, and reuse
+  `isWorkflowSupportedForProvider` to skip unsupported workflows in the custom
+  loop (the hardcoded `speckit` entry stays).
+- `package.json` — add a `supportedAiProviders` property to the
+  `speckit.customWorkflows` items schema (array of strings; the item schema has
+  `additionalProperties: false`, so without this the field is rejected by settings
+  validation). Describe it and reference the valid provider ids.
+- `README.md` — document `supportedAiProviders` in the Custom Workflows
+  properties table (per the CLAUDE.md feature→README map: a new sub-document /
+  workflow property).
+- `src/features/workflows/__tests__/workflowManager.test.ts` — tests for the
+  predicate, provider-aware `getWorkflows()` filtering, default-always-present,
+  and validation of the new field.
+
+## Testing Strategy
+
+- **Unit**: with the VS Code config mock, set `speckit.aiProvider` and
+  `speckit.customWorkflows`, then assert `getWorkflows()` includes/excludes each
+  workflow. Cover: claude-only workflow hidden under `copilot`, shown under
+  `claude`; no-declaration workflow always present; empty-array treated as all;
+  `speckit` default always present even when nothing else matches; unknown
+  provider id never matches (stays hidden).
+- **Edge cases**: `validateWorkflow` rejects a non-array `supportedAiProviders`;
+  warns on an unknown id but keeps the workflow valid.
+
+## Risks
+
+- Importing `getConfiguredProviderType` into `workflowManager.ts`: verify it
+  introduces no circular import (`aiProvider.ts` imports only `constants`, not
+  `workflows`, so it should be safe). If a cycle appears, read the config inline
+  (`getConfiguration('speckit').get('aiProvider', 'claude')`) instead.

--- a/specs/105-workflow-provider-filter/spec.md
+++ b/specs/105-workflow-provider-filter/spec.md
@@ -1,0 +1,91 @@
+# Spec: Provider-Aware Workflow Filtering
+
+**Slug**: 105-workflow-provider-filter | **Date**: 2026-05-23
+
+## Summary
+
+Custom workflows can declare which AI providers they support, and the extension
+hides any workflow whose supported-providers list excludes the currently active
+provider (`speckit.aiProvider`). This removes dead affordances like the
+Claude-only SDD workflow (`/sdd:*` skills) appearing under GitHub Copilot,
+Gemini, Qwen, or Codex — where its commands dispatch to a host chat that has no
+idea what they are and can never succeed. The rule is generic: any future
+provider-specific workflow is handled by its own declaration instead of a
+one-off check.
+
+## Requirements
+
+- **R001** (MUST): Add an optional `supportedAiProviders?: string[]` field to the
+  `WorkflowConfig` type. Each entry is an AI provider id (e.g. `"claude"`,
+  `"copilot"`). When the field is omitted or an empty array, the workflow is
+  treated as supported by **all** providers (current behavior preserved).
+- **R002** (MUST): When the field is present and non-empty, the workflow is
+  surfaced only if the active provider — `getConfiguredProviderType()` reading
+  `speckit.aiProvider` — is in the list. Otherwise it is hidden entirely (no
+  greyed-out / disabled state).
+- **R003** (MUST): Apply the same provider filter in **both** workflow-listing
+  paths: `getWorkflows()` in [workflowManager.ts](../../src/features/workflows/workflowManager.ts)
+  (feeds the QuickPick selector, `getWorkflow`, viewer footer/steps) and the
+  private `getWorkflows()` in [specEditorProvider.ts](../../src/features/spec-editor/specEditorProvider.ts)
+  (feeds the spec-editor webview workflow picker).
+- **R004** (MUST): The built-in default `speckit` workflow must never be filtered
+  out — it has no `supportedAiProviders` declaration and always remains the
+  baseline so at least one workflow is always available.
+- **R005** (SHOULD): Comparison is case-sensitive against the canonical provider
+  id strings in `AIProviders` (`claude`, `gemini`, `copilot`, `codex`, `qwen`,
+  `opencode`, `ide-chat`, `claude-vscode`). `claude-vscode` and `claude` are
+  distinct ids and must each be listed explicitly if both are intended.
+- **R006** (SHOULD): `validateWorkflow()` accepts `supportedAiProviders` when it
+  is an array of strings; a non-array value is an error and a workflow with an
+  unknown provider id logs a warning (the unknown id simply never matches, so
+  the workflow stays hidden for every real provider).
+- **R007** (SHOULD): A workflow hidden because the active provider was changed
+  becomes visible again when the provider is switched back — no caching that
+  outlives a `speckit.aiProvider` change.
+
+## Scenarios
+
+### SDD hidden under an incompatible provider
+
+**When** the SDD custom workflow declares `supportedAiProviders: ["claude"]` and
+the active provider is `copilot`
+**Then** SDD does not appear in the spec-editor workflow picker, the QuickPick
+selector, or any footer/step affordance, and `getWorkflow("sdd")` returns
+`undefined` (callers fall back to the default `speckit` workflow for display).
+
+### SDD visible under Claude
+
+**When** the same SDD workflow is declared Claude-only and the active provider is
+`claude`
+**Then** SDD appears in every workflow surface exactly as it does today.
+
+### Workflow with no declaration
+
+**When** a custom workflow omits `supportedAiProviders` (or sets `[]`)
+**Then** it appears under every provider, unchanged from current behavior.
+
+### Provider switched at runtime
+
+**When** the user changes `speckit.aiProvider` from `claude` to `gemini` while a
+Claude-only workflow exists
+**Then** the next time workflows are listed (selector opened, editor opened,
+viewer refreshed) that workflow is absent; switching back to `claude` restores
+it.
+
+### Default workflow always present
+
+**When** the active provider matches no custom workflow's declaration
+**Then** the built-in `speckit` workflow is still listed and selectable.
+
+## Out of Scope
+
+- Making SDD (or any workflow) actually *run* on non-Claude providers.
+- Per-command (vs per-workflow) provider gating.
+- Runtime probing of provider capabilities — declarations are static config.
+- A settings UI to edit `supportedAiProviders` — config/definition-level only.
+- Authoring the SDD workflow's `supportedAiProviders: ["claude"]` value itself:
+  the SDD workflow definition is installed into the user's
+  `speckit.customWorkflows` settings by the **SDD skill installer** (separate
+  repo), not shipped by this extension. This spec delivers the extension-side
+  field + filtering mechanism that the declaration relies on; tagging SDD is a
+  one-line config change made wherever that workflow is defined.

--- a/specs/105-workflow-provider-filter/tasks.md
+++ b/specs/105-workflow-provider-filter/tasks.md
@@ -1,0 +1,37 @@
+# Tasks: Provider-Aware Workflow Filtering
+
+**Plan**: [plan.md](./plan.md)
+
+> Format reference: `[P]` markers and parallel groups — see `skills/tasks/SKILL.md` § Phase rules.
+
+## Phase 1: Core Implementation
+
+- [x] **T001** Add `supportedAiProviders` to `WorkflowConfig` — `src/features/workflows/types.ts` | R001
+  - **Do**: Add `supportedAiProviders?: string[];` to the `WorkflowConfig` interface (after `commands`), with a doc comment: omitted or empty array = supported by all providers; otherwise the workflow is only surfaced when the active provider id is in the list.
+  - **Verify**: `npm run compile` type-checks clean.
+  - **Leverage**: existing optional fields in `WorkflowConfig` ([src/features/workflows/types.ts](../../src/features/workflows/types.ts#L59-L76)).
+
+- [x] **T002** [P] Predicate + provider filter + validation in workflow manager *(depends on T001)* — `src/features/workflows/workflowManager.ts` | R002, R003, R004, R005, R006
+  - **Do**: (1) Export `isWorkflowSupportedForProvider(workflow: WorkflowConfig, providerType: AIProviderType): boolean` — returns `true` when `supportedAiProviders` is undefined/empty, else `true` only if `providerType` is included. (2) In `getWorkflows()`, read the active provider via `getConfiguredProviderType()` once, and after the duplicate check skip any custom workflow for which the predicate returns `false` (log a line via `outputChannel`); push `DEFAULT_WORKFLOW` unconditionally so it is never filtered. (3) In `validateWorkflow()`, if `supportedAiProviders` is present and not an array of strings push an error; for each entry not in `AIProviders` push a non-blocking warning.
+  - **Verify**: `npm run compile` passes; no circular-import error from importing `getConfiguredProviderType`/`AIProviderType` (if one appears, read `aiProvider` config inline per plan Risks).
+  - **Leverage**: `getConfiguredProviderType()` + `AIProviders` ([src/ai-providers/aiProvider.ts](../../src/ai-providers/aiProvider.ts#L419-L426), [src/core/constants.ts](../../src/core/constants.ts#L250-L260)); existing `getWorkflows()` loop ([src/features/workflows/workflowManager.ts](../../src/features/workflows/workflowManager.ts#L160-L189)).
+
+- [x] **T003** [P] Add `supportedAiProviders` to the settings schema *(depends on T001)* — `package.json` | R001
+  - **Do**: Add a `supportedAiProviders` property to the `speckit.customWorkflows` items schema (the item schema sets `additionalProperties: false`, so the field is rejected without this): `type: array`, `items: { type: string }`, with a description listing valid provider ids (`claude`, `gemini`, `copilot`, `codex`, `qwen`, `opencode`, `ide-chat`, `claude-vscode`) and noting empty/omitted = all providers.
+  - **Verify**: `package.json` stays valid JSON; the field is accepted in settings without a validation squiggle.
+  - **Leverage**: existing `commands`/`steps` property definitions in the same schema block ([package.json](../../package.json#L864-L991)).
+
+- [x] **T004** [P] Document `supportedAiProviders` *(depends on T001)* — `README.md` | R001
+  - **Do**: Add `supportedAiProviders` to the Custom Workflows properties table (string array; omitted/empty = all providers; lists which workflows show under which providers) and note SDD is Claude-only as the motivating example.
+  - **Verify**: README renders; entry matches the field name and semantics.
+  - **Leverage**: existing Custom Workflows properties table in README.
+
+- [x] **T005** Filter the spec-editor webview workflow list *(depends on T002)* — `src/features/spec-editor/specEditorProvider.ts` | R003
+  - **Do**: Add `supportedAiProviders?: string[]` to the inline `customWorkflows` type in the private `getWorkflows()`, and in the custom-workflow loop skip any workflow for which `isWorkflowSupportedForProvider(...)` (imported from `workflowManager`) returns `false`, using `getConfiguredProviderType()`. Leave the hardcoded `speckit` entry unconditional.
+  - **Verify**: `npm run compile` passes; under a non-Claude provider the editor picker omits Claude-only workflows.
+  - **Leverage**: existing imports from `workflowManager` and the loop at [src/features/spec-editor/specEditorProvider.ts](../../src/features/spec-editor/specEditorProvider.ts#L54-L100).
+
+- [x] **T006** [P] Tests for predicate, filtering, and validation *(depends on T002)* — `src/features/workflows/__tests__/workflowManager.test.ts` | R002, R004, R005, R006
+  - **Do**: Add BDD tests: claude-only workflow hidden when `speckit.aiProvider` is `copilot` and shown when `claude`; no-declaration and empty-array workflows always present; `speckit` default always present even when no custom workflow matches; unknown provider id never matches; `validateWorkflow` errors on non-array `supportedAiProviders` and warns (stays valid) on an unknown id.
+  - **Verify**: `npm test` passes.
+  - **Leverage**: existing VS Code config mocking pattern in [workflowManager.test.ts](../../src/features/workflows/__tests__/workflowManager.test.ts).

--- a/src/features/spec-editor/specEditorProvider.ts
+++ b/src/features/spec-editor/specEditorProvider.ts
@@ -8,9 +8,10 @@ import type {
     AttachedImage,
     WorkflowDefinition
 } from './types';
-import { normalizeWorkflowConfig, resolveStepCommand } from '../workflows';
+import { normalizeWorkflowConfig, resolveStepCommand, isWorkflowSupportedForProvider } from '../workflows';
+import type { WorkflowConfig } from '../workflows';
 import { formatCommandForProvider } from '../../ai-providers/aiProvider';
-import { AIProviders, WorkflowSteps } from '../../core/constants';
+import { AIProviders, WorkflowSteps, ConfigKeys } from '../../core/constants';
 
 /**
  * Generates a random nonce for CSP
@@ -52,17 +53,11 @@ export class SpecEditorProvider {
      * Get available workflows from settings
      */
     private getWorkflows(): WorkflowDefinition[] {
-        const config = vscode.workspace.getConfiguration('speckit');
-        const customWorkflows = config.get<Array<{
-            name: string;
-            displayName?: string;
-            description?: string;
-            'step-specify'?: string;
-            'step-plan'?: string;
-            'step-implement'?: string;
-        }>>('customWorkflows', []);
+        const config = vscode.workspace.getConfiguration(ConfigKeys.namespace);
+        const customWorkflows = config.get<WorkflowConfig[]>('customWorkflows', []);
+        const activeProvider = getConfiguredProviderType();
 
-        // Always include default workflow
+        // Always include default workflow (no provider declaration → never filtered)
         const workflows: WorkflowDefinition[] = [
             {
                 name: 'speckit',
@@ -72,10 +67,11 @@ export class SpecEditorProvider {
             }
         ];
 
-        // Add custom workflows
+        // Add custom workflows the active provider supports
         for (const wf of customWorkflows) {
-            if (wf.name && wf.name !== 'speckit' && wf.name !== 'default') {
-                const normalized = normalizeWorkflowConfig(wf as any);
+            if (wf.name && wf.name !== 'speckit' && wf.name !== 'default'
+                && isWorkflowSupportedForProvider(wf, activeProvider)) {
+                const normalized = normalizeWorkflowConfig(wf);
                 workflows.push({
                     name: wf.name,
                     displayName: wf.displayName || wf.name,
@@ -83,9 +79,9 @@ export class SpecEditorProvider {
                     stepSpecify: `/${formatCommandForProvider(resolveStepCommand(normalized, WorkflowSteps.SPECIFY))}`,
                     stepPlan: formatCommandForProvider(wf[WorkflowSteps.CONFIG_PLAN] || (normalized.steps?.find(s => s.name === WorkflowSteps.PLAN)?.command) || 'speckit.plan'),
                     stepImplement: formatCommandForProvider(wf[WorkflowSteps.CONFIG_IMPLEMENT] || (normalized.steps?.find(s => s.name === WorkflowSteps.IMPLEMENT)?.command) || 'speckit.implement'),
-                    specifyCommands: ((wf as any).commands || [])
-                        .filter((c: any) => c.step === WorkflowSteps.SPECIFY)
-                        .map((c: any) => ({ name: c.name, title: c.title || c.name, command: c.command, tooltip: c.tooltip })),
+                    specifyCommands: (wf.commands || [])
+                        .filter(c => c.step === WorkflowSteps.SPECIFY)
+                        .map(c => ({ name: c.name, title: c.title || c.name, command: c.command, tooltip: c.tooltip })),
                 });
             }
         }

--- a/src/features/spec-editor/specEditorProvider.ts
+++ b/src/features/spec-editor/specEditorProvider.ts
@@ -86,7 +86,10 @@ export class SpecEditorProvider {
             }
         }
 
-        // Cache workflows for lookup
+        // Cache workflows for lookup. Rebuilt on every panel open; correctness
+        // across an aiProvider change relies on that change forcing a window
+        // reload (see extension.ts) which disposes this provider. If live
+        // provider switching is ever added, rebuild this on panel reveal too.
         this.workflows.clear();
         for (const wf of workflows) {
             this.workflows.set(wf.name, wf);

--- a/src/features/workflows/__tests__/workflowManager.test.ts
+++ b/src/features/workflows/__tests__/workflowManager.test.ts
@@ -9,6 +9,7 @@ const mockGetConfig = jest.fn();
 import {
     getWorkflowCommands,
     getWorkflows,
+    getWorkflow,
     isWorkflowSupportedForProvider,
     validateWorkflow,
 } from '../workflowManager';
@@ -185,5 +186,22 @@ describe('validateWorkflow supportedAiProviders', () => {
         const result = validateWorkflow({ name: 'sdd', supportedAiProviders: ['bogus'] });
         expect(result.valid).toBe(true);
         expect(result.warnings.some(w => w.includes('bogus'))).toBe(true);
+    });
+});
+
+describe('getWorkflow resolves regardless of active provider', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('still resolves a claude-only workflow under a non-claude provider', () => {
+        // The picker hides it (getWorkflows filters), but an existing spec that
+        // already selected it must keep its real steps.
+        mockConfig('ide-chat', [
+            { name: 'sdd', supportedAiProviders: ['claude'], steps: [{ name: 'specify', command: 'sdd:specify' }] },
+        ]);
+
+        expect(getWorkflows().map(w => w.name)).not.toContain('sdd'); // hidden from selection
+        expect(getWorkflow('sdd')?.name).toBe('sdd');                  // but still resolvable
     });
 });

--- a/src/features/workflows/__tests__/workflowManager.test.ts
+++ b/src/features/workflows/__tests__/workflowManager.test.ts
@@ -6,7 +6,28 @@ const mockGetConfig = jest.fn();
     get: mockGetConfig,
 });
 
-import { getWorkflowCommands } from '../workflowManager';
+import {
+    getWorkflowCommands,
+    getWorkflows,
+    isWorkflowSupportedForProvider,
+    validateWorkflow,
+} from '../workflowManager';
+
+/**
+ * Make the shared config mock key-aware so getWorkflows() can read both
+ * `customWorkflows` and `aiProvider` (the latter via getConfiguredProviderType).
+ */
+function mockConfig(provider: string, customWorkflows: unknown[]): void {
+    mockGetConfig.mockImplementation((key: string, def?: unknown) => {
+        if (key === 'aiProvider') {
+            return provider;
+        }
+        if (key === 'customWorkflows') {
+            return customWorkflows;
+        }
+        return def;
+    });
+}
 
 describe('getWorkflowCommands', () => {
     beforeEach(() => {
@@ -51,5 +72,118 @@ describe('getWorkflowCommands', () => {
         const result = getWorkflowCommands('speckit');
 
         expect(result).toEqual([]);
+    });
+});
+
+describe('isWorkflowSupportedForProvider', () => {
+    it('supports every provider when supportedAiProviders is omitted', () => {
+        expect(isWorkflowSupportedForProvider({ name: 'wf' }, 'copilot')).toBe(true);
+    });
+
+    it('supports every provider when supportedAiProviders is empty', () => {
+        expect(isWorkflowSupportedForProvider({ name: 'wf', supportedAiProviders: [] }, 'gemini')).toBe(true);
+    });
+
+    it('supports only the declared providers', () => {
+        const wf = { name: 'sdd', supportedAiProviders: ['claude'] };
+        expect(isWorkflowSupportedForProvider(wf, 'claude')).toBe(true);
+        expect(isWorkflowSupportedForProvider(wf, 'copilot')).toBe(false);
+    });
+
+    it('treats claude and claude-vscode as distinct ids', () => {
+        const wf = { name: 'sdd', supportedAiProviders: ['claude'] };
+        expect(isWorkflowSupportedForProvider(wf, 'claude-vscode')).toBe(false);
+    });
+
+    it('never matches an unknown provider id', () => {
+        const wf = { name: 'wf', supportedAiProviders: ['bogus'] };
+        expect(isWorkflowSupportedForProvider(wf, 'claude')).toBe(false);
+    });
+});
+
+describe('getWorkflows provider filtering', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('hides a claude-only workflow under a non-claude provider', () => {
+        mockConfig('copilot', [
+            { name: 'sdd', supportedAiProviders: ['claude'], steps: [{ name: 'specify', command: 'sdd.specify' }] },
+        ]);
+
+        const names = getWorkflows().map(w => w.name);
+
+        expect(names).not.toContain('sdd');
+    });
+
+    it('shows a claude-only workflow under claude', () => {
+        mockConfig('claude', [
+            { name: 'sdd', supportedAiProviders: ['claude'], steps: [{ name: 'specify', command: 'sdd.specify' }] },
+        ]);
+
+        const names = getWorkflows().map(w => w.name);
+
+        expect(names).toContain('sdd');
+    });
+
+    it('shows workflows with no declaration under any provider', () => {
+        mockConfig('gemini', [
+            { name: 'generic', steps: [{ name: 'specify', command: 'x.specify' }] },
+        ]);
+
+        const names = getWorkflows().map(w => w.name);
+
+        expect(names).toContain('generic');
+    });
+
+    it('treats an empty supportedAiProviders as all providers', () => {
+        mockConfig('qwen', [
+            { name: 'anywhere', supportedAiProviders: [], steps: [{ name: 'specify', command: 'x.specify' }] },
+        ]);
+
+        const names = getWorkflows().map(w => w.name);
+
+        expect(names).toContain('anywhere');
+    });
+
+    it('always includes the default speckit workflow even when nothing else matches', () => {
+        mockConfig('codex', [
+            { name: 'sdd', supportedAiProviders: ['claude'], steps: [{ name: 'specify', command: 'sdd.specify' }] },
+        ]);
+
+        const names = getWorkflows().map(w => w.name);
+
+        expect(names).toContain('speckit');
+        expect(names).not.toContain('sdd');
+    });
+
+    it('hides a workflow whose only declared provider id is unknown', () => {
+        mockConfig('claude', [
+            { name: 'broken', supportedAiProviders: ['bogus'], steps: [{ name: 'specify', command: 'x.specify' }] },
+        ]);
+
+        const names = getWorkflows().map(w => w.name);
+
+        expect(names).not.toContain('broken');
+    });
+});
+
+describe('validateWorkflow supportedAiProviders', () => {
+    it('accepts a valid array of known provider ids', () => {
+        const result = validateWorkflow({ name: 'sdd', supportedAiProviders: ['claude', 'claude-vscode'] });
+        expect(result.valid).toBe(true);
+        expect(result.warnings).toHaveLength(0);
+    });
+
+    it('errors when supportedAiProviders is not an array', () => {
+        const result = validateWorkflow({ name: 'sdd', supportedAiProviders: 'claude' as unknown as string[] });
+        expect(result.valid).toBe(false);
+        expect(result.errors.some(e => e.includes('supportedAiProviders'))).toBe(true);
+    });
+
+    it('warns but stays valid on an unknown provider id', () => {
+        const result = validateWorkflow({ name: 'sdd', supportedAiProviders: ['bogus'] });
+        expect(result.valid).toBe(true);
+        expect(result.warnings.some(w => w.includes('bogus'))).toBe(true);
     });
 });

--- a/src/features/workflows/index.ts
+++ b/src/features/workflows/index.ts
@@ -38,6 +38,7 @@ export {
     resolveStepCommand,
     validateWorkflowsOnActivation,
     registerWorkflowConfigChangeListener,
+    isWorkflowSupportedForProvider,
 } from './workflowManager';
 
 // Workflow Selector

--- a/src/features/workflows/types.ts
+++ b/src/features/workflows/types.ts
@@ -73,6 +73,12 @@ export interface WorkflowConfig {
     checkpoints?: CheckpointConfig[];
     /** Custom command buttons shown next to step actions */
     commands?: WorkflowCommandConfig[];
+    /**
+     * AI provider ids this workflow supports (e.g. `["claude"]`).
+     * Omitted or empty = supported by all providers. When non-empty, the
+     * workflow is only surfaced while the active provider id is in the list.
+     */
+    supportedAiProviders?: string[];
 }
 
 /**

--- a/src/features/workflows/workflowManager.ts
+++ b/src/features/workflows/workflowManager.ts
@@ -18,7 +18,8 @@ import {
     WORKFLOW_NAME_PATTERN,
     FEATURE_CONTEXT_FILE,
 } from './types';
-import { ConfigKeys, WorkflowSteps } from '../../core/constants';
+import { ConfigKeys, WorkflowSteps, AIProviders } from '../../core/constants';
+import { getConfiguredProviderType, AIProviderType } from '../../ai-providers/aiProvider';
 
 /**
  * Legacy alias — existing .spec-context.json files may use "default".
@@ -87,6 +88,25 @@ export function normalizeWorkflowConfig(config: WorkflowConfig): WorkflowConfig 
 }
 
 /**
+ * Whether a workflow should be surfaced for the given AI provider.
+ *
+ * A workflow with no `supportedAiProviders` (undefined or empty array) is
+ * supported everywhere. Otherwise it is supported only when `providerType`
+ * appears in the list — comparison is case-sensitive against the canonical
+ * provider ids in `AIProviders`.
+ */
+export function isWorkflowSupportedForProvider(
+    config: WorkflowConfig,
+    providerType: AIProviderType
+): boolean {
+    const supported = config.supportedAiProviders;
+    if (!supported || supported.length === 0) {
+        return true;
+    }
+    return supported.includes(providerType);
+}
+
+/**
  * Validate a workflow configuration
  * @param config Workflow configuration to validate
  * @returns Validation result with errors and warnings
@@ -146,6 +166,24 @@ export function validateWorkflow(config: WorkflowConfig): ValidationResult {
         }
     }
 
+    // Validate supportedAiProviders
+    if (config.supportedAiProviders !== undefined) {
+        if (!Array.isArray(config.supportedAiProviders)) {
+            errors.push('supportedAiProviders must be an array of provider ids');
+        } else {
+            const knownProviders = Object.values(AIProviders) as string[];
+            for (const provider of config.supportedAiProviders) {
+                if (typeof provider !== 'string') {
+                    errors.push('supportedAiProviders entries must be strings');
+                } else if (!knownProviders.includes(provider)) {
+                    warnings.push(
+                        `Unknown AI provider "${provider}" in supportedAiProviders — workflow will be hidden for every provider until corrected`
+                    );
+                }
+            }
+        }
+    }
+
     return {
         valid: errors.length === 0,
         errors,
@@ -160,7 +198,10 @@ export function validateWorkflow(config: WorkflowConfig): ValidationResult {
 export function getWorkflows(outputChannel?: vscode.OutputChannel): WorkflowConfig[] {
     const config = vscode.workspace.getConfiguration(ConfigKeys.namespace);
     const customWorkflows = config.get<WorkflowConfig[]>('customWorkflows', []);
+    const activeProvider = getConfiguredProviderType();
 
+    // The default workflow has no provider declaration, so it is never filtered —
+    // at least one workflow is always available.
     const validWorkflows: WorkflowConfig[] = [DEFAULT_WORKFLOW];
     const seenNames = new Set<string>(['speckit', LEGACY_DEFAULT_NAME]);
 
@@ -171,6 +212,13 @@ export function getWorkflows(outputChannel?: vscode.OutputChannel): WorkflowConf
             if (seenNames.has(workflow.name)) {
                 outputChannel?.appendLine(
                     `[Workflows] Duplicate workflow name "${workflow.name}" - skipping duplicate`
+                );
+                continue;
+            }
+            // Hide workflows the active provider can't run
+            if (!isWorkflowSupportedForProvider(workflow, activeProvider)) {
+                outputChannel?.appendLine(
+                    `[Workflows] Workflow "${workflow.name}" not supported by provider "${activeProvider}" - hiding`
                 );
                 continue;
             }

--- a/src/features/workflows/workflowManager.ts
+++ b/src/features/workflows/workflowManager.ts
@@ -26,6 +26,9 @@ import { getConfiguredProviderType, AIProviderType } from '../../ai-providers/ai
  */
 const LEGACY_DEFAULT_NAME = 'default';
 
+/** Canonical provider ids — used to validate workflow `supportedAiProviders` entries. */
+const KNOWN_PROVIDERS = Object.values(AIProviders) as string[];
+
 /**
  * Default workflow configuration (always available)
  */
@@ -171,13 +174,12 @@ export function validateWorkflow(config: WorkflowConfig): ValidationResult {
         if (!Array.isArray(config.supportedAiProviders)) {
             errors.push('supportedAiProviders must be an array of provider ids');
         } else {
-            const knownProviders = Object.values(AIProviders) as string[];
             for (const provider of config.supportedAiProviders) {
                 if (typeof provider !== 'string') {
                     errors.push('supportedAiProviders entries must be strings');
-                } else if (!knownProviders.includes(provider)) {
+                } else if (!KNOWN_PROVIDERS.includes(provider)) {
                     warnings.push(
-                        `Unknown AI provider "${provider}" in supportedAiProviders — workflow will be hidden for every provider until corrected`
+                        `Unknown AI provider "${provider}" in supportedAiProviders — this id will never match any provider and is ignored`
                     );
                 }
             }
@@ -195,7 +197,14 @@ export function validateWorkflow(config: WorkflowConfig): ValidationResult {
  * Get all configured workflows including the default
  * @returns Array of workflow configurations
  */
-export function getWorkflows(outputChannel?: vscode.OutputChannel): WorkflowConfig[] {
+/**
+ * Build the validated, de-duplicated workflow list (default + custom workflows).
+ * When `filterByProvider` is true, workflows the active provider can't run are
+ * hidden — for SELECTION surfaces (picker, spec-editor). Resolution of an
+ * already-chosen workflow (`getWorkflow`) must NOT filter, otherwise an existing
+ * spec would lose its real steps when viewed under a different provider.
+ */
+function buildWorkflows(filterByProvider: boolean, outputChannel?: vscode.OutputChannel): WorkflowConfig[] {
     const config = vscode.workspace.getConfiguration(ConfigKeys.namespace);
     const customWorkflows = config.get<WorkflowConfig[]>('customWorkflows', []);
     const activeProvider = getConfiguredProviderType();
@@ -207,33 +216,45 @@ export function getWorkflows(outputChannel?: vscode.OutputChannel): WorkflowConf
 
     for (const workflow of customWorkflows) {
         const result = validateWorkflow(workflow);
-        if (result.valid) {
-            // Check for duplicates
-            if (seenNames.has(workflow.name)) {
-                outputChannel?.appendLine(
-                    `[Workflows] Duplicate workflow name "${workflow.name}" - skipping duplicate`
-                );
-                continue;
-            }
-            // Hide workflows the active provider can't run
-            if (!isWorkflowSupportedForProvider(workflow, activeProvider)) {
-                outputChannel?.appendLine(
-                    `[Workflows] Workflow "${workflow.name}" not supported by provider "${activeProvider}" - hiding`
-                );
-                continue;
-            }
-            seenNames.add(workflow.name);
-            validWorkflows.push(normalizeWorkflowConfig(workflow));
-        } else {
-            // Log validation errors
-            const errorMsg = result.errors.join('; ');
+        if (!result.valid) {
             outputChannel?.appendLine(
-                `[Workflows] Invalid workflow "${workflow.name || 'unnamed'}": ${errorMsg}`
+                `[Workflows] Invalid workflow "${workflow.name || 'unnamed'}": ${result.errors.join('; ')}`
             );
+            continue;
         }
+        if (seenNames.has(workflow.name)) {
+            outputChannel?.appendLine(
+                `[Workflows] Duplicate workflow name "${workflow.name}" - skipping duplicate`
+            );
+            continue;
+        }
+        if (filterByProvider && !isWorkflowSupportedForProvider(workflow, activeProvider)) {
+            outputChannel?.appendLine(
+                `[Workflows] Workflow "${workflow.name}" not supported by provider "${activeProvider}" - hiding`
+            );
+            continue;
+        }
+        seenNames.add(workflow.name);
+        validWorkflows.push(normalizeWorkflowConfig(workflow));
     }
 
     return validWorkflows;
+}
+
+/**
+ * Workflows for SELECTION surfaces — filtered to those the active provider can run.
+ */
+export function getWorkflows(outputChannel?: vscode.OutputChannel): WorkflowConfig[] {
+    return buildWorkflows(true, outputChannel);
+}
+
+/**
+ * All configured workflows regardless of the active provider. Used to RESOLVE an
+ * already-selected workflow (e.g. an existing spec's stored workflow) so it keeps
+ * its real steps even when the active provider couldn't newly select it.
+ */
+export function getAllWorkflows(): WorkflowConfig[] {
+    return buildWorkflows(false);
 }
 
 /**
@@ -244,7 +265,9 @@ export function getWorkflows(outputChannel?: vscode.OutputChannel): WorkflowConf
 export function getWorkflow(name: string): WorkflowConfig | undefined {
     // Treat legacy "default" as "speckit"
     const resolvedName = name === LEGACY_DEFAULT_NAME ? 'speckit' : name;
-    const workflows = getWorkflows();
+    // Resolve against the unfiltered set: a spec that already selected this
+    // workflow must keep its steps even if the active provider can't select it.
+    const workflows = getAllWorkflows();
     return workflows.find(w => w.name === resolvedName);
 }
 


### PR DESCRIPTION
## What

- Add an optional `supportedAiProviders` field to custom workflow definitions
- Hide any workflow whose declared providers exclude the active `speckit.aiProvider` — across the workflow picker, spec editor, and step/footer actions
- The default `speckit` workflow has no declaration and is always available, so at least one workflow is always selectable
- Add the field to the `speckit.customWorkflows` settings schema and document it in the README (new "Provider Compatibility" section)

## Why

The SDD workflow is built from Claude Code skills (`/sdd:*`), so it does nothing under GitHub Copilot, Gemini, Qwen, or Codex — a dead path the user can trigger but that can never succeed. Declaring per-workflow provider support hides it for incompatible providers and generalizes the rule so any future provider-specific workflow is handled automatically instead of needing a one-off check.

## Testing

- `npm run compile` — clean (no circular import from `workflowManager` → `aiProvider`)
- `npm test` (workflowManager) — 18/18 pass, covering the predicate, provider-aware listing (hidden/shown/default-always-present/unknown-id), and validation