### PR TITLE
fix(spec-viewer): in-flight footer as status chip + secondary override (115)

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,1 +1,1 @@
-{"feature_directory": "specs/113-round3-state-followup"}
+{"feature_directory": "specs/115-footer-generating-status"}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+
+- **Spec viewer in-flight footer** (spec 115): `Generating <Step>…` is no longer rendered as a disabled primary button — it's now a non-clickable accent-tinted status chip (pill + spinner) on the **right** with `role="status"` / `aria-live="polite"`. The `Mark step complete` manual override moves to the **left** styled as a quiet secondary action, communicating "one thing is happening, one thing is a fallback override." Applies uniformly to specify / plan / tasks / implement. No behavior change to the override click handler; approve / inline-comment / post-completion footer modes are unchanged.
+
 ## [0.21.0] - 2026-05-27
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -254,5 +254,5 @@ the baseline after playing around: `git restore specs/_00_demo-specified specs/_
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan:
-`specs/097-inline-comment-composer/plan.md`
+`specs/115-footer-generating-status/plan.md`
 <!-- SPECKIT END -->

--- a/docs/viewer-states.md
+++ b/docs/viewer-states.md
@@ -110,10 +110,16 @@
 > `completedAt` is set — at `implemented` the spec-scope
 > `Mark Completed` is the right surface, not `Approve`.
 >
-> **Generating-during-in-flight (spec 099)**: While a step is
-> mid-generation, the footer's forward button is **disabled and
-> labeled `Generating <step>…` with a spinner** rather than the
-> footer being hidden. The renderer in
+> **Generating-during-in-flight (spec 099, restyled in spec 115)**:
+> While a step is mid-generation, the footer renders **two
+> non-competing affordances**: a non-clickable accent-tinted
+> `Generating <step>…` status chip (`<span
+> class="footer-generating-chip">` + spinner) on the **right**, and
+> the secondary `Mark step complete` override button on the
+> **left**. The status chip is not a button — it has
+> `pointer-events: none`, `role="status"`, and `aria-live="polite"`,
+> so it cannot be clicked or focused and is announced as ambient
+> live status rather than an interactive control. The renderer in
 > `webview/src/spec-viewer/components/FooterActions.tsx` shows this
 > state while the running step (`startedAt` set, no `completedAt`)
 > has **not** yet produced its artifact. Completion is content-aware:
@@ -129,10 +135,10 @@
 > `implement` step has no single artifact and is treated ready at
 > 100% task completion).
 >
-> Two escape hatches keep the button from stranding: a **"Mark step
-> complete"** secondary button (posts `markStepComplete`, which
+> Two escape hatches keep the footer from stranding: the left-side
+> `Mark step complete` override (posts `markStepComplete`, which
 > calls `completeStep` for the running step) and a **10-minute
-> recovery timeout** after which the footer falls back to its normal
+> recovery timeout** after which the footer reverts to its normal
 > enabled buttons. The header status badge and the active step's
 > pulse remain the ambient "AI is working" cues; the sidebar's
 > per-row Archive remains as an escape hatch.

--- a/specs/115-footer-generating-status/.spec-context.json
+++ b/specs/115-footer-generating-status/.spec-context.json
@@ -1,0 +1,162 @@
+{
+  "workflow": "speckit",
+  "specName": "Footer Generating Status",
+  "branch": "115-footer-generating-status",
+  "selectedAt": "2026-05-27T15:55:50.348Z",
+  "currentStep": "implement",
+  "status": "implemented",
+  "history": [
+    {
+      "step": "specify",
+      "substep": null,
+      "kind": "start",
+      "from": {
+        "step": null,
+        "substep": null
+      },
+      "by": "extension",
+      "at": "2026-05-27T15:55:50.348Z"
+    },
+    {
+      "step": "specify",
+      "substep": null,
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-05-27T15:58:20Z"
+    },
+    {
+      "step": "plan",
+      "substep": null,
+      "kind": "start",
+      "from": {
+        "step": "specify",
+        "substep": null
+      },
+      "by": "extension",
+      "at": "2026-05-27T15:59:48.283Z"
+    },
+    {
+      "step": "plan",
+      "substep": null,
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-05-27T16:02:37Z"
+    },
+    {
+      "step": "tasks",
+      "substep": null,
+      "kind": "start",
+      "from": {
+        "step": "plan",
+        "substep": null
+      },
+      "by": "extension",
+      "at": "2026-05-27T16:08:09.986Z"
+    },
+    {
+      "step": "tasks",
+      "substep": null,
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-05-27T16:09:29Z"
+    },
+    {
+      "step": "plan",
+      "substep": null,
+      "kind": "start",
+      "from": {
+        "step": "tasks",
+        "substep": null
+      },
+      "by": "extension",
+      "at": "2026-05-27T17:13:21.268Z"
+    },
+    {
+      "step": "plan",
+      "substep": null,
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-05-27T17:14:22Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "kind": "start",
+      "from": {
+        "step": "plan",
+        "substep": null
+      },
+      "by": "ai",
+      "at": "2026-05-27T17:17:12Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-05-27T17:20:54Z"
+    }
+  ],
+  "task_summaries": {
+    "T001": {
+      "status": "DONE",
+      "did": "Added .footer-generating-chip CSS — accent-tinted pill with pointer-events:none and a sized .btn-spinner child.",
+      "files": ["webview/styles/spec-viewer/_footer.css"]
+    },
+    "T002": {
+      "status": "DONE",
+      "did": "Restructured the isGenerating early-return: Mark step complete moved to actions-left as a secondary Button; live indicator is now a non-clickable <span class=\"footer-generating-chip\"> with role=status and a btn-spinner.",
+      "files": ["webview/src/spec-viewer/components/FooterActions.tsx"]
+    },
+    "T003": {
+      "status": "DONE",
+      "did": "Audited GeneratingPlan / GeneratingTasks / GeneratingArtifactReady / GeneratingTimedOut stories — navState shapes still trigger the branch and pick up the new layout automatically; refreshed two doc comments to describe the chip + secondary layout.",
+      "files": ["webview/src/spec-viewer/components/FooterActions.stories.tsx"]
+    },
+    "T004": {
+      "status": "DONE_WITH_CONCERNS",
+      "did": "Implementation supports all five edge cases per code review, but Extension-Development-Host visual verification (rapid step transitions, long-running implement, approve/inline-comment modes unchanged, status-detection failure, narrow widths) is a user-side manual gate.",
+      "files": [],
+      "concerns": [
+        "Manual visual verification in the Extension Development Host (SC-001..SC-004) is the user's responsibility — install-local + step-dispatch each of specify/plan/tasks/implement and confirm the chip + left-secondary layout, plus narrow-viewer behavior."
+      ]
+    },
+    "T005": {
+      "status": "DONE",
+      "did": "Updated the Generating-during-in-flight callout in docs/viewer-states.md to describe the chip (right) + secondary override (left) layout and its a11y attributes.",
+      "files": ["docs/viewer-states.md"]
+    },
+    "T006": {
+      "status": "DONE",
+      "did": "Added an [Unreleased] / Changed CHANGELOG entry summarizing the visual-hierarchy fix for the in-flight footer.",
+      "files": ["CHANGELOG.md"]
+    }
+  },
+  "updated": "2026-05-27",
+  "reviewComments": [
+    {
+      "id": "ref-1779897599663-b413c",
+      "doc": "spec",
+      "anchor": {
+        "heading": "Feature Specification: Footer \"Generating…\" as status, \"Mark step complete\" as secondary",
+        "blockText": "",
+        "line": 7
+      },
+      "comment": "test spec",
+      "status": "pending",
+      "createdAt": "2026-05-27T15:59:59.664Z"
+    },
+    {
+      "id": "ref-1779897611656-ifx14",
+      "doc": "checklists/requirements",
+      "anchor": {
+        "heading": "Content Quality",
+        "blockText": "- [x] All mandatory sections completed",
+        "line": 12
+      },
+      "comment": "test reqs",
+      "status": "pending",
+      "createdAt": "2026-05-27T16:00:11.657Z"
+    }
+  ]
+}

--- a/specs/115-footer-generating-status/checklists/.spec-context.json
+++ b/specs/115-footer-generating-status/checklists/.spec-context.json
@@ -1,0 +1,23 @@
+{
+  "workflow": "sdd",
+  "specName": "checklists",
+  "branch": "checklists",
+  "selectedAt": "2026-05-27T15:59:36.803Z",
+  "currentStep": "specify",
+  "status": "draft",
+  "history": [],
+  "reviewComments": [
+    {
+      "id": "ref-1779897581734-2j3yp",
+      "doc": "requirements",
+      "anchor": {
+        "heading": "Content Quality",
+        "blockText": "- [x] No implementation details (languages, frameworks, APIs)",
+        "line": 9
+      },
+      "comment": "test 2",
+      "status": "pending",
+      "createdAt": "2026-05-27T15:59:41.737Z"
+    }
+  ]
+}

--- a/specs/115-footer-generating-status/checklists/requirements.md
+++ b/specs/115-footer-generating-status/checklists/requirements.md
@@ -1,0 +1,35 @@
+# Specification Quality Checklist: Footer "Generating…" as status, "Mark step complete" as secondary
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-27
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Items marked incomplete require spec updates before `/speckit.clarify` or `/speckit.plan`
+- Source brief explicitly scoped this as a visual-hierarchy change only; behavioral / data / status-detection work is out of scope and documented as such in the spec.

--- a/specs/115-footer-generating-status/plan.md
+++ b/specs/115-footer-generating-status/plan.md
@@ -1,0 +1,244 @@
+# Implementation Plan: Footer "Generating…" as status, "Mark step complete" as secondary
+
+**Branch**: `115-footer-generating-status` | **Date**: 2026-05-27 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/115-footer-generating-status/spec.md`
+
+## Summary
+
+While a pipeline step is in flight, the spec viewer footer currently renders two button-shaped affordances side by side on the right — a disabled primary-styled "Generating <Step>…" button and a secondary "Mark step complete" button. Demote the override and remove button shape from the live indicator:
+
+- Render "Generating <Step>…" as a non-clickable status chip (pill + spinner + label) on the **right**, reusing the existing `.activity-status-pill` visual idiom rather than the primary-button shell.
+- Move "Mark step complete" to the **left** region of the footer and style it visibly lighter than a primary button (existing `secondary` Button variant is already ghost/outline — that's the target).
+- Apply uniformly to all four pipeline steps (specify, plan, tasks, implement). No behavior change to the manual-override click handler.
+- Post-completion / approve / inline-comment footer modes are unchanged.
+
+The change is local to one early-return branch in `webview/src/spec-viewer/components/FooterActions.tsx` plus one CSS class for the chip.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.3+ (ES2022, strict mode)
+**Primary Dependencies**: VS Code Extension API (`@types/vscode ^1.84.0`), Preact (webview)
+**Storage**: N/A (rendering-only change — no persisted state)
+**Testing**: Jest + ts-jest (extension); Storybook for footer visual states (`FooterActions.stories.tsx`)
+**Target Platform**: VS Code webview (browser context, Preact runtime)
+**Project Type**: VS Code extension with webview UI (single project)
+**Performance Goals**: N/A — purely visual; no new state, no new render path
+**Constraints**: Must not regress click handler for "Mark step complete"; must not affect any non-in-flight footer mode (approve, inline-comment, post-completion)
+**Scale/Scope**: 1 component branch (`isGenerating && runningStep` early-return in `FooterActions.tsx`), 1 new CSS class, 4 new Storybook stories (one per step) updated to reflect the new layout
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- **I. Extensibility and Configuration** — PASS. Footer state machine already discriminates modes (generating / post-completion / approve / inline-comment). This change refines the visual rendering of one existing mode; no new configuration surface required.
+- **II. Spec-Driven Workflow** — PASS. The change applies uniformly to all four canonical pipeline steps (specify → plan → tasks → implement). It does not weaken or fragment the pipeline; it improves the visual cue for "step is running."
+- **III. Visual and Interactive** — PASS. The whole point of the change is to honor visual hierarchy: one live action, one quiet fallback. Reuses the existing `activity-status-pill` idiom rather than introducing a new pattern.
+- **IV. Modular Architecture for Complex Features** — PASS. Confined to the existing modular footer component (`FooterActions.tsx`) and CSS partial (`_footer.css`); no new modules, no cross-cutting refactor.
+
+No violations. No entries in Complexity Tracking.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/115-footer-generating-status/
+├── plan.md              # This file
+├── spec.md              # Already authored
+└── checklists/          # (existing, untouched by this plan)
+```
+
+No `research.md`, `data-model.md`, `contracts/`, or `quickstart.md` are
+generated for this feature. Rationale:
+
+- **No NEEDS CLARIFICATION** in Technical Context — every choice is grounded
+  in code that already exists (`activity-status-pill`, `secondary` Button
+  variant, `actions-left` / `actions-right` regions).
+- **No entities** — this is rendering-only; no new persisted shape, no new
+  message type, no new viewer state field.
+- **No external contracts** — the manual-override click handler
+  (`postMessage({ type: 'markStepComplete' })`) is preserved verbatim. No
+  new webview ↔ extension messages are added.
+- **No quickstart** — the visual change is exercised via existing Storybook
+  stories (`GeneratingPlan`, `GeneratingTasks`, etc.) and by triggering any
+  `/speckit.*` command from the viewer in the Extension Development Host.
+
+### Source Code (repository root)
+
+Files this feature touches:
+
+```text
+webview/src/spec-viewer/components/
+└── FooterActions.tsx                  # The `if (isGenerating && runningStep)` branch (lines ~94–115)
+
+webview/src/spec-viewer/components/
+└── FooterActions.stories.tsx          # Refresh GeneratingPlan / GeneratingTasks / GeneratingArtifactReady stories to reflect new layout
+
+webview/styles/spec-viewer/
+└── _footer.css                        # Add `.actions .footer-generating-chip` rule (chip + spinner; reuses existing `spin` keyframe and `activity-status-pill` aesthetic, scoped to the footer)
+```
+
+Files explicitly **not** touched:
+
+- `src/features/spec-viewer/specViewerProvider.ts`, `stateDerivation.ts`,
+  `stepArtifact.ts`, `types.ts` — the extension-side computation of
+  `runningStepArtifactReady`, `runningStepLabel`, `runningStepStartedAt`
+  is reused unchanged.
+- The non-generating branches of `FooterActions.tsx` (catalog path with
+  `vs.footer`, legacy fallback path) — they handle the post-completion /
+  approve / archive / reactivate modes that are explicitly out of scope.
+- `Button.tsx` — the existing `secondary` variant is already the target
+  ghost/outline style; no new variant needed.
+
+**Structure Decision**: Single-project VS Code extension layout
+(`src/` extension host, `webview/` browser context). The change lives
+entirely inside `webview/`.
+
+## Phase 0: Research
+
+No open questions. Implementation choices below are pinned to existing
+code rather than discovered through research:
+
+- **Why a chip, not a disabled button?** The viewer already renders
+  non-clickable status indicators as `.activity-status-pill` (see
+  `webview/styles/spec-viewer/_activity.css:100`). Reusing that idiom
+  satisfies FR-001 ("does not visually invite a click") and Assumption #4
+  ("status indicator's spinner / pill rendering follows whatever the
+  viewer already uses").
+- **Why the `secondary` Button variant for the override?** It's already
+  the ghost/outline style (transparent background, 1px border, muted
+  text — see `_footer.css:66`), which is the literal definition of
+  "visually lighter than primary." No new variant needed. FR-002 is met
+  by the move to `actions-left` (region) plus this existing variant.
+- **Why is "behaviorally unchanged" trivially satisfied?** The
+  `onClick={send({ type: 'markStepComplete' })}` handler is preserved
+  verbatim; only the parent region (`actions-left` instead of
+  `actions-right`) and visual ordering change. FR-005 is therefore a
+  no-op concern.
+- **Narrow-viewer collision (Edge Case)** — `actions-left` uses
+  `margin-right: auto` (`_footer.css:26`) and the chip / button are
+  `flex-shrink: 0`. The existing flex layout already wraps gracefully;
+  no new media query needed.
+
+## Phase 1: Design & Contracts
+
+### Component change (FooterActions.tsx)
+
+Inside the existing `if (isGenerating && runningStep)` block (currently
+at `webview/src/spec-viewer/components/FooterActions.tsx:94`), restructure
+the returned JSX as follows (illustrative — exact wording finalized at
+implementation time):
+
+```tsx
+return (
+    <footer class="actions">
+        <Toast id="action-toast" />
+        <div class="actions-left">
+            <Button
+                label="Mark step complete"
+                variant="secondary"
+                title="Manually mark this step complete if auto-detection doesn't fire"
+                onClick={send({ type: 'markStepComplete' })}
+            />
+        </div>
+        <div class="actions-right">
+            <span
+                class="footer-generating-chip is-running"
+                role="status"
+                aria-live="polite"
+                title="The AI is generating this step — this status updates once the artifact is ready"
+            >
+                <span class="btn-spinner" aria-hidden="true" />
+                Generating {ns.runningStepLabel ?? 'step'}…
+            </span>
+        </div>
+    </footer>
+);
+```
+
+Key points:
+
+- The status chip is a `<span>` (not `<button>`) — cannot receive focus,
+  cannot be clicked. Reuses `.btn-spinner` for the spinning ring.
+- `role="status"` + `aria-live="polite"` give screen readers the running
+  status without announcing it as an interactive control.
+- "Mark step complete" stays a `Button` with `variant="secondary"` —
+  identical styling to other ghost/outline footer buttons; nothing new in
+  `Button.tsx`.
+
+### CSS change (`_footer.css`)
+
+Add one new selector block near the existing footer button rules:
+
+```css
+.actions .footer-generating-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 6px 12px;
+    border-radius: 999px;
+    border: 1px solid color-mix(in srgb, var(--accent) 50%, transparent);
+    background: color-mix(in srgb, var(--accent) 12%, transparent);
+    color: var(--accent);
+    font-size: 12px;
+    font-weight: 600;
+    letter-spacing: 0.02em;
+    user-select: none;
+    pointer-events: none;            /* FR-001: does not respond to clicks */
+    flex-shrink: 0;
+}
+
+.actions .footer-generating-chip .btn-spinner {
+    width: 11px;
+    height: 11px;
+    border-width: 2px;
+}
+```
+
+Visual rationale: matches `.activity-status-pill.is-implementing` color
+treatment (accent + 12% tint) so the in-flight cue reads consistently with
+the running-step pill that already appears in the activity panel.
+
+### Storybook stories (`FooterActions.stories.tsx`)
+
+Existing stories `GeneratingPlan`, `GeneratingTasks`, `GeneratingTasks`
+(and the recovery / artifact-ready variants) drive themselves from
+navState shape — no story-data changes required. The visual snapshot in
+each story will reflect the new layout automatically once the component
+is updated.
+
+If we add a snapshot/visual-regression sweep, the four-step matrix
+(specify / plan / tasks / implement) gives us SC-001 coverage.
+
+### Agent context update
+
+Update the `<!-- SPECKIT START --> … <!-- SPECKIT END -->` block in
+`CLAUDE.md` to point at this plan:
+`specs/115-footer-generating-status/plan.md`.
+
+## Complexity Tracking
+
+> No Constitution Check violations. Table intentionally empty.
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|--------------------------------------|
+| (none) | — | — |
+
+---
+
+## Plain-English Summary
+
+**Problem:** While a step is running, the viewer footer shows two buttons
+side-by-side — a disabled "Generating …" pill and a "Mark step complete"
+override. Users can't tell at a glance which one is the live thing and
+which one is the fallback.
+
+**Solution:** Stop drawing the live indicator as a button. Render it as a
+small accent-tinted status chip on the right (spinner + label, not
+clickable). Move "Mark step complete" to the left side of the footer
+using the existing quiet/ghost button style. Everything else about the
+footer — post-completion, approve, inline-comment modes — is left alone.
+
+**Where it lives:** one early-return branch in `FooterActions.tsx`, one
+new CSS class in `_footer.css`, and the existing Storybook stories pick
+up the new look automatically.

--- a/specs/115-footer-generating-status/spec.md
+++ b/specs/115-footer-generating-status/spec.md
@@ -1,0 +1,66 @@
+# Feature Specification: Footer "Generating…" as status, "Mark step complete" as secondary
+
+**Feature Branch**: `115-footer-generating-status`
+**Created**: 2026-05-27
+**Status**: Draft
+**Input**: User description: "While a step is in flight, the spec viewer footer renders two button-shaped elements side by side — a disabled 'Generating <Step>…' pill and a primary-looking 'Mark step complete' button. Demote 'Mark step complete' to a secondary affordance on the left, and render 'Generating…' as a status indicator (not a button) so the row honestly communicates 'one thing is happening, one thing is a fallback override.'"
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - In-flight footer reads as one live action, not two competing buttons (Priority: P1)
+
+While a step (specify / plan / tasks / implement) is generating, the spec viewer footer shows a clear visual hierarchy: the live "Generating <Step>…" affordance is rendered as a non-clickable status chip, and the "Mark step complete" manual override sits on the **left** styled as a quiet secondary action. The user immediately understands that work is in progress and that "Mark step complete" is a fallback override rather than the recommended action.
+
+**Why this priority**: This is the entire feature — the visual hierarchy fix. Without it, the footer continues to mis-cue users into clicking the manual override instead of waiting for the live process to finish. There is no smaller MVP slice; the whole footer restructure for the in-flight state ships together.
+
+**Independent Test**: Trigger any step that produces a "Generating…" footer (e.g., dispatch `/speckit.plan` from the viewer and watch the in-flight state). Confirm: (a) "Generating <Step>…" is no longer a button shape and does not invite a click; (b) "Mark step complete" appears on the left side of the footer with a visibly lighter / secondary style; (c) "Mark step complete" remains usable the entire time generation is happening; (d) once generation finishes, the footer flips back to the normal post-completion next-step CTA on the right with no leftover in-flight chrome.
+
+**Acceptance Scenarios**:
+
+1. **Given** a spec is mid-generation for any pipeline step (specify, plan, tasks, implement), **When** the user opens the spec viewer, **Then** the footer renders "Generating <Step>…" as a non-button status indicator (chip / pill / inline label with spinner) that does not look or behave like a clickable button.
+2. **Given** a spec is mid-generation, **When** the user views the footer, **Then** "Mark step complete" appears on the **left** side of the footer in a secondary / tertiary visual weight, clearly subordinate to the live status indicator.
+3. **Given** a spec is mid-generation, **When** the user clicks "Mark step complete", **Then** the manual-override behavior still fires exactly as it does today (no behavioral regression — the change is purely visual hierarchy).
+4. **Given** a step finishes generating, **When** the footer rerenders, **Then** the in-flight status chip and the secondary "Mark step complete" both disappear and the footer reverts to its normal post-completion next-step CTA on the right.
+
+---
+
+### Edge Cases
+
+- **Rapid step transitions**: A step completes and the next step immediately starts generating. The footer should never display two in-flight status chips simultaneously, and the "Mark step complete" override should reset its association to the newly-active step.
+- **Implement step running long**: For implement runs that take many minutes, the secondary "Mark step complete" must remain reachable and clickable the whole time — no auto-hide, no disabled state.
+- **Approve / inline-comment footers**: When the footer is in Approve or inline-comment mode (not the generating mode), the new in-flight styling does not apply. Those modes are explicitly out of scope.
+- **Status-detection failure**: If the underlying state never reports "completed" (the original bug that justifies "Mark step complete" existing), the secondary override remains the user's escape hatch — the chip stays "Generating…" indefinitely until the user clicks the override.
+- **Narrow viewer widths**: When the viewer panel is dragged narrow, the left-aligned secondary action and the right-aligned status chip must not collide or overlap; one wraps or compresses gracefully.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: While any pipeline step (specify, plan, tasks, implement) is in the in-progress lifecycle status, the spec viewer footer MUST render the "Generating <Step>…" affordance as a non-button status element (e.g., chip, pill, or inline label with spinner) that does not visually invite a click and does not respond to clicks.
+- **FR-002**: While any pipeline step is in the in-progress lifecycle status, the spec viewer footer MUST render the "Mark step complete" action on the **left** side of the footer, visually styled as a secondary / tertiary affordance with lighter weight than a primary button.
+- **FR-003**: The "Mark step complete" action MUST remain enabled and clickable for the entire duration the step is in the in-progress lifecycle status (no auto-disable, no auto-hide while generating).
+- **FR-004**: When a step transitions out of the in-progress lifecycle status (to its completed form), the footer MUST remove both the in-flight status indicator and the secondary "Mark step complete" affordance, and revert to the post-completion next-step CTA on the right as it does today.
+- **FR-005**: Clicking "Mark step complete" while in the in-flight state MUST trigger the same manual-override behavior it triggers today (functional parity — this change is visual only).
+- **FR-006**: The new in-flight footer styling MUST apply uniformly to every step that can surface this combination — specify, plan, tasks, and implement — without per-step variation.
+- **FR-007**: The change MUST NOT alter the Approve flow footer, the inline-comment composer footer, or any other footer mode that is not the in-flight "Generating…" state.
+
+### Key Entities
+
+- **Footer state — In-flight**: The spec viewer footer mode displayed while the current pipeline step is in an in-progress lifecycle status (specifying, planning, tasking, implementing). After this change, it contains: a non-button status indicator on the right ("Generating <Step>…") and a secondary action on the left ("Mark step complete").
+- **Footer state — Post-completion**: The spec viewer footer mode displayed after the current step reaches its completed lifecycle form. Unchanged by this feature; continues to show the normal next-step CTA on the right.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: In every screenshot of an in-flight spec viewer footer, a non-technical reviewer can identify within 5 seconds which element is the live action and which is the manual override, with 100% accuracy across the four pipeline steps (specify, plan, tasks, implement).
+- **SC-002**: Zero clicks land on the "Generating <Step>…" element during in-flight states (the element does not respond to clicks and does not look clickable), measured by absence of click events on that element in manual testing across the four pipeline steps.
+- **SC-003**: "Mark step complete" remains successfully clickable across the full duration of an in-flight step in 100% of manual test runs, including long-running implement steps.
+- **SC-004**: When a step transitions from in-progress to completed, the footer reverts to the post-completion next-step CTA within the same viewer render cycle in 100% of manual test runs — no leftover in-flight chrome.
+
+## Assumptions
+
+- "Mark step complete" remains a needed manual override because the underlying status-detection reliability problem is still open (per the source brief). This spec does not attempt to remove or replace it — only to demote it visually.
+- The footer's existing distinction between modes (in-flight vs. post-completion vs. approve vs. inline-comment) is correct and continues to be the right way to gate which controls are visible.
+- "Secondary / tertiary action" styling is interpreted as a button visually lighter than a primary CTA (e.g., text-button or ghost/outline style) — the exact token / class used is an implementation decision for the plan phase.
+- The status indicator's spinner / pill rendering follows whatever the viewer already uses for non-clickable status chips elsewhere, rather than introducing a new pattern.

--- a/specs/115-footer-generating-status/tasks.md
+++ b/specs/115-footer-generating-status/tasks.md
@@ -1,0 +1,134 @@
+---
+description: "Task list for feature 115-footer-generating-status"
+---
+
+# Tasks: Footer "Generating…" as status, "Mark step complete" as secondary
+
+**Input**: Design documents from `/specs/115-footer-generating-status/`
+**Prerequisites**: plan.md, spec.md
+
+**Tests**: No automated test tasks generated — the spec relies on manual
+visual verification via Storybook + Extension Development Host (per plan.md
+"No quickstart" rationale). Acceptance is covered by existing
+`FooterActions.stories.tsx` snapshots and SC-001..SC-004 manual checks.
+
+**Organization**: Single user story (P1). All implementation work belongs
+to US1; no foundational prerequisites beyond the existing footer module.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: User story label (US1 only here)
+- File paths are absolute or repo-root-relative
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: No new setup required — the change is confined to existing
+webview component + CSS partial. The bundler / TS config / Preact runtime
+are all in place.
+
+_(intentionally empty)_
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: No foundational work — `runningStep`, `runningStepLabel`,
+`runningStepArtifactReady`, `runningStepStartedAt`, the
+`markStepComplete` message, the `secondary` Button variant, the
+`actions-left` / `actions-right` flex regions, and the `.btn-spinner`
+keyframe all already exist and are reused as-is.
+
+_(intentionally empty)_
+
+---
+
+## Phase 3: User Story 1 - In-flight footer reads as one live action, not two competing buttons (Priority: P1) 🎯 MVP
+
+**Goal**: Restructure the in-flight footer so "Generating <Step>…"
+renders as a non-clickable status chip on the right and
+"Mark step complete" sits on the left styled as a quiet secondary
+override — uniformly across specify / plan / tasks / implement.
+
+**Independent Test**: Dispatch `/speckit.plan` (or any pipeline step)
+from the spec viewer in the Extension Development Host and watch the
+in-flight state. Confirm: (a) "Generating <Step>…" is no longer
+button-shaped and does not invite a click; (b) "Mark step complete" is
+on the **left** with a visibly lighter/secondary style; (c)
+"Mark step complete" stays clickable for the full in-flight duration;
+(d) once generation finishes, the footer reverts to the normal
+post-completion next-step CTA on the right with no leftover in-flight
+chrome.
+
+### Implementation for User Story 1
+
+- [X] T001 [P] [US1] Add `.actions .footer-generating-chip` selector block to `webview/styles/spec-viewer/_footer.css` (pill shape via `border-radius: 999px`, accent-tinted background using `color-mix(in srgb, var(--accent) 12%, transparent)`, accent border at 50% alpha, accent text color, `font-size: 12px`, `font-weight: 600`, `letter-spacing: 0.02em`, `padding: 6px 12px`, `display: inline-flex`, `align-items: center`, `gap: 6px`, `user-select: none`, `pointer-events: none`, `flex-shrink: 0`) plus a nested `.actions .footer-generating-chip .btn-spinner` rule sizing the spinner to `width: 11px`, `height: 11px`, `border-width: 2px`. (FR-001)
+
+- [X] T002 [US1] Restructure the `if (isGenerating && runningStep)` early-return branch in `webview/src/spec-viewer/components/FooterActions.tsx` (lines ~94–115): move the `Button label="Mark step complete" variant="secondary"` into the `actions-left` div, and replace the `Button label="Generating …" variant="primary" loading` in `actions-right` with a `<span class="footer-generating-chip is-running" role="status" aria-live="polite" title="The AI is generating this step — this status updates once the artifact is ready">` containing `<span class="btn-spinner" aria-hidden="true" />` followed by the text `Generating {ns.runningStepLabel ?? 'step'}…`. Preserve the existing `onClick={send({ type: 'markStepComplete' })}` handler verbatim and keep the surrounding `<Toast id="action-toast" />`. (FR-001, FR-002, FR-003, FR-005, FR-006)
+
+- [X] T003 [US1] In `webview/src/spec-viewer/components/FooterActions.stories.tsx`, audit the in-flight stories (`GeneratingPlan`, `GeneratingTasks`, and any sibling `Generating*` / `*ArtifactReady` stories) to confirm their navState shape still triggers the `isGenerating && runningStep` branch with the new layout. No story-data changes are expected (per plan.md); update only if a story relied on the prior right-side button arrangement and now mis-snapshots. Re-snapshot the four-step matrix (specify / plan / tasks / implement) for SC-001 coverage if a snapshot/visual-regression sweep is in use. (SC-001)
+
+- [ ] T004 [US1] (USER MANUAL VERIFICATION) Manually verify the four edge cases listed in spec.md against the updated footer in the Extension Development Host: (a) rapid step transitions — only one in-flight chip visible at a time, "Mark step complete" re-associates to the newly active step; (b) long-running implement step — "Mark step complete" stays clickable indefinitely, chip never auto-hides; (c) approve / inline-comment footer modes — unchanged by the new styling; (d) status-detection failure — chip stays "Generating…" until user clicks the override; (e) narrow viewer widths — left action and right chip wrap/compress without overlap. (FR-007, SC-002, SC-003, SC-004, all Edge Cases)
+
+**Checkpoint**: In-flight footer renders with one live status chip on the right and one quiet secondary override on the left, uniformly across all four pipeline steps. All other footer modes (post-completion, approve, inline-comment, archived, reactivate) are visually unchanged.
+
+---
+
+## Phase 4: Polish & Cross-Cutting Concerns
+
+- [X] T005 [P] Update `docs/viewer-states.md` "Footer button matrix" section to reflect the new in-flight footer layout (left: secondary "Mark step complete"; right: non-clickable "Generating <Step>…" chip) per CLAUDE.md docs map for footer/button changes.
+
+- [X] T006 [P] Add a CHANGELOG.md entry under the next-version "Fixed" or "Changed" heading summarizing: "Spec viewer in-flight footer: 'Generating <Step>…' is now a non-clickable status chip on the right; 'Mark step complete' demoted to a secondary action on the left."
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1 (Setup)**: empty — skip.
+- **Phase 2 (Foundational)**: empty — skip.
+- **Phase 3 (US1)**: starts immediately. T001 and T002 are independent files (CSS vs. TSX) and can run in parallel. T003 depends on T002 (the rendered DOM changes). T004 depends on T001+T002 landing (it's the manual verification pass).
+- **Phase 4 (Polish)**: depends on US1 completion. T005 and T006 are independent files and can run in parallel.
+
+### Within User Story 1
+
+- T001 (CSS) ∥ T002 (TSX) — different files, no dependency.
+- T003 (stories audit) — after T002.
+- T004 (manual edge-case verification) — after T001 + T002.
+
+### Parallel Opportunities
+
+- T001 ∥ T002 within Phase 3.
+- T005 ∥ T006 within Phase 4.
+
+---
+
+## Parallel Example: User Story 1
+
+```bash
+# Launch CSS and component changes together:
+Task: "Add .footer-generating-chip selector block to webview/styles/spec-viewer/_footer.css"
+Task: "Restructure isGenerating && runningStep branch in webview/src/spec-viewer/components/FooterActions.tsx"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Phase 1 + Phase 2 are empty — start directly at Phase 3.
+2. Land T001 + T002 in parallel.
+3. Run T003 to confirm Storybook still tells the truth.
+4. Run T004 manual verification across the four steps + edge cases.
+5. **STOP and VALIDATE**: SC-001..SC-004 met against the live viewer.
+6. Polish (T005 + T006) and ship.
+
+### Notes
+
+- The feature is intentionally small — one component branch, one CSS class, one CHANGELOG line, one doc table update.
+- No automated tests added; manual visual checks per SC-001..SC-004 are the acceptance gate (consistent with plan.md "No quickstart" rationale).
+- Out of scope: approve flow, inline-comment composer, post-completion next-step CTA, archive/reactivate footers, any `runningStep*` derivation logic in `src/features/spec-viewer/`.

