### PR TITLE
fix(ai-providers): advance currentStep on step completion so phases progress

### DIFF
--- a/specs/109-prompt-advance-step/.spec-context.json
+++ b/specs/109-prompt-advance-step/.spec-context.json
@@ -1,0 +1,254 @@
+{
+  "workflow": "sdd",
+  "currentStep": "done",
+  "currentTask": null,
+  "progress": null,
+  "next": "done",
+  "updated": "2026-05-26",
+  "selectedAt": "2026-05-26T18:02:36Z",
+  "specName": "Prompt Advance Step",
+  "branch": "main",
+  "workingBranch": "fix/prompt-advance-step",
+  "type": "fix",
+  "createdAt": "2026-05-26T18:02:36Z",
+  "loadedDomains": [],
+  "step_summaries": {
+    "specify": {
+      "complexity": "minimal",
+      "requirements": 4,
+      "scenarios": 3,
+      "key_finding": "promptBuilder.ts already centralizes preamble rendering through renderPreamble + renderLifecycleBody, and has COMPLETED_STATUS_BY_STEP / DONE_PHRASE_BY_STEP step-keyed maps \u2014 the next-step map fits the same pattern."
+    }
+  },
+  "transitions": [
+    {
+      "step": "specify",
+      "substep": "parsing",
+      "from": null,
+      "by": "sdd",
+      "at": "2026-05-26T18:02:36Z"
+    },
+    {
+      "step": "specify",
+      "substep": "exploring",
+      "from": {
+        "step": "specify",
+        "substep": "parsing"
+      },
+      "by": "sdd",
+      "at": "2026-05-26T18:02:50Z"
+    },
+    {
+      "step": "specify",
+      "substep": "detecting",
+      "from": {
+        "step": "specify",
+        "substep": "exploring"
+      },
+      "by": "sdd",
+      "at": "2026-05-26T18:03:05Z"
+    },
+    {
+      "step": "specify",
+      "substep": "writing-spec",
+      "from": {
+        "step": "specify",
+        "substep": "detecting"
+      },
+      "by": "sdd",
+      "at": "2026-05-26T18:03:15Z"
+    },
+    {
+      "step": "tasks",
+      "substep": null,
+      "from": {
+        "step": "specify",
+        "substep": "writing-spec"
+      },
+      "by": "sdd",
+      "at": "2026-05-26T18:03:39Z"
+    },
+    {
+      "step": "implement",
+      "substep": "phase1",
+      "from": {
+        "step": "tasks",
+        "substep": null
+      },
+      "by": "sdd",
+      "at": "2026-05-26T18:04:50.965Z"
+    },
+    {
+      "step": "implement",
+      "substep": "phase1",
+      "from": {
+        "step": "implement",
+        "substep": "phase1"
+      },
+      "by": "sdd",
+      "at": "2026-05-26T18:05:30.511Z"
+    },
+    {
+      "step": "implement",
+      "substep": "phase1",
+      "from": {
+        "step": "implement",
+        "substep": "phase1"
+      },
+      "by": "sdd",
+      "at": "2026-05-26T18:06:27.000Z"
+    },
+    {
+      "step": "implement",
+      "substep": "phase1",
+      "from": {
+        "step": "implement",
+        "substep": "phase1"
+      },
+      "by": "sdd",
+      "at": "2026-05-26T18:06:27.368Z"
+    },
+    {
+      "step": "implement",
+      "substep": "phase1",
+      "from": {
+        "step": "implement",
+        "substep": "phase1"
+      },
+      "by": "sdd",
+      "at": "2026-05-26T18:08:35.000Z"
+    },
+    {
+      "step": "implement",
+      "substep": "phase1",
+      "from": {
+        "step": "implement",
+        "substep": "phase1"
+      },
+      "by": "sdd",
+      "at": "2026-05-26T18:08:35.100Z"
+    },
+    {
+      "step": "implement",
+      "substep": "phase1",
+      "from": {
+        "step": "implement",
+        "substep": "phase1"
+      },
+      "by": "sdd",
+      "at": "2026-05-26T18:08:35.277Z"
+    },
+    {
+      "step": "implement",
+      "substep": "hooks",
+      "from": {
+        "step": "implement",
+        "substep": "phase1"
+      },
+      "by": "sdd",
+      "at": "2026-05-26T18:08:36.000Z"
+    },
+    {
+      "step": "implement",
+      "substep": "code-review",
+      "from": {
+        "step": "implement",
+        "substep": "hooks"
+      },
+      "by": "sdd",
+      "at": "2026-05-26T18:16:52.373Z"
+    },
+    {
+      "step": "implement",
+      "substep": "test-results",
+      "from": {
+        "step": "implement",
+        "substep": "code-review"
+      },
+      "by": "sdd",
+      "at": "2026-05-26T18:24:19.708Z"
+    },
+    {
+      "step": "implement",
+      "substep": "commit-review",
+      "from": {
+        "step": "implement",
+        "substep": "test-results"
+      },
+      "by": "sdd",
+      "at": "2026-05-26T18:25:03.393Z"
+    },
+    {
+      "step": "done",
+      "substep": null,
+      "from": {
+        "step": "implement",
+        "substep": "commit-review"
+      },
+      "by": "sdd",
+      "at": "2026-05-26T18:29:57.200Z"
+    }
+  ],
+  "status": "completed",
+  "task_summaries": {
+    "T001": {
+      "status": "DONE",
+      "did": "Added NEXT_STEP_BY_STEP map to promptBuilder.ts mirroring COMPLETED_STATUS_BY_STEP / DONE_PHRASE_BY_STEP shape.",
+      "files": [
+        "src/ai-providers/promptBuilder.ts"
+      ]
+    },
+    "T002": {
+      "status": "DONE",
+      "did": "Extended renderPreamble MUST-DO block with a (d) clause that sets currentStep to the next step (or notes terminal for implement); updated header to 'all four required' and added failure-mode sentence.",
+      "files": [
+        "src/ai-providers/promptBuilder.ts"
+      ]
+    },
+    "T003": {
+      "status": "DONE",
+      "did": "Added bullet 4 to renderLifecycleBody instructing AI to advance currentStep after each step, with implement as terminal.",
+      "files": [
+        "src/ai-providers/promptBuilder.ts"
+      ]
+    },
+    "T004": {
+      "status": "DONE",
+      "did": "Added per-step advance-currentStep assertions for specify/plan/tasks and a terminal-state assertion for implement in promptBuilder.test.ts.",
+      "files": [
+        "src/ai-providers/__tests__/promptBuilder.test.ts"
+      ]
+    },
+    "T005": {
+      "status": "DONE",
+      "did": "Added advance-rule assertions for buildLifecyclePrompt and buildSpecifyCreationPreamble preambles.",
+      "files": [
+        "src/ai-providers/__tests__/promptBuilder.test.ts"
+      ]
+    },
+    "T006": {
+      "status": "DONE_WITH_CONCERNS",
+      "did": "npm run compile and npm test pass (57 suites, 669 tests); had to relax the preamble-length budget from 2400 to 2600 chars to accommodate the new (d) clause and trim the failure-mode sentence to keep the increase minimal.",
+      "files": [
+        "src/ai-providers/promptBuilder.ts",
+        "src/ai-providers/__tests__/promptBuilder.test.ts"
+      ]
+    }
+  },
+  "last_action": "T006 done \u2014 all tests pass after preamble-length budget bump.",
+  "files_modified": [
+    "src/ai-providers/promptBuilder.ts",
+    "src/ai-providers/__tests__/promptBuilder.test.ts"
+  ],
+  "drainedSeq": 12,
+  "concerns": [
+    {
+      "task": "T006",
+      "note": "Preamble-length budget raised from 2400 to 2600 chars; new total is ~2495. Considered acceptable since the test name already used '~' and the (d) instruction is essential. Revisit if the budget needs to be tightened elsewhere."
+    }
+  ],
+  "checkpointStatus": {
+    "commit": true,
+    "pr": true
+  }
+}

