### PR TITLE
fix(spec-viewer, specs): disable not-created sidebar rows + navState type fix (114)

### DIFF
--- a/specs/114-disable-not-created-rows/.spec-context.json
+++ b/specs/114-disable-not-created-rows/.spec-context.json
@@ -1,0 +1,107 @@
+{
+  "workflow": "sdd",
+  "specName": "Disable Not Created Rows",
+  "branch": "main",
+  "selectedAt": "2026-05-27T14:48:03.572Z",
+  "currentStep": "implement",
+  "status": "completed",
+  "type": "fix",
+  "history": [
+    {
+      "step": "specify",
+      "substep": null,
+      "kind": "start",
+      "from": {
+        "step": null,
+        "substep": null
+      },
+      "by": "extension",
+      "at": "2026-05-27T14:48:03.572Z"
+    },
+    {
+      "step": "specify",
+      "substep": null,
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-05-27T14:51:02Z"
+    },
+    {
+      "step": "plan",
+      "substep": null,
+      "kind": "start",
+      "from": {
+        "step": "specify",
+        "substep": null
+      },
+      "by": "ai",
+      "at": "2026-05-27T14:51:02Z"
+    },
+    {
+      "step": "plan",
+      "substep": null,
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-05-27T14:51:02Z"
+    },
+    {
+      "step": "tasks",
+      "substep": null,
+      "kind": "start",
+      "from": {
+        "step": "plan",
+        "substep": null
+      },
+      "by": "ai",
+      "at": "2026-05-27T14:51:02Z"
+    },
+    {
+      "step": "tasks",
+      "substep": null,
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-05-27T14:51:02Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "kind": "start",
+      "from": {
+        "step": "tasks",
+        "substep": null
+      },
+      "by": "extension",
+      "at": "2026-05-27T14:52:23.205Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-05-27T14:53:18Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "kind": "complete",
+      "by": "user",
+      "at": "2026-05-27T14:56:26Z"
+    }
+  ],
+  "task_summaries": {
+    "T001": {
+      "status": "DONE",
+      "did": "Pass undefined as the command argument to SpecItem when status === 'empty' so not-created step rows are inert on click while keeping label, contextValue, and right-click menu intact.",
+      "files": [
+        "src/features/specs/specExplorerProvider.ts"
+      ]
+    }
+  },
+  "step_summaries": {
+    "specify": {
+      "complexity": "minimal",
+      "requirements": 4,
+      "scenarios": 3,
+      "key_finding": "Sidebar step rows are constructed in specExplorerProvider.ts:602 with an unconditional createOpenCommand — disabling activation is a one-line conditional on the existing `status === 'empty'` check that already drives the 'not created' description."
+    }
+  }
+}

--- a/specs/114-disable-not-created-rows/plan.md
+++ b/specs/114-disable-not-created-rows/plan.md
@@ -1,0 +1,11 @@
+# Plan: Disable Not Created Rows
+
+**Spec**: [spec.md](./spec.md)
+
+## Approach
+
+Drop the `command` argument on `SpecItem` construction when a step file's resolved `status` is `'empty'`. The `command` property is what VS Code's TreeView uses to wire row activation; setting it to `undefined` makes the row inert on click while leaving label, description, icon, `contextValue`, and the right-click menu intact.
+
+## Files to Change
+
+- `src/features/specs/specExplorerProvider.ts` — at the `new SpecItem(...)` call that builds step rows (around line 602), pass `status === 'empty' ? undefined : createOpenCommand(resolvedFilePath, `Open ${label}`)` instead of always calling `createOpenCommand(...)`. Single-site change; no other call to `createOpenCommand` exists.

