### PR TITLE
feat(speckit-extension): foundation + after_specify state-write hook (v1)

### DIFF
--- a/.agents/skills/speckit-companion-capture/SKILL.md
+++ b/.agents/skills/speckit-companion-capture/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: speckit-companion-capture
+description: Capture the current spec-kit step into .spec-context.json for the Companion
+  GUI
+compatibility: Requires spec-kit project structure with .specify/ directory
+metadata:
+  author: github-spec-kit
+  source: companion:commands/speckit.companion.capture.md
+---
+
+# Capture Spec Context
+
+Record the active feature's current pipeline step into `.spec-context.json` so the
+SpecKit Companion GUI re-renders with the correct step and status. This command
+runs as the `after_specify` lifecycle hook — **state-writing only**; the spec
+directory and files are created by the core `/speckit.specify` workflow.
+
+## Prerequisites
+
+- Verify Python is available by running `python3 --version`.
+- If `python3` is not available, warn the user and skip the capture:
+  `[companion] Warning: python3 not detected; skipped .spec-context.json capture`.
+  Do not fail the host command.
+
+## Execution
+
+Run the writer script from the repository root:
+
+```bash
+python3 speckit-extension/scripts/write-context.py --step specify --status specified --by extension
+```
+
+The script resolves the active feature directory on its own, in this order:
+`--feature-dir` → `SPECIFY_FEATURE_DIRECTORY` env → `SPECIFY_FEATURE` env →
+`.specify/feature.json` → current git branch prefix.
+
+If you already know the feature directory (e.g. the one `/speckit.specify` just
+created), pass it explicitly so resolution is unambiguous:
+
+```bash
+python3 speckit-extension/scripts/write-context.py --feature-dir specs/<NNN>-<slug> --step specify --status specified --by extension
+```
+
+## Graceful Degradation
+
+The script is best-effort and never fails the host command:
+- If `python3` is missing, skip with the warning above.
+- If the active feature directory cannot be resolved, the script prints a warning
+  to stderr and exits 0 without writing.
+
+## Output
+
+On success the script prints the path it updated and the values written, e.g.:
+`[companion] Updated specs/<NNN>-<slug>/.spec-context.json (currentStep=specify, status=specified, by=extension)`.
+The write is atomic (temp file + rename) and appends to `transitions` without
+rewriting existing history.

--- a/.claude/skills/speckit-companion-capture/SKILL.md
+++ b/.claude/skills/speckit-companion-capture/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: speckit-companion-capture
+description: Capture the current spec-kit step into .spec-context.json for the Companion
+  GUI
+compatibility: Requires spec-kit project structure with .specify/ directory
+metadata:
+  author: github-spec-kit
+  source: companion:commands/speckit.companion.capture.md
+---
+
+# Capture Spec Context
+
+Record the active feature's current pipeline step into `.spec-context.json` so the
+SpecKit Companion GUI re-renders with the correct step and status. This command
+runs as the `after_specify` lifecycle hook — **state-writing only**; the spec
+directory and files are created by the core `/speckit.specify` workflow.
+
+## Prerequisites
+
+- Verify Python is available by running `python3 --version`.
+- If `python3` is not available, warn the user and skip the capture:
+  `[companion] Warning: python3 not detected; skipped .spec-context.json capture`.
+  Do not fail the host command.
+
+## Execution
+
+Run the writer script from the repository root:
+
+```bash
+python3 speckit-extension/scripts/write-context.py --step specify --status specified --by extension
+```
+
+The script resolves the active feature directory on its own, in this order:
+`--feature-dir` → `SPECIFY_FEATURE_DIRECTORY` env → `SPECIFY_FEATURE` env →
+`.specify/feature.json` → current git branch prefix.
+
+If you already know the feature directory (e.g. the one `/speckit.specify` just
+created), pass it explicitly so resolution is unambiguous:
+
+```bash
+python3 speckit-extension/scripts/write-context.py --feature-dir specs/<NNN>-<slug> --step specify --status specified --by extension
+```
+
+## Graceful Degradation
+
+The script is best-effort and never fails the host command:
+- If `python3` is missing, skip with the warning above.
+- If the active feature directory cannot be resolved, the script prints a warning
+  to stderr and exits 0 without writing.
+
+## Output
+
+On success the script prints the path it updated and the values written, e.g.:
+`[companion] Updated specs/<NNN>-<slug>/.spec-context.json (currentStep=specify, status=specified, by=extension)`.
+The write is atomic (temp file + rename) and appends to `transitions` without
+rewriting existing history.

--- a/.cursor/skills/speckit-companion-capture/SKILL.md
+++ b/.cursor/skills/speckit-companion-capture/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: speckit-companion-capture
+description: Capture the current spec-kit step into .spec-context.json for the Companion
+  GUI
+compatibility: Requires spec-kit project structure with .specify/ directory
+metadata:
+  author: github-spec-kit
+  source: companion:commands/speckit.companion.capture.md
+---
+
+# Capture Spec Context
+
+Record the active feature's current pipeline step into `.spec-context.json` so the
+SpecKit Companion GUI re-renders with the correct step and status. This command
+runs as the `after_specify` lifecycle hook — **state-writing only**; the spec
+directory and files are created by the core `/speckit.specify` workflow.
+
+## Prerequisites
+
+- Verify Python is available by running `python3 --version`.
+- If `python3` is not available, warn the user and skip the capture:
+  `[companion] Warning: python3 not detected; skipped .spec-context.json capture`.
+  Do not fail the host command.
+
+## Execution
+
+Run the writer script from the repository root:
+
+```bash
+python3 speckit-extension/scripts/write-context.py --step specify --status specified --by extension
+```
+
+The script resolves the active feature directory on its own, in this order:
+`--feature-dir` → `SPECIFY_FEATURE_DIRECTORY` env → `SPECIFY_FEATURE` env →
+`.specify/feature.json` → current git branch prefix.
+
+If you already know the feature directory (e.g. the one `/speckit.specify` just
+created), pass it explicitly so resolution is unambiguous:
+
+```bash
+python3 speckit-extension/scripts/write-context.py --feature-dir specs/<NNN>-<slug> --step specify --status specified --by extension
+```
+
+## Graceful Degradation
+
+The script is best-effort and never fails the host command:
+- If `python3` is missing, skip with the warning above.
+- If the active feature directory cannot be resolved, the script prints a warning
+  to stderr and exits 0 without writing.
+
+## Output
+
+On success the script prints the path it updated and the values written, e.g.:
+`[companion] Updated specs/<NNN>-<slug>/.spec-context.json (currentStep=specify, status=specified, by=extension)`.
+The write is atomic (temp file + rename) and appends to `transitions` without
+rewriting existing history.

--- a/.gemini/commands/speckit.companion.capture.toml
+++ b/.gemini/commands/speckit.companion.capture.toml
@@ -1,0 +1,52 @@
+description = "Capture the current spec-kit step into .spec-context.json for the Companion GUI"
+
+# Source: companion
+
+prompt = """
+# Capture Spec Context
+
+Record the active feature's current pipeline step into `.spec-context.json` so the
+SpecKit Companion GUI re-renders with the correct step and status. This command
+runs as the `after_specify` lifecycle hook — **state-writing only**; the spec
+directory and files are created by the core `/speckit.specify` workflow.
+
+## Prerequisites
+
+- Verify Python is available by running `python3 --version`.
+- If `python3` is not available, warn the user and skip the capture:
+  `[companion] Warning: python3 not detected; skipped .spec-context.json capture`.
+  Do not fail the host command.
+
+## Execution
+
+Run the writer script from the repository root:
+
+```bash
+python3 speckit-extension/scripts/write-context.py --step specify --status specified --by extension
+```
+
+The script resolves the active feature directory on its own, in this order:
+`--feature-dir` → `SPECIFY_FEATURE_DIRECTORY` env → `SPECIFY_FEATURE` env →
+`.specify/feature.json` → current git branch prefix.
+
+If you already know the feature directory (e.g. the one `/speckit.specify` just
+created), pass it explicitly so resolution is unambiguous:
+
+```bash
+python3 speckit-extension/scripts/write-context.py --feature-dir specs/<NNN>-<slug> --step specify --status specified --by extension
+```
+
+## Graceful Degradation
+
+The script is best-effort and never fails the host command:
+- If `python3` is missing, skip with the warning above.
+- If the active feature directory cannot be resolved, the script prints a warning
+  to stderr and exits 0 without writing.
+
+## Output
+
+On success the script prints the path it updated and the values written, e.g.:
+`[companion] Updated specs/<NNN>-<slug>/.spec-context.json (currentStep=specify, status=specified, by=extension)`.
+The write is atomic (temp file + rename) and appends to `transitions` without
+rewriting existing history.
+"""

--- a/.github/agents/speckit.companion.capture.agent.md
+++ b/.github/agents/speckit.companion.capture.agent.md
@@ -1,0 +1,54 @@
+---
+description: Capture the current spec-kit step into .spec-context.json for the Companion
+  GUI
+---
+
+
+<!-- Extension: companion -->
+<!-- Config: .specify/extensions/companion/ -->
+# Capture Spec Context
+
+Record the active feature's current pipeline step into `.spec-context.json` so the
+SpecKit Companion GUI re-renders with the correct step and status. This command
+runs as the `after_specify` lifecycle hook — **state-writing only**; the spec
+directory and files are created by the core `/speckit.specify` workflow.
+
+## Prerequisites
+
+- Verify Python is available by running `python3 --version`.
+- If `python3` is not available, warn the user and skip the capture:
+  `[companion] Warning: python3 not detected; skipped .spec-context.json capture`.
+  Do not fail the host command.
+
+## Execution
+
+Run the writer script from the repository root:
+
+```bash
+python3 speckit-extension/scripts/write-context.py --step specify --status specified --by extension
+```
+
+The script resolves the active feature directory on its own, in this order:
+`--feature-dir` → `SPECIFY_FEATURE_DIRECTORY` env → `SPECIFY_FEATURE` env →
+`.specify/feature.json` → current git branch prefix.
+
+If you already know the feature directory (e.g. the one `/speckit.specify` just
+created), pass it explicitly so resolution is unambiguous:
+
+```bash
+python3 speckit-extension/scripts/write-context.py --feature-dir specs/<NNN>-<slug> --step specify --status specified --by extension
+```
+
+## Graceful Degradation
+
+The script is best-effort and never fails the host command:
+- If `python3` is missing, skip with the warning above.
+- If the active feature directory cannot be resolved, the script prints a warning
+  to stderr and exits 0 without writing.
+
+## Output
+
+On success the script prints the path it updated and the values written, e.g.:
+`[companion] Updated specs/<NNN>-<slug>/.spec-context.json (currentStep=specify, status=specified, by=extension)`.
+The write is atomic (temp file + rename) and appends to `transitions` without
+rewriting existing history.

--- a/.github/prompts/speckit.companion.capture.prompt.md
+++ b/.github/prompts/speckit.companion.capture.prompt.md
@@ -1,0 +1,3 @@
+---
+agent: speckit.companion.capture
+---

--- a/.qwen/commands/speckit.companion.capture.md
+++ b/.qwen/commands/speckit.companion.capture.md
@@ -1,0 +1,54 @@
+---
+description: Capture the current spec-kit step into .spec-context.json for the Companion
+  GUI
+---
+
+
+<!-- Extension: companion -->
+<!-- Config: .specify/extensions/companion/ -->
+# Capture Spec Context
+
+Record the active feature's current pipeline step into `.spec-context.json` so the
+SpecKit Companion GUI re-renders with the correct step and status. This command
+runs as the `after_specify` lifecycle hook — **state-writing only**; the spec
+directory and files are created by the core `/speckit.specify` workflow.
+
+## Prerequisites
+
+- Verify Python is available by running `python3 --version`.
+- If `python3` is not available, warn the user and skip the capture:
+  `[companion] Warning: python3 not detected; skipped .spec-context.json capture`.
+  Do not fail the host command.
+
+## Execution
+
+Run the writer script from the repository root:
+
+```bash
+python3 speckit-extension/scripts/write-context.py --step specify --status specified --by extension
+```
+
+The script resolves the active feature directory on its own, in this order:
+`--feature-dir` → `SPECIFY_FEATURE_DIRECTORY` env → `SPECIFY_FEATURE` env →
+`.specify/feature.json` → current git branch prefix.
+
+If you already know the feature directory (e.g. the one `/speckit.specify` just
+created), pass it explicitly so resolution is unambiguous:
+
+```bash
+python3 speckit-extension/scripts/write-context.py --feature-dir specs/<NNN>-<slug> --step specify --status specified --by extension
+```
+
+## Graceful Degradation
+
+The script is best-effort and never fails the host command:
+- If `python3` is missing, skip with the warning above.
+- If the active feature directory cannot be resolved, the script prints a warning
+  to stderr and exits 0 without writing.
+
+## Output
+
+On success the script prints the path it updated and the values written, e.g.:
+`[companion] Updated specs/<NNN>-<slug>/.spec-context.json (currentStep=specify, status=specified, by=extension)`.
+The write is atomic (temp file + rename) and appends to `transitions` without
+rewriting existing history.

--- a/.specify/extensions.yml
+++ b/.specify/extensions.yml
@@ -1,4 +1,5 @@
-installed: []
+installed:
+- companion
 settings:
   auto_execute_hooks: true
 hooks:
@@ -89,6 +90,13 @@ hooks:
     optional: true
     prompt: Commit specification changes?
     description: Auto-commit after specification
+    condition: null
+  - extension: companion
+    command: speckit.companion.capture
+    enabled: true
+    optional: false
+    prompt: Execute speckit.companion.capture?
+    description: Record specify completion into .spec-context.json for the Companion GUI
     condition: null
   after_clarify:
   - extension: git

--- a/.specify/extensions.yml
+++ b/.specify/extensions.yml
@@ -96,7 +96,8 @@ hooks:
     enabled: true
     optional: false
     prompt: Execute speckit.companion.capture?
-    description: Record specify completion into .spec-context.json for the Companion GUI
+    description: Record specify completion (currentStep=specify, status=specified)
+      into .spec-context.json
     condition: null
   after_clarify:
   - extension: git

--- a/.specify/extensions/.registry
+++ b/.specify/extensions/.registry
@@ -53,6 +53,41 @@
       },
       "registered_skills": [],
       "installed_at": "2026-05-21T18:09:23.850204+00:00"
+    },
+    "companion": {
+      "version": "0.1.0",
+      "source": "local",
+      "manifest_hash": "sha256:827c7a27b9fd6693d4a5cc9a0b43492964001a60ef631d656d5b1ac96a16eba1",
+      "enabled": true,
+      "priority": 10,
+      "registered_commands": {
+        "agy": [
+          "speckit.companion.capture"
+        ],
+        "claude": [
+          "speckit.companion.capture"
+        ],
+        "codex": [
+          "speckit.companion.capture"
+        ],
+        "copilot": [
+          "speckit.companion.capture"
+        ],
+        "cursor-agent": [
+          "speckit.companion.capture"
+        ],
+        "gemini": [
+          "speckit.companion.capture"
+        ],
+        "qwen": [
+          "speckit.companion.capture"
+        ],
+        "windsurf": [
+          "speckit.companion.capture"
+        ]
+      },
+      "registered_skills": [],
+      "installed_at": "2026-05-25T13:25:56.875312+00:00"
     }
   }
 }