--- a/specs/109-prompt-advance-step/.spec-context.json
+++ b/specs/109-prompt-advance-step/.spec-context.json
@@ -187,6 +187,16 @@
       },
       "by": "sdd",
       "at": "2026-05-26T18:29:57.200Z"
+    },
+    {
+      "step": "done",
+      "substep": null,
+      "from": {
+        "step": "done",
+        "substep": null
+      },
+      "by": "sdd",
+      "at": "2026-05-26T18:31:19.795Z"
     }
   ],
   "status": "completed",
@@ -235,12 +245,12 @@
       ]
     }
   },
-  "last_action": "T006 done \u2014 all tests pass after preamble-length budget bump.",
+  "last_action": "PR #177 opened \u2014 fix(ai-providers): advance currentStep on step completion so phases progress",
   "files_modified": [
     "src/ai-providers/promptBuilder.ts",
     "src/ai-providers/__tests__/promptBuilder.test.ts"
   ],
-  "drainedSeq": 12,
+  "drainedSeq": 13,
   "concerns": [
     {
       "task": "T006",
@@ -250,5 +260,7 @@
   "checkpointStatus": {
     "commit": true,
     "pr": true
-  }
+  },
+  "prUrl": "https://github.com/alfredoperez/speckit-companion/pull/177",
+  "prNumber": 177
 }

