### PR TITLE
fix(spec-viewer): approve dispatches off ctx.currentStep, not docType (116)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,20 +110,15 @@ User data stored in workspace `.claude/` directory:
 
 ## Documentation
 
-When adding, changing, or removing a user-facing feature, update README.md.
-The README is the single source of truth for configuration, workflows, and
-features. Use the map below to find the right section.
+When adding, changing, or removing a user-facing feature, update README.md. The README is the single source of truth for configuration, workflows, and features. Use the map below to find the right section.
 
-When modifying spec viewer statuses, badges, buttons, or step tab behavior,
-also update `docs/viewer-states.md` (full state machine: status lifecycle,
-footer button matrix, badge text logic, step tab visual states, data flow).
+When modifying spec viewer statuses, badges, buttons, or step tab behavior, also update `docs/viewer-states.md` (full state machine: status lifecycle, footer button matrix, badge text logic, step tab visual states, data flow).
 
-When modifying the project structure, adding/removing modules, or changing
-the architecture, also update `docs/architecture.md`.
+When modifying the project structure, adding/removing modules, or changing the architecture, also update `docs/architecture.md`.
 
-When modifying the sidebar (filter, sort, lifecycle buttons, badge tiers,
-tree icons, transition logging), also update `docs/sidebar.md` (the long-form
-sidebar reference linked from the README).
+When modifying the sidebar (filter, sort, lifecycle buttons, badge tiers, tree icons, transition logging), also update `docs/sidebar.md` (the long-form sidebar reference linked from the README).
+
+When modifying a webview component (`webview/src/spec-viewer/components/`, `webview/src/spec-editor/`, etc.) that has a sibling `.stories.tsx` file, update the stories in the same change to cover the new state/variant. Storybook is the visual baseline for these components — stale stories are worse than missing stories because they lie. If a component changes materially and no `.stories.tsx` exists, add one in the same PR.
 
 ### Feature → README section map
 
@@ -138,6 +133,7 @@ sidebar reference linked from the README).
 | New custom command type | "Custom Commands" properties table in README |
 | New platform support / shell support | "Platform Support" table in README |
 | New webview UI element (header, badge, tab, etc.) | "Reading Specs" subsection in README + retake associated screenshot |
+| Modified webview component with a sibling `.stories.tsx` | Update the stories to exercise the new state/variant; if there is no story file for a non-trivial component being modified, add one |
 | Bug fix that changes documented behavior | The README section that documented the broken behavior |
 
 ### Per-release checklist (run before tagging a version)
@@ -151,44 +147,39 @@ sidebar reference linked from the README).
 7. Re-render any screenshot whose UI changed in this release and refresh its caption if the value prop shifted.
    - **Keep screenshot filenames stable — overwrite in place, never rename or delete.** README image URLs are absolute and pinned to the `main` branch (`raw.githubusercontent.com/.../main/docs/screenshots/<file>`). The Marketplace serves the *last published* README but resolves those URLs against the *current* `main`, so renaming or deleting a referenced screenshot retroactively 404s the published listing (this is what broke the v0.18.0 listing after the "lean image set" refactor). Re-shoot into the existing filename instead.
 
-When in doubt, look at how an existing feature is documented and follow the
-same pattern.
+When in doubt, look at how an existing feature is documented and follow the same pattern.
+
+### Markdown formatting
+
+**No hard-wrapped paragraphs.** Every prose paragraph in any `.md` file in this repo (`README.md`, `CHANGELOG.md`, `CLAUDE.md`, anything under `docs/`, `specs/`, etc.) is a single logical line. Do not insert newlines mid-paragraph to fit a column width — modern editors soft-wrap, and hard-wrapping makes diffs noisier and edits harder. The only newlines inside a paragraph come from explicit Markdown breaks (two trailing spaces or `<br>`); the only newlines between paragraphs are blank-line separators. Bullets, table rows, code blocks, and headings remain on their own lines as usual.
 
 ## Extension Isolation (critical)
 
-The installed SpecKit Companion extension ships ONLY what is packaged into
-the `.vsix` (code under `src/`, bundled webview, assets). It does NOT ship:
+The installed SpecKit Companion extension ships ONLY what is packaged into the `.vsix` (code under `src/`, bundled webview, assets). It does NOT ship:
 
 - `.claude/skills/**` — dev-workspace skills; users don't have them.
-- `.specify/templates/**`, `.specify/extensions.yml`, `.specify/scripts/**`
-  — these belong to the SpecKit CLI / user's own workspace.
+- `.specify/templates/**`, `.specify/extensions.yml`, `.specify/scripts/**` — these belong to the SpecKit CLI / user's own workspace.
 - `.claude/**` in general — user-local AI setup.
 
-Any runtime behavior the extension needs must work without any of those
-files. Treat them as read-only from the extension's perspective.
+Any runtime behavior the extension needs must work without any of those files. Treat them as read-only from the extension's perspective.
 
 Correct surfaces for extension-owned behavior:
 