--- a/.specify/extensions/companion/README.md
+++ b/.specify/extensions/companion/README.md
@@ -1,0 +1,126 @@
+# SpecKit Companion — spec-kit Extension
+
+Optional workflow enhancements for the [SpecKit Companion](https://github.com/alfredoperez/speckit-companion) product. This is the spec-kit-side half (`id: companion`) that captures your spec-kit lifecycle activity into `.spec-context.json` so the **SpecKit Companion** VS Code GUI lights up on your *existing* spec-kit flow — no template change, no GUI code change. It's the first slice of a larger set of optional features (status/resume, an opinionated pipeline, living-specs/drift, auto-mode) that layer SDD onto spec-kit over time.
+
+This directory is the spec-kit-catalog half of the SpecKit Companion monorepo; it lives beside the VS Code extension (`src/`, `webview/`) and is published/installed independently. It does **not** read or depend on the GUI at runtime — it only writes the canonical `.spec-context.json` the GUI already consumes.
+
+> **Status: foundation spike (v1, one hook).** This ships the de-risking slice from spec `106-speckit-extension-foundation`: a single `after_specify` hook that writes `.spec-context.json`. The other lifecycle hooks, the derive-from-files fallback, and the `status`/`resume` commands are deferred to later steps.
+
+## What's here
+
+```
+speckit-extension/
+├── extension.yml                          # manifest: id companion, one after_specify hook
+├── commands/
+│   └── speckit.companion.capture.md        # command-markdown: "run the writer script"
+├── scripts/
+│   └── write-context.py                    # the writer (stdlib Python, atomic, append-only)
+└── README.md
+```
+
+The chain mirrors spec-kit's bundled `git` extension exactly: **hook → command-markdown → "run this script."**
+
+```
+/speckit.specify  →  after_specify hook  →  speckit.companion.capture.md  →  write-context.py  →  .spec-context.json  →  Companion GUI re-renders
+```
+
+## What the writer does
+
+`write-context.py` does a crash-safe **read-merge-write** of the active feature's `.spec-context.json`:
+
+- **Active-dir resolution** (spec-kit's order, most-specific first): `--feature-dir` → `SPECIFY_FEATURE_DIRECTORY` env → `SPECIFY_FEATURE` env → `.specify/feature.json` → current git-branch numeric prefix.
+- **Preserves** every existing/unknown top-level key (e.g. Companion-owned `reviewComments`) — never clobbers.
+- **Append-only** `transitions` (`by: "extension"`); `from` is the prior `{step, substep}`, or `null` on first write.
+- **Never regresses** a more-advanced spec: if the target is already at a later step or a terminal status (`implemented`/`completed`/`archived`), it is left untouched.
+- **Atomic**: writes a temp file then `os.replace()`.
+- Writes Companion-canonical values (`currentStep: "specify"`, `status: "specified"`); **never** the legacy `currentStep: "done"`.
+
+The canonical schema is owned by the GUI repo at `src/core/types/spec-context.schema.json` — the writer targets it directly (no vendored copy).
+
+## Requirements
+
+- **An extension-capable spec-kit.** The extension subsystem (`specify extension …`) ships in the **GitHub-source** build of spec-kit, *not* the stock PyPI `specify-cli` package — see [Install](#install) below.
+- `requires.speckit_version: ">=0.8.5"` — the floor for the workflow `integration: auto` path later phases ride.
+
+  > ⚠ **Confirm the exact `after_specify` floor.** The spec-kit release that first wired the `after_specify` / `after_plan` lifecycle hooks may differ from `0.8.5`. Verify against the installed spec-kit and raise this floor if needed.
+- `python3` — declared as an **optional** tool. The capture is best-effort and degrades gracefully (warns + skips) if `python3` is absent; it never fails the host spec-kit command.
+
+## Install
+
+### Prerequisite — an extension-capable spec-kit
+
+The `specify extension` subsystem is part of the **GitHub-source** spec-kit. The stock PyPI `specify-cli` package only exposes `init` / `check` / `version` and will fail with *"No such command 'extension'"*. Install from source (a global `uv` tool change, not project-local):
+
+```bash
+uv tool install specify-cli --from git+https://github.com/github/spec-kit.git --force
+specify extension --help     # confirm `add` / `list` are present
+```
+
+### Local / development (today)
+
+Not published to the spec-kit catalog yet, so install straight from this directory. From the repo root:
+
+```bash
+specify extension add ./speckit-extension --dev   # installs into .specify/extensions/companion/
+specify extension list                            # confirm "companion" is listed
+```
+
+`--dev` copies the extension into `.specify/extensions/companion/` (where spec-kit resolves command-markdown), registers its hooks in `.specify/extensions.yml`, and emits the per-agent command (e.g. into `.claude/`) so the hook is actually resolvable. A bare registration in `.specify/extensions.yml` is **not** enough on its own — that placement + emission is what the install does.
+
+> This repo commits a registration stub for `companion`. If `specify extension add` reports it's already installed, run `specify extension remove companion` first, then re-run the `add ./speckit-extension --dev` above.
+
+### Catalog (future)
+
+Once published:
+
+```bash
+specify extension add companion --ai-skills
+```
+
+> **`--ai-skills` is non-destructive on update.** Re-installing will *not* overwrite an existing `SKILL.md`; use `--force` / re-init to upgrade installed Claude assets.
+
+### Fallback — CLI-less manual install
+
+If you're stuck on the stock PyPI build and can't reinstall, you can replicate what the CLI does by hand: copy `speckit-extension/` → `.specify/extensions/companion/`, add a `companion` entry to `.specify/extensions/.registry`, and emit a `.claude/skills/speckit-companion-capture/SKILL.md` mirroring `.claude/skills/speckit-git-commit/SKILL.md`. This is a stopgap — the supported path is the source install above.
+
+## End-to-end proof (the de-risk)
+
+The whole migration rests on one unproven chain: *user runs a spec-kit command → the agent runs our hook → our script writes `.spec-context.json` → the Companion GUI re-renders.* Reproduce it:
+
+### A. Script + resolution (deterministic — no GUI needed)
+
+Mimics exactly what the `after_specify` hook invokes:
+
+```bash
+# Point spec-kit's active-feature pointer at a throwaway spec dir (as a real
+# `specify` would), then run the capture the way the hook does:
+mkdir -p specs/_zzz-proof-demo && printf '# Spec: Proof Demo\n' > specs/_zzz-proof-demo/spec.md
+python3 speckit-extension/scripts/write-context.py --feature-dir specs/_zzz-proof-demo \
+  --step specify --status specified --by extension
+cat specs/_zzz-proof-demo/.spec-context.json   # currentStep=specify, status=specified, transitions[].by=extension
+rm -rf specs/_zzz-proof-demo
+```
+
+Expected: a valid canonical `.spec-context.json` with `currentStep: "specify"`, `status: "specified"`, and a single `transitions` entry `{ "by": "extension", "from": null }`. Re-running appends a second transition (with `from` set) and preserves any pre-existing keys.
+
+### B. Live hook + GUI (manual — needs the VS Code GUI)
+
+1. **Install the extension** so the hook is resolvable (see [Install](#install) — both the source prerequisite and the `--dev` step):
+   ```bash
+   specify extension add ./speckit-extension --dev
+   specify extension list      # confirm "companion" appears
+   ```
+2. Install/enable the SpecKit Companion **VS Code** extension and open this repo.
+3. In Claude Code, run a real `/speckit.specify "throwaway proof feature"`.
+4. When the `after_specify` hook fires, let it run `speckit.companion.capture`. (Hooks are agent-mediated — note whether it auto-fires or needs a nudge; that observation is the point of this proof.)
+5. Confirm the new `specs/<NNN>-<slug>/.spec-context.json` carries `currentStep: specify` / `status: specified` / a `by: extension` transition:
+   ```bash
+   cat specs/<NNN>-<slug>/.spec-context.json
+   ```
+6. Open the SpecKit Companion sidebar/viewer — the new spec should render at the **specify** step with **specified** status, with no GUI code change.
+7. Clean up: delete the throwaway spec dir; optionally `specify extension remove companion`.
+
+### Observed result
+
+- **A (script + resolution):** ✅ Verified — the writer creates/updates a canonical `.spec-context.json` with the expected values; append-only transitions and unknown-key preservation confirmed by the spec's probe test.
+- **B (live hook + GUI):** ⏳ Pending manual confirmation in an interactive VS Code session (records whether the agent auto-fires the `after_specify` prompt — hooks are agent-mediated, so this is the behavior the spike exists to observe).

--- a/.specify/extensions/companion/commands/speckit.companion.capture.md
+++ b/.specify/extensions/companion/commands/speckit.companion.capture.md
@@ -1,0 +1,50 @@
+---
+description: "Capture the current spec-kit step into .spec-context.json for the Companion GUI"
+---
+
+# Capture Spec Context
+
+Record the active feature's current pipeline step into `.spec-context.json` so the
+SpecKit Companion GUI re-renders with the correct step and status. This command
+runs as the `after_specify` lifecycle hook — **state-writing only**; the spec
+directory and files are created by the core `/speckit.specify` workflow.
+
+## Prerequisites
+
+- Verify Python is available by running `python3 --version`.
+- If `python3` is not available, warn the user and skip the capture:
+  `[companion] Warning: python3 not detected; skipped .spec-context.json capture`.
+  Do not fail the host command.
+
+## Execution
+
+Run the writer script from the repository root:
+
+```bash
+python3 speckit-extension/scripts/write-context.py --step specify --status specified --by extension
+```
+
+The script resolves the active feature directory on its own, in this order:
+`--feature-dir` → `SPECIFY_FEATURE_DIRECTORY` env → `SPECIFY_FEATURE` env →
+`.specify/feature.json` → current git branch prefix.
+
+If you already know the feature directory (e.g. the one `/speckit.specify` just
+created), pass it explicitly so resolution is unambiguous:
+
+```bash
+python3 speckit-extension/scripts/write-context.py --feature-dir specs/<NNN>-<slug> --step specify --status specified --by extension
+```
+
+## Graceful Degradation
+
+The script is best-effort and never fails the host command:
+- If `python3` is missing, skip with the warning above.
+- If the active feature directory cannot be resolved, the script prints a warning
+  to stderr and exits 0 without writing.
+
+## Output
+
+On success the script prints the path it updated and the values written, e.g.:
+`[companion] Updated specs/<NNN>-<slug>/.spec-context.json (currentStep=specify, status=specified, by=extension)`.
+The write is atomic (temp file + rename) and appends to `transitions` without
+rewriting existing history.

--- a/.specify/extensions/companion/extension.yml
+++ b/.specify/extensions/companion/extension.yml
@@ -1,0 +1,36 @@
+schema_version: "1.0"
+
+extension:
+  id: companion
+  name: "SpecKit Companion"
+  version: "0.1.0"
+  description: "Optional workflow enhancements for SpecKit Companion — surfaces live spec-driven progress in the VS Code companion and layers on SDD's pipeline, living specs, and auto-mode"
+  author: alfredoperez
+  repository: https://github.com/alfredoperez/speckit-companion
+  license: MIT
+
+requires:
+  # Floor for the workflow `integration: auto` path the later phases ride.
+  # Confirm/raise once the exact spec-kit release that wired after_specify /
+  # after_plan hooks is verified against the installed CLI (see README).
+  speckit_version: ">=0.8.5"
+  tools:
+    - name: python3
+      required: false
+
+provides:
+  commands:
+    - name: speckit.companion.capture
+      file: commands/speckit.companion.capture.md
+      description: "Capture the current spec-kit step into .spec-context.json for the Companion GUI"
+
+hooks:
+  after_specify:
+    command: speckit.companion.capture
+    optional: false
+    description: "Record specify completion (currentStep=specify, status=specified) into .spec-context.json"
+
+tags:
+  - "spec-driven-development"
+  - "tracking"
+  - "companion"

--- a/.specify/extensions/companion/scripts/write-context.py
+++ b/.specify/extensions/companion/scripts/write-context.py
@@ -1,0 +1,300 @@
+#!/usr/bin/env python3
+"""Write/update a feature's .spec-context.json from a spec-kit lifecycle hook.
+
+Invoked by the `speckit.companion.capture` command-markdown (registered on the
+`after_specify` hook). Resolves the active feature directory using spec-kit's
+own precedence, then does a crash-safe read-merge-write of the Companion's
+canonical .spec-context.json:
+
+  - preserves every existing/unknown top-level key (read-then-merge)
+  - appends to `transitions` (append-only; never rewritten or shrunk)
+  - writes atomically (temp file + os.replace)
+  - emits Companion-canonical values; never the legacy `currentStep: "done"`
+
+Stdlib only. Safe to run anywhere `python3` is available.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+# Canonical vocab (mirrors src/core/types/specContext.ts). Kept here only to
+# reject the legacy terminal step and to avoid regressing an advanced spec.
+CANONICAL_STEPS = {"specify", "clarify", "plan", "tasks", "analyze", "implement"}
+STEP_ORDER = {"specify": 0, "clarify": 1, "plan": 2, "tasks": 3, "analyze": 4, "implement": 5}
+# A spec at one of these statuses must never be dragged backward by a hook that
+# fires after an earlier step (e.g. after_specify re-resolving to a shipped spec).
+TERMINAL_STATUSES = {"implemented", "completed", "archived"}
+
+PREFIX_RE = re.compile(r"^(\d+)-")
+
+
+def _now_iso() -> str:
+    now = datetime.datetime.now(datetime.timezone.utc)
+    return now.strftime("%Y-%m-%dT%H:%M:%S.") + f"{now.microsecond // 1000:03d}Z"
+
+
+def _today() -> str:
+    return datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%d")
+
+
+def _repo_root() -> Path:
+    try:
+        out = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            capture_output=True, text=True, check=True,
+        ).stdout.strip()
+        if out:
+            return Path(out)
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        pass
+    return Path.cwd()
+
+
+def _git_branch(root: Path) -> str | None:
+    try:
+        out = subprocess.run(
+            ["git", "-C", str(root), "rev-parse", "--abbrev-ref", "HEAD"],
+            capture_output=True, text=True, check=True,
+        ).stdout.strip()
+        return out or None
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return None
+
+
+def _match_by_prefix(specs_dir: Path, name: str) -> Path | None:
+    """Map a branch/feature name to specs/<prefix>-* by its numeric prefix.
+
+    Mirrors common.sh find_feature_dir_by_prefix. Exact dir name wins first.
+    """
+    exact = specs_dir / name
+    if exact.is_dir():
+        return exact
+    m = PREFIX_RE.match(name)
+    if not m:
+        return None
+    prefix = str(int(m.group(1)))  # normalize 007 -> 7 for comparison
+    matches = []
+    if specs_dir.is_dir():
+        for child in sorted(specs_dir.iterdir()):
+            if not child.is_dir():
+                continue
+            cm = PREFIX_RE.match(child.name)
+            if cm and str(int(cm.group(1))) == prefix:
+                matches.append(child)
+    if len(matches) == 1:
+        return matches[0]
+    if len(matches) > 1:
+        print(
+            f"[companion] Warning: multiple spec dirs with prefix '{m.group(1)}': "
+            f"{', '.join(c.name for c in matches)}; skipping ambiguous match",
+            file=sys.stderr,
+        )
+    return None
+
+
+def resolve_feature_dir(root: Path, explicit: str | None) -> Path | None:
+    """spec-kit resolution precedence, most-specific first."""
+    specs_dir = root / "specs"
+
+    # 1. explicit --feature-dir
+    if explicit:
+        p = Path(explicit)
+        return p if p.is_absolute() else root / p
+
+    # 2. SPECIFY_FEATURE_DIRECTORY env (a path)
+    env_dir = os.environ.get("SPECIFY_FEATURE_DIRECTORY")
+    if env_dir:
+        p = Path(env_dir)
+        return p if p.is_absolute() else root / p
+
+    # 3. SPECIFY_FEATURE env (a feature name)
+    env_feature = os.environ.get("SPECIFY_FEATURE")
+    if env_feature:
+        hit = _match_by_prefix(specs_dir, env_feature)
+        if hit:
+            return hit
+
+    # 4. .specify/feature.json -> feature_directory
+    feature_json = root / ".specify" / "feature.json"
+    if feature_json.is_file():
+        try:
+            data = json.loads(feature_json.read_text(encoding="utf-8"))
+            fd = data.get("feature_directory")
+            if fd:
+                p = Path(fd)
+                return p if p.is_absolute() else root / p
+        except (json.JSONDecodeError, OSError):
+            pass
+
+    # 5. git current branch -> numeric-prefix match
+    branch = _git_branch(root)
+    if branch:
+        hit = _match_by_prefix(specs_dir, branch)
+        if hit:
+            return hit
+
+    return None
+
+
+def _spec_name(feature_dir: Path) -> str:
+    spec_md = feature_dir / "spec.md"
+    if spec_md.is_file():
+        try:
+            for line in spec_md.read_text(encoding="utf-8").splitlines():
+                line = line.strip()
+                if line.startswith("# "):
+                    title = line[2:].strip()
+                    # Drop a leading "Feature Specification:" / "Spec:" label.
+                    title = re.sub(r"^(Feature Specification|Spec|Feature)\s*:\s*", "", title)
+                    if title:
+                        return title
+        except OSError:
+            pass
+    # Fallback: humanized slug from the dir name (strip NNN- prefix).
+    slug = PREFIX_RE.sub("", feature_dir.name)
+    return slug.replace("-", " ").strip() or feature_dir.name
+
+
+def _is_more_advanced(ctx: dict, step: str) -> bool:
+    """True if the existing context already records a state past `step` — so a
+    hook firing after an earlier step must not regress it."""
+    if ctx.get("status") in TERMINAL_STATUSES:
+        return True
+    cur = ctx.get("currentStep")
+    return cur in STEP_ORDER and STEP_ORDER[cur] > STEP_ORDER[step]
+
+
+def update_context(feature_dir: Path, step: str, status: str, by: str) -> Path | None:
+    target = feature_dir / ".spec-context.json"
+    now = _now_iso()
+    root = _repo_root()
+    branch = _git_branch(root) or "main"
+
+    if target.is_file():
+        try:
+            ctx = json.loads(target.read_text(encoding="utf-8"))
+            if not isinstance(ctx, dict):
+                ctx = {}
+        except (json.JSONDecodeError, OSError):
+            ctx = {}
+    else:
+        ctx = {}
+
+    # Never drag a more-advanced (e.g. shipped) spec backward. Leave it fully
+    # intact — this is the bug the schema reconciliation exists to prevent.
+    if ctx and _is_more_advanced(ctx, step):
+        print(
+            f"[companion] {target} already at currentStep={ctx.get('currentStep')} / "
+            f"status={ctx.get('status')}; not regressing to {step}/{status}.",
+            file=sys.stderr,
+        )
+        return None
+
+    transitions = ctx.get("transitions")
+    if not isinstance(transitions, list):
+        transitions = []
+
+    # `from` = prior {step, substep}, or null on first write. Guard against a
+    # malformed last entry and normalize a non-canonical prior step (e.g. legacy
+    # "done") to null, which the schema's `from.step` enum permits.
+    if transitions and isinstance(transitions[-1], dict):
+        last = transitions[-1]
+        prior_step = last.get("step")
+        prior = {
+            "step": prior_step if prior_step in CANONICAL_STEPS else None,
+            "substep": last.get("substep"),
+        }
+    else:
+        prior = None
+
+    # Required-set defaults only when missing (read-then-merge preserves the rest).
+    ctx.setdefault("workflow", "speckit")
+    ctx.setdefault("specName", _spec_name(feature_dir))
+    ctx.setdefault("branch", branch)
+
+    ctx["currentStep"] = step
+    ctx["status"] = status
+    ctx["updated"] = _today()
+
+    step_history = ctx.get("stepHistory")
+    if not isinstance(step_history, dict):
+        step_history = {}
+    entry = step_history.get(step) if isinstance(step_history.get(step), dict) else {}
+    entry.setdefault("startedAt", now)
+    entry["completedAt"] = now
+    step_history[step] = entry
+    ctx["stepHistory"] = step_history
+
+    transitions.append({
+        "step": step,
+        "substep": None,
+        "from": prior,
+        "by": by,
+        "at": now,
+    })
+    ctx["transitions"] = transitions
+
+    tmp = target.with_suffix(target.suffix + ".tmp")
+    try:
+        tmp.write_text(json.dumps(ctx, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+        os.replace(tmp, target)
+    except OSError:
+        try:
+            tmp.unlink(missing_ok=True)  # don't litter on a failed write
+        except OSError:
+            pass
+        raise
+    return target
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Write/update a feature's .spec-context.json")
+    parser.add_argument("--step", default="specify")
+    parser.add_argument("--status", default="specified")
+    parser.add_argument("--by", default="extension")
+    parser.add_argument("--feature-dir", default=None)
+    args = parser.parse_args()
+
+    # Best-effort guard: a non-canonical step is a no-op, never a host failure.
+    # Terminal state belongs in `status`, not `currentStep`.
+    if args.step == "done" or args.step not in CANONICAL_STEPS:
+        print(
+            f"[companion] Skipping: '{args.step}' is not a canonical currentStep "
+            f"({', '.join(sorted(CANONICAL_STEPS))}).",
+            file=sys.stderr,
+        )
+        return 0
+
+    root = _repo_root()
+    feature_dir = resolve_feature_dir(root, args.feature_dir)
+    if feature_dir is None or not feature_dir.is_dir():
+        print(
+            "[companion] Could not resolve the active feature directory "
+            "(checked --feature-dir, SPECIFY_FEATURE_DIRECTORY, SPECIFY_FEATURE, "
+            ".specify/feature.json, git branch prefix). Skipping context write.",
+            file=sys.stderr,
+        )
+        return 0  # best-effort: never fail the host command
+
+    # Never let a bookkeeping write fail the host spec-kit command.
+    try:
+        target = update_context(feature_dir, args.step, args.status, args.by)
+    except Exception as exc:  # noqa: BLE001 - best-effort, swallow + report
+        print(f"[companion] Warning: skipped .spec-context.json write: {exc}", file=sys.stderr)
+        return 0
+
+    if target is not None:
+        print(f"[companion] Updated {target} (currentStep={args.step}, status={args.status}, by={args.by})")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.windsurf/workflows/speckit.companion.capture.md
+++ b/.windsurf/workflows/speckit.companion.capture.md
@@ -1,0 +1,54 @@
+---
+description: Capture the current spec-kit step into .spec-context.json for the Companion
+  GUI
+---
+
+
+<!-- Extension: companion -->
+<!-- Config: .specify/extensions/companion/ -->
+# Capture Spec Context
+
+Record the active feature's current pipeline step into `.spec-context.json` so the
+SpecKit Companion GUI re-renders with the correct step and status. This command
+runs as the `after_specify` lifecycle hook — **state-writing only**; the spec
+directory and files are created by the core `/speckit.specify` workflow.
+
+## Prerequisites
+
+- Verify Python is available by running `python3 --version`.
+- If `python3` is not available, warn the user and skip the capture:
+  `[companion] Warning: python3 not detected; skipped .spec-context.json capture`.
+  Do not fail the host command.
+
+## Execution
+
+Run the writer script from the repository root:
+
+```bash
+python3 speckit-extension/scripts/write-context.py --step specify --status specified --by extension
+```
+
+The script resolves the active feature directory on its own, in this order:
+`--feature-dir` → `SPECIFY_FEATURE_DIRECTORY` env → `SPECIFY_FEATURE` env →
+`.specify/feature.json` → current git branch prefix.
+
+If you already know the feature directory (e.g. the one `/speckit.specify` just
+created), pass it explicitly so resolution is unambiguous:
+
+```bash
+python3 speckit-extension/scripts/write-context.py --feature-dir specs/<NNN>-<slug> --step specify --status specified --by extension
+```
+
+## Graceful Degradation
+
+The script is best-effort and never fails the host command:
+- If `python3` is missing, skip with the warning above.
+- If the active feature directory cannot be resolved, the script prints a warning
+  to stderr and exits 0 without writing.
+
+## Output
+
+On success the script prints the path it updated and the values written, e.g.:
+`[companion] Updated specs/<NNN>-<slug>/.spec-context.json (currentStep=specify, status=specified, by=extension)`.
+The write is atomic (temp file + rename) and appends to `transitions` without
+rewriting existing history.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,8 @@ Thanks for considering a contribution. This guide tells you how to get the exten
 
 If you only have five minutes, skim **Quick Start** and the **README docs map** sections — those two cover 80% of what reviewers care about.
 
+> **Two extensions live in this repo.** This guide is for the **VS Code extension** (the GUI — `src/`, `webview/`, `package.json`). The **spec-kit extension** (`speckit-extension/`, `id: companion`) is a separate, independently-versioned product with its own dev loop, changelog, and version — if you're working on it, follow **[speckit-extension/docs/contributing.md](speckit-extension/docs/contributing.md)** instead.
+
 ---
 
 ## Quick Start

--- a/speckit-extension/CHANGELOG.md
+++ b/speckit-extension/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Changelog — SpecKit Companion spec-kit Extension
+
+All notable changes to the **spec-kit extension** (`id: companion`) are documented here.
+
+> This is **not** the VS Code extension. The spec-kit extension is versioned independently (`extension.yml` `version`); the VS Code GUI's changelog lives at the repo root: [`../CHANGELOG.md`](../CHANGELOG.md).
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/); this extension follows [Semantic Versioning](https://semver.org/).
+
+## [Unreleased]
+
+## [0.1.0] - 2026-05-25
+
+Foundation + state-write spike — the v1 first slice (PR #173). See [ROADMAP.md](./ROADMAP.md).
+
+### Added
+- `extension.yml` manifest (`id: companion`) registering one `after_specify` lifecycle hook and the `speckit.companion.capture` command — mirrors spec-kit's bundled `git` extension shape.
+- `commands/speckit.companion.capture.md` — the command-markdown the hook runs.
+- `scripts/write-context.py` — a stdlib-only writer that captures spec-kit activity into the canonical `.spec-context.json` (`currentStep`/`status` + append-only `transitions` with `by: extension`). Crash-safe (atomic temp+rename), preserves unknown top-level keys, never regresses a more-advanced/shipped spec, never emits the legacy `currentStep: "done"`.
+- Docs: `README.md`, `ROADMAP.md` (8-step plan), and `docs/` (install, commands, how-it-works, contributing).
+
+### Changed
+- Aligned the canonical schema `src/core/types/spec-context.schema.json` `status` enum (added `implemented`) so terminal state matches the TypeScript `Status` type.
+
+### Verified
+- End-to-end (2026-05-25): a real `/speckit.specify` auto-fired the `after_specify` hook (`optional: false`, no nudge) and wrote a canonical `.spec-context.json` with `workflow: "speckit"` on a plain spec-kit flow.

--- a/speckit-extension/README.md
+++ b/speckit-extension/README.md
@@ -1,19 +1,10 @@
 # SpecKit Companion — spec-kit Extension
 
-A [spec-kit](https://github.com/github/spec-kit) extension (`id: companion`) that
-captures your spec-kit lifecycle activity into `.spec-context.json`, so the
-**SpecKit Companion** VS Code GUI lights up on your *existing* spec-kit flow — no
-template change, no GUI code change.
+Optional workflow enhancements for the [SpecKit Companion](https://github.com/alfredoperez/speckit-companion) product. This is the spec-kit-side half (`id: companion`) that captures your spec-kit lifecycle activity into `.spec-context.json` so the **SpecKit Companion** VS Code GUI lights up on your *existing* spec-kit flow — no template change, no GUI code change. It's the first slice of a larger set of optional features (status/resume, an opinionated pipeline, living-specs/drift, auto-mode) that layer SDD onto spec-kit over time.
 
-This directory is the spec-kit-catalog half of the SpecKit Companion monorepo; it
-lives beside the VS Code extension (`src/`, `webview/`) and is published/installed
-independently. It does **not** read or depend on the GUI at runtime — it only
-writes the canonical `.spec-context.json` the GUI already consumes.
+This directory is the spec-kit-catalog half of the SpecKit Companion monorepo; it lives beside the VS Code extension (`src/`, `webview/`) and is published/installed independently. It does **not** read or depend on the GUI at runtime — it only writes the canonical `.spec-context.json` the GUI already consumes.
 
-> **Status: foundation spike (v1, one hook).** This ships the de-risking slice
-> from spec `106-speckit-extension-foundation`: a single `after_specify` hook that
-> writes `.spec-context.json`. The other lifecycle hooks, the derive-from-files
-> fallback, and the `status`/`resume` commands are deferred to later steps.
+> **Status: foundation spike (v1, one hook).** This ships the de-risking slice from spec `106-speckit-extension-foundation`: a single `after_specify` hook that writes `.spec-context.json`. The other lifecycle hooks, the derive-from-files fallback, and the `status`/`resume` commands are deferred to later steps.
 
 ## What's here
 
@@ -27,8 +18,7 @@ speckit-extension/
 └── README.md
 ```
 
-The chain mirrors spec-kit's bundled `git` extension exactly:
-**hook → command-markdown → "run this script."**
+The chain mirrors spec-kit's bundled `git` extension exactly: **hook → command-markdown → "run this script."**
 
 ```
 /speckit.specify  →  after_specify hook  →  speckit.companion.capture.md  →  write-context.py  →  .spec-context.json  →  Companion GUI re-renders
@@ -36,56 +26,66 @@ The chain mirrors spec-kit's bundled `git` extension exactly:
 
 ## What the writer does
 
-`write-context.py` does a crash-safe **read-merge-write** of the active feature's
-`.spec-context.json`:
+`write-context.py` does a crash-safe **read-merge-write** of the active feature's `.spec-context.json`:
 
-- **Active-dir resolution** (spec-kit's order, most-specific first):
-  `--feature-dir` → `SPECIFY_FEATURE_DIRECTORY` env → `SPECIFY_FEATURE` env →
-  `.specify/feature.json` → current git-branch numeric prefix.
-- **Preserves** every existing/unknown top-level key (e.g. Companion-owned
-  `reviewComments`) — never clobbers.
-- **Append-only** `transitions` (`by: "extension"`); `from` is the prior
-  `{step, substep}`, or `null` on first write.
+- **Active-dir resolution** (spec-kit's order, most-specific first): `--feature-dir` → `SPECIFY_FEATURE_DIRECTORY` env → `SPECIFY_FEATURE` env → `.specify/feature.json` → current git-branch numeric prefix.
+- **Preserves** every existing/unknown top-level key (e.g. Companion-owned `reviewComments`) — never clobbers.
+- **Append-only** `transitions` (`by: "extension"`); `from` is the prior `{step, substep}`, or `null` on first write.
+- **Never regresses** a more-advanced spec: if the target is already at a later step or a terminal status (`implemented`/`completed`/`archived`), it is left untouched.
 - **Atomic**: writes a temp file then `os.replace()`.
-- Writes Companion-canonical values (`currentStep: "specify"`,
-  `status: "specified"`); **never** the legacy `currentStep: "done"`.
+- Writes Companion-canonical values (`currentStep: "specify"`, `status: "specified"`); **never** the legacy `currentStep: "done"`.
 
-The canonical schema is owned by the GUI repo at
-`src/core/types/spec-context.schema.json` — the writer targets it directly (no
-vendored copy).
+The canonical schema is owned by the GUI repo at `src/core/types/spec-context.schema.json` — the writer targets it directly (no vendored copy).
 
 ## Requirements
 
-- `requires.speckit_version: ">=0.8.5"` — the floor for the workflow
-  `integration: auto` path later phases ride.
+- **An extension-capable spec-kit.** The extension subsystem (`specify extension …`) ships in the **GitHub-source** build of spec-kit, *not* the stock PyPI `specify-cli` package — see [Install](#install) below.
+- `requires.speckit_version: ">=0.8.5"` — the floor for the workflow `integration: auto` path later phases ride.
 
-  > ⚠ **Confirm the exact `after_specify` floor.** The spec-kit release that first
-  > wired the `after_specify` / `after_plan` lifecycle hooks may differ from
-  > `0.8.5`. Verify against the installed spec-kit and raise this floor if needed.
-- `python3` — declared as an **optional** tool. The capture is best-effort and
-  degrades gracefully (warns + skips) if `python3` is absent; it never fails the
-  host spec-kit command.
+  > ⚠ **Confirm the exact `after_specify` floor.** The spec-kit release that first wired the `after_specify` / `after_plan` lifecycle hooks may differ from `0.8.5`. Verify against the installed spec-kit and raise this floor if needed.
+- `python3` — declared as an **optional** tool. The capture is best-effort and degrades gracefully (warns + skips) if `python3` is absent; it never fails the host spec-kit command.
 
 ## Install
 
-Install into a spec-kit project and emit Claude assets:
+### Prerequisite — an extension-capable spec-kit
+
+The `specify extension` subsystem is part of the **GitHub-source** spec-kit. The stock PyPI `specify-cli` package only exposes `init` / `check` / `version` and will fail with *"No such command 'extension'"*. Install from source (a global `uv` tool change, not project-local):
+
+```bash
+uv tool install specify-cli --from git+https://github.com/github/spec-kit.git --force
+specify extension --help     # confirm `add` / `list` are present
+```
+
+### Local / development (today)
+
+Not published to the spec-kit catalog yet, so install straight from this directory. From the repo root:
+
+```bash
+specify extension add ./speckit-extension --dev   # installs into .specify/extensions/companion/
+specify extension list                            # confirm "companion" is listed
+```
+
+`--dev` copies the extension into `.specify/extensions/companion/` (where spec-kit resolves command-markdown), registers its hooks in `.specify/extensions.yml`, and emits the per-agent command (e.g. into `.claude/`) so the hook is actually resolvable. A bare registration in `.specify/extensions.yml` is **not** enough on its own — that placement + emission is what the install does.
+
+> This repo commits a registration stub for `companion`. If `specify extension add` reports it's already installed, run `specify extension remove companion` first, then re-run the `add ./speckit-extension --dev` above.
+
+### Catalog (future)
+
+Once published:
 
 ```bash
 specify extension add companion --ai-skills
 ```
 
-> **Note — `--ai-skills` is non-destructive on update.** Re-installing will *not*
-> overwrite an existing `SKILL.md`; use `--force` / re-init to upgrade installed
-> Claude assets.
+> **`--ai-skills` is non-destructive on update.** Re-installing will *not* overwrite an existing `SKILL.md`; use `--force` / re-init to upgrade installed Claude assets.
 
-Registration lives in `.specify/extensions.yml` (this repo wires it under
-`after_specify`, alongside the bundled `git` extension's auto-commit — both run).
+### Fallback — CLI-less manual install
+
+If you're stuck on the stock PyPI build and can't reinstall, you can replicate what the CLI does by hand: copy `speckit-extension/` → `.specify/extensions/companion/`, add a `companion` entry to `.specify/extensions/.registry`, and emit a `.claude/skills/speckit-companion-capture/SKILL.md` mirroring `.claude/skills/speckit-git-commit/SKILL.md`. This is a stopgap — the supported path is the source install above.
 
 ## End-to-end proof (the de-risk)
 
-The whole migration rests on one unproven chain: *user runs a spec-kit command →
-the agent runs our hook → our script writes `.spec-context.json` → the Companion
-GUI re-renders.* Reproduce it:
+The whole migration rests on one unproven chain: *user runs a spec-kit command → the agent runs our hook → our script writes `.spec-context.json` → the Companion GUI re-renders.* Reproduce it:
 
 ### A. Script + resolution (deterministic — no GUI needed)
 
@@ -101,30 +101,26 @@ cat specs/_zzz-proof-demo/.spec-context.json   # currentStep=specify, status=spe
 rm -rf specs/_zzz-proof-demo
 ```
 
-Expected: a valid canonical `.spec-context.json` with `currentStep: "specify"`,
-`status: "specified"`, and a single `transitions` entry `{ "by": "extension",
-"from": null }`. Re-running appends a second transition (with `from` set) and
-preserves any pre-existing keys.
+Expected: a valid canonical `.spec-context.json` with `currentStep: "specify"`, `status: "specified"`, and a single `transitions` entry `{ "by": "extension", "from": null }`. Re-running appends a second transition (with `from` set) and preserves any pre-existing keys.
 
 ### B. Live hook + GUI (manual — needs the VS Code GUI)
 
-1. Install the SpecKit Companion VS Code extension and open this repo.
-2. Ensure `companion` is registered under `after_specify` in
-   `.specify/extensions.yml` (it is, in this repo).
+1. **Install the extension** so the hook is resolvable (see [Install](#install) — both the source prerequisite and the `--dev` step):
+   ```bash
+   specify extension add ./speckit-extension --dev
+   specify extension list      # confirm "companion" appears
+   ```
+2. Install/enable the SpecKit Companion **VS Code** extension and open this repo.
 3. In Claude Code, run a real `/speckit.specify "throwaway proof feature"`.
-4. When the `after_specify` hook prompt fires, let it run
-   `speckit.companion.capture`.
-5. Confirm the new `specs/<NNN>-<slug>/.spec-context.json` carries
-   `currentStep: specify` / `status: specified` / a `by: extension` transition.
-6. Open the SpecKit Companion sidebar/viewer — the new spec should render at the
-   **specify** step with **specified** status, with no GUI code change.
-7. Delete the throwaway spec.
+4. When the `after_specify` hook fires, let it run `speckit.companion.capture`. (Hooks are agent-mediated — note whether it auto-fires or needs a nudge; that observation is the point of this proof.)
+5. Confirm the new `specs/<NNN>-<slug>/.spec-context.json` carries `currentStep: specify` / `status: specified` / a `by: extension` transition:
+   ```bash
+   cat specs/<NNN>-<slug>/.spec-context.json
+   ```
+6. Open the SpecKit Companion sidebar/viewer — the new spec should render at the **specify** step with **specified** status, with no GUI code change.
+7. Clean up: delete the throwaway spec dir; optionally `specify extension remove companion`.
 
 ### Observed result
 
-- **A (script + resolution):** ✅ Verified — the writer creates/updates a canonical
-  `.spec-context.json` with the expected values; append-only transitions and
-  unknown-key preservation confirmed by the spec's probe test.
-- **B (live hook + GUI):** ⏳ Pending manual confirmation in an interactive VS
-  Code session (records whether the agent auto-fires the `after_specify` prompt —
-  hooks are agent-mediated, so this is the behavior the spike exists to observe).
+- **A (script + resolution):** ✅ Verified — the writer creates/updates a canonical `.spec-context.json` with the expected values; append-only transitions and unknown-key preservation confirmed by the spec's probe test.
+- **B (live hook + GUI):** ⏳ Pending manual confirmation in an interactive VS Code session (records whether the agent auto-fires the `after_specify` prompt — hooks are agent-mediated, so this is the behavior the spike exists to observe).

--- a/speckit-extension/README.md
+++ b/speckit-extension/README.md
@@ -4,7 +4,7 @@ Optional workflow enhancements for the [SpecKit Companion](https://github.com/al
 
 This directory is the spec-kit-catalog half of the SpecKit Companion monorepo; it lives beside the VS Code extension (`src/`, `webview/`) and is published/installed independently. It does **not** read or depend on the GUI at runtime — it only writes the canonical `.spec-context.json` the GUI already consumes.
 
-> **Status: foundation spike (v1, one hook).** This ships the de-risking slice from spec `106-speckit-extension-foundation`: a single `after_specify` hook that writes `.spec-context.json`. The other lifecycle hooks, the derive-from-files fallback, and the `status`/`resume` commands are deferred to later steps.
+> **Status:** v1 foundation shipped & proven — a single `after_specify` hook that writes `.spec-context.json` (spec `106-speckit-extension-foundation`). The other lifecycle hooks, the derive-from-files fallback, and the `status`/`resume` commands are later steps. See **[ROADMAP.md](./ROADMAP.md)** for the full 8-step plan and per-step status.
 
 ## What's here
 
@@ -120,7 +120,6 @@ Expected: a valid canonical `.spec-context.json` with `currentStep: "specify"`, 
 6. Open the SpecKit Companion sidebar/viewer — the new spec should render at the **specify** step with **specified** status, with no GUI code change.
 7. Clean up: delete the throwaway spec dir; optionally `specify extension remove companion`.
 
-### Observed result
+### Status
 
-- **A (script + resolution):** ✅ Verified — the writer creates/updates a canonical `.spec-context.json` with the expected values; append-only transitions and unknown-key preservation confirmed by the spec's probe test.
-- **B (live hook + GUI):** ⏳ Pending manual confirmation in an interactive VS Code session (records whether the agent auto-fires the `after_specify` prompt — hooks are agent-mediated, so this is the behavior the spike exists to observe).
+Per-step progress lives in **[ROADMAP.md](./ROADMAP.md)**. Step 1 (this) is **shipped and proven** — the `after_specify` hook auto-fires (`optional: false`) and writes a canonical `.spec-context.json`, verified end-to-end on a real `/speckit.specify` run.

--- a/speckit-extension/README.md
+++ b/speckit-extension/README.md
@@ -1,125 +1,36 @@
 # SpecKit Companion — spec-kit Extension
 
-Optional workflow enhancements for the [SpecKit Companion](https://github.com/alfredoperez/speckit-companion) product. This is the spec-kit-side half (`id: companion`) that captures your spec-kit lifecycle activity into `.spec-context.json` so the **SpecKit Companion** VS Code GUI lights up on your *existing* spec-kit flow — no template change, no GUI code change. It's the first slice of a larger set of optional features (status/resume, an opinionated pipeline, living-specs/drift, auto-mode) that layer SDD onto spec-kit over time.
+Make your spec-driven work **visible**. This is the spec-kit-side half of [SpecKit Companion](https://github.com/alfredoperez/speckit-companion) (`id: companion`): it records your spec-kit lifecycle activity into `.spec-context.json` so the **SpecKit Companion VS Code GUI lights up on your existing spec-kit flow** — no template change, no GUI code change.
 
-This directory is the spec-kit-catalog half of the SpecKit Companion monorepo; it lives beside the VS Code extension (`src/`, `webview/`) and is published/installed independently. It does **not** read or depend on the GUI at runtime — it only writes the canonical `.spec-context.json` the GUI already consumes.
+> **Status:** v1 foundation shipped & proven. See **[ROADMAP.md](./ROADMAP.md)** for the full 8-step plan and per-step status.
 
-> **Status:** v1 foundation shipped & proven — a single `after_specify` hook that writes `.spec-context.json` (spec `106-speckit-extension-foundation`). The other lifecycle hooks, the derive-from-files fallback, and the `status`/`resume` commands are later steps. See **[ROADMAP.md](./ROADMAP.md)** for the full 8-step plan and per-step status.
+## Why install it
 
-## What's here
+- **Live progress in the GUI** — each spec-kit step (specify → … → implement) appears in the Companion sidebar as it happens, with status and history.
+- **Zero workflow change** — it rides your *existing* spec-kit commands via lifecycle hooks; there are no new commands to learn to get tracking.
+- **Agent-agnostic** — works wherever spec-kit runs (Claude Code, Copilot, Cursor, Gemini, …), with extra depth on Claude.
+- **Safe by design** — writes are atomic and append-only, preserve your data, never regress a shipped spec, and never fail your spec-kit command.
+- **More coming** — status/resume, an opinionated pipeline + preset, living-specs & drift, and auto-mode (see the [roadmap](./ROADMAP.md)).
 
-```
-speckit-extension/
-├── extension.yml                          # manifest: id companion, one after_specify hook
-├── commands/
-│   └── speckit.companion.capture.md        # command-markdown: "run the writer script"
-├── scripts/
-│   └── write-context.py                    # the writer (stdlib Python, atomic, append-only)
-└── README.md
-```
+## Quick start
 
-The chain mirrors spec-kit's bundled `git` extension exactly: **hook → command-markdown → "run this script."**
-
-```
-/speckit.specify  →  after_specify hook  →  speckit.companion.capture.md  →  write-context.py  →  .spec-context.json  →  Companion GUI re-renders
-```
-
-## What the writer does
-
-`write-context.py` does a crash-safe **read-merge-write** of the active feature's `.spec-context.json`:
-
-- **Active-dir resolution** (spec-kit's order, most-specific first): `--feature-dir` → `SPECIFY_FEATURE_DIRECTORY` env → `SPECIFY_FEATURE` env → `.specify/feature.json` → current git-branch numeric prefix.
-- **Preserves** every existing/unknown top-level key (e.g. Companion-owned `reviewComments`) — never clobbers.
-- **Append-only** `transitions` (`by: "extension"`); `from` is the prior `{step, substep}`, or `null` on first write.
-- **Never regresses** a more-advanced spec: if the target is already at a later step or a terminal status (`implemented`/`completed`/`archived`), it is left untouched.
-- **Atomic**: writes a temp file then `os.replace()`.
-- Writes Companion-canonical values (`currentStep: "specify"`, `status: "specified"`); **never** the legacy `currentStep: "done"`.
-
-The canonical schema is owned by the GUI repo at `src/core/types/spec-context.schema.json` — the writer targets it directly (no vendored copy).
-
-## Requirements
-
-- **An extension-capable spec-kit.** The extension subsystem (`specify extension …`) ships in the **GitHub-source** build of spec-kit, *not* the stock PyPI `specify-cli` package — see [Install](#install) below.
-- `requires.speckit_version: ">=0.8.5"` — the floor for the workflow `integration: auto` path later phases ride.
-
-  > ⚠ **Confirm the exact `after_specify` floor.** The spec-kit release that first wired the `after_specify` / `after_plan` lifecycle hooks may differ from `0.8.5`. Verify against the installed spec-kit and raise this floor if needed.
-- `python3` — declared as an **optional** tool. The capture is best-effort and degrades gracefully (warns + skips) if `python3` is absent; it never fails the host spec-kit command.
-
-## Install
-
-### Prerequisite — an extension-capable spec-kit
-
-The `specify extension` subsystem is part of the **GitHub-source** spec-kit. The stock PyPI `specify-cli` package only exposes `init` / `check` / `version` and will fail with *"No such command 'extension'"*. Install from source (a global `uv` tool change, not project-local):
+Requires a **github-source** spec-kit (the stock PyPI `specify-cli` has no `extension` CLI). From the repo root:
 
 ```bash
-uv tool install specify-cli --from git+https://github.com/github/spec-kit.git --force
-specify extension --help     # confirm `add` / `list` are present
+specify extension add ./speckit-extension --dev
 ```
 
-### Local / development (today)
+Then run your normal `/speckit.specify` — the Companion sidebar updates. Full prerequisites, catalog install, and a CLI-less fallback are in **[docs/install.md](./docs/install.md)**.
 
-Not published to the spec-kit catalog yet, so install straight from this directory. From the repo root:
+## Docs
 
-```bash
-specify extension add ./speckit-extension --dev   # installs into .specify/extensions/companion/
-specify extension list                            # confirm "companion" is listed
-```
+- **[docs/install.md](./docs/install.md)** — install (dev / catalog / fallback) + verification.
+- **[docs/commands.md](./docs/commands.md)** — the commands and the lifecycle hooks they run.
+- **[docs/how-it-works.md](./docs/how-it-works.md)** — the hook → script → `.spec-context.json` chain, the writer's guarantees, the canonical schema, and the end-to-end proof.
+- **[docs/contributing.md](./docs/contributing.md)** — dev loop for building the next steps (this is the *spec-kit* extension, separate from the VS Code one).
+- **[ROADMAP.md](./ROADMAP.md)** — the 8-step migration plan and status.
+- **[CHANGELOG.md](./CHANGELOG.md)** — version history (independent of the VS Code extension).
 
-`--dev` copies the extension into `.specify/extensions/companion/` (where spec-kit resolves command-markdown), registers its hooks in `.specify/extensions.yml`, and emits the per-agent command (e.g. into `.claude/`) so the hook is actually resolvable. A bare registration in `.specify/extensions.yml` is **not** enough on its own — that placement + emission is what the install does.
+---
 
-> This repo commits a registration stub for `companion`. If `specify extension add` reports it's already installed, run `specify extension remove companion` first, then re-run the `add ./speckit-extension --dev` above.
-
-### Catalog (future)
-
-Once published:
-
-```bash
-specify extension add companion --ai-skills
-```
-
-> **`--ai-skills` is non-destructive on update.** Re-installing will *not* overwrite an existing `SKILL.md`; use `--force` / re-init to upgrade installed Claude assets.
-
-### Fallback — CLI-less manual install
-
-If you're stuck on the stock PyPI build and can't reinstall, you can replicate what the CLI does by hand: copy `speckit-extension/` → `.specify/extensions/companion/`, add a `companion` entry to `.specify/extensions/.registry`, and emit a `.claude/skills/speckit-companion-capture/SKILL.md` mirroring `.claude/skills/speckit-git-commit/SKILL.md`. This is a stopgap — the supported path is the source install above.
-
-## End-to-end proof (the de-risk)
-
-The whole migration rests on one unproven chain: *user runs a spec-kit command → the agent runs our hook → our script writes `.spec-context.json` → the Companion GUI re-renders.* Reproduce it:
-
-### A. Script + resolution (deterministic — no GUI needed)
-
-Mimics exactly what the `after_specify` hook invokes:
-
-```bash
-# Point spec-kit's active-feature pointer at a throwaway spec dir (as a real
-# `specify` would), then run the capture the way the hook does:
-mkdir -p specs/_zzz-proof-demo && printf '# Spec: Proof Demo\n' > specs/_zzz-proof-demo/spec.md
-python3 speckit-extension/scripts/write-context.py --feature-dir specs/_zzz-proof-demo \
-  --step specify --status specified --by extension
-cat specs/_zzz-proof-demo/.spec-context.json   # currentStep=specify, status=specified, transitions[].by=extension
-rm -rf specs/_zzz-proof-demo
-```
-
-Expected: a valid canonical `.spec-context.json` with `currentStep: "specify"`, `status: "specified"`, and a single `transitions` entry `{ "by": "extension", "from": null }`. Re-running appends a second transition (with `from` set) and preserves any pre-existing keys.
-
-### B. Live hook + GUI (manual — needs the VS Code GUI)
-
-1. **Install the extension** so the hook is resolvable (see [Install](#install) — both the source prerequisite and the `--dev` step):
-   ```bash
-   specify extension add ./speckit-extension --dev
-   specify extension list      # confirm "companion" appears
-   ```
-2. Install/enable the SpecKit Companion **VS Code** extension and open this repo.
-3. In Claude Code, run a real `/speckit.specify "throwaway proof feature"`.
-4. When the `after_specify` hook fires, let it run `speckit.companion.capture`. (Hooks are agent-mediated — note whether it auto-fires or needs a nudge; that observation is the point of this proof.)
-5. Confirm the new `specs/<NNN>-<slug>/.spec-context.json` carries `currentStep: specify` / `status: specified` / a `by: extension` transition:
-   ```bash
-   cat specs/<NNN>-<slug>/.spec-context.json
-   ```
-6. Open the SpecKit Companion sidebar/viewer — the new spec should render at the **specify** step with **specified** status, with no GUI code change.
-7. Clean up: delete the throwaway spec dir; optionally `specify extension remove companion`.
-
-### Status
-
-Per-step progress lives in **[ROADMAP.md](./ROADMAP.md)**. Step 1 (this) is **shipped and proven** — the `after_specify` hook auto-fires (`optional: false`) and writes a canonical `.spec-context.json`, verified end-to-end on a real `/speckit.specify` run.
+It lives beside the VS Code extension in the monorepo and is published/installed independently; it does **not** read or depend on the GUI at runtime — it only writes the canonical `.spec-context.json` the GUI already consumes.

--- a/speckit-extension/README.md
+++ b/speckit-extension/README.md
@@ -1,0 +1,130 @@
+# SpecKit Companion — spec-kit Extension
+
+A [spec-kit](https://github.com/github/spec-kit) extension (`id: companion`) that
+captures your spec-kit lifecycle activity into `.spec-context.json`, so the
+**SpecKit Companion** VS Code GUI lights up on your *existing* spec-kit flow — no
+template change, no GUI code change.
+
+This directory is the spec-kit-catalog half of the SpecKit Companion monorepo; it
+lives beside the VS Code extension (`src/`, `webview/`) and is published/installed
+independently. It does **not** read or depend on the GUI at runtime — it only
+writes the canonical `.spec-context.json` the GUI already consumes.
+
+> **Status: foundation spike (v1, one hook).** This ships the de-risking slice
+> from spec `106-speckit-extension-foundation`: a single `after_specify` hook that
+> writes `.spec-context.json`. The other lifecycle hooks, the derive-from-files
+> fallback, and the `status`/`resume` commands are deferred to later steps.
+
+## What's here
+
+```
+speckit-extension/
+├── extension.yml                          # manifest: id companion, one after_specify hook
+├── commands/
+│   └── speckit.companion.capture.md        # command-markdown: "run the writer script"
+├── scripts/
+│   └── write-context.py                    # the writer (stdlib Python, atomic, append-only)
+└── README.md
+```
+
+The chain mirrors spec-kit's bundled `git` extension exactly:
+**hook → command-markdown → "run this script."**
+
+```
+/speckit.specify  →  after_specify hook  →  speckit.companion.capture.md  →  write-context.py  →  .spec-context.json  →  Companion GUI re-renders
+```
+
+## What the writer does
+
+`write-context.py` does a crash-safe **read-merge-write** of the active feature's
+`.spec-context.json`:
+
+- **Active-dir resolution** (spec-kit's order, most-specific first):
+  `--feature-dir` → `SPECIFY_FEATURE_DIRECTORY` env → `SPECIFY_FEATURE` env →
+  `.specify/feature.json` → current git-branch numeric prefix.
+- **Preserves** every existing/unknown top-level key (e.g. Companion-owned
+  `reviewComments`) — never clobbers.
+- **Append-only** `transitions` (`by: "extension"`); `from` is the prior
+  `{step, substep}`, or `null` on first write.
+- **Atomic**: writes a temp file then `os.replace()`.
+- Writes Companion-canonical values (`currentStep: "specify"`,
+  `status: "specified"`); **never** the legacy `currentStep: "done"`.
+
+The canonical schema is owned by the GUI repo at
+`src/core/types/spec-context.schema.json` — the writer targets it directly (no
+vendored copy).
+
+## Requirements
+
+- `requires.speckit_version: ">=0.8.5"` — the floor for the workflow
+  `integration: auto` path later phases ride.
+
+  > ⚠ **Confirm the exact `after_specify` floor.** The spec-kit release that first
+  > wired the `after_specify` / `after_plan` lifecycle hooks may differ from
+  > `0.8.5`. Verify against the installed spec-kit and raise this floor if needed.
+- `python3` — declared as an **optional** tool. The capture is best-effort and
+  degrades gracefully (warns + skips) if `python3` is absent; it never fails the
+  host spec-kit command.
+
+## Install
+
+Install into a spec-kit project and emit Claude assets:
+
+```bash
+specify extension add companion --ai-skills
+```
+
+> **Note — `--ai-skills` is non-destructive on update.** Re-installing will *not*
+> overwrite an existing `SKILL.md`; use `--force` / re-init to upgrade installed
+> Claude assets.
+
+Registration lives in `.specify/extensions.yml` (this repo wires it under
+`after_specify`, alongside the bundled `git` extension's auto-commit — both run).
+
+## End-to-end proof (the de-risk)
+
+The whole migration rests on one unproven chain: *user runs a spec-kit command →
+the agent runs our hook → our script writes `.spec-context.json` → the Companion
+GUI re-renders.* Reproduce it:
+
+### A. Script + resolution (deterministic — no GUI needed)
+
+Mimics exactly what the `after_specify` hook invokes:
+
+```bash
+# Point spec-kit's active-feature pointer at a throwaway spec dir (as a real
+# `specify` would), then run the capture the way the hook does:
+mkdir -p specs/_zzz-proof-demo && printf '# Spec: Proof Demo\n' > specs/_zzz-proof-demo/spec.md
+python3 speckit-extension/scripts/write-context.py --feature-dir specs/_zzz-proof-demo \
+  --step specify --status specified --by extension
+cat specs/_zzz-proof-demo/.spec-context.json   # currentStep=specify, status=specified, transitions[].by=extension
+rm -rf specs/_zzz-proof-demo
+```
+
+Expected: a valid canonical `.spec-context.json` with `currentStep: "specify"`,
+`status: "specified"`, and a single `transitions` entry `{ "by": "extension",
+"from": null }`. Re-running appends a second transition (with `from` set) and
+preserves any pre-existing keys.
+
+### B. Live hook + GUI (manual — needs the VS Code GUI)
+
+1. Install the SpecKit Companion VS Code extension and open this repo.
+2. Ensure `companion` is registered under `after_specify` in
+   `.specify/extensions.yml` (it is, in this repo).
+3. In Claude Code, run a real `/speckit.specify "throwaway proof feature"`.
+4. When the `after_specify` hook prompt fires, let it run
+   `speckit.companion.capture`.
+5. Confirm the new `specs/<NNN>-<slug>/.spec-context.json` carries
+   `currentStep: specify` / `status: specified` / a `by: extension` transition.
+6. Open the SpecKit Companion sidebar/viewer — the new spec should render at the
+   **specify** step with **specified** status, with no GUI code change.
+7. Delete the throwaway spec.
+
+### Observed result
+
+- **A (script + resolution):** ✅ Verified — the writer creates/updates a canonical
+  `.spec-context.json` with the expected values; append-only transitions and
+  unknown-key preservation confirmed by the spec's probe test.
+- **B (live hook + GUI):** ⏳ Pending manual confirmation in an interactive VS
+  Code session (records whether the agent auto-fires the `after_specify` prompt —
+  hooks are agent-mediated, so this is the behavior the spike exists to observe).

--- a/speckit-extension/ROADMAP.md
+++ b/speckit-extension/ROADMAP.md
@@ -1,0 +1,31 @@
+# SpecKit Companion — spec-kit Extension Roadmap
+
+This extension is SDD rebuilt as a spec-kit extension — the spec-kit-side half of the [SpecKit Companion](../README.md) product (the VS Code GUI is the other half). It ships as **8 ordered, PR-sized steps**. **v1 = steps 1–3**: get rich activity tracking working on a user's *existing* spec-kit flow, no template change, with the Companion GUI lit up.
+
+Design sources: `sdd` repo → `specs/024-speckit-extension-foundation/spec.md` (R001–R015) and ADR `0003-sdd-as-speckit-extension.md`.
+
+## Steps
+
+| # | Step | Scope | Status |
+|---|------|-------|--------|
+| 1 | **Foundation + `after_specify` spike** | one hook → `write-context.py` → `.spec-context.json`; minimal canonical-schema alignment | ✅ **Shipped & proven** ([PR #173](https://github.com/alfredoperez/speckit-companion/pull/173)) |
+| 2 | Full lifecycle capture + fallback | `after_plan`/`after_tasks`/`after_implement` hooks; derive-from-files when a hook didn't fire | ◻ Planned |
+| 3 | `status` + `resume` commands | pipeline view (`--json`) + next-step detection — **completes v1** | ◻ Planned |
+| 4 | Own pipeline commands + `sdd-lean` preset | namespaced `/speckit.companion.*` + a files/deps template pack | ◻ Planned |
+| 5 | Complexity detector + fast path | right-size small changes (spec+plan+tasks in one pass) | ◻ Planned |
+| 6 | Living specs + drift | domain specs + drift detection — *the differentiator* | ◻ Planned |
+| 7 | Auto-mode workflow | a spec-kit `workflow.yml` driving specify→implement, with a no-gate variant | ◻ Planned |
+| 8 | Agent-team `[P]` parallelism | Claude-only fan-out of independent task groups; sequential fallback elsewhere | ◻ Planned |
+
+Legend: ✅ shipped · ◻ planned.
+
+## Step 1 — what's proven
+
+The whole migration rested on one unproven, agent-mediated chain: *user runs a spec-kit command → the agent runs our hook → our script writes `.spec-context.json` → the Companion GUI re-renders.* Step 1 proved it.
+
+- **A — script + resolution (deterministic):** ✅ `write-context.py` creates/updates a canonical `.spec-context.json` (active-dir resolution via spec-kit's order), with append-only transitions, unknown-key preservation, and a no-backward-clobber guard. Covered by the probe/regression suite.
+- **B — live hook + GUI:** ✅ Verified 2026-05-25. One real `/speckit.specify` **auto-fired** the `after_specify` companion hook (`optional: false` → no nudge) → `write-context.py` → `specs/<NNN>-<slug>/.spec-context.json` at `currentStep: specify` / `status: specified` with a `by: extension` transition. The artifact carried `workflow: "speckit"`, proving it works on a **plain spec-kit flow** with no SDD present.
+
+The reproducible proof procedure lives in the [README](./README.md#end-to-end-proof-the-de-risk).
+
+> The build-in-public devlog for each step is the "My SDD" Build Log series.

--- a/speckit-extension/commands/speckit.companion.capture.md
+++ b/speckit-extension/commands/speckit.companion.capture.md
@@ -1,0 +1,50 @@
+---
+description: "Capture the current spec-kit step into .spec-context.json for the Companion GUI"
+---
+
+# Capture Spec Context
+
+Record the active feature's current pipeline step into `.spec-context.json` so the
+SpecKit Companion GUI re-renders with the correct step and status. This command
+runs as the `after_specify` lifecycle hook — **state-writing only**; the spec
+directory and files are created by the core `/speckit.specify` workflow.
+
+## Prerequisites
+
+- Verify Python is available by running `python3 --version`.
+- If `python3` is not available, warn the user and skip the capture:
+  `[companion] Warning: python3 not detected; skipped .spec-context.json capture`.
+  Do not fail the host command.
+
+## Execution
+
+Run the writer script from the repository root:
+
+```bash
+python3 speckit-extension/scripts/write-context.py --step specify --status specified --by extension
+```
+
+The script resolves the active feature directory on its own, in this order:
+`--feature-dir` → `SPECIFY_FEATURE_DIRECTORY` env → `SPECIFY_FEATURE` env →
+`.specify/feature.json` → current git branch prefix.
+
+If you already know the feature directory (e.g. the one `/speckit.specify` just
+created), pass it explicitly so resolution is unambiguous:
+
+```bash
+python3 speckit-extension/scripts/write-context.py --feature-dir specs/<NNN>-<slug> --step specify --status specified --by extension
+```
+
+## Graceful Degradation
+
+The script is best-effort and never fails the host command:
+- If `python3` is missing, skip with the warning above.
+- If the active feature directory cannot be resolved, the script prints a warning
+  to stderr and exits 0 without writing.
+
+## Output
+
+On success the script prints the path it updated and the values written, e.g.:
+`[companion] Updated specs/<NNN>-<slug>/.spec-context.json (currentStep=specify, status=specified, by=extension)`.
+The write is atomic (temp file + rename) and appends to `transitions` without
+rewriting existing history.

--- a/speckit-extension/docs/commands.md
+++ b/speckit-extension/docs/commands.md
@@ -1,0 +1,40 @@
+# Commands & hooks
+
+The extension follows spec-kit's bundled-extension pattern exactly: a **lifecycle hook** runs a **command-markdown** file, which tells the agent to **run a script**.
+
+```
+/speckit.specify  →  after_specify hook  →  speckit.companion.capture  →  write-context.py  →  .spec-context.json
+```
+
+## Lifecycle hooks
+
+Registered in the extension's `extension.yml` (and, once installed, in the project's `.specify/extensions.yml`):
+
+| Hook | Command | optional | Effect |
+|------|---------|----------|--------|
+| `after_specify` | `speckit.companion.capture` | `false` (auto-runs) | Record specify completion into `.spec-context.json` |
+
+`optional: false` means the agent runs it **automatically** with no prompt. (For contrast, the bundled `git` extension's `after_specify` commit hook is `optional: true`, so it only *offers* to run.) Steps 2+ add `after_plan` / `after_tasks` / `after_implement` — see [../ROADMAP.md](../ROADMAP.md).
+
+## `speckit.companion.capture`
+
+The only command today. It carries no business logic itself — it resolves the active feature and invokes the writer script, mirroring `speckit.git.feature.md`.
+
+**What the agent runs:**
+
+```bash
+python3 speckit-extension/scripts/write-context.py --step specify --status specified --by extension
+```
+
+**Flags** (`scripts/write-context.py`):
+
+| Flag | Default | Meaning |
+|------|---------|---------|
+| `--step` | `specify` | Canonical step (`specify`/`clarify`/`plan`/`tasks`/`analyze`/`implement`). A non-canonical value (incl. legacy `done`) is a no-op. |
+| `--status` | `specified` | Canonical lifecycle status written to the file. |
+| `--by` | `extension` | Authorship tag on the appended transition. |
+| `--feature-dir` | — | Explicit target dir; otherwise resolved (see [how-it-works.md](./how-it-works.md#active-directory-resolution)). |
+
+**Graceful degradation:** if `python3` is missing the command warns and skips; if the active feature directory can't be resolved the script warns and exits 0. It never fails the host spec-kit command.
+
+See [how-it-works.md](./how-it-works.md) for what the writer guarantees (atomic, append-only, no-regress) and the canonical schema.

--- a/speckit-extension/docs/contributing.md
+++ b/speckit-extension/docs/contributing.md
@@ -1,0 +1,50 @@
+# Contributing to the spec-kit extension
+
+This guide is for working on the **spec-kit extension** (`speckit-extension/`, `id: companion`).
+
+> **Two extensions, one repo.** This monorepo ships two independently-versioned products:
+> - the **VS Code extension** (the GUI) — see the repo-root [`CONTRIBUTING.md`](../../CONTRIBUTING.md), [`README.md`](../../README.md), [`CHANGELOG.md`](../../CHANGELOG.md), `package.json` (v0.18.x);
+> - the **spec-kit extension** (this folder) — its own [`README.md`](../README.md), [`ROADMAP.md`](../ROADMAP.md), [`CHANGELOG.md`](../CHANGELOG.md), and `extension.yml` (v0.1.0).
+>
+> They're published to different places (VS Code Marketplace vs the spec-kit catalog) and versioned separately. This doc covers only the spec-kit extension.
+
+## Layout
+
+```
+speckit-extension/
+├── extension.yml          # manifest: id, version, requires, provides.commands, hooks
+├── commands/              # command-markdown (the agent runs these)
+├── scripts/               # write-context.py (the writer)
+├── docs/                  # install, commands, how-it-works, contributing (this file)
+├── README.md  ROADMAP.md  CHANGELOG.md
+```
+
+`speckit-extension/` is the **source**. When installed, spec-kit copies it into `.specify/extensions/companion/` (the **installed fixture**) — that copy is what makes the hooks resolvable at runtime. Both are committed (the fixture mirrors how the bundled `git` extension is committed); edit the **source**, then re-install to refresh the fixture.
+
+## Dev loop (per roadmap step)
+
+Each migration step (see [ROADMAP.md](../ROADMAP.md)) is one PR-sized change:
+
+1. **Branch from `main`.** Don't stack on a previously-merged branch — the repo squash-merges, so old commits won't be in your new branch's history.
+2. **Edit the source** in `speckit-extension/`: register a hook in `extension.yml`, add a `commands/speckit.companion.<cmd>.md`, and/or extend `scripts/write-context.py`.
+3. **Install locally to test:**
+   ```bash
+   specify extension add ./speckit-extension --dev
+   ```
+   This refreshes `.specify/extensions/companion/`, re-registers hooks in `.specify/extensions.yml`, and re-emits the per-agent commands so your change is live. (Prereq: a github-source spec-kit — see [install.md](./install.md).)
+4. **Run the real command** (`/speckit.specify`, `/speckit.plan`, …), watch the hook fire, and confirm `.spec-context.json` updates (and the Companion GUI re-renders). See [how-it-works.md](./how-it-works.md#end-to-end-proof).
+5. **Commit** the source **and** the refreshed fixture/per-agent files together; open a PR; squash-merge; return to `main`.
+
+## Per-release checklist
+
+- Bump `version` in `extension.yml` (SemVer; independent of the VS Code extension's `package.json`).
+- Add a `CHANGELOG.md` entry under a new version heading.
+- Update `ROADMAP.md` status for the shipped step.
+- Update the relevant `docs/` page if behavior or commands changed; keep the README a lean "why install / quick start / links" page.
+
+## Good to know
+
+- **`companion` is installed in this repo (dogfooding).** Running `/speckit.specify` here auto-fires the `after_specify` capture — expected, harmless.
+- **Coexists with SDD.** The `/sdd:*` flow writes `.spec-context.json` itself; this extension only fires on `/speckit.*`. Mixed authorship in `transitions[].by` is normal.
+- **Best-effort contract.** The writer must never fail the host spec-kit command — keep new script paths warn-and-exit-0 on error (see `write-context.py`).
+- **Schema is owned by the GUI repo** at `src/core/types/spec-context.schema.json`; extend it there, never vendor a copy.

--- a/speckit-extension/docs/how-it-works.md
+++ b/speckit-extension/docs/how-it-works.md
@@ -1,0 +1,57 @@
+# How it works
+
+The extension lives beside the VS Code GUI in the monorepo and is published/installed independently. At runtime it does **not** read or depend on the GUI — it only writes the canonical `.spec-context.json` the GUI already consumes.
+
+```
+/speckit.specify  →  after_specify hook  →  speckit.companion.capture.md  →  write-context.py  →  .spec-context.json  →  Companion GUI re-renders
+```
+
+(The command/hook layer is documented in [commands.md](./commands.md).)
+
+## The writer (`scripts/write-context.py`)
+
+A stdlib-only Python script that does a crash-safe **read-merge-write** of the active feature's `.spec-context.json`:
+
+- **Preserves** every existing/unknown top-level key (e.g. Companion-owned `reviewComments`) — never clobbers.
+- **Append-only** `transitions` (`by: "extension"`); `from` is the prior `{step, substep}`, or `null` on first write.
+- **Never regresses** a more-advanced spec: if the target is already at a later step or a terminal status (`implemented`/`completed`/`archived`), it's left untouched — this prevents a stray hook from dragging a shipped spec backward.
+- **Atomic:** writes a temp file then `os.replace()`.
+- Writes Companion-canonical values (e.g. `currentStep: "specify"`, `status: "specified"`); **never** the legacy `currentStep: "done"`.
+
+## Active-directory resolution
+
+The writer resolves which feature dir to update using spec-kit's order, most-specific first:
+
+`--feature-dir` → `SPECIFY_FEATURE_DIRECTORY` env → `SPECIFY_FEATURE` env → `.specify/feature.json` → current git-branch numeric prefix.
+
+It never falls back to "most-recently-modified dir containing `tasks.md`."
+
+## Canonical schema
+
+The schema is owned by the GUI repo at `src/core/types/spec-context.schema.json`; the writer targets it directly — **no vendored copy, no cross-repo reconciliation**. v1 added `"implemented"` to the `status` enum so terminal state matches the TypeScript `Status` type.
+
+## End-to-end proof
+
+The migration rests on one agent-mediated chain: *spec-kit command → agent runs our hook → script writes `.spec-context.json` → Companion GUI re-renders.* Reproduce it:
+
+### A. Script + resolution (deterministic — no GUI)
+
+```bash
+mkdir -p specs/_zzz-proof-demo && printf '# Spec: Proof Demo\n' > specs/_zzz-proof-demo/spec.md
+python3 speckit-extension/scripts/write-context.py --feature-dir specs/_zzz-proof-demo \
+  --step specify --status specified --by extension
+cat specs/_zzz-proof-demo/.spec-context.json   # currentStep=specify, status=specified, transitions[].by=extension
+rm -rf specs/_zzz-proof-demo
+```
+
+Expected: a valid canonical `.spec-context.json` with `currentStep: "specify"`, `status: "specified"`, and a single `transitions` entry `{ "by": "extension", "from": null }`. Re-running appends a second transition (with `from` set) and preserves any pre-existing keys.
+
+### B. Live hook + GUI
+
+1. Install the extension ([install.md](./install.md)) and open the repo with the SpecKit Companion VS Code extension enabled.
+2. Run a real `/speckit.specify "throwaway proof feature"` in your agent.
+3. Let the `after_specify` hook run `speckit.companion.capture` (it auto-runs at `optional: false`).
+4. Confirm `specs/<NNN>-<slug>/.spec-context.json` carries `currentStep: specify` / `status: specified` / a `by: extension` transition, and the Companion sidebar renders it at **specify / specified** — no GUI code change.
+5. Clean up: delete the throwaway spec; optionally `specify extension remove companion`.
+
+**Verified 2026-05-25:** one real `/speckit.specify` auto-fired the hook (no nudge) and wrote a canonical file with `workflow: "speckit"` (a plain spec-kit flow, no SDD). See [../ROADMAP.md](../ROADMAP.md#step-1--whats-proven).

--- a/speckit-extension/docs/install.md
+++ b/speckit-extension/docs/install.md
@@ -1,0 +1,49 @@
+# Install
+
+## Prerequisite — an extension-capable spec-kit
+
+The `specify extension` subsystem ships in the **GitHub-source** build of spec-kit. The stock PyPI `specify-cli` package only exposes `init` / `check` / `version` and will fail with *"No such command 'extension'"*. Install from source (a global `uv` tool change, not project-local):
+
+```bash
+uv tool install specify-cli --from git+https://github.com/github/spec-kit.git --force
+specify extension --help     # confirm `add` / `list` are present
+```
+
+`python3` is also used by the capture script — but it's an **optional** tool: the capture degrades gracefully (warns + skips) if `python3` is absent and never fails the host spec-kit command.
+
+> **Version floor:** the extension declares `requires.speckit_version: ">=0.8.5"` (the floor for the workflow `integration: auto` path later phases ride). Confirm/raise once the exact spec-kit release that wired `after_specify`/`after_plan` is verified.
+
+## Local / development (today)
+
+Not published to the spec-kit catalog yet, so install straight from this directory. From the repo root:
+
+```bash
+specify extension add ./speckit-extension --dev   # installs into .specify/extensions/companion/
+specify extension list                            # confirm "companion" is listed
+```
+
+`--dev` copies the extension into `.specify/extensions/companion/` (where spec-kit resolves command-markdown), registers its hooks in `.specify/extensions.yml`, and emits the per-agent command (e.g. into `.claude/`) so the hook is actually resolvable. A bare registration in `.specify/extensions.yml` is **not** enough on its own — that placement + emission is what the install does.
+
+> This repo commits a registration stub for `companion`. If `specify extension add` reports it's already installed, run `specify extension remove companion` first, then re-run the `add ./speckit-extension --dev` above.
+
+## Catalog (future)
+
+Once published:
+
+```bash
+specify extension add companion --ai-skills
+```
+
+> **`--ai-skills` is non-destructive on update.** Re-installing will *not* overwrite an existing `SKILL.md`; use `--force` / re-init to upgrade installed Claude assets.
+
+## Fallback — CLI-less manual install
+
+If you're stuck on the stock PyPI build and can't reinstall, replicate what the CLI does by hand: copy `speckit-extension/` → `.specify/extensions/companion/`, add a `companion` entry to `.specify/extensions/.registry`, and emit a `.claude/skills/speckit-companion-capture/SKILL.md` mirroring `.claude/skills/speckit-git-commit/SKILL.md`. This is a stopgap — the supported path is the source install above.
+
+## Verify
+
+```bash
+specify extension list        # companion present
+```
+
+Then run a real `/speckit.specify` and confirm `specs/<NNN>-<slug>/.spec-context.json` is written — see [how-it-works.md](./how-it-works.md#end-to-end-proof) for the full check.

--- a/speckit-extension/extension.yml
+++ b/speckit-extension/extension.yml
@@ -4,7 +4,7 @@ extension:
   id: companion
   name: "SpecKit Companion"
   version: "0.1.0"
-  description: "Captures spec-kit lifecycle activity into .spec-context.json so the SpecKit Companion GUI lights up on your existing spec-kit flow"
+  description: "Optional workflow enhancements for SpecKit Companion — surfaces live spec-driven progress in the VS Code companion and layers on SDD's pipeline, living specs, and auto-mode"
   author: alfredoperez
   repository: https://github.com/alfredoperez/speckit-companion
   license: MIT

--- a/speckit-extension/extension.yml
+++ b/speckit-extension/extension.yml
@@ -1,0 +1,36 @@
+schema_version: "1.0"
+
+extension:
+  id: companion
+  name: "SpecKit Companion"
+  version: "0.1.0"
+  description: "Captures spec-kit lifecycle activity into .spec-context.json so the SpecKit Companion GUI lights up on your existing spec-kit flow"
+  author: alfredoperez
+  repository: https://github.com/alfredoperez/speckit-companion
+  license: MIT
+
+requires:
+  # Floor for the workflow `integration: auto` path the later phases ride.
+  # Confirm/raise once the exact spec-kit release that wired after_specify /
+  # after_plan hooks is verified against the installed CLI (see README).
+  speckit_version: ">=0.8.5"
+  tools:
+    - name: python3
+      required: false
+
+provides:
+  commands:
+    - name: speckit.companion.capture
+      file: commands/speckit.companion.capture.md
+      description: "Capture the current spec-kit step into .spec-context.json for the Companion GUI"
+
+hooks:
+  after_specify:
+    command: speckit.companion.capture
+    optional: false
+    description: "Record specify completion (currentStep=specify, status=specified) into .spec-context.json"
+
+tags:
+  - "spec-driven-development"
+  - "tracking"
+  - "companion"

--- a/speckit-extension/scripts/write-context.py
+++ b/speckit-extension/scripts/write-context.py
@@ -1,0 +1,300 @@
+#!/usr/bin/env python3
+"""Write/update a feature's .spec-context.json from a spec-kit lifecycle hook.
+
+Invoked by the `speckit.companion.capture` command-markdown (registered on the
+`after_specify` hook). Resolves the active feature directory using spec-kit's
+own precedence, then does a crash-safe read-merge-write of the Companion's
+canonical .spec-context.json:
+
+  - preserves every existing/unknown top-level key (read-then-merge)
+  - appends to `transitions` (append-only; never rewritten or shrunk)
+  - writes atomically (temp file + os.replace)
+  - emits Companion-canonical values; never the legacy `currentStep: "done"`
+
+Stdlib only. Safe to run anywhere `python3` is available.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+# Canonical vocab (mirrors src/core/types/specContext.ts). Kept here only to
+# reject the legacy terminal step and to avoid regressing an advanced spec.
+CANONICAL_STEPS = {"specify", "clarify", "plan", "tasks", "analyze", "implement"}
+STEP_ORDER = {"specify": 0, "clarify": 1, "plan": 2, "tasks": 3, "analyze": 4, "implement": 5}
+# A spec at one of these statuses must never be dragged backward by a hook that
+# fires after an earlier step (e.g. after_specify re-resolving to a shipped spec).
+TERMINAL_STATUSES = {"implemented", "completed", "archived"}
+
+PREFIX_RE = re.compile(r"^(\d+)-")
+
+
+def _now_iso() -> str:
+    now = datetime.datetime.now(datetime.timezone.utc)
+    return now.strftime("%Y-%m-%dT%H:%M:%S.") + f"{now.microsecond // 1000:03d}Z"
+
+
+def _today() -> str:
+    return datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%d")
+
+
+def _repo_root() -> Path:
+    try:
+        out = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            capture_output=True, text=True, check=True,
+        ).stdout.strip()
+        if out:
+            return Path(out)
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        pass
+    return Path.cwd()
+
+
+def _git_branch(root: Path) -> str | None:
+    try:
+        out = subprocess.run(
+            ["git", "-C", str(root), "rev-parse", "--abbrev-ref", "HEAD"],
+            capture_output=True, text=True, check=True,
+        ).stdout.strip()
+        return out or None
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return None
+
+
+def _match_by_prefix(specs_dir: Path, name: str) -> Path | None:
+    """Map a branch/feature name to specs/<prefix>-* by its numeric prefix.
+
+    Mirrors common.sh find_feature_dir_by_prefix. Exact dir name wins first.
+    """
+    exact = specs_dir / name
+    if exact.is_dir():
+        return exact
+    m = PREFIX_RE.match(name)
+    if not m:
+        return None
+    prefix = str(int(m.group(1)))  # normalize 007 -> 7 for comparison
+    matches = []
+    if specs_dir.is_dir():
+        for child in sorted(specs_dir.iterdir()):
+            if not child.is_dir():
+                continue
+            cm = PREFIX_RE.match(child.name)
+            if cm and str(int(cm.group(1))) == prefix:
+                matches.append(child)
+    if len(matches) == 1:
+        return matches[0]
+    if len(matches) > 1:
+        print(
+            f"[companion] Warning: multiple spec dirs with prefix '{m.group(1)}': "
+            f"{', '.join(c.name for c in matches)}; skipping ambiguous match",
+            file=sys.stderr,
+        )
+    return None
+
+
+def resolve_feature_dir(root: Path, explicit: str | None) -> Path | None:
+    """spec-kit resolution precedence, most-specific first."""
+    specs_dir = root / "specs"
+
+    # 1. explicit --feature-dir
+    if explicit:
+        p = Path(explicit)
+        return p if p.is_absolute() else root / p
+
+    # 2. SPECIFY_FEATURE_DIRECTORY env (a path)
+    env_dir = os.environ.get("SPECIFY_FEATURE_DIRECTORY")
+    if env_dir:
+        p = Path(env_dir)
+        return p if p.is_absolute() else root / p
+
+    # 3. SPECIFY_FEATURE env (a feature name)
+    env_feature = os.environ.get("SPECIFY_FEATURE")
+    if env_feature:
+        hit = _match_by_prefix(specs_dir, env_feature)
+        if hit:
+            return hit
+
+    # 4. .specify/feature.json -> feature_directory
+    feature_json = root / ".specify" / "feature.json"
+    if feature_json.is_file():
+        try:
+            data = json.loads(feature_json.read_text(encoding="utf-8"))
+            fd = data.get("feature_directory")
+            if fd:
+                p = Path(fd)
+                return p if p.is_absolute() else root / p
+        except (json.JSONDecodeError, OSError):
+            pass
+
+    # 5. git current branch -> numeric-prefix match
+    branch = _git_branch(root)
+    if branch:
+        hit = _match_by_prefix(specs_dir, branch)
+        if hit:
+            return hit
+
+    return None
+
+
+def _spec_name(feature_dir: Path) -> str:
+    spec_md = feature_dir / "spec.md"
+    if spec_md.is_file():
+        try:
+            for line in spec_md.read_text(encoding="utf-8").splitlines():
+                line = line.strip()
+                if line.startswith("# "):
+                    title = line[2:].strip()
+                    # Drop a leading "Feature Specification:" / "Spec:" label.
+                    title = re.sub(r"^(Feature Specification|Spec|Feature)\s*:\s*", "", title)
+                    if title:
+                        return title
+        except OSError:
+            pass
+    # Fallback: humanized slug from the dir name (strip NNN- prefix).
+    slug = PREFIX_RE.sub("", feature_dir.name)
+    return slug.replace("-", " ").strip() or feature_dir.name
+
+
+def _is_more_advanced(ctx: dict, step: str) -> bool:
+    """True if the existing context already records a state past `step` — so a
+    hook firing after an earlier step must not regress it."""
+    if ctx.get("status") in TERMINAL_STATUSES:
+        return True
+    cur = ctx.get("currentStep")
+    return cur in STEP_ORDER and STEP_ORDER[cur] > STEP_ORDER[step]
+
+
+def update_context(feature_dir: Path, step: str, status: str, by: str) -> Path | None:
+    target = feature_dir / ".spec-context.json"
+    now = _now_iso()
+    root = _repo_root()
+    branch = _git_branch(root) or "main"
+
+    if target.is_file():
+        try:
+            ctx = json.loads(target.read_text(encoding="utf-8"))
+            if not isinstance(ctx, dict):
+                ctx = {}
+        except (json.JSONDecodeError, OSError):
+            ctx = {}
+    else:
+        ctx = {}
+
+    # Never drag a more-advanced (e.g. shipped) spec backward. Leave it fully
+    # intact — this is the bug the schema reconciliation exists to prevent.
+    if ctx and _is_more_advanced(ctx, step):
+        print(
+            f"[companion] {target} already at currentStep={ctx.get('currentStep')} / "
+            f"status={ctx.get('status')}; not regressing to {step}/{status}.",
+            file=sys.stderr,
+        )
+        return None
+
+    transitions = ctx.get("transitions")
+    if not isinstance(transitions, list):
+        transitions = []
+
+    # `from` = prior {step, substep}, or null on first write. Guard against a
+    # malformed last entry and normalize a non-canonical prior step (e.g. legacy
+    # "done") to null, which the schema's `from.step` enum permits.
+    if transitions and isinstance(transitions[-1], dict):
+        last = transitions[-1]
+        prior_step = last.get("step")
+        prior = {
+            "step": prior_step if prior_step in CANONICAL_STEPS else None,
+            "substep": last.get("substep"),
+        }
+    else:
+        prior = None
+
+    # Required-set defaults only when missing (read-then-merge preserves the rest).
+    ctx.setdefault("workflow", "speckit")
+    ctx.setdefault("specName", _spec_name(feature_dir))
+    ctx.setdefault("branch", branch)
+
+    ctx["currentStep"] = step
+    ctx["status"] = status
+    ctx["updated"] = _today()
+
+    step_history = ctx.get("stepHistory")
+    if not isinstance(step_history, dict):
+        step_history = {}
+    entry = step_history.get(step) if isinstance(step_history.get(step), dict) else {}
+    entry.setdefault("startedAt", now)
+    entry["completedAt"] = now
+    step_history[step] = entry
+    ctx["stepHistory"] = step_history
+
+    transitions.append({
+        "step": step,
+        "substep": None,
+        "from": prior,
+        "by": by,
+        "at": now,
+    })
+    ctx["transitions"] = transitions
+
+    tmp = target.with_suffix(target.suffix + ".tmp")
+    try:
+        tmp.write_text(json.dumps(ctx, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+        os.replace(tmp, target)
+    except OSError:
+        try:
+            tmp.unlink(missing_ok=True)  # don't litter on a failed write
+        except OSError:
+            pass
+        raise
+    return target
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Write/update a feature's .spec-context.json")
+    parser.add_argument("--step", default="specify")
+    parser.add_argument("--status", default="specified")
+    parser.add_argument("--by", default="extension")
+    parser.add_argument("--feature-dir", default=None)
+    args = parser.parse_args()
+
+    # Best-effort guard: a non-canonical step is a no-op, never a host failure.
+    # Terminal state belongs in `status`, not `currentStep`.
+    if args.step == "done" or args.step not in CANONICAL_STEPS:
+        print(
+            f"[companion] Skipping: '{args.step}' is not a canonical currentStep "
+            f"({', '.join(sorted(CANONICAL_STEPS))}).",
+            file=sys.stderr,
+        )
+        return 0
+
+    root = _repo_root()
+    feature_dir = resolve_feature_dir(root, args.feature_dir)
+    if feature_dir is None or not feature_dir.is_dir():
+        print(
+            "[companion] Could not resolve the active feature directory "
+            "(checked --feature-dir, SPECIFY_FEATURE_DIRECTORY, SPECIFY_FEATURE, "
+            ".specify/feature.json, git branch prefix). Skipping context write.",
+            file=sys.stderr,
+        )
+        return 0  # best-effort: never fail the host command
+
+    # Never let a bookkeeping write fail the host spec-kit command.
+    try:
+        target = update_context(feature_dir, args.step, args.status, args.by)
+    except Exception as exc:  # noqa: BLE001 - best-effort, swallow + report
+        print(f"[companion] Warning: skipped .spec-context.json write: {exc}", file=sys.stderr)
+        return 0
+
+    if target is not None:
+        print(f"[companion] Updated {target} (currentStep={args.step}, status={args.status}, by={args.by})")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/specs/106-speckit-extension-foundation/.spec-context.json
+++ b/specs/106-speckit-extension-foundation/.spec-context.json
@@ -240,6 +240,16 @@
       },
       "by": "sdd",
       "at": "2026-05-24T23:03:42.603Z"
+    },
+    {
+      "step": "done",
+      "substep": null,
+      "from": {
+        "step": "done",
+        "substep": null
+      },
+      "by": "sdd",
+      "at": "2026-05-24T23:04:31.846Z"
     }
   ],
   "task_summaries": {
@@ -294,7 +304,7 @@
       ]
     }
   },
-  "last_action": "Code review: hardened write-context.py (4 fixes), installed 0.18.1 locally",
+  "last_action": "PR #173 opened \u2014 feat(speckit-extension): add foundation + after_specify state-write hook",
   "files_modified": [
     "speckit-extension/scripts/write-context.py",
     "src/core/types/spec-context.schema.json",
@@ -303,7 +313,7 @@
     ".specify/extensions.yml",
     "speckit-extension/README.md"
   ],
-  "drainedSeq": 8,
+  "drainedSeq": 9,
   "concerns": [
     {
       "task": "T006",
@@ -324,5 +334,7 @@
   "checkpointStatus": {
     "commit": true,
     "pr": true
-  }
+  },
+  "prUrl": "https://github.com/alfredoperez/speckit-companion/pull/173",
+  "prNumber": 173
 }

--- a/specs/106-speckit-extension-foundation/.spec-context.json
+++ b/specs/106-speckit-extension-foundation/.spec-context.json
@@ -1,0 +1,328 @@
+{
+  "workflow": "sdd",
+  "currentStep": "done",
+  "currentTask": null,
+  "progress": null,
+  "next": "done",
+  "updated": "2026-05-24",
+  "selectedAt": "2026-05-24T21:48:33.000Z",
+  "specName": "SpecKit Companion spec-kit Extension \u2014 Foundation & State-Write Spike",
+  "branch": "main",
+  "workingBranch": "feat/speckit-extension-foundation",
+  "type": "feat",
+  "auto": false,
+  "createdAt": "2026-05-24T21:48:33.000Z",
+  "loadedDomains": [],
+  "status": "completed",
+  "approach": "Add a new top-level speckit-extension/ mirroring spec-kit's bundled git extension (extension.yml -> capture command-markdown -> write-context.py) with a single after_specify hook; the writer resolves the active feature dir via spec-kit's precedence and does a crash-safe read-merge-write of canonical .spec-context.json, with the only GUI-side change being adding 'implemented' to the schema status enum.",
+  "stepHistory": {
+    "specify": {
+      "startedAt": "2026-05-24T21:48:33.000Z",
+      "completedAt": "2026-05-24T21:48:33.000Z"
+    },
+    "plan": {
+      "startedAt": "2026-05-24T21:52:00.000Z",
+      "completedAt": "2026-05-24T21:52:00.000Z"
+    },
+    "tasks": {
+      "startedAt": "2026-05-24T21:54:00.000Z",
+      "completedAt": "2026-05-24T21:54:00.000Z"
+    },
+    "implement": {
+      "startedAt": "2026-05-24T22:21:15.492Z",
+      "completedAt": null
+    }
+  },
+  "step_summaries": {
+    "specify": {
+      "complexity": "normal",
+      "requirements": 15,
+      "scenarios": 5,
+      "key_finding": "The canonical schema already lives in-repo at src/core/types/spec-context.schema.json and already covers everything an after_specify writer emits (currentStep:specify, status:specified, transitions[].by:extension, stepHistory); the only real drift is the JSON schema's status enum missing 'implemented' that the TS Status type already has. The bundled git extension at .specify/extensions/git/ is the exact hook -> command-markdown -> script pattern to mirror, and .sdd.json sets branchStage:implement so branching stays deferred."
+    },
+    "plan": {
+      "approach_summary": "Add a new top-level speckit-extension/ mirroring spec-kit's bundled git extension (extension.yml -> capture command-markdown -> write-context.py) with a single after_specify hook; the writer resolves the active feature dir via spec-kit's precedence and does a crash-safe read-merge-write of canonical .spec-context.json, with the only GUI-side change being adding 'implemented' to the schema status enum.",
+      "files_planned": 6,
+      "risks": [
+        "Exact after_specify version floor unconfirmed; declare >=0.8.5 conservatively and confirm against installed spec-kit.",
+        "Hooks are agent-mediated (prompt-driven) so after_specify may not fire; optional:false maximizes auto-run and the spike observes actual behavior.",
+        "Stale .specify/feature.json could point at the wrong dir; resolution precedence puts explicit --feature-dir/env ahead of feature.json."
+      ],
+      "principles_concerns": 0,
+      "domain_concerns": 0,
+      "significance_score": 2
+    }
+  },
+  "transitions": [
+    {
+      "step": "specify",
+      "substep": "parsing",
+      "from": null,
+      "by": "sdd",
+      "at": "2026-05-24T21:48:33.000Z"
+    },
+    {
+      "step": "specify",
+      "substep": "exploring",
+      "from": {
+        "step": "specify",
+        "substep": "parsing"
+      },
+      "by": "sdd",
+      "at": "2026-05-24T21:48:34.000Z"
+    },
+    {
+      "step": "specify",
+      "substep": "detecting",
+      "from": {
+        "step": "specify",
+        "substep": "exploring"
+      },
+      "by": "sdd",
+      "at": "2026-05-24T21:48:35.000Z"
+    },
+    {
+      "step": "specify",
+      "substep": "writing-spec",
+      "from": {
+        "step": "specify",
+        "substep": "detecting"
+      },
+      "by": "sdd",
+      "at": "2026-05-24T21:48:36.000Z"
+    },
+    {
+      "step": "specify",
+      "substep": null,
+      "from": {
+        "step": "specify",
+        "substep": "writing-spec"
+      },
+      "by": "sdd",
+      "at": "2026-05-24T21:48:37.000Z"
+    },
+    {
+      "step": "plan",
+      "substep": "loading",
+      "from": {
+        "step": "specify",
+        "substep": null
+      },
+      "by": "sdd",
+      "at": "2026-05-24T21:51:00.000Z"
+    },
+    {
+      "step": "plan",
+      "substep": "writing-plan",
+      "from": {
+        "step": "plan",
+        "substep": "loading"
+      },
+      "by": "sdd",
+      "at": "2026-05-24T21:51:30.000Z"
+    },
+    {
+      "step": "plan",
+      "substep": null,
+      "from": {
+        "step": "plan",
+        "substep": "writing-plan"
+      },
+      "by": "sdd",
+      "at": "2026-05-24T21:52:00.000Z"
+    },
+    {
+      "step": "tasks",
+      "substep": "loading",
+      "from": {
+        "step": "plan",
+        "substep": null
+      },
+      "by": "sdd",
+      "at": "2026-05-24T21:53:30.000Z"
+    },
+    {
+      "step": "tasks",
+      "substep": "writing-tasks",
+      "from": {
+        "step": "tasks",
+        "substep": "loading"
+      },
+      "by": "sdd",
+      "at": "2026-05-24T21:53:45.000Z"
+    },
+    {
+      "step": "tasks",
+      "substep": null,
+      "from": {
+        "step": "tasks",
+        "substep": "writing-tasks"
+      },
+      "by": "sdd",
+      "at": "2026-05-24T21:54:00.000Z"
+    },
+    {
+      "step": "implement",
+      "substep": "phase1",
+      "from": {
+        "step": "tasks",
+        "substep": null
+      },
+      "by": "sdd",
+      "at": "2026-05-24T22:19:53.444Z"
+    },
+    {
+      "step": "implement",
+      "substep": "phase1",
+      "from": {
+        "step": "implement",
+        "substep": "phase1"
+      },
+      "by": "sdd",
+      "at": "2026-05-24T22:21:15.492Z"
+    },
+    {
+      "step": "implement",
+      "substep": "phase1",
+      "from": {
+        "step": "implement",
+        "substep": "phase1"
+      },
+      "by": "sdd",
+      "at": "2026-05-24T22:21:53.134Z"
+    },
+    {
+      "step": "implement",
+      "substep": "phase1",
+      "from": {
+        "step": "implement",
+        "substep": "phase1"
+      },
+      "by": "sdd",
+      "at": "2026-05-24T22:22:56.832Z"
+    },
+    {
+      "step": "implement",
+      "substep": "hooks",
+      "from": {
+        "step": "implement",
+        "substep": "phase1"
+      },
+      "by": "sdd",
+      "at": "2026-05-24T22:23:13.600Z"
+    },
+    {
+      "step": "implement",
+      "substep": "code-review",
+      "from": {
+        "step": "implement",
+        "substep": "hooks"
+      },
+      "by": "sdd",
+      "at": "2026-05-24T22:32:51.682Z"
+    },
+    {
+      "step": "implement",
+      "substep": "commit-review",
+      "from": {
+        "step": "implement",
+        "substep": "code-review"
+      },
+      "by": "sdd",
+      "at": "2026-05-24T23:00:08.552Z"
+    },
+    {
+      "step": "done",
+      "substep": null,
+      "from": {
+        "step": "implement",
+        "substep": "commit-review"
+      },
+      "by": "sdd",
+      "at": "2026-05-24T23:03:42.603Z"
+    }
+  ],
+  "task_summaries": {
+    "T001": {
+      "status": "DONE",
+      "did": "Created stdlib write-context.py: spec-kit feature-dir precedence, read-merge preserving unknown keys, append-only transitions, atomic temp+replace; probe test (create+append+unknown-key) passes",
+      "files": [
+        "speckit-extension/scripts/write-context.py"
+      ],
+      "concerns": []
+    },
+    "T002": {
+      "status": "DONE",
+      "did": "Added 'implemented' to status enum in spec-context.schema.json to match TS Status type",
+      "files": [
+        "src/core/types/spec-context.schema.json"
+      ],
+      "concerns": []
+    },
+    "T003": {
+      "status": "DONE",
+      "did": "Created extension.yml manifest (id companion, one after_specify hook, python3 optional tool, >=0.8.5 floor) mirroring the bundled git extension",
+      "files": [
+        "speckit-extension/extension.yml"
+      ],
+      "concerns": []
+    },
+    "T004": {
+      "status": "DONE",
+      "did": "Created speckit.companion.capture.md command-markdown (run-this-script pattern, graceful python3 degradation) with flags matching write-context.py CLI",
+      "files": [
+        "speckit-extension/commands/speckit.companion.capture.md"
+      ],
+      "concerns": []
+    },
+    "T005": {
+      "status": "DONE",
+      "did": "Registered companion in .specify/extensions.yml: added to installed and appended to after_specify alongside git; git entries untouched",
+      "files": [
+        ".specify/extensions.yml"
+      ],
+      "concerns": []
+    },
+    "T006": {
+      "status": "DONE_WITH_CONCERNS",
+      "did": "Wrote speckit-extension/README.md (overview, version-floor caveat, install/--ai-skills note, reproducible proof). Proof A (script+feature.json resolution) verified deterministically; Proof B (live /speckit.specify hook + GUI render) documented as pending manual confirmation",
+      "files": [
+        "speckit-extension/README.md"
+      ],
+      "concerns": [
+        "Proof B (agent auto-fires after_specify + GUI visually renders specify/specified) requires an interactive VS Code session; verified the script/resolution/write half deterministically but not the live agent-mediated hook + GUI"
+      ]
+    }
+  },
+  "last_action": "Code review: hardened write-context.py (4 fixes), installed 0.18.1 locally",
+  "files_modified": [
+    "speckit-extension/scripts/write-context.py",
+    "src/core/types/spec-context.schema.json",
+    "speckit-extension/extension.yml",
+    "speckit-extension/commands/speckit.companion.capture.md",
+    ".specify/extensions.yml",
+    "speckit-extension/README.md"
+  ],
+  "drainedSeq": 8,
+  "concerns": [
+    {
+      "task": "T006",
+      "note": "Live GUI proof (proof B) pending manual confirmation in an interactive VS Code session; hooks are agent-mediated so auto-fire is the behavior to observe"
+    },
+    {
+      "task": "T001",
+      "note": "Resolution divergences from spec-kit's bash resolver left as documented risks (not bugs): int()-normalized variable-width prefix matching (97 vs 097), feature.json ranked before git branch (by design per R007/ADR since our branch is non-numeric), and non-prefixed-branch resolves to no-op. Acceptable for best-effort capture; revisit if misresolution observed."
+    },
+    {
+      "task": "T006",
+      "note": "Live GUI proof (proof B) still pending manual confirmation in an interactive VS Code session."
+    }
+  ],
+  "decisions": [
+    "write-context.py: added monotonic guard so a hook never regresses a shipped/completed spec; normalized non-canonical prior from.step (e.g. legacy 'done') to null per schema; made all writes best-effort (bad step + OSError warn and exit 0, orphan .tmp cleaned up); guarded malformed transitions[-1]"
+  ],
+  "checkpointStatus": {
+    "commit": true,
+    "pr": true
+  }
+}

--- a/specs/106-speckit-extension-foundation/plan.md
+++ b/specs/106-speckit-extension-foundation/plan.md
@@ -1,0 +1,60 @@
+# Plan: SpecKit Companion spec-kit Extension — Foundation & State-Write Spike
+
+**Spec**: [spec.md](./spec.md)
+
+## Approach
+
+Add a new top-level `speckit-extension/` that mirrors spec-kit's bundled `git` extension shape exactly — `extension.yml` (manifest) → `commands/speckit.companion.capture.md` (agent-run command-markdown) → `scripts/write-context.py` (the actual writer) — registering a single `after_specify` hook. The writer resolves the active feature dir using spec-kit's own precedence, then does a crash-safe read-merge-write of `.spec-context.json` with Companion-canonical values (`currentStep: specify`, `status: specified`, an appended `by: extension` transition). The only GUI-side change is a one-value backward-compatible alignment of the canonical JSON schema (add `implemented` to the `status` enum to match the TS `Status` type). We then register the hook in the repo's checked-in `.specify/extensions.yml` fixture and run a real `/speckit.specify` to prove the chain end-to-end.
+
+## Architecture
+
+```mermaid
+graph LR
+  A[/speckit.specify] --> B[after_specify hook]
+  B --> C[speckit.companion.capture.md]
+  C --> D[write-context.py]
+  D --> E[.spec-context.json<br/>atomic write]
+  E --> F[Companion GUI<br/>re-renders]
+```
+
+## Files
+
+### Create
+
+- `speckit-extension/extension.yml` — manifest mirroring `.specify/extensions/git/extension.yml`: `schema_version: "1.0"`; `extension.id: companion`, name/version/description/author/license; `requires.speckit_version: ">=0.8.5"`; `requires.tools: [python3 (required:false)]`; `provides.commands: [speckit.companion.capture → commands/speckit.companion.capture.md]`; `hooks.after_specify: { command: speckit.companion.capture, optional: false }`. No other hooks.
+- `speckit-extension/commands/speckit.companion.capture.md` — command-markdown (frontmatter `description:` + body) that: states it runs after specify; resolves the active feature dir (prefer passing it explicitly if known, else let the script resolve); runs `python3 speckit-extension/scripts/write-context.py --step specify --status specified --by extension` (optionally `--feature-dir <dir>`); degrades gracefully if `python3` is unavailable (warn, skip). Carries no business logic itself — mirrors `speckit.git.feature.md`'s "run this script" pattern.
+- `speckit-extension/scripts/write-context.py` — the writer (stdlib only). Responsibilities below in Data Model + Testing.
+- `speckit-extension/README.md` — what the extension is, the version floor rationale, the **manual end-to-end proof procedure** (R015), and the `--ai-skills` / install note. Keeps the proof reproducible for later phases.
+
+### Modify
+
+- `src/core/types/spec-context.schema.json` — add `"implemented"` to the `status` enum (line ~24), aligning the JSON schema with the canonical TS `Status` type. Backward-compatible (additive enum value). **No change to `specContext.ts`** — it already has `implemented`.
+- `.specify/extensions.yml` — register `companion`: add `companion` to `installed: []`, and append a `companion` entry under the existing `after_specify:` hook list (alongside `git`'s `speckit.git.commit`), `enabled: true`, `optional: false`. Leave every `git` registration untouched.
+
+## Data Model
+
+`write-context.py` operates on the canonical `.spec-context.json` (schema: `src/core/types/spec-context.schema.json`). Behavior:
+
+- **Active-dir resolution** (mirror spec-kit's real precedence, most-specific first):
+  1. `--feature-dir <dir>` CLI arg if passed by the command-markdown.
+  2. `SPECIFY_FEATURE_DIRECTORY` env (a path), if set.
+  3. `SPECIFY_FEATURE` env (a feature name) → `specs/<name>` or numeric-prefix match `specs/<prefix>-*`.
+  4. `.specify/feature.json` → `feature_directory`.
+  5. git current branch → numeric-prefix match `specs/<prefix>-*` (per `common.sh find_feature_dir_by_prefix`).
+  - Never the "most-recently-modified dir containing tasks.md" rule.
+- **Read-merge** (R008/R010): if the target `.spec-context.json` exists, load it and preserve every existing top-level key (incl. unknown / Companion-owned like `reviewComments`). If absent, create with the schema's required set: `workflow` (default `"speckit"`), `specName` (from `spec.md` H1, else slug), `branch` (current git branch), `currentStep`, `status`, `stepHistory`, `transitions`.
+- **Canonical write**: set `currentStep="specify"`, `status="specified"`, `updated=<today>`; ensure `stepHistory.specify` has `startedAt`/`completedAt`; never emit `currentStep:"done"` (R009).
+- **Append-only transitions** (R008/NFR001): append `{ step:"specify", substep:null, from:<prior {step,substep} or null on first write>, by:"extension", at:<iso> }`. Never rewrite/shrink the array.
+- **Atomic write** (NFR001): write to `<file>.tmp` in the same dir, `os.replace()` over the target.
+
+## Testing Strategy
+
+- **Script self-test (manual/CLI)**: run `write-context.py` against (a) a missing file → asserts a valid canonical file is created with one `from:null` transition; (b) an existing SDD-authored file → asserts unknown keys preserved, transitions appended (length grows by 1), `from` set to prior state, `status`→`specified`. Use a throwaway temp `specs/_zzz-writer-probe/` and delete after.
+- **End-to-end proof (R015, the actual de-risk)**: with `companion` registered in `.specify/extensions.yml`, run a real `/speckit.specify "<throwaway feature>"` in this repo; confirm the new `specs/<NNN>-<slug>/.spec-context.json` carries `currentStep:specify` / `status:specified` / a `by:extension` transition; open the SpecKit Companion sidebar/viewer and confirm it renders that spec at **specify / specified** with no GUI code change. Record outcome in `speckit-extension/README.md` + PR description. Clean up the throwaway spec after.
+- **Schema sanity**: confirm the canonical file validates against the updated `spec-context.schema.json` (the added `implemented` value doesn't break existing files).
+
+## Risks
+
+- **Exact `after_specify` version floor unconfirmed**: the spec-kit release that first wired `after_specify`/`after_plan` isn't pinned to a number here. Mitigation: declare `>=0.8.5` (the workflow `integration:auto` floor, which is conservative) and note in `README.md` to confirm/raise once the wiring release is verified against the installed spec-kit.
+- **Hook may not fire (agent-mediated)**: spec-kit hooks are prompt-driven; the agent must obey the `after_specify` prompt. This spike's whole point is to observe whether it fires. Mitigation: `optional:false` to maximize auto-run; the README proof documents the observed behavior; derive-from-files fallback is deferred (out of scope) but noted as the backstop for later.
+- **`feature.json` may point at a stale feature**: `.specify/feature.json` currently references an old spec; relying on it alone could write the wrong dir. Mitigation: resolution precedence puts explicit `--feature-dir`/env ahead of `feature.json`, and after a fresh specify the git extension updates `feature.json` to the new dir.

--- a/specs/106-speckit-extension-foundation/spec.md
+++ b/specs/106-speckit-extension-foundation/spec.md
@@ -1,0 +1,83 @@
+# Spec: SpecKit Companion spec-kit Extension — Foundation & State-Write Spike
+
+**Slug**: 106-speckit-extension-foundation | **Date**: 2026-05-24
+
+## Summary
+
+Stand up a new `speckit-extension/` in this monorepo (beside the VS Code GUI) and prove the single riskiest assumption behind the whole spec-kit migration: that a spec-kit lifecycle hook can write `.spec-context.json` and the Companion GUI picks it up live. The deliverable is intentionally tiny — one `extension.yml`, one `after_specify` hook, one command-markdown, one Python writer script, a minimal canonical-schema alignment — wired into `.specify/extensions.yml` and proven end-to-end by running a real `/speckit.specify` and watching the GUI light up. This is the de-risking spike that everything in Steps 2+ builds on (see `sdd` repo spec `024-speckit-extension-foundation` R001–R008, R013–R014; ADR 0003).
+
+## Requirements
+
+### Foundation & home
+
+- **R001** (MUST): The spec-kit extension lives in this repo under `speckit-extension/`, beside the VS Code extension (monorepo). It does not relocate or depend on the GUI code at runtime.
+- **R002** (MUST): Ship a `speckit-extension/extension.yml` valid against spec-kit's extension schema, mirroring the bundled `git` extension's shape (`schema_version`, `extension`, `requires`, `provides.commands`, `hooks`). Extension `id` is `companion`, so the command is namespaced `speckit.companion.capture`.
+- **R003** (MUST): Declare version floors in `requires.speckit_version` — at minimum the spec-kit release that wired the `after_specify`/`after_plan` lifecycle hooks (and `>=0.8.5` for the workflow `integration: auto` path the later phases need). The exact floor string is recorded in the plan.
+
+### Hook-driven state capture (one hook only)
+
+- **R004** (MUST): Register exactly one lifecycle hook — `after_specify` → `speckit.companion.capture` — in `speckit-extension/extension.yml`. No other lifecycle hooks are registered in this spike.
+- **R005** (MUST): Ship one command-markdown (`speckit-extension/commands/speckit.companion.capture.md`) that instructs the agent to run the writer script, mirroring spec-kit's bundled `git` extension pattern (hook → command-markdown → "run this script"). It carries no business logic itself beyond resolving inputs and invoking the script.
+- **R006** (MUST): Ship a Python writer script (`speckit-extension/scripts/write-context.py`) that creates or updates `specs/<NNN>-<slug>/.spec-context.json` for the active feature, writing Companion-canonical values: `currentStep: "specify"`, `status: "specified"`, and an appended `transitions[]` entry with `by: "extension"`.
+- **R007** (MUST): The writer resolves the active feature directory using spec-kit's resolution order — `SPECIFY_FEATURE_DIRECTORY` env → `.specify/feature.json` → branch-name prefix — and never falls back to "most-recently-modified dir containing `tasks.md`."
+- **R008** (MUST): The writer is read-then-merge: it preserves all existing/unknown top-level keys, appends to `transitions` (never rewrites or shrinks it), and writes atomically (temp file + rename). On first write for a feature it initializes `transitions` with a `from: null` entry; on update it sets `from` to the prior `{step, substep}`.
+- **R009** (MUST): The writer never emits the legacy `currentStep: "done"`; terminal state is expressed only via `status`. Step values stay within the canonical set (`specify`, `clarify`, `plan`, `tasks`, `analyze`, `implement`).
+
+### Canonical schema (owned in this repo)
+
+- **R010** (MUST): The extension reads/writes this repo's canonical `src/core/types/spec-context.schema.json` directly — no vendored copy, no second schema under `speckit-extension/`.
+- **R011** (SHOULD): Align the canonical JSON schema with the canonical TypeScript `Status` type backward-compatibly — specifically add the missing `implemented` value to the schema's `status` enum so terminal state validates (the TS `Status` already has it). This is the only schema change in scope; all other fields the `after_specify` writer emits (`currentStep`, `status: specified`, `transitions[].by: extension`, `stepHistory`) are already covered.
+
+### Constraints carried from ADR 0003
+
+- **R012** (MUST): `.sdd.json` remains SDD's own config; this spike adds nothing to it. spec-kit's `extensions.yml` carries only the thin `after_specify` hook registration that triggers the script.
+- **R013** (MUST): Branch creation is NOT added here — it defers to spec-kit's bundled `git` extension (`before_specify: speckit.git.feature`). The companion extension registers no branch hook.
+
+### End-to-end proof
+
+- **R014** (MUST): Register the hook in this repo's `.specify/extensions.yml` (a checked-in manual-testing fixture) so a real `/speckit.specify` triggers `speckit.companion.capture`. The `companion` entry is added to `installed` and the `after_specify` hook list, alongside the existing `git` registration, without removing or breaking `git`.
+- **R015** (MUST): Demonstrate the chain end-to-end: run a real spec-kit `specify`, confirm `.spec-context.json` is written/updated with the canonical values, and confirm the SpecKit Companion GUI renders the correct step (`specify`) and status (`specified`) with no change to GUI code. The validation procedure and its result are recorded (in the plan / PR description).
+
+## Scenarios
+
+### Companion lights up on a real spec-kit specify
+
+**When** a developer with the `companion` extension registered runs `/speckit.specify "<some feature>"` on Claude Code
+**Then** the `after_specify` hook runs `speckit.companion.capture`, the writer creates/updates that feature's `.spec-context.json` with `currentStep: "specify"` / `status: "specified"` / a `by: "extension"` transition, and the Companion GUI shows that spec at the **specify** step with **specified** status — no GUI code change.
+
+### Re-running specify preserves history
+
+**When** the hook fires a second time for the same feature (e.g. the spec is regenerated)
+**Then** the writer appends a new `transitions[]` entry (with `from` set to the prior state) rather than rewriting the array, and preserves every pre-existing top-level key (including any Companion-owned fields like `reviewComments`).
+
+### Active-dir resolution is unambiguous
+
+**When** multiple feature directories exist under `specs/`
+**Then** the writer targets the dir resolved by spec-kit's order (env → `.specify/feature.json` → branch prefix), not the most-recently-touched dir — so the correct feature is updated even when several have `tasks.md`.
+
+### Write is crash-safe
+
+**When** the writer is interrupted mid-write
+**Then** the existing `.spec-context.json` is never left truncated or partially written, because the writer writes to a temp file and atomically renames over the target.
+
+### Git extension still owns branching
+
+**When** both the bundled `git` extension and `companion` are registered
+**Then** `before_specify: speckit.git.feature` still creates the feature branch and `companion` adds only the `after_specify` capture — no double-branching, no hook collision.
+
+## Non-Functional Requirements
+
+- **NFR001** (MUST): Writes to `.spec-context.json` are atomic (temp + rename) and `transitions` are append-only, matching the Companion's existing write contract.
+- **NFR002** (SHOULD): The extension is agent-agnostic at the file level; the single Python script runs anywhere `python3` is available (spec-kit's own CLI is Python). No Claude-only payload is required for this spike.
+- **NFR003** (SHOULD): The canonical-schema change ships in the same change as the writer that depends on it (docs/schema-forward), per the repo's Docs Sync Rule.
+
+## Out of Scope
+
+Deferred to later phases (noted, not built here):
+
+- The other lifecycle hooks (`after_plan`, `after_tasks`, `after_implement`) and their captures.
+- The derive-from-files fallback (reconstructing state when hooks didn't fire).
+- `/speckit.companion.status` and `/speckit.companion.resume` commands.
+- Pipeline commands (`/speckit.companion.specify|plan|tasks|implement`), templates/presets, complexity detection, living-specs/drift, auto-mode workflow.
+- Any change to the SpecKit Companion GUI beyond the single `status`-enum schema alignment in R011.
+- A second publish target / catalog packaging (the spec-kit catalog publish is a later step).

--- a/specs/106-speckit-extension-foundation/tasks.md
+++ b/specs/106-speckit-extension-foundation/tasks.md
@@ -1,0 +1,43 @@
+# Tasks: SpecKit Companion spec-kit Extension — Foundation & State-Write Spike
+
+**Plan**: [plan.md](./plan.md)
+
+> Format reference: `[P]` markers and parallel groups — see `skills/tasks/SKILL.md` § Phase rules.
+
+## Phase 1: Core Implementation
+
+### Group A — independent foundation files (parallel)
+
+- [x] **T001** [P] Writer script `write-context.py` — `speckit-extension/scripts/write-context.py` | R006, R007, R008, R009, R010, NFR001
+  - **Do**: Create a stdlib-only Python script. CLI: `--step` (default `specify`), `--status` (default `specified`), `--by` (default `extension`), optional `--feature-dir`. Resolve the active feature dir by precedence: (1) `--feature-dir`, (2) `SPECIFY_FEATURE_DIRECTORY` env path, (3) `SPECIFY_FEATURE` env name → `specs/<name>` or numeric-prefix match `specs/<prefix>-*`, (4) `.specify/feature.json` `feature_directory`, (5) git current branch → numeric-prefix match. Read-merge `.spec-context.json` if present (preserve ALL existing/unknown top-level keys); else create with required set (`workflow` default `"speckit"`, `specName` from `spec.md` H1 else slug, `branch` from git, `currentStep`, `status`, `stepHistory`, `transitions`). Set `currentStep`/`status`/`updated`; ensure `stepHistory.specify` start/complete; append one transition `{step, substep:null, from:<prior or null>, by, at:<iso>}` (never shrink the array); never emit `currentStep:"done"`. Write atomically via temp file + `os.replace()`.
+  - **Verify**: Run against a throwaway `specs/_zzz-writer-probe/` twice — first run creates a valid canonical file with one `from:null` transition; second run appends (length +1, `from` = prior state) and preserves an injected unknown key (e.g. `reviewComments`). Delete the probe dir after.
+  - **Leverage**: `.specify/scripts/bash/common.sh` (`find_feature_dir_by_prefix`, `get_current_branch` precedence); `specs/105-workflow-provider-filter/.spec-context.json` (canonical field shape); `src/core/types/spec-context.schema.json` (required fields + enums).
+
+- [x] **T002** [P] Align schema `status` enum — `src/core/types/spec-context.schema.json` | R011
+  - **Do**: Add `"implemented"` to the `status` enum (between `"implementing"` and `"completed"`) so the JSON schema matches the canonical TS `Status` type. No other change; do NOT touch `specContext.ts` (already has it).
+  - **Verify**: `npm run compile` passes; the existing `specs/*/.spec-context.json` files still validate (additive enum value is backward-compatible).
+  - **Leverage**: `src/core/types/specContext.ts` (canonical `Status` ordering).
+
+- [x] **T003** [P] Extension manifest — `speckit-extension/extension.yml` | R001, R002, R003, R004, R013
+  - **Do**: Create `extension.yml` mirroring `.specify/extensions/git/extension.yml`: `schema_version: "1.0"`; `extension.id: companion` (+ name/version `0.1.0`/description/author/license); `requires.speckit_version: ">=0.8.5"` and `requires.tools: [{name: python3, required: false}]`; `provides.commands: [{name: speckit.companion.capture, file: commands/speckit.companion.capture.md, description: ...}]`; `hooks.after_specify: {command: speckit.companion.capture, optional: false, description: ...}`. Register NO branch hook (branching defers to the git extension).
+  - **Verify**: YAML parses; structure matches the git extension's schema (same top-level keys); only `after_specify` appears under `hooks`.
+  - **Leverage**: `.specify/extensions/git/extension.yml` (exact manifest shape).
+
+### Group B — wiring that references Group A (parallel)
+
+- [x] **T004** [P] Capture command-markdown *(depends on T001)* — `speckit-extension/commands/speckit.companion.capture.md` | R005
+  - **Do**: Create the command-markdown (frontmatter `description:` + body) mirroring `speckit.git.feature.md`'s "run this script" pattern. Body: states it runs after specify; resolves the active feature dir (pass `--feature-dir` if known, else let the script resolve); runs `python3 speckit-extension/scripts/write-context.py --step specify --status specified --by extension`; degrades gracefully with a warning if `python3` is unavailable. No business logic beyond invoking the script (matching T001's CLI exactly).
+  - **Verify**: Markdown invocation flags match `write-context.py`'s CLI from T001; graceful-degradation line present.
+  - **Leverage**: `.specify/extensions/git/commands/speckit.git.feature.md` (command-markdown structure + graceful-degradation wording).
+
+- [x] **T005** [P] Register hook in fixture *(depends on T003)* — `.specify/extensions.yml` | R014
+  - **Do**: Add `companion` to `installed: []`. Append a `companion` entry under the existing `after_specify:` hook list (alongside `git`'s `speckit.git.commit`): `extension: companion`, `command: speckit.companion.capture`, `enabled: true`, `optional: false`, `prompt`/`description` set, `condition: null`. Leave every `git` registration untouched.
+  - **Verify**: YAML parses; `after_specify` now lists both `git` and `companion`; no other hook lists changed; `git` entries byte-identical to before.
+  - **Leverage**: `.specify/extensions.yml` (existing `after_specify` list shape).
+
+### Group C — end-to-end proof + docs (gate)
+
+- [x] **T006** README + live end-to-end proof *(depends on T001–T005)* — `speckit-extension/README.md` | R015, R003, NFR003
+  - **Do**: Write `speckit-extension/README.md` (what the extension is, the `>=0.8.5` floor rationale + a note to confirm the exact `after_specify`-wiring release, install/`--ai-skills` note, and the reproducible manual proof procedure). Then run the proof: trigger a real `/speckit.specify "<throwaway feature>"`, confirm the new `specs/<NNN>-<slug>/.spec-context.json` carries `currentStep:specify` / `status:specified` / a `by:extension` transition, and confirm the SpecKit Companion GUI renders it at **specify / specified** with no GUI code change. Record the observed result in the README + PR description. Clean up the throwaway spec after.
+  - **Verify**: `.spec-context.json` for the throwaway spec shows the canonical values + `by:extension` transition; GUI screenshot/observation captured; throwaway spec removed; README proof section reflects actual outcome (incl. whether the hook auto-fired).
+  - **Leverage**: T001–T005 outputs; the spec's § Testing Strategy.

--- a/src/core/types/spec-context.schema.json
+++ b/src/core/types/spec-context.schema.json
@@ -20,7 +20,7 @@
         "draft", "specifying", "specified",
         "planning", "planned",
         "tasking", "ready-to-implement",
-        "implementing", "completed", "archived"
+        "implementing", "implemented", "completed", "archived"
       ]
     },
     "stepHistory": {


### PR DESCRIPTION
## What

The first slice of **SpecKit Companion's spec-kit extension** (`id: companion`) — the spec-kit-catalog half of the product, living beside the VS Code GUI. It captures lifecycle activity into `.spec-context.json` so the Companion GUI lights up on an *existing* spec-kit flow, no template change.

- **`speckit-extension/`** mirrors the bundled `git` extension: `extension.yml` → `commands/speckit.companion.capture.md` → stdlib `scripts/write-context.py`. One `after_specify` hook.
- **The writer** does a crash-safe read-merge-write of the canonical `.spec-context.json` (`currentStep: specify` / `status: specified` / `by: extension`): preserves unknown top-level keys, append-only `transitions`, atomic temp+rename, **never regresses a shipped/`completed` spec**, never emits the legacy `currentStep: "done"`.
- **Schema alignment:** added `"implemented"` to `src/core/types/spec-context.schema.json` `status` enum to match the canonical TS `Status` type.
- **Installed as a spec-kit fixture** (`.specify/extensions/companion/` + `.registry` + per-agent command emissions) so the hook is resolvable and the live proof is reproducible from a fresh checkout — same way the bundled `git` extension is committed.
- **`speckit-extension/ROADMAP.md`** — the 8-step migration plan + per-step status (v1 = steps 1–3); README links to it.

## Why

De-risk the migration's single unproven, agent-mediated chain — *spec-kit command → agent runs our hook → script writes `.spec-context.json` → Companion GUI re-renders* — before building capture for every phase. v1 foundation slice of `sdd` spec `024-speckit-extension-foundation` (R001–R015) per ADR 0003.

## Proven (verified 2026-05-25)

A real `/speckit.specify` **auto-fired** the `after_specify` companion hook (`optional: false`, no nudge) → `write-context.py` → `.spec-context.json` at `specify`/`specified` with a `by: extension` transition. The artifact carried `workflow: "speckit"` — proving it works on a **plain spec-kit flow** with no SDD present. The agent-mediated chain holds.

## Notes

- `speckit-extension/` is the **source**; `.specify/extensions/companion/` is the **installed fixture** (a copy), mirroring `.specify/extensions/git/`. Install for testing: `specify extension add ./speckit-extension --dev` — note the `extension` CLI ships in **github-source** spec-kit, not the stock PyPI `specify-cli` (see README).
- Scope is intentionally **one hook**. Steps 2–8 are in `ROADMAP.md`.
- No version bump included.

## Test plan

- [x] Writer probe + regression suite (create/append, unknown-key preservation, no-backward-clobber, bad-step no-op, malformed transitions)
- [x] Live `/speckit.specify` → `after_specify` auto-fires → `.spec-context.json` written with canonical values
- [x] `npm run compile`