--- a/specs/109-prompt-advance-step/plan.md
+++ b/specs/109-prompt-advance-step/plan.md
@@ -1,0 +1,16 @@
+# Plan: Prompt Advance Step
+
+**Slug**: 109-prompt-advance-step | **Date**: 2026-05-26
+
+## Approach
+
+Extend the existing prompt fragments in `src/ai-providers/promptBuilder.ts` with one additional instruction: after the AI appends the completion transition and flips `status`, it must also set `currentStep` to the next step in the canonical four-step order, except when the completing step is `implement` (terminal — no advancement).
+
+Encode the next-step lookup once near the existing `COMPLETED_STATUS_BY_STEP` / `DONE_PHRASE_BY_STEP` maps as `NEXT_STEP_BY_STEP: Record<PromptStep, PromptStep | null>` (with `implement → null`), and reference it from `renderPreamble`. For the two lifecycle preambles, append a single sentence to `renderLifecycleBody` describing the same rule (the multi-step preamble is intentionally less procedural, so a one-line rule is enough; the per-step `currentStep` set in step 1 of the next iteration will pick it up naturally).
+
+Update the existing `promptBuilder.test.ts` to cover the new behavior — both shapes — without rewriting the surrounding tests.
+
+## Files to Change
+
+- `src/ai-providers/promptBuilder.ts` — add `NEXT_STEP_BY_STEP` map; extend `renderPreamble`'s "MUST DO BEFORE ENDING" block with a `(d)` clause for non-terminal steps and an explicit terminal-state note for `implement`; add a corresponding one-liner to `renderLifecycleBody`.
+- `src/ai-providers/__tests__/promptBuilder.test.ts` — add cases asserting (1) preamble for `specify`/`plan`/`tasks` instructs setting `currentStep` to the next step, (2) preamble for `implement` instructs leaving `currentStep` on `implement`, and (3) the lifecycle preamble produced by `buildLifecyclePrompt` and `buildSpecifyCreationPreamble` includes the rule.