--- a/webview/src/spec-viewer/components/FooterActions.stories.tsx
+++ b/webview/src/spec-viewer/components/FooterActions.stories.tsx
@@ -98,11 +98,13 @@ const REFINE_ACTION: FooterEntry = {
 
 const withRefine = (footer: FooterEntry[]): FooterEntry[] => [REFINE_ACTION, ...footer];
 
-// Helper to mark a story as in-flight on a given step. The renderer shows the
-// disabled "Generating <step>…" footer while the step's artifact is not yet
-// ready. `runningStepStartedAt` is stamped "now" so the recovery timeout has
-// not elapsed and `runningStepArtifactReady` is false, so isGenerating fires.
-// `runningStepLabel` mirrors what the provider ships via getDocTypeLabel.
+// Helper to mark a story as in-flight on a given step. The renderer shows a
+// non-clickable "Generating <step>…" status chip on the right and the
+// secondary "Mark step complete" override on the left while the step's
+// artifact is not yet ready. `runningStepStartedAt` is stamped "now" so the
+// recovery timeout has not elapsed and `runningStepArtifactReady` is false,
+// so isGenerating fires. `runningStepLabel` mirrors what the provider ships
+// via getDocTypeLabel.
 const STEP_LABELS: Record<string, string> = { spec: 'Spec', plan: 'Plan', tasks: 'Tasks' };
 const inFlightNavState = (specStatus: string, step: string) =>
     mockNavState({
@@ -268,11 +270,12 @@ export const Archived: Story = {
     },
 };
 
-// ── Generating state (spec 099) ─────────────────────────────
-// The forward button is disabled and reads "Generating <step>…" with a
-// spinner while the running step's artifact is not yet on disk, plus a
-// manual "Mark step complete" fallback. Once the artifact lands (or the
-// recovery timeout elapses) the normal footer returns.
+// ── Generating state (spec 099 → restyled in spec 115) ─────────────────
+// The right side shows a non-clickable "Generating <step>…" status chip
+// (pill + spinner) while the running step's artifact is not yet on disk;
+// the left side shows the secondary "Mark step complete" override. Once
+// the artifact lands (or the recovery timeout elapses) the normal footer
+// returns.
 
 export const GeneratingTasks: Story = {
     name: 'Generating — Tasks',

--- a/webview/src/spec-viewer/components/FooterActions.tsx
+++ b/webview/src/spec-viewer/components/FooterActions.tsx
@@ -88,27 +88,32 @@ export function FooterActions({ initialSpecStatus }: FooterActionsProps) {
         setRegenerateToastActive(false);
     };
 
-    // While a step is generating, replace the forward button with a disabled
-    // "Generating <step>…" spinner plus a manual completion fallback. Applies to
-    // every step transition.
+    // While a step is generating, render the live status as a non-clickable
+    // chip on the right and demote the manual override to a secondary action
+    // on the left. The two affordances communicate "one thing is happening,
+    // one thing is a fallback override."
     if (isGenerating && runningStep) {
         return (
             <footer class="actions">
                 <Toast id="action-toast" />
-                <div class="actions-left"></div>
-                <div class="actions-right">
-                    <Button
-                        label={`Generating ${ns.runningStepLabel ?? 'step'}…`}
-                        variant="primary"
-                        loading
-                        title="The AI is generating this step — the button re-enables once the artifact is ready"
-                    />
+                <div class="actions-left">
                     <Button
                         label="Mark step complete"
                         variant="secondary"
                         title="Manually mark this step complete if auto-detection doesn't fire"
                         onClick={send({ type: 'markStepComplete' })}
                     />
+                </div>
+                <div class="actions-right">
+                    <span
+                        class="footer-generating-chip is-running"
+                        role="status"
+                        aria-live="polite"
+                        title="The AI is generating this step — this status updates once the artifact is ready"
+                    >
+                        <span class="btn-spinner" aria-hidden="true" />
+                        Generating {ns.runningStepLabel ?? 'step'}…
+                    </span>
                 </div>
             </footer>
         );

--- a/webview/styles/spec-viewer/_footer.css
+++ b/webview/styles/spec-viewer/_footer.css
@@ -102,6 +102,32 @@
     box-shadow: none;
 }
 
+/* In-flight status chip — non-clickable accent-tinted pill that signals
+   "the AI is generating this step." Matches the .activity-status-pill idiom
+   used elsewhere so the live cue reads consistently. */
+.actions .footer-generating-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 6px 12px;
+    border-radius: 999px;
+    border: 1px solid color-mix(in srgb, var(--accent) 50%, transparent);
+    background: color-mix(in srgb, var(--accent) 12%, transparent);
+    color: var(--accent);
+    font-size: 12px;
+    font-weight: 600;
+    letter-spacing: 0.02em;
+    user-select: none;
+    pointer-events: none;
+    flex-shrink: 0;
+}
+
+.actions .footer-generating-chip .btn-spinner {
+    width: 11px;
+    height: 11px;
+    border-width: 2px;
+}
+
 /* ============================================
    Action Toast (floating)
    ============================================ */


### PR DESCRIPTION
## Summary

- Replaced the disabled `Generating <Step>…` primary button with a non-clickable accent-tinted status chip (pill + spinner, `role=status`, `aria-live=polite`, `pointer-events:none`) on the right side of the footer.
- Demoted `Mark step complete` to a secondary action on the left so the two affordances communicate "one thing is happening, one thing is a fallback override" — uniformly across specify / plan / tasks / implement.
- No behavior change to the override click handler; approve / inline-comment / post-completion footer modes are untouched.

## Test plan

- [ ] Install locally and dispatch `/speckit.plan` (or any step) from the viewer; confirm the chip reads as live status and is not clickable.
- [ ] Confirm `Mark step complete` is on the left in a quiet secondary style and remains clickable for the full in-flight duration.
- [ ] Drag the viewer narrow — confirm chip and left button wrap/compress without overlap.
- [ ] Let a step finish — confirm the footer reverts to the post-completion next-step CTA on the right with no leftover in-flight chrome.
- [ ] Verify approve flow, inline-comment composer, archive/reactivate footers are visually unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)