--- a/specs/114-disable-not-created-rows/spec.md
+++ b/specs/114-disable-not-created-rows/spec.md
@@ -1,0 +1,38 @@
+# Spec: Disable Not Created Rows
+
+**Slug**: 114-disable-not-created-rows | **Date**: 2026-05-27
+
+## Summary
+
+In the SPECS sidebar, step rows whose underlying document does not exist yet (labelled "not created") are currently clickable and open the spec viewer in an empty state. Make these rows non-activatable so clicking does nothing, while keeping the row visible, informative, and available for right-click actions that could help create the step.
+
+## Requirements
+
+- **R001** (MUST): Sidebar step rows whose document status is `empty` ("not created") MUST NOT dispatch the open-step command on activation (click / Enter).
+- **R002** (MUST): The row MUST remain visible with its existing label and "not created" description — this is a disabled / informational state, not a hidden one.
+- **R003** (MUST): Right-click / context-menu actions on the row MUST remain available (the row's `contextValue` is unchanged), so any "create this step" affordances continue to work.
+- **R004** (MUST): Behavior MUST apply to every lifecycle step that can be in the `not created` state (Plan, Tasks, and any other step file surfaced by the workflow), not just one step type.
+
+## Scenarios
+
+### Clicking a not-created step row
+
+**When** the user clicks the "Plan not created" or "Tasks not created" row under a spec in the SPECS sidebar
+**Then** nothing happens — no spec viewer opens, no editor is focused, no command runs
+
+### Clicking a created step row
+
+**When** the user clicks a step row whose document exists (status is `partial` or `complete`)
+**Then** the spec viewer opens for that step (existing behavior is preserved)
+
+### Right-clicking a not-created step row
+
+**When** the user right-clicks a "not created" step row
+**Then** the context menu still appears with any actions registered against the row's `contextValue`
+
+## Out of Scope
+
+- Introducing a "create this step now" CTA on the row itself.
+- Changing how a step transitions out of the `not created` state.
+- Sidebar styling unrelated to this state (icons for other statuses, tree-row spacing, etc.).
+- Custom pointer-cursor or hover affordances — VS Code's TreeView controls the cursor; removing the command is the available lever.

--- a/specs/114-disable-not-created-rows/tasks.md
+++ b/specs/114-disable-not-created-rows/tasks.md
@@ -1,0 +1,9 @@
+# Tasks: Disable Not Created Rows
+
+**Plan**: [plan.md](./plan.md)
+
+## Phase 1: Core Implementation
+
+- [x] **T001** Skip open-command for not-created step rows — `src/features/specs/specExplorerProvider.ts` | R001, R002, R003, R004
+  - **Do**: In the step-row loop near line 602, replace the unconditional `createOpenCommand(resolvedFilePath, `Open ${label}`)` argument passed to `new SpecItem(...)` with `status === 'empty' ? undefined : createOpenCommand(resolvedFilePath, `Open ${label}`)`. Leave every other argument (label, contextValue, status, etc.) unchanged so the row still renders with its "not created" description and right-click menu.
+  - **Verify**: `npm run compile` succeeds. Reload the Extension Development Host; in a spec where Plan / Tasks files don't exist, clicking those rows in the SPECS sidebar does nothing (no viewer opens), the "not created" label still shows, and right-click still surfaces the context menu. Clicking a row whose file does exist still opens the viewer as before.

--- a/src/features/specs/specExplorerProvider.ts
+++ b/src/features/specs/specExplorerProvider.ts
@@ -606,7 +606,7 @@ export class SpecExplorerProvider extends BaseTreeDataProvider<SpecItem> {
                 this.context,
                 specName,
                 step.name,
-                createOpenCommand(resolvedFilePath, `Open ${label}`),
+                status === 'empty' ? undefined : createOpenCommand(resolvedFilePath, `Open ${label}`),
                 relativeFilePath,
                 specPath,
                 status,

--- a/webview/src/spec-viewer/index.tsx
+++ b/webview/src/spec-viewer/index.tsx
@@ -84,7 +84,7 @@ function handleMessage(event: MessageEvent): void {
             viewerState.value = message.viewerState;
             historyEntries.value = message.viewerState.history ?? [];
             if (message.navState) {
-                navState.value = { ...navState.value, ...message.navState };
+                navState.value = { ...navState.value, ...message.navState } as NavState;
             }
             break;
 


### PR DESCRIPTION
## Summary

Two small fixes plus the spec 114 dir.

### Spec 114 — disable not-created sidebar rows

In `SpecExplorerProvider`, when a child step row has status `'empty'` (no file exists on disk yet), skip attaching the open command. Previously clicking an empty row tried to open a non-existent file and surfaced a VS Code error toast. Now the row stays inert until the AI generates the doc.

### F16 navState type strictness

PR #183's F16 fix introduced a TS error in the webview that the prior install pipeline was tolerating. The spread `{ ...navState.value, ...message.navState }` is provably complete (the base carries all required fields), but TypeScript's structural inference widens the result to `Partial<NavState>`. Cast to `NavState` resolves it.

This was slipping past `tsc -p ./` (extension-only compile) and only failing in `npm run package-web` (webpack ts-loader). PR #182's install-pipeline fix now makes the failure visible, which is how I caught it.

Spec 114 ships with `status: completed`. The redundant backlog item `sidebar-not-created-steps-not-clickable.md` was removed from the obsidian backlog in the same session.

## Test plan

- [x] `npm run compile` clean
- [x] `npm test` — 678/678 passing
- [x] `npm run package` succeeds with no webpack errors (was failing on the navState type before this fix)
- [x] v0.20.1 installed locally; sidebar empty rows are inert as intended

🤖 Generated with [Claude Code](https://claude.com/claude-code)