--- a/specs/109-prompt-advance-step/spec.md
+++ b/specs/109-prompt-advance-step/spec.md
@@ -1,0 +1,38 @@
+# Spec: Prompt Advance Step
+
+**Slug**: 109-prompt-advance-step | **Date**: 2026-05-26
+
+## Summary
+
+The step-completion instruction injected by `promptBuilder.ts` tells the AI to flip `status` and append a completion transition, but never tells it to move `currentStep` to the next step. Every spec dispatched through the extension stays pinned on the completed step, so the PhasesCard reads "in progress" until the user manually triggers the next command. This change adds an explicit "advance currentStep" instruction to the prompt preamble so the workflow visibly progresses on its own.
+
+## Requirements
+
+- **R001** (MUST): After the completion transition is appended, the AI is instructed to set `currentStep` to the next step in the canonical order `specify → plan → tasks → implement`.
+- **R002** (MUST): For the terminal step (`implement`), the AI is instructed NOT to advance `currentStep` — it stays on `implement` once completed.
+- **R003** (MUST): The new instruction appears in BOTH preamble shapes — the single-step preamble (`renderPreamble`) used by `buildPrompt`, and the multi-step lifecycle body (`renderLifecycleBody`) used by `buildLifecyclePrompt` and `buildSpecifyCreationPreamble` — so every provider path that goes through `promptBuilder` carries the rule.
+- **R004** (SHOULD): The step-order sequence in the prompt mirrors the existing typed source of truth (e.g., the four-step subset of `STEP_NAMES` already referenced through `CANONICAL_SUBSTEPS`) rather than being declared as an independent magic list inside the prompt string.
+
+## Scenarios
+
+### Specify completes and advances to plan
+
+**When** the AI finishes `/speckit.specify` (or the SDD equivalent) and writes the completion transition
+**Then** it also sets `currentStep` to `"plan"` in `.spec-context.json`, the status flips to `"specified"`, and the PhasesCard advances the active tab to Plan instead of leaving Specify ringed.
+
+### Implement completes and stays terminal
+
+**When** the AI finishes `/speckit.implement` and writes the completion transition
+**Then** `currentStep` remains `"implement"`, `status` flips to `"completed"`, and no further advancement is attempted.
+
+### All provider paths receive the instruction
+
+**When** a command is dispatched via any provider (`buildPrompt`, `buildLifecyclePrompt`, or `buildSpecifyCreationPreamble`)
+**Then** the rendered preamble between the `speckit-companion:context-update` markers includes the "advance currentStep" instruction.
+
+## Out of Scope
+
+- Spec #107 (inline comment persistence).
+- Any TypeScript-side enforcement that would mutate `currentStep` from the extension instead of via the prompt.
+- Redesign of `.spec-context.json` schema, `stepHistory`, or PhasesCard rendering.
+- Changes to the `clarify` / `analyze` optional steps — only the four-step canonical sequence is in scope.

--- a/specs/109-prompt-advance-step/tasks.md
+++ b/specs/109-prompt-advance-step/tasks.md
@@ -1,0 +1,12 @@
+# Tasks: Prompt Advance Step
+
+**Date**: 2026-05-26
+
+## Phase 1
+
+- [x] **T001** — In `src/ai-providers/promptBuilder.ts`, add a `NEXT_STEP_BY_STEP: Record<PromptStep, PromptStep | null>` map next to `COMPLETED_STATUS_BY_STEP`: `specify → plan`, `plan → tasks`, `tasks → implement`, `implement → null`.
+- [x] **T002** — In `renderPreamble`, extend the "MUST DO BEFORE ENDING" block with a `(d)` clause: when `NEXT_STEP_BY_STEP[step]` is non-null, instruct the AI to set `currentStep` to that next step after appending the completion transition; when null (i.e. `implement`), state explicitly that `currentStep` stays on `implement`. Mirror the failure-mode sentence pattern used for clauses (a)/(b)/(c).
+- [x] **T003** — In `renderLifecycleBody`, append a single instruction after the existing step-loop bullets: "After completing a step, also set `currentStep` to the next step in `specify → plan → tasks → implement`; after `implement`, leave it on `implement`."
+- [x] **T004** — In `src/ai-providers/__tests__/promptBuilder.test.ts`, add a test that iterates `['specify', 'plan', 'tasks']` and asserts the rendered preamble contains both `currentStep` and the expected next step name, plus a separate case for `implement` that asserts the terminal-state phrasing is present.
+- [x] **T005** — Add a test that calls `buildLifecyclePrompt` (and a second test for `buildSpecifyCreationPreamble`) and asserts the lifecycle one-liner from T003 appears in the output.
+- [x] **T006** — Run `npm run compile && npm test` and confirm the new and existing prompt-builder tests pass.

--- a/src/ai-providers/__tests__/promptBuilder.test.ts
+++ b/src/ai-providers/__tests__/promptBuilder.test.ts
@@ -94,11 +94,11 @@ describe('buildPrompt', () => {
         });
     });
 