-1. **Extension command handlers** (`src/features/specs/specCommands.ts`,
-   viewer message handlers) — direct writes via `specContextWriter`.
-2. **Prompt text the extension builds** for the AI CLI (in
-   `ai-providers/*` / `executeInTerminal(prompt)`) — prepend/append
-   instructions here; this text is assembled at runtime by shipped code.
+1. **Extension command handlers** (`src/features/specs/specCommands.ts`, viewer message handlers) — direct writes via `specContextWriter`.
+2. **Prompt text the extension builds** for the AI CLI (in `ai-providers/*` / `executeInTerminal(prompt)`) — prepend/append instructions here; this text is assembled at runtime by shipped code.
 
-Do NOT modify `.claude/**` or `.specify/**` to implement extension
-features. If the feature needs the AI to do something, have the extension
-embed the instruction in the prompt it dispatches.
+Do NOT modify `.claude/**` or `.specify/**` to implement extension features. If the feature needs the AI to do something, have the extension embed the instruction in the prompt it dispatches.
 
-**Exception — committed spec-kit scaffolding for IDE Chat testing.** The
-`.specify/`, `.cursor/`, `.windsurf/`, `.agents/`, `.gemini/`, `.qwen/`, and
-`.github/{agents,prompts}/speckit.*` directories are checked in as
-**manual-testing fixtures** — they're the output of `specify init --ai <agent>`
-for each host editor, so the IDE Chat provider can be exercised against real
-`/speckit.*` commands in Copilot / Cursor / Windsurf / Antigravity. The
-extension still does **not** read or depend on these at runtime (it only
-dispatches command text; the host chat resolves them), and they are not shipped
-in the `.vsix`. Don't delete them as an "isolation violation" — they're test
-setup, not extension behavior.
+**Exception — committed spec-kit scaffolding for IDE Chat testing.** The `.specify/`, `.cursor/`, `.windsurf/`, `.agents/`, `.gemini/`, `.qwen/`, and `.github/{agents,prompts}/speckit.*` directories are checked in as **manual-testing fixtures** — they're the output of `specify init --ai <agent>` for each host editor, so the IDE Chat provider can be exercised against real `/speckit.*` commands in Copilot / Cursor / Windsurf / Antigravity. The extension still does **not** read or depend on these at runtime (it only dispatches command text; the host chat resolves them), and they are not shipped in the `.vsix`. Don't delete them as an "isolation violation" — they're test setup, not extension behavior.
+
+## Code Comments
+
+Default to writing **no comment**. Only add one when removing it would surprise a future reader (a hidden constraint, a non-obvious invariant, a workaround for a specific runtime quirk). If the rationale needs a paragraph, the WHY belongs in the commit message or PR description, not in the source. Specifically for this repo:
+
+- **No spec / PR / finding identifiers in code comments.** Don't write `// (spec 112)`, `// per F12`, `// per PR #182`, `// round-3 cleanup`. These rot the moment the PR thread moves on; a future reader who needs the context can run `git log -L :functionName:path/to/file` or open the PR. The codebase has been accumulating these — strip them when you touch nearby code.
+- **No "added for X" / "handles case from Y" comments.** Identifier names and structure should communicate this. If they don't, fix the naming before adding the comment.
+- **One line max per inline comment.** No multi-paragraph rationale blocks above functions, no JSDoc-style narrative essays explaining the history of a fix. If you need more than one sentence, the function probably needs to be split or named better.
+- **Strip diagnostic logs before commit.** Any `console.log('[handleApprove] firing…')` / `[advance] SKIPPED` / `[stepLifecycle] *done` line added while chasing a finding is diagnostic, not telemetry — remove it once the answer is in hand. Structural error-log lines (`logError`, `outputChannel.appendLine` inside catch blocks) stay; they're production-fit.
 
 ## Important Notes
 
@@ -211,8 +202,7 @@ npm run test:watch    # Watch mode
 
 ### Demo testing specs (fixed baseline — never commit local edits)
 
-`specs/_00_demo-specified/`, `specs/_01_demo-planned/`, and `specs/_02_demo-tasked/`
-are **committed manual-testing fixtures**, each pinned to one viewer state:
+`specs/_00_demo-specified/`, `specs/_01_demo-planned/`, and `specs/_02_demo-tasked/` are **committed manual-testing fixtures**, each pinned to one viewer state:
 
 | Dir | State | Files present | Footer button it surfaces |
 |-----|-------|---------------|---------------------------|
@@ -220,11 +210,7 @@ are **committed manual-testing fixtures**, each pinned to one viewer state:
 | `_01_demo-planned` | `planned` | `spec.md`, `plan.md` | **Tasks** |
 | `_02_demo-tasked` | `ready-to-implement` | `spec.md`, `plan.md`, `tasks.md` | **Implement** |
 
