### PR TITLE
fix(spec-viewer): gate file-ref pills on extension allow-list, not dot heuristic

### DIFF
--- a/specs/117-fix-inline-code-fileref/.spec-context.json
+++ b/specs/117-fix-inline-code-fileref/.spec-context.json
@@ -1,0 +1,111 @@
+{
+  "workflow": "sdd",
+  "specName": "Fix Inline-Code Misdetected as File-Ref",
+  "branch": "main",
+  "selectedAt": "2026-05-27T21:11:00.089Z",
+  "currentStep": "implement",
+  "status": "implemented",
+  "approach": "Replace the loose filename heuristic in parseInline's backtick handler with an allow-list match on known file extensions.",
+  "step_summaries": {
+    "plan": {
+      "approach_summary": "Replace the loose filename heuristic in parseInline's backtick handler with an allow-list match on known file extensions.",
+      "files_planned": 2,
+      "risks": [
+        "Allow-list omits an extension that appears in real specs (e.g. .toml, .svg): user-visible regression where a real filename renders as plain <code>. Mitigation: the R002 list already covers every extension currently appearing in specs/** and the repo source tree; widening it is a one-line edit."
+      ],
+      "principles_concerns": 0,
+      "domain_concerns": 0,
+      "significance_score": 0
+    },
+    "tasks": {
+      "tasks_total": 2,
+      "parallel_groups": 1
+    }
+  },
+  "task_summaries": {
+    "T001": {
+      "status": "DONE",
+      "did": "Replaced the loose filename regex in parseInline with a KNOWN_EXTENSIONS allow-list gate; basename/path/title emission unchanged.",
+      "files": ["webview/src/spec-viewer/markdown/inline.ts"]
+    },
+    "T002": {
+      "status": "DONE",
+      "did": "Added four negative-case tests covering ctx.currentStep, process.env, instance.panel.visible, and weird.xyz; all assert plain <code> and no file-ref/button.",
+      "files": ["webview/src/spec-viewer/markdown/inline.test.ts"]
+    }
+  },
+  "history": [
+    {
+      "step": "specify",
+      "substep": null,
+      "kind": "start",
+      "from": {
+        "step": null,
+        "substep": null
+      },
+      "by": "extension",
+      "at": "2026-05-27T21:11:00.089Z"
+    },
+    {
+      "step": "specify",
+      "substep": null,
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-05-27T21:11:39Z"
+    },
+    {
+      "step": "plan",
+      "substep": null,
+      "kind": "start",
+      "from": {
+        "step": "specify",
+        "substep": null
+      },
+      "by": "extension",
+      "at": "2026-05-27T21:27:51.988Z"
+    },
+    {
+      "step": "plan",
+      "substep": null,
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-05-27T21:29:23Z"
+    },
+    {
+      "step": "tasks",
+      "substep": null,
+      "kind": "start",
+      "from": {
+        "step": "plan",
+        "substep": null
+      },
+      "by": "extension",
+      "at": "2026-05-27T21:42:54Z"
+    },
+    {
+      "step": "tasks",
+      "substep": null,
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-05-27T21:43:13Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "kind": "start",
+      "from": {
+        "step": "tasks",
+        "substep": null
+      },
+      "by": "extension",
+      "at": "2026-05-27T21:44:03.661Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-05-27T21:45:53Z"
+    }
+  ]
+}

--- a/specs/117-fix-inline-code-fileref/.spec-context.json
+++ b/specs/117-fix-inline-code-fileref/.spec-context.json
@@ -4,7 +4,9 @@
   "branch": "main",
   "selectedAt": "2026-05-27T21:11:00.089Z",
   "currentStep": "implement",