-    it('preamble stays under ~2400 chars per step', () => {
+    it('preamble stays under ~2600 chars per step', () => {
         mockConfig(true);
         for (const step of ['specify', 'plan', 'tasks', 'implement'] as const) {
             const out = buildPrompt({ command: 'x', step, specDir: 'specs/001-demo' });
-            expect(out.length).toBeLessThan(2400);
+            expect(out.length).toBeLessThan(2600);
         }
     });
 
@@ -107,6 +107,28 @@ describe('buildPrompt', () => {
         const out = buildPrompt({ command: 'x', step: 'specify', specDir: 'specs/001-demo' });
         expect(out).toContain('Canonical statuses:');
         expect(out).toContain('ready-to-implement');
+    });
+
+    it('instructs the model to advance currentStep to the next step on completion', () => {
+        mockConfig(true);
+        const cases: Array<{ step: 'specify' | 'plan' | 'tasks'; next: string }> = [
+            { step: 'specify', next: 'plan' },
+            { step: 'plan', next: 'tasks' },
+            { step: 'tasks', next: 'implement' },
+        ];
+        for (const { step, next } of cases) {
+            const out = buildPrompt({ command: 'x', step, specDir: 'specs/001-demo' });
+            expect(out).toContain(`Set currentStep to "${next}"`);
+            expect(out).toContain('specify → plan → tasks → implement');
+        }
+    });
+
+    it('instructs the model NOT to advance currentStep after the implement step', () => {
+        mockConfig(true);
+        const out = buildPrompt({ command: 'x', step: 'implement', specDir: 'specs/001-demo' });
+        expect(out).toContain('Leave currentStep on "implement"');
+        expect(out).toContain('terminal step');
+        expect(out).not.toContain('Set currentStep to "');
     });
 });
 
@@ -137,6 +159,13 @@ describe('buildLifecyclePrompt', () => {
         mockConfig(false);
         const cmd = '/sdd:auto "specs/001"';
         expect(buildLifecyclePrompt(cmd, 'specs/001')).toBe(cmd);
+    });
+
+    it('instructs the model to advance currentStep across the canonical sequence', () => {
+        mockConfig(true);
+        const out = buildLifecyclePrompt('/sdd:auto "specs/001"', 'specs/001');
+        expect(out).toContain('set currentStep to the next step in the canonical sequence specify → plan → tasks → implement');
+        expect(out).toContain('After implement, leave currentStep on "implement"');
     });
 });
 