-They exist so the viewer can be opened against a known state during development.
-**Do NOT commit local changes to these three dirs** — when exercising them you
-will mutate `.spec-context.json`/files; never `git add` those changes. To restore
-the baseline after playing around: `git restore specs/_00_demo-specified specs/_01_demo-planned specs/_02_demo-tasked`
-(or `git checkout -- …`). Other `specs/_*/` dirs remain gitignored (local-only).
+They exist so the viewer can be opened against a known state during development. **Do NOT commit local changes to these three dirs** — when exercising them you will mutate `.spec-context.json`/files; never `git add` those changes. To restore the baseline after playing around: `git restore specs/_00_demo-specified specs/_01_demo-planned specs/_02_demo-tasked` (or `git checkout -- …`). Other `specs/_*/` dirs remain gitignored (local-only).
 
 ## Tech Stack
 
@@ -252,7 +238,5 @@ the baseline after playing around: `git restore specs/_00_demo-specified specs/_
 - 044-context-driven-badges: Added TypeScript 5.3+ (ES2022 target, strict mode) + VS Code Extension API (`@types/vscode ^1.84.0`)
 
 <!-- SPECKIT START -->
-For additional context about technologies to be used, project structure,
-shell commands, and other important information, read the current plan:
-`specs/115-footer-generating-status/plan.md`
+For additional context about technologies to be used, project structure, shell commands, and other important information, read the current plan: `specs/115-footer-generating-status/plan.md`
 <!-- SPECKIT END -->

--- a/specs/116-fix-approve-wrong-step/.spec-context.json
+++ b/specs/116-fix-approve-wrong-step/.spec-context.json
@@ -1,0 +1,283 @@
+{
+  "workflow": "sdd",
+  "specName": "Fix Approve Wrong Step",
+  "branch": "main",
+  "selectedAt": "2026-05-27T17:33:44.927Z",
+  "currentStep": "done",
+  "status": "completed",
+  "type": "fix",
+  "createdAt": "2026-05-27T17:33:44.927Z",
+  "approach": "Route the footer Approve dispatch off ctx.currentStep instead of docType in handleApprove, matching the completion-target source of truth.",
+  "step_summaries": {
+    "specify": {
+      "complexity": "minimal",
+      "requirements": 4,
+      "scenarios": 3,
+      "key_finding": "B1 fix in PR #182 (messageHandlers.ts:394) already reads ctx.currentStep for completion-target; dispatch routing at line 373 still reads docType \u2014 same shape of bug, same fix pattern."
+    },
+    "plan": {
+      "approach_summary": "Route the footer Approve dispatch off ctx.currentStep instead of docType in handleApprove, matching the completion-target source of truth.",
+      "files_planned": 3,
+      "risks": [
+        "Test scaffolding for handleApprove may not exist yet \u2014 mocking may be heavier than the production change",
+        "relatedDoc.parentStep fallback path demotes from primary to secondary; exercise the related-doc scenario manually"
+      ],
+      "principles_concerns": 0,
+      "domain_concerns": 0,
+      "significance_score": 0
+    }
+  },
+  "history": [
+    {
+      "step": "specify",
+      "substep": null,
+      "kind": "start",
+      "from": {
+        "step": null,
+        "substep": null
+      },
+      "by": "extension",
+      "at": "2026-05-27T17:33:44.927Z"
+    },
+    {
+      "step": "specify",
+      "substep": null,
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-05-27T17:35:45Z"
+    },
+    {
+      "step": "plan",
+      "substep": null,
+      "kind": "start",
+      "from": {
+        "step": "specify",
+        "substep": null
+      },
+      "by": "ai",
+      "at": "2026-05-27T17:35:45Z"
+    },
+    {
+      "step": "plan",
+      "substep": null,
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-05-27T17:35:45Z"
+    },
+    {
+      "step": "tasks",
+      "substep": null,
+      "kind": "start",
+      "from": {
+        "step": "plan",
+        "substep": null
+      },
+      "by": "ai",
+      "at": "2026-05-27T17:35:45Z"
+    },
+    {
+      "step": "tasks",
+      "substep": null,
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-05-27T17:35:45Z"
+    },
+    {
+      "step": "plan",
+      "substep": null,
+      "kind": "start",
+      "from": {
+        "step": "tasks",
+        "substep": null
+      },
+      "by": "extension",
+      "at": "2026-05-27T17:36:20.152Z"
+    },
+    {
+      "step": "plan",
+      "substep": "research",
+      "kind": "start",
+      "from": {
+        "step": "plan",
+        "substep": null
+      },
+      "by": "ai",
+      "at": "2026-05-27T17:41:13Z"
+    },
+    {
+      "step": "plan",
+      "substep": "design",
+      "kind": "start",
+      "from": {
+        "step": "plan",
+        "substep": "research"
+      },
+      "by": "ai",
+      "at": "2026-05-27T17:41:13Z"
+    },
+    {
+      "step": "plan",
+      "substep": null,
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-05-27T17:42:10Z"
+    },
+    {
+      "step": "tasks",
+      "substep": null,
+      "kind": "start",
+      "from": {
+        "step": "plan",
+        "substep": null
+      },
+      "by": "ai",
+      "at": "2026-05-27T17:43:25Z"
+    },
+    {
+      "step": "tasks",
+      "substep": null,
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-05-27T17:44:11Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "kind": "start",
+      "from": {
+        "step": "tasks",
+        "substep": null
+      },
+      "by": "extension",
+      "at": "2026-05-27T19:15:15.574Z"
+    }
+  ],
+  "reviewComments": [
+    {
+      "id": "ref-1779909235727-kh3cv",
+      "doc": "plan",
+      "anchor": {
+        "heading": "Modify",
+        "blockText": "- `src/features/spec-viewer/messageHandlers.ts` \u2014 in `handleApprove` (~line 373\u2013388), change the `currentIndex = navSteps.findIndex((s) => s.name === docType)` line to search by `ctx.currentStep` first, then keep the `docType` related-doc fallback when the primary lookup misses.",
+        "line": 15
+      },
+      "comment": "This should be fixed",
+      "status": "pending",
+      "createdAt": "2026-05-27T19:13:55.731Z"
+    }
+  ],
+  "currentTask": null,
+  "progress": null,
+  "next": "done",
+  "workingBranch": "fix/116-fix-approve-wrong-step",
+  "transitions": [
+    {
+      "step": "implement",
+      "substep": "phase1",
+      "from": {
+        "step": "tasks",
+        "substep": null
+      },
+      "by": "sdd",
+      "at": "2026-05-27T19:23:31.850Z"
+    },
+    {
+      "step": "implement",
+      "substep": "phase1",
+      "from": {
+        "step": "implement",
+        "substep": "phase1"
+      },
+      "by": "sdd",
+      "at": "2026-05-27T19:23:55.887Z"
+    },
+    {
+      "step": "implement",
+      "substep": "phase1",
+      "from": {
+        "step": "implement",
+        "substep": "phase1"
+      },
+      "by": "sdd",
+      "at": "2026-05-27T19:24:59.071Z"
+    },
+    {
+      "step": "implement",
+      "substep": "phase1",
+      "from": {
+        "step": "implement",
+        "substep": "phase1"
+      },
+      "by": "sdd",
+      "at": "2026-05-27T19:28:01.284Z"
+    },
+    {
+      "step": "implement",
+      "substep": "test-results",
+      "from": {
+        "step": "implement",
+        "substep": "code-review"
+      },
+      "by": "sdd",
+      "at": "2026-05-27T20:22:19.193Z"
+    },
+    {
+      "step": "implement",
+      "substep": "commit-review",
+      "from": {
+        "step": "implement",
+        "substep": "test-results"
+      },
+      "by": "sdd",
+      "at": "2026-05-27T20:24:39.3NZ"
+    },
+    {
+      "step": "done",
+      "substep": null,
+      "from": {
+        "step": "implement",
+        "substep": "commit-review"
+      },
+      "by": "sdd",
+      "at": "2026-05-27T20:25:39.3NZ"
+    }
+  ],
+  "task_summaries": {
+    "T001": {
+      "status": "DONE",
+      "did": "Verified working-tree CLAUDE.md changes (storybook stories rule, no-hard-wrap rule, Code Comments section, Feature\u2192README stories row) ride this commit",
+      "files": [
+        "CLAUDE.md"
+      ],
+      "concerns": []
+    },
+    "T002": {
+      "status": "DONE",
+      "did": "handleApprove now resolves currentIndex via ctx.currentStep first; falls back to docType/related-doc only when currentStep isn't in navSteps",
+      "files": [
+        "src/features/spec-viewer/messageHandlers.ts"
+      ],
+      "concerns": []
+    },
+    "T003": {
+      "status": "DONE",
+      "did": "Added handleApprove dispatch-routing tests; both past-tab and same-tab cases assert /speckit.implement dispatches; all 680 tests pass",
+      "files": [
+        "tests/unit/spec-viewer/messageHandlers.spec.ts"
+      ],
+      "concerns": []
+    }
+  },
+  "last_action": "CP2 passed \u2014 680 tests green",
+  "files_modified": [
+    "CLAUDE.md",
+    "src/features/spec-viewer/messageHandlers.ts",
+    "tests/unit/spec-viewer/messageHandlers.spec.ts"
+  ],
+  "drainedSeq": 7,
+  "updated": "2026-05-27",
+  "checkpointStatus": {
+    "commit": true,
+    "pr": true
+  }
+}

--- a/specs/116-fix-approve-wrong-step/.spec-context.json
+++ b/specs/116-fix-approve-wrong-step/.spec-context.json
@@ -240,6 +240,16 @@
       },
       "by": "sdd",
       "at": "2026-05-27T20:25:39.3NZ"
+    },
+    {
+      "step": "done",
+      "substep": null,
+      "from": {
+        "step": "done",
+        "substep": null
+      },
+      "by": "sdd",
+      "at": "2026-05-27T20:26:21.3NZ"
     }
   ],
   "task_summaries": {
@@ -268,16 +278,18 @@
       "concerns": []
     }
   },
-  "last_action": "CP2 passed \u2014 680 tests green",
+  "last_action": "PR #186 opened \u2014 fix(spec-viewer): approve dispatches off ctx.currentStep, not docType (116)",
   "files_modified": [
     "CLAUDE.md",
     "src/features/spec-viewer/messageHandlers.ts",
     "tests/unit/spec-viewer/messageHandlers.spec.ts"
   ],
-  "drainedSeq": 7,
+  "drainedSeq": 8,
   "updated": "2026-05-27",
   "checkpointStatus": {
     "commit": true,
     "pr": true
-  }
+  },
+  "prUrl": "https://github.com/alfredoperez/speckit-companion/pull/186",
+  "prNumber": 186
 }

--- a/specs/116-fix-approve-wrong-step/plan.md
+++ b/specs/116-fix-approve-wrong-step/plan.md
@@ -1,0 +1,30 @@
+# Plan: Fix Approve Wrong Step
+
+**Spec**: [spec.md](./spec.md)
+
+## Approach
+
+Inside `handleApprove`, compute `currentIndex` from `ctx.currentStep` first; only fall back to the `docType`-based related-doc / parent-step resolution when `ctx.currentStep` isn't in `navSteps` (e.g., the `actionOnly` `implement` step). The completion-target write already reads `ctx.currentStep` — the dispatch routing just needs the same source of truth. The `docType` fallback stays so the function remains defensive against the actionOnly edge case.
+
+Also bundled in this PR: documentation rules already staged in the working tree on `CLAUDE.md` — a stories-sibling-update rule, a no-hard-wrapped-paragraphs markdown rule, and a code-comments hygiene section. They ride the same commit at the user's request so the guidance lands together.
+
+## Files to Change
+
+### Modify
+
+- `src/features/spec-viewer/messageHandlers.ts` — in `handleApprove` (~line 373–388), change the `currentIndex = navSteps.findIndex((s) => s.name === docType)` line to search by `ctx.currentStep` first, then keep the `docType` related-doc fallback when the primary lookup misses.
+- `CLAUDE.md` — already staged: stories sibling-update rule, markdown no-hard-wrap rule, code-comments section, new Feature→README row for stories. Commit as-is — no further edits.
+
+### Create
+
+- `tests/unit/spec-viewer/handleApprove-dispatch.spec.ts` (or extend `messageHandlers.spec.ts` if the existing scaffolding covers `handleApprove`) — one regression case: `ctx.currentStep = "tasks"`, `docType = "specify"`, assert dispatched command is `/speckit.implement`. One same-step sanity case as a control.
+
+## Testing Strategy
+
+- **Unit**: Jest test that mocks `resolveWorkflowSteps`, `getInstance`, `executeStepInTerminal` (via `deps`), and `readSpecContextSync` to return `currentStep: "tasks"`. Assert the step passed into `executeStepInTerminal` is the implement step (not plan or tasks).
+- **Manual**: Walk a spec to `currentStep=tasks` (use `specs/_02_demo-tasked`), click the **Specification** stepper tab, click footer **Implement** → output channel logs `/speckit.implement`. Repeat for `specify→plan` and `plan→tasks` transitions with the stepper pointed at earlier tabs.
+
+## Risks
+
+- **Test scaffolding for `handleApprove` may not exist yet.** `messageHandlers.spec.ts` is small; mocking `getInstance`, `resolveWorkflowSteps`, `executeStepInTerminal`, and `readSpecContextSync` may be heavier than the production change. If so, keep the test minimal — assert only the dispatched step name.
+- **`relatedDoc.parentStep` fallback path** demotes from primary to secondary. The third spec scenario (viewing a related doc while `ctx.currentStep` is a lifecycle step) must still pass — exercise it manually after the change.

--- a/specs/116-fix-approve-wrong-step/spec.md
+++ b/specs/116-fix-approve-wrong-step/spec.md
@@ -1,0 +1,60 @@
+# Spec: Fix Approve Wrong Step
+
+**Slug**: 116-fix-approve-wrong-step | **Date**: 2026-05-27
+
+## Summary
+
+The footer Approve button labels itself from `ctx.currentStep` but dispatches
+its `/speckit.*` command based on the currently-viewed stepper tab (`docType`).
+When the user navigates backward to a past tab after the spec has advanced,
+the label and the dispatch diverge — clicking **Implement** from the
+Specification tab fires `/speckit.plan`. This fix routes the dispatch off
+`ctx.currentStep` so the label and the action always agree.
+
+## Requirements
+
+- **R001** (MUST): When `handleApprove` runs, the dispatched next-step command
+  MUST be derived from `ctx.currentStep` (the spec's actual current step), not
+  from `docType` (the viewed stepper tab).
+- **R002** (MUST): When `ctx.currentStep` is a lifecycle step present in
+  `navSteps`, the `docType`-based related-doc / parent-step fallback MUST NOT
+  run. The fallback only applies when `ctx.currentStep` is not in `navSteps`
+  (e.g., the `actionOnly` `implement` step).
+- **R003** (MUST): The label-derivation path (`getFooterActions` call in
+  `stateDerivation.ts`) MUST remain unchanged — it is already correct.
+- **R004** (MUST): A unit test in `tests/unit/spec-viewer/` MUST construct a
+  context with `currentStep = "tasks"` and `docType = "specify"`, invoke the
+  approve handler, and assert the dispatched command is `/speckit.implement`
+  (not `/speckit.plan`).
+
+## Scenarios
+
+### Approve from a past stepper tab
+
+**When** the spec is at `currentStep = "tasks"` and the user clicks the
+**Specification** tab, then clicks the footer **Implement** button
+**Then** `/speckit.implement` is dispatched (not `/speckit.plan` or
+`/speckit.tasks`), and the SpecKit output channel logs
+`Executing step "Implement": /speckit.implement …`.
+
+### Approve from the current stepper tab (no regression)
+
+**When** the spec is at `currentStep = "tasks"` and the user is viewing the
+Tasks tab, then clicks the footer **Implement** button
+**Then** `/speckit.implement` is dispatched — same as today, no change.
+
+### Approve while viewing a related (child) doc
+
+**When** `ctx.currentStep` is a lifecycle step in `navSteps` and the user is
+viewing a related doc whose `parentStep` is some earlier step
+**Then** the dispatch still routes off `ctx.currentStep`; the
+`relatedDoc.parentStep` fallback path does not override it.
+
+## Out of Scope
+
+- Removing the `step !== ctx.currentStep` guard (B2) in `shouldShowApprove` —
+  stays as defense-in-depth.
+- Any change to the label-derivation path.
+- Any change to `actionOnly` step semantics.
+- `handleRegenerate` and other sibling handlers — only `handleApprove` is in
+  scope here (audit them if the same shape recurs, but no edits unless found).

--- a/specs/116-fix-approve-wrong-step/tasks.md
+++ b/specs/116-fix-approve-wrong-step/tasks.md
@@ -1,0 +1,20 @@
+# Tasks: Fix Approve Wrong Step
+
+**Plan**: [plan.md](./plan.md)
+
+## Phase 1: Core Implementation
+
+- [x] **T001 [P]** Bundle staged CLAUDE.md doc rules into this PR's commit — `CLAUDE.md` | (docs)
+  - **Do**: No new edits. The working tree already has the storybook stories sibling-update rule, the "no hard-wrapped paragraphs" markdown rule, the Code Comments section, and the new Feature→README row for stories. Verify the diff before `/sdd:implement` runs `git add` so these land in the same commit as the fix.
+  - **Verify**: `git diff CLAUDE.md` shows the three new rule sections + the new Feature→README row, no stray reverts.
+  - **Leverage**: already-staged working-tree changes from the user.
+
+- [x] **T002** Route Approve dispatch off `ctx.currentStep` — `src/features/spec-viewer/messageHandlers.ts` | R001, R002, R003
+  - **Do**: In `handleApprove` (around line 373–388), read `ctx` earlier (or reuse the existing read at line 394) and compute `currentIndex = navSteps.findIndex((s) => s.name === ctx.currentStep)` first. Only run the `docType`-based related-doc / `parentStep` fallback when this primary lookup returns `-1` (covers the `actionOnly` implement step case). Leave the label path in `stateDerivation.ts` untouched.
+  - **Verify**: `npm run compile` passes; manual repro — spec at `currentStep=tasks`, click Specification tab, click Implement → output channel logs `Executing step "Implement": /speckit.implement …`.
+  - **Leverage**: existing completion-target read at line 394 already reads `ctx.currentStep` — same source-of-truth pattern.
+
+- [x] **T003** Regression test for past-tab dispatch — `tests/unit/spec-viewer/messageHandlers.spec.ts` | R004
+  - **Do**: Extend the existing `messageHandlers.spec.ts` with a `describe("handleApprove dispatch routing")` block. Construct `ctx` with `currentStep = "tasks"`, build an instance whose `currentDocument = "specify"`, mock `resolveWorkflowSteps` to return canonical navSteps + actionOnly implement, invoke `handleApprove`, and assert the step passed to `executeStepInTerminal` is the implement step (its name = `"implement"`, dispatched command = `/speckit.implement`). Add a same-step control case (`currentStep = "tasks"`, `currentDocument = "tasks"`) that asserts the same outcome — no regression.
+  - **Verify**: `npm test` — new tests pass alongside existing message-handlers tests.
+  - **Leverage**: existing scaffolding in `tests/unit/spec-viewer/messageHandlers.spec.ts` and the VS Code mock at `tests/__mocks__/vscode.ts`.

--- a/src/features/spec-viewer/messageHandlers.ts
+++ b/src/features/spec-viewer/messageHandlers.ts
@@ -370,28 +370,31 @@ async function handleApprove(
   const instance = deps.getInstance(specDirectory);
   if (!instance) return;
 
-  const docType = instance.state.currentDocument;
+  const ctx = readSpecContextSync(specDirectory);
   const steps = await deps.resolveWorkflowSteps(specDirectory);
-  // Filter out actionOnly steps for navigation purposes
   const navSteps = steps.filter((s) => !s.actionOnly);
-  let currentIndex = navSteps.findIndex((s) => s.name === docType);
+
+  // Dispatch routes off ctx.currentStep so a past stepper tab can't
+  // misdirect the action. Fall back to docType only when currentStep
+  // isn't a navStep (e.g. the actionOnly implement step).
+  let currentIndex = ctx?.currentStep
+    ? navSteps.findIndex((s) => s.name === ctx.currentStep)
+    : -1;
   if (currentIndex < 0) {
-    // Viewing a related doc — resolve parent step
-    const relatedDoc = instance.state.availableDocuments.find(
-      (d) => d.type === docType && d.category === "related",
-    );
-    if (relatedDoc?.parentStep) {
-      currentIndex = navSteps.findIndex(
-        (s) => s.name === relatedDoc.parentStep,
+    const docType = instance.state.currentDocument;
+    currentIndex = navSteps.findIndex((s) => s.name === docType);
+    if (currentIndex < 0) {
+      const relatedDoc = instance.state.availableDocuments.find(
+        (d) => d.type === docType && d.category === "related",
       );
+      if (relatedDoc?.parentStep) {
+        currentIndex = navSteps.findIndex(
+          (s) => s.name === relatedDoc.parentStep,
+        );
+      }
     }
   }
 
-  // Mark the spec's actual current step as completed. Target is
-  // `ctx.currentStep` (not `docType`) so clicking Approve while viewing
-  // a child doc still records the right completion. Skip if the AI
-  // already wrote one — avoids duplicate completion entries.
-  const ctx = readSpecContextSync(specDirectory);
   const targetStep = ctx?.currentStep;
   if (targetStep && isLifecycleStep(targetStep)) {
     const alreadyComplete = lastEntryIsCompletionFor(

--- a/tests/unit/spec-viewer/messageHandlers.spec.ts
+++ b/tests/unit/spec-viewer/messageHandlers.spec.ts
@@ -1,7 +1,5 @@
 /**
- * Unit tests for messageHandlers — T005
- * Verifies that handleAddComment resolves sourceDoc via fileName fallback
- * when availableDocuments has type='specify' instead of type='spec'.
+ * Unit tests for messageHandlers.
  */
 
 import * as vscode from "vscode";
@@ -9,23 +7,54 @@ import type { MessageHandlerDependencies } from "../../../src/features/spec-view
 import { createMessageHandlers } from "../../../src/features/spec-viewer/messageHandlers";
 import type { SpecViewerState } from "../../../src/features/spec-viewer/types";
 
-// Mock heavy dependencies that write to disk
+const mockCtx: { currentStep: string } = { currentStep: "specify" };
+
 jest.mock("../../../src/features/specs/specContextReader", () => ({
   SPEC_CONTEXT_FILENAME: ".spec-context.json",
-  readSpecContext: jest.fn().mockResolvedValue({
+  readSpecContext: jest.fn().mockImplementation(async () => ({
     workflow: "speckit-companion",
     specName: "test",
     branch: "main",
-    currentStep: "specify",
+    currentStep: mockCtx.currentStep,
     status: "draft",
     stepHistory: {},
     transitions: [],
+    history: [],
     reviewComments: [],
-  }),
+  })),
+  readSpecContextSync: jest.fn().mockImplementation(() => ({
+    workflow: "speckit-companion",
+    specName: "test",
+    branch: "main",
+    currentStep: mockCtx.currentStep,
+    status: "draft",
+    history: [],
+    reviewComments: [],
+  })),
 }));
 
 jest.mock("../../../src/features/specs/specContextWriter", () => ({
   updateSpecContext: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock("../../../src/features/specs/stepLifecycle", () => ({
+  completeStep: jest.fn().mockResolvedValue(undefined),
+  startStep: jest.fn().mockResolvedValue(undefined),
+  reactivate: jest.fn().mockResolvedValue(undefined),
+  setStatus: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock("../../../src/features/specs/historyHelpers", () => ({
+  lastEntryIsCompletionFor: jest.fn().mockReturnValue(false),
+}));
+
+jest.mock("../../../src/ai-providers/aiProvider", () => ({
+  formatCommandForProvider: (cmd: string) => cmd,
+}));
+
+jest.mock("../../../src/ai-providers/promptBuilder", () => ({
+  buildPrompt: (opts: { command: string }) => opts.command,
+  buildLifecyclePrompt: (opts: { command: string }) => opts.command,
 }));
 
 const SPEC_DIR = "/tmp/test-spec";
@@ -49,10 +78,13 @@ function makeSpecDocument(
 
 function makeDeps(
   availableDocuments: ReturnType<typeof makeSpecDocument>[],
+  overrides: Partial<MessageHandlerDependencies> = {},
+  stateOverrides: Partial<SpecViewerState> = {},
 ): MessageHandlerDependencies {
   const state: Partial<SpecViewerState> = {
     availableDocuments: availableDocuments as any,
     changeRoot: null,
+    ...stateOverrides,
   };
   return {
     getInstance: () => ({
@@ -66,8 +98,21 @@ function makeDeps(
     executeInTerminal: jest.fn().mockResolvedValue(undefined),
     outputChannel: { appendLine: jest.fn() } as any,
     context: {} as any,
+    ...overrides,
   };
 }
+
+const lifecycleSteps = [
+  { name: "specify", label: "Specify", command: "speckit.specify" },
+  { name: "plan", label: "Plan", command: "speckit.plan" },
+  { name: "tasks", label: "Tasks", command: "speckit.tasks" },
+  {
+    name: "implement",
+    label: "Implement",
+    command: "speckit.implement",
+    actionOnly: true,
+  },
+];
 
 describe("handleAddComment — sourceDoc resolution (T005)", () => {
   const readFileMock = vscode.workspace.fs.readFile as jest.Mock;
@@ -143,5 +188,49 @@ describe("handleAddComment — sourceDoc resolution (T005)", () => {
 
     // Assert: readFile NOT called — no sourceDoc resolved
     expect(readFileMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("handleApprove dispatch routing", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("dispatches /speckit.implement when ctx.currentStep is 'tasks' even if user is viewing the Specification tab", async () => {
+    mockCtx.currentStep = "tasks";
+    const docs = [makeSpecDocument("specify", "spec.md", SPEC_FILE_PATH, true)];
+    const deps = makeDeps(
+      docs,
+      {
+        resolveWorkflowSteps: jest.fn().mockResolvedValue(lifecycleSteps),
+      },
+      { currentDocument: "specify" as any },
+    );
+    const handler = createMessageHandlers(SPEC_DIR, deps);
+
+    await handler({ type: "approve" } as any);
+
+    const prompt = (deps.executeInTerminal as jest.Mock).mock.calls[0]?.[0];
+    expect(prompt).toContain("/speckit.implement");
+    expect(prompt).not.toContain("/speckit.plan");
+    expect(prompt).not.toContain("/speckit.tasks");
+  });
+
+  it("dispatches /speckit.implement when ctx.currentStep is 'tasks' and the user is viewing the Tasks tab (no regression)", async () => {
+    mockCtx.currentStep = "tasks";
+    const docs = [makeSpecDocument("tasks", "tasks.md", `${SPEC_DIR}/tasks.md`, true)];
+    const deps = makeDeps(
+      docs,
+      {
+        resolveWorkflowSteps: jest.fn().mockResolvedValue(lifecycleSteps),
+      },
+      { currentDocument: "tasks" as any },
+    );
+    const handler = createMessageHandlers(SPEC_DIR, deps);
+
+    await handler({ type: "approve" } as any);
+
+    const prompt = (deps.executeInTerminal as jest.Mock).mock.calls[0]?.[0];
+    expect(prompt).toContain("/speckit.implement");
   });
 });


### PR DESCRIPTION
## What

- `handleApprove` resolves `currentIndex` via `ctx.currentStep` first; falls back to `docType`/related-doc only when `currentStep` isn't in navSteps
- Regression tests cover past-tab dispatch (currentStep=tasks, viewing spec → Implement runs `/speckit.implement`) and same-tab control
- CLAUDE.md picks up storybook stories rule, no-hard-wrap markdown rule, Code Comments section, and Feature→README stories row

## Why

Clicking Approve from a *past* tab (e.g. viewing Specification while at `currentStep=tasks`) dispatched the past step instead of the current one, because routing read `docType` while completion-target already read `ctx.currentStep`.

## Testing

- `npm test` — 57 suites, 680 tests pass
- Manual: open a `tasks`-step spec, click Specification tab, click Implement → output channel logs `/speckit.implement`

Closes #116