-  "status": "implemented",
+  "status": "completed",
+  "prUrl": "https://github.com/alfredoperez/speckit-companion/pull/187",
+  "prNumber": 187,
   "approach": "Replace the loose filename heuristic in parseInline's backtick handler with an allow-list match on known file extensions.",
   "step_summaries": {
     "plan": {

--- a/specs/117-fix-inline-code-fileref/plan.md
+++ b/specs/117-fix-inline-code-fileref/plan.md
@@ -1,0 +1,18 @@
+# Plan: Fix Inline-Code Misdetected as File-Ref
+
+**Spec**: [spec.md](./spec.md)
+
+## Approach
+
+Replace the loose filename heuristic in `parseInline`'s backtick handler with an allow-list match on known file extensions. The current regex `/[^\s/\\]+\.[a-zA-Z][a-zA-Z0-9]+$/` upgrades any dotted identifier (`ctx.currentStep`, `process.env`) into a `.file-ref` pill; the fix swaps it for a single `KNOWN_EXTENSIONS` set check against the stem's trailing extension. Markup, attributes, and basename/path split stay byte-identical so no CSS, click handler, or downstream code is affected.
+
+## Files
+
+### Modify
+
+- `webview/src/spec-viewer/markdown/inline.ts` — define `KNOWN_EXTENSIONS` (R002 allow-list), replace the inline regex test with a "strip last `.ext`, check membership" gate that still supports path prefixes; keep `data-filename`/`title`/basename emission unchanged.
+- `webview/src/spec-viewer/markdown/inline.test.ts` — add negative cases for `` `ctx.currentStep` ``, `` `process.env` ``, `` `instance.panel.visible` `` and one for an unknown extension (`weird.xyz`); leave all existing positive/negative cases intact.
+
+## Risks
+
+- Allow-list omits an extension that appears in real specs (e.g. `.toml`, `.svg`): user-visible regression where a real filename renders as plain `<code>`. Mitigation: the R002 list already covers every extension currently appearing in `specs/**` and the repo source tree; widening it is a one-line edit.

--- a/specs/117-fix-inline-code-fileref/spec.md
+++ b/specs/117-fix-inline-code-fileref/spec.md
@@ -1,0 +1,45 @@
+# Spec: Fix Inline-Code Misdetected as File-Ref
+
+**Slug**: 117-fix-inline-code-fileref | **Date**: 2026-05-27
+
+## Summary
+
+The spec viewer's inline-markdown renderer upgrades any backtick span ending in `.<letters>` into a clickable `.file-ref` pill, which catches dotted identifiers like `ctx.currentStep`, `process.env`, and `vscode.WorkspaceFolder`. Those render as pills pointing at nonexistent paths and behave like dead links. Tighten the heuristic in `parseInline` so only spans with a known file extension (or a path separator + known extension) become `.file-ref` pills; everything else falls through to plain `<code>`.
+
+## Requirements
+
+- **R001** (MUST): A backtick span whose stem is a dotted identifier (camelCase or dot-namespaced) such as `` `ctx.currentStep` ``, `` `process.env` ``, `` `instance.panel.visible` ``, `` `vscode.WorkspaceFolder` `` MUST render as plain `<code>` — not as `<button class="file-ref">`.
+- **R002** (MUST): A backtick span ending in a known file extension MUST still render as `.file-ref`. The allow-list is: `.ts`, `.tsx`, `.js`, `.jsx`, `.mjs`, `.cjs`, `.md`, `.json`, `.jsonc`, `.css`, `.scss`, `.html`, `.htm`, `.yml`, `.yaml`, `.py`, `.sh`, `.bash`, `.zsh`, `.toml`, `.lock`, `.txt`, `.svg`, `.png`, `.jpg`, `.jpeg`, `.gif`, `.webp`, `.ico`, `.vsix`. Existing positive cases (`package.json`, `card.component.ts`, `_tasks.css`, `src/foo.ts`) continue to render as today.
+- **R003** (MUST): A backtick span containing a path separator (`/` or `\`) followed by a stem ending in a known extension MUST render as `.file-ref`, with the full path preserved in `data-filename`, the same value in `title`, and the basename shown inside `<code>` — same behavior as today.
+- **R004** (MUST): The `data-filename` / `title` / basename split currently in `parseInline` MUST be preserved unchanged. Only the file-vs-code dispatch changes; the `.file-ref` button markup is identical.
+- **R005** (MUST): `webview/src/spec-viewer/markdown/inline.test.ts` MUST be extended with negative cases for `` `ctx.currentStep` ``, `` `process.env` ``, and `` `instance.panel.visible` `` asserting that the output contains `<code>…</code>` and does NOT contain `file-ref` or `<button`. All existing positive and negative cases MUST continue to pass.
+
+## Scenarios
+
+### Dotted identifier in prose
+
+**When** a spec body contains `` `ctx.currentStep` `` and the viewer renders it
+**Then** the output is `<code>ctx.currentStep</code>` — no `.file-ref` pill, no `data-filename`, no tooltip, no clickable affordance.
+
+### Real filename in prose
+
+**When** a spec body contains `` `package.json` `` or `` `card.component.ts` ``
+**Then** the output is `<button class="file-ref" data-filename="…"><code>…</code></button>` — unchanged from today.
+
+### Path-prefixed real file
+
+**When** a spec body contains `` `src/foo.ts` `` or `` `webview/src/spec-viewer/markdown/inline.ts` ``
+**Then** the output is a `.file-ref` button whose `data-filename` and `title` hold the full path and whose `<code>` text shows only the basename — unchanged from today.
+
+### Unknown extension
+
+**When** a spec body contains `` `weird.xyz` `` (an extension not on the allow-list)
+**Then** the output is plain `<code>weird.xyz</code>`. This is an accepted trade-off: an allow-list keeps the heuristic conservative; new extensions are added by editing the list when they show up in real specs.
+
+## Out of Scope
+
+- Changing the visual style, hover behavior, or click handler of `.file-ref` pills.
+- Reworking the inline markdown renderer or replacing it with a library.
+- Making the extension allow-list user-configurable per workspace or per workflow.
+- Tightening other dispatch heuristics in `parseInline` (links, images, emphasis) — only the backtick-handler filename branch is in scope.
+- Any change to how `.file-ref` clicks resolve files in the extension host.

--- a/specs/117-fix-inline-code-fileref/tasks.md
+++ b/specs/117-fix-inline-code-fileref/tasks.md
@@ -1,0 +1,16 @@
+# Tasks: Fix Inline-Code Misdetected as File-Ref
+
+**Plan**: [plan.md](./plan.md)
+
+> Format reference: `[P]` markers and parallel groups — see `skills/tasks/SKILL.md` § Phase rules.
+
+## Phase 1: Core Implementation
+
+- [x] **T001** Replace filename heuristic with extension allow-list — `webview/src/spec-viewer/markdown/inline.ts` | R001, R002, R003, R004
+  - **Do**: Add a module-level `KNOWN_EXTENSIONS` `Set<string>` with the R002 list (`.ts`, `.tsx`, `.js`, `.jsx`, `.mjs`, `.cjs`, `.md`, `.json`, `.jsonc`, `.css`, `.scss`, `.html`, `.htm`, `.yml`, `.yaml`, `.py`, `.sh`, `.bash`, `.zsh`, `.toml`, `.lock`, `.txt`, `.svg`, `.png`, `.jpg`, `.jpeg`, `.gif`, `.webp`, `.ico`, `.vsix`). In the `.replace(/`([^`]+)`/g, …)` callback, derive the basename (split on `/` and `\`), grab its last `.<ext>` segment via a single regex, and dispatch to the `.file-ref` branch only when `KNOWN_EXTENSIONS.has('.' + ext.toLowerCase())`. Keep the existing `data-filename` / `title` / basename emission byte-identical — only the gate changes.
+  - **Verify**: `npm test -- inline.test` passes; `npm run compile` clean.
+
+- [x] **T002** [P] Add negative-case tests for dotted identifiers and unknown extensions — `webview/src/spec-viewer/markdown/inline.test.ts` | R005
+  - **Do**: Inside the existing `describe('non-filename code span → plain <code>', …)` block, add four `it` cases asserting `parseInline` output contains `<code>…</code>` and does NOT contain `file-ref` or `<button` for inputs `` `ctx.currentStep` ``, `` `process.env` ``, `` `instance.panel.visible` ``, and `` `weird.xyz` ``. Leave all existing positive and negative cases untouched.
+  - **Verify**: `npm test -- inline.test` — all old cases still green, four new cases green.
+  - **Leverage**: existing `'renders a shell command as plain <code>, not a button'` test in the same file as the assertion shape.

--- a/webview/src/spec-viewer/markdown/inline.test.ts
+++ b/webview/src/spec-viewer/markdown/inline.test.ts
@@ -109,6 +109,58 @@ describe('parseInline', () => {
             expect(result).toContain('<code>foobar</code>');
             expect(result).not.toContain('file-ref');
         });
+
+        it('renders a dotted property accessor as plain <code>, not a button', () => {
+            // Arrange
+            const input = '`ctx.currentStep`';
+
+            // Act
+            const result = parseInline(input);
+
+            // Assert
+            expect(result).toContain('<code>ctx.currentStep</code>');
+            expect(result).not.toContain('file-ref');
+            expect(result).not.toContain('<button');
+        });
+
+        it('renders a process.env reference as plain <code>, not a button', () => {
+            // Arrange
+            const input = '`process.env`';
+
+            // Act
+            const result = parseInline(input);
+
+            // Assert
+            expect(result).toContain('<code>process.env</code>');
+            expect(result).not.toContain('file-ref');
+            expect(result).not.toContain('<button');
+        });
+
+        it('renders a multi-segment property chain as plain <code>, not a button', () => {
+            // Arrange
+            const input = '`instance.panel.visible`';
+
+            // Act
+            const result = parseInline(input);
+
+            // Assert
+            expect(result).toContain('<code>instance.panel.visible</code>');
+            expect(result).not.toContain('file-ref');
+            expect(result).not.toContain('<button');
+        });
+
+        it('renders an unknown extension as plain <code>, not a button', () => {
+            // Arrange
+            const input = '`weird.xyz`';
+
+            // Act
+            const result = parseInline(input);
+
+            // Assert
+            expect(result).toContain('<code>weird.xyz</code>');
+            expect(result).not.toContain('file-ref');
+            expect(result).not.toContain('<button');
+        });
     });
 
     // -------------------------------------------------------------------------

--- a/webview/src/spec-viewer/markdown/inline.ts
+++ b/webview/src/spec-viewer/markdown/inline.ts
@@ -3,6 +3,18 @@
  * Handles inline markdown elements like bold, italic, code, links
  */
 
+const KNOWN_EXTENSIONS = new Set<string>([
+    '.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs',
+    '.md', '.json', '.jsonc',
+    '.css', '.scss',
+    '.html', '.htm',
+    '.yml', '.yaml',
+    '.py', '.sh', '.bash', '.zsh',
+    '.toml', '.lock', '.txt',
+    '.svg', '.png', '.jpg', '.jpeg', '.gif', '.webp', '.ico',
+    '.vsix',
+]);
+
 /**
  * Escape HTML entities
  */
@@ -41,10 +53,12 @@ export function parseInline(text: string): string {
         .replace(/>/g, '&gt;')
         // Stash inline code
         .replace(/`([^`]+)`/g, (_match, code) => {
-            const filenamePattern = /[^\s/\\]+\.[a-zA-Z][a-zA-Z0-9]+$/;
-            if (filenamePattern.test(code)) {
+            const lastSlash = Math.max(code.lastIndexOf('/'), code.lastIndexOf('\\'));
+            const basename = lastSlash >= 0 ? code.slice(lastSlash + 1) : code;
+            const extMatch = basename.match(/\.[a-zA-Z0-9]+$/);
+            const ext = extMatch ? extMatch[0].toLowerCase() : '';
+            if (ext && KNOWN_EXTENSIONS.has(ext)) {
                 const hasDir = code.includes('/');
-                const basename = hasDir ? code.slice(code.lastIndexOf('/') + 1) : code;
                 const titleAttr = hasDir ? ` title="${code}"` : '';
                 codeSpans.push(`<button class="file-ref" data-filename="${code}"${titleAttr}><code>${basename}</code></button>`);
             } else {


### PR DESCRIPTION
## What

- Replace the loose filename heuristic (`/[^\s/\\]+\.[a-zA-Z][a-zA-Z0-9]+$/`) in `parseInline` with an allow-list check against a `KNOWN_EXTENSIONS` set.
- Dotted identifiers like `ctx.currentStep`, `process.env`, and `instance.panel.visible` now render as plain `<code>` instead of clickable `file-ref` buttons that 404 on click.
- Real filenames (`card.component.ts`, `src/utils/helpers.ts`, etc.) still render as `file-ref` buttons — `data-filename`/`title`/basename emission is byte-identical.

## Why

The previous regex matched anything `name.something` shape, so prose like `ctx.currentStep` got upgraded into a file-ref pill and clicking it asked VS Code to open a nonexistent file. Switching to an explicit extension allow-list (R002 list from the spec) gates the pill on file-ish suffixes only.

## Testing

- `npm test -- inline.test` — 17/17 passing (4 new negative cases: dotted accessor, `process.env`, multi-segment chain, unknown extension).
- `npm run compile` — clean.
- Manually verify in the viewer: inline code with property accessors no longer renders as buttons; real file paths still do.