@@ -179,6 +208,13 @@ describe('buildSpecifyCreationPreamble', () => {
         const out = buildSpecifyCreationPreamble('speckit', null);
         expect(out).toContain('For EACH step you work on');
         expect(out).toContain('specify, plan, tasks, implement');
+    });
+
+    it('carries the advance-currentStep rule into the seeded creation preamble', () => {
+        mockConfig(true);
+        const out = buildSpecifyCreationPreamble('speckit', null);
+        expect(out).toContain('set currentStep to the next step in the canonical sequence specify → plan → tasks → implement');
+        expect(out).toContain('After implement, leave currentStep on "implement"');
     });
 
     it('includes the date -u timestamp rule from SHARED_RULES', () => {

--- a/src/ai-providers/promptBuilder.ts
+++ b/src/ai-providers/promptBuilder.ts
@@ -61,11 +61,25 @@ const DONE_PHRASE_BY_STEP: Record<PromptStep, string> = {
     implement: 'Done implementing',
 };
 
+const NEXT_STEP_BY_STEP: Record<PromptStep, PromptStep | null> = {
+    specify: 'plan',
+    plan: 'tasks',
+    tasks: 'implement',
+    implement: null,
+};
+
 function renderPreamble(step: PromptStep, specDir: string): string {
     const substeps = CANONICAL_SUBSTEPS[step].join(', ');
     const target = specDir ? `${specDir}/.spec-context.json` : '<specDir>/.spec-context.json';
     const completedStatus = COMPLETED_STATUS_BY_STEP[step];
     const donePhrase = DONE_PHRASE_BY_STEP[step];
+    const nextStep = NEXT_STEP_BY_STEP[step];
+    const advanceClause = nextStep
+        ? `  (d) Set currentStep to "${nextStep}" (canonical: specify → plan → tasks → implement).`
+        : `  (d) Leave currentStep on "${step}" — this is the terminal step; do not advance further.`;
+    const advanceFailureNote = nextStep
+        ? `; skipping (d) pins currentStep on "${step}" and the PhasesCard reads "in progress" forever`
+        : '';
     return [
         MARKER_OPEN,
         `Before and after this step runs, update ${target}:`,
@@ -77,11 +91,12 @@ function renderPreamble(step: PromptStep, specDir: string): string {
         '',
         `Canonical substeps for ${step}: ${substeps}. For each substep boundary append a transition with that substep name (and a real timestamp) — do NOT write substep entries inside stepHistory.`,
         '',
-        `MUST DO BEFORE ENDING — all three required:`,
+        `MUST DO BEFORE ENDING — all four required:`,
         `  (a) Flip status to "${completedStatus}".`,
         `  (b) Append a completion transition { step: "${step}", substep: null, from: { step: "${step}", substep: null }, by: "extension", at: <real timestamp> }. This is what clears the "in-flight" ring on the ${step} tab.`,
         `  (c) Print "${donePhrase}" as the final terminal line.`,
-        `Skipping (a) leaves the badge stuck on the in-progress form; skipping (b) leaves the step timer running indefinitely; skipping (c) hides the completion from the activity log.`,
+        advanceClause,
+        `Skipping (a) leaves the badge stuck on the in-progress form; skipping (b) leaves the step timer running indefinitely; skipping (c) hides the completion from the activity log${advanceFailureNote}.`,
         '',
         SHARED_RULES,
         '',
@@ -100,6 +115,7 @@ function renderLifecycleBody(target: string): string {
         '1. Before starting: set currentStep = "<step>" and status = in-progress form. Append a transition { step: "<step>", substep: null, from, by: "extension", at: <real timestamp> }.',
         '2. After completing: flip status = completed form. Append a completion transition { step: "<step>", substep: null, from: { step: "<step>", substep: null }, by: "extension", at: <real timestamp> } — this is what clears the in-flight ring on the tab.',
         '3. Append a transition entry for each substep boundary too, using a real timestamp.',
+        '4. After completing a step, also set currentStep to the next step in the canonical sequence specify → plan → tasks → implement. After implement, leave currentStep on "implement" — it is terminal.',
         '',
         SHARED_RULES,
         '',


### PR DESCRIPTION
## What

- Add a `NEXT_STEP_BY_STEP` map mirroring the existing step-keyed maps in `promptBuilder.ts`.
- Extend `renderPreamble`'s "MUST DO BEFORE ENDING" block with a `(d)` clause that sets `currentStep` to the next step in the canonical sequence `specify → plan → tasks → implement` (or leaves it on `implement` as the terminal step).
- Add bullet 4 to `renderLifecycleBody` so the same rule rides along with `buildLifecyclePrompt` and `buildSpecifyCreationPreamble`.
- Cover all three preamble shapes with new `promptBuilder.test.ts` assertions; relax the preamble-length budget from 2400 to 2600 chars to fit the new clause.

## Why

The step-completion instruction told the AI to flip `status` and append a completion transition, but never to advance `currentStep`. Every spec dispatched through the extension stayed pinned on the just-completed step, so the PhasesCard read "in progress" forever until the user manually kicked off the next command. This change adds the missing explicit instruction so the workflow visibly progresses on its own.

## Testing

- [x] `npm run compile` — clean.
- [x] `npm test` — 57 suites / 669 tests pass, including 4 new assertions covering per-step advance (specify/plan/tasks), terminal-state behavior on `implement`, and lifecycle/creation preamble coverage.
- [ ] End-to-end: run `/speckit.specify` against any provider and confirm `.spec-context.json` shows `currentStep: "plan"` after completion (instead of staying on `"specify"`).