### PR TITLE
fix(spec-context): refuse to clobber unreadable .spec-context.json on tab clicks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- **`.spec-context.json` wipe on tab click**: a transient read failure (concurrent CLI write → partial JSON → `JSON.parse` throws) used to be conflated with "file doesn't exist" at every layer — `readSpecContext`, `getFeatureWorkflow`, and `writeSpecContext` all silently treated read errors as `null`. The spec viewer's `ensureSpecContext` would then write a fresh `backfillMinimalContext` (raw-basename `specName`, empty `history`, `status: 'draft'`) over the real file, destroying lifecycle history. Fixed across the stack: the readers now return `null` only for `ENOENT` and throw on parse/IO errors; `writeSpecContext` stat-guards the target and refuses to write when an existing file is present-but-unreadable; the spec viewer's `updateContent` only calls `ensureSpecContext` on the first open of a panel (subsequent tab clicks are strictly read-only); `saveFeatureWorkflow` only emits a minimal context on `ENOENT`. New regression tests (`specContextWipeGuard.test.ts`) pin the on-disk file-unchanged invariant.
+
 ### Changed
 
 - **Spec viewer in-flight footer** (spec 115): `Generating <Step>…` is no longer rendered as a disabled primary button — it's now a non-clickable accent-tinted status chip (pill + spinner) on the **right** with `role="status"` / `aria-live="polite"`. The `Mark step complete` manual override moves to the **left** styled as a quiet secondary action, communicating "one thing is happening, one thing is a fallback override." Applies uniformly to specify / plan / tasks / implement. No behavior change to the override click handler; approve / inline-comment / post-completion footer modes are unchanged.

--- a/src/features/spec-viewer/messageHandlers.ts
+++ b/src/features/spec-viewer/messageHandlers.ts
@@ -32,7 +32,7 @@ import {
   startStep,
 } from "../specs/stepLifecycle";
 import { getFeatureWorkflow, getWorkflowCommands } from "../workflows";
-import type { WorkflowStepConfig } from "../workflows/types";
+import type { FeatureWorkflowContext, WorkflowStepConfig } from "../workflows/types";
 import { isOptionalCommand } from "./optionalCommands";
 import {
   addComment as addCommentToCtx,
@@ -444,7 +444,14 @@ async function handleMarkStepComplete(
   const instance = deps.getInstance(specDirectory);
   if (!instance) return;
 
-  const ctx = await readSpecContext(specDirectory);
+  let ctx: SpecContext | null = null;
+  try {
+    ctx = await readSpecContext(specDirectory);
+  } catch (err) {
+    deps.outputChannel.appendLine(
+      `[SpecViewer] markStepComplete: readSpecContext failed — ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
   const derived = ctx
     ? deriveStepHistory(ctx.history ?? [], ctx.currentStep, ctx.status)
     : undefined;
@@ -571,11 +578,20 @@ async function handleClarify(
     return;
   }
 
-  // Fall back to workflow commands
-  const featureCtx = await getFeatureWorkflow(
-    specDirectory,
-    instance.state.changeRoot,
-  );
+  // Fall back to workflow commands. Tolerate transient read failures —
+  // the dispatch should not crash if .spec-context.json is briefly
+  // unreadable (e.g., mid-write by the AI CLI).
+  let featureCtx: FeatureWorkflowContext | undefined;
+  try {
+    featureCtx = await getFeatureWorkflow(
+      specDirectory,
+      instance.state.changeRoot,
+    );
+  } catch (err) {
+    deps.outputChannel.appendLine(
+      `[SpecViewer] dispatchDocRefinement: getFeatureWorkflow failed — ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
   if (featureCtx?.workflow) {
     for (const wfCmd of getWorkflowCommands(featureCtx.workflow)) {
       if (!wfCmd.command) continue;
@@ -809,7 +825,17 @@ async function persistCommentMutation(
   deps: MessageHandlerDependencies,
 ): Promise<void> {
   const run = async () => {
-    const current = await readSpecContext(specDirectory);
+    let current: SpecContext | null = null;
+    try {
+      current = await readSpecContext(specDirectory);
+    } catch (err) {
+      // Refuse to persist when the existing context is unreadable —
+      // doing so would risk overwriting a real file with the fallback.
+      deps.outputChannel.appendLine(
+        `[SpecViewer] Skipping comment persist — readSpecContext failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      return;
+    }
     if (!current) {
       deps.outputChannel.appendLine(
         "[SpecViewer] No .spec-context.json — skipping comment persist",
@@ -909,7 +935,15 @@ async function dispatchDocRefinement(
 ): Promise<void> {
   const instance = deps.getInstance(specDirectory);
   if (!instance) return;
-  const ctx = await readSpecContext(specDirectory);
+  let ctx: SpecContext | null = null;
+  try {
+    ctx = await readSpecContext(specDirectory);
+  } catch (err) {
+    deps.outputChannel.appendLine(
+      `[SpecViewer] dispatchDocRefinement(comments): readSpecContext failed — ${err instanceof Error ? err.message : String(err)}`,
+    );
+    return;
+  }
   if (!ctx) return;
 
   const pending = pendingForDoc(ctx, doc);

--- a/src/features/spec-viewer/specViewerProvider.ts
+++ b/src/features/spec-viewer/specViewerProvider.ts
@@ -113,13 +113,31 @@ function deriveStepBadgesWithAlias(
  * Create a minimal `.spec-context.json` when none exists (FR-011).
  * Marks only what can be verified: workflow, branch, specName, status=draft.
  * Never reads step files to infer completion.
- * Returns the (newly created or already existing) context.
+ *
+ * On a READ failure (file exists but is mid-write / corrupt / unreadable),
+ * returns an in-memory backfill WITHOUT touching disk — clobbering a real
+ * file because we couldn't parse it would destroy lifecycle history.
  */
 async function ensureSpecContext(
   specDirectory: string,
-  workflowName?: string
+  workflowName?: string,
+  outputChannel?: vscode.OutputChannel,
 ): Promise<ReturnType<typeof readSpecContext> extends Promise<infer T> ? T : never> {
-  const existing = await readSpecContext(specDirectory);
+  let existing: Awaited<ReturnType<typeof readSpecContext>>;
+  try {
+    existing = await readSpecContext(specDirectory);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    outputChannel?.appendLine(
+      `[SpecViewer] readSpecContext failed for ${specDirectory}: ${msg} — rendering with in-memory backfill, NOT writing.`,
+    );
+    const specName = path.basename(specDirectory);
+    return backfillMinimalContext({
+      workflow: workflowName || 'speckit-companion',
+      specName,
+      branch: specName,
+    });
+  }
   if (existing) return existing;
   const specName = path.basename(specDirectory);
   const ctx = backfillMinimalContext({
@@ -129,8 +147,11 @@ async function ensureSpecContext(
   });
   try {
     await writeSpecContext(specDirectory, ctx);
-  } catch {
-    // Non-fatal: viewer still renders.
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    outputChannel?.appendLine(
+      `[SpecViewer] writeSpecContext failed for ${specDirectory}: ${msg}`,
+    );
   }
   return ctx;
 }
@@ -143,6 +164,11 @@ interface PanelInstance {
   state: SpecViewerState;
   debounceTimer: NodeJS.Timeout | undefined;
   lastFeatureCtx?: FeatureWorkflowContext | null;
+  // True after the first updateContent run for this panel. Gates the
+  // ensureSpecContext write so tab clicks never (re)create the file —
+  // first-open may write a backfill if the file is missing; every
+  // subsequent navigation is strictly read-only.
+  firstOpenComplete: boolean;
 }
 
 /**
@@ -419,6 +445,7 @@ export class SpecViewerProvider {
       panel,
       state: initialState,
       debounceTimer: undefined,
+      firstOpenComplete: false,
     };
 
     // Store in map
@@ -494,13 +521,33 @@ export class SpecViewerProvider {
       const specName = path.basename(specDirectory);
 
       // Single context read: determine spec status + drive stepHistory badges.
-      let featureCtx = await getFeatureWorkflow(specDirectory, changeRoot);
-      if (!featureCtx) {
+      // Tolerate getFeatureWorkflow throws (post-Fix-2 it raises on
+      // parse/IO errors instead of silently returning undefined) — a
+      // transient read failure must not crash a tab click.
+      let featureCtx: FeatureWorkflowContext | undefined;
+      try {
+        featureCtx = await getFeatureWorkflow(specDirectory, changeRoot);
+      } catch (err) {
+        this.outputChannel.appendLine(
+          `[SpecViewer] getFeatureWorkflow failed for ${specDirectory}: ${err instanceof Error ? err.message : String(err)} — rendering without context.`,
+        );
+        featureCtx = undefined;
+      }
+      // First-open only: create the context file if missing. Subsequent
+      // tab clicks are strictly read-only — never re-trigger ensureSpecContext
+      // because a transient read failure mid-write could otherwise wipe
+      // real lifecycle history.
+      if (!featureCtx && !instance.firstOpenComplete) {
         const workflowName =
           (await resolveWorkflow(specDirectory))?.name ?? DEFAULT_WORKFLOW.name;
-        await ensureSpecContext(specDirectory, workflowName);
-        featureCtx = await getFeatureWorkflow(specDirectory, changeRoot);
+        await ensureSpecContext(specDirectory, workflowName, this.outputChannel);
+        try {
+          featureCtx = await getFeatureWorkflow(specDirectory, changeRoot);
+        } catch {
+          featureCtx = undefined;
+        }
       }
+      instance.firstOpenComplete = true;
 
       // Find the requested document (or fallback to first available)
       let doc = documents.find(d => d.type === documentType);
@@ -906,9 +953,18 @@ export class SpecViewerProvider {
         }
       }
 
-      // Determine spec status for lifecycle buttons
+      // Determine spec status for lifecycle buttons. Tolerate transient
+      // read failures so a render pass during a concurrent CLI write
+      // degrades to "active" rather than crashing the whole update.
       const changeRoot = instance.state.changeRoot;
-      const featureCtx = await getFeatureWorkflow(specDirectory, changeRoot);
+      let featureCtx: FeatureWorkflowContext | undefined;
+      try {
+        featureCtx = await getFeatureWorkflow(specDirectory, changeRoot);
+      } catch (err) {
+        this.outputChannel.appendLine(
+          `[SpecViewer] sendContentUpdateMessage: getFeatureWorkflow failed — ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
       let specStatus: string;
       if (featureCtx?.status === SpecStatuses.ARCHIVED || featureCtx?.currentStep === SpecStatuses.ARCHIVED) {
         specStatus = SpecStatuses.ARCHIVED;

--- a/src/features/specs/__tests__/specContextWipeGuard.test.ts
+++ b/src/features/specs/__tests__/specContextWipeGuard.test.ts
@@ -1,0 +1,188 @@
+/**
+ * Regression tests for the spec-context wipe bug.
+ *
+ * Before the fix, a transient read failure (concurrent writer → partial
+ * JSON → JSON.parse throws) was silently treated as "file missing." The
+ * spec viewer's ensureSpecContext would then write a fresh minimal context,
+ * destroying the real lifecycle history. These tests pin the three new
+ * contracts that prevent the regression:
+ *
+ *   1. readSpecContext distinguishes ENOENT (returns null) from any other
+ *      read/parse failure (throws).
+ *   2. writeSpecContext refuses to clobber an existing-but-unreadable file
+ *      (throws rather than blind-merging the new ctx over a "null" prior).
+ *   3. saveFeatureWorkflow only emits a minimal context on ENOENT — every
+ *      other read failure aborts the write.
+ */
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import {
+    SPEC_CONTEXT_FILENAME,
+    readSpecContext,
+    readSpecContextSync,
+} from '../specContextReader';
+import { writeSpecContext } from '../specContextWriter';
+import { saveFeatureWorkflow } from '../../workflows/workflowManager';
+import { FEATURE_CONTEXT_FILE } from '../../workflows/types';
+import type { SpecContext } from '../../../core/types/specContext';
+
+function makeTmpDir(): string {
+    return fs.mkdtempSync(path.join(os.tmpdir(), 'speckit-wipeguard-'));
+}
+
+function makeCtx(overrides: Partial<SpecContext> = {}): SpecContext {
+    return {
+        workflow: 'speckit',
+        specName: 'Real Spec',
+        branch: '999-real-spec',
+        currentStep: 'implement',
+        status: 'implemented',
+        history: [
+            {
+                step: 'specify',
+                substep: null,
+                kind: 'start',
+                from: { step: null, substep: null },
+                by: 'extension',
+                at: '2026-05-27T22:11:29Z',
+            },
+            {
+                step: 'specify',
+                substep: null,
+                kind: 'complete',
+                by: 'ai',
+                at: '2026-05-27T22:13:06Z',
+            },
+        ],
+        ...overrides,
+    };
+}
+
+describe('readSpecContext — ENOENT vs. other failures', () => {
+    it('returns null when the file genuinely does not exist (ENOENT)', async () => {
+        const dir = makeTmpDir();
+        try {
+            await expect(readSpecContext(dir)).resolves.toBeNull();
+        } finally {
+            fs.rmSync(dir, { recursive: true, force: true });
+        }
+    });
+
+    it('throws when the file exists but contains invalid JSON', async () => {
+        const dir = makeTmpDir();
+        try {
+            fs.writeFileSync(path.join(dir, SPEC_CONTEXT_FILENAME), '{ this is not json');
+            await expect(readSpecContext(dir)).rejects.toThrow(/invalid JSON/);
+        } finally {
+            fs.rmSync(dir, { recursive: true, force: true });
+        }
+    });
+
+    it('sync variant: returns null for ENOENT, throws for invalid JSON', () => {
+        const dir = makeTmpDir();
+        try {
+            expect(readSpecContextSync(dir)).toBeNull();
+            fs.writeFileSync(path.join(dir, SPEC_CONTEXT_FILENAME), 'oops');
+            expect(() => readSpecContextSync(dir)).toThrow(/invalid JSON/);
+        } finally {
+            fs.rmSync(dir, { recursive: true, force: true });
+        }
+    });
+});
+
+describe('writeSpecContext — refuses to clobber unreadable existing file', () => {
+    it('writes happily when the target file does not exist', async () => {
+        const dir = makeTmpDir();
+        try {
+            const ctx = makeCtx();
+            await writeSpecContext(dir, ctx);
+            const onDisk = JSON.parse(
+                fs.readFileSync(path.join(dir, SPEC_CONTEXT_FILENAME), 'utf-8'),
+            );
+            expect(onDisk.specName).toBe('Real Spec');
+            expect(onDisk.history).toHaveLength(2);
+        } finally {
+            fs.rmSync(dir, { recursive: true, force: true });
+        }
+    });
+
+    it('refuses to write (throws) when the existing file is not valid JSON', async () => {
+        const dir = makeTmpDir();
+        try {
+            const target = path.join(dir, SPEC_CONTEXT_FILENAME);
+            // Simulate a mid-write partial file.
+            fs.writeFileSync(target, '{ partia');
+            const original = fs.readFileSync(target, 'utf-8');
+
+            const freshCtx = makeCtx({
+                specName: '999-real-spec', // fallback-shape specName (raw basename)
+                history: [],
+                status: 'draft',
+                currentStep: 'specify',
+            });
+
+            await expect(writeSpecContext(dir, freshCtx)).rejects.toThrow(
+                /not valid JSON|unreadable/,
+            );
+            // Critical: on-disk content must be unchanged after the refusal.
+            expect(fs.readFileSync(target, 'utf-8')).toBe(original);
+        } finally {
+            fs.rmSync(dir, { recursive: true, force: true });
+        }
+    });
+});
+
+describe('saveFeatureWorkflow — ENOENT vs. other failures', () => {
+    it('creates a minimal context when the file is missing (ENOENT)', async () => {
+        const dir = makeTmpDir();
+        try {
+            await saveFeatureWorkflow(dir, 'sdd');
+            const onDisk = JSON.parse(
+                fs.readFileSync(path.join(dir, FEATURE_CONTEXT_FILE), 'utf-8'),
+            );
+            expect(onDisk.workflow).toBe('sdd');
+            expect(typeof onDisk.selectedAt).toBe('string');
+        } finally {
+            fs.rmSync(dir, { recursive: true, force: true });
+        }
+    });
+
+    it('preserves all other fields when merging into an existing valid file', async () => {
+        const dir = makeTmpDir();
+        try {
+            const target = path.join(dir, FEATURE_CONTEXT_FILE);
+            const before = makeCtx();
+            fs.writeFileSync(target, JSON.stringify(before, null, 2), 'utf-8');
+
+            await saveFeatureWorkflow(dir, 'sdd');
+
+            const after = JSON.parse(fs.readFileSync(target, 'utf-8'));
+            expect(after.workflow).toBe('sdd');
+            expect(after.specName).toBe('Real Spec');
+            expect(after.history).toHaveLength(2);
+            expect(after.currentStep).toBe('implement');
+            expect(after.status).toBe('implemented');
+        } finally {
+            fs.rmSync(dir, { recursive: true, force: true });
+        }
+    });
+
+    it('refuses to write (throws) when the existing file is unparseable', async () => {
+        const dir = makeTmpDir();
+        try {
+            const target = path.join(dir, FEATURE_CONTEXT_FILE);
+            fs.writeFileSync(target, '{ partia');
+            const original = fs.readFileSync(target, 'utf-8');
+
+            await expect(saveFeatureWorkflow(dir, 'sdd')).rejects.toThrow(
+                /not valid JSON|unreadable/,
+            );
+            expect(fs.readFileSync(target, 'utf-8')).toBe(original);
+        } finally {
+            fs.rmSync(dir, { recursive: true, force: true });
+        }
+    });
+});

--- a/src/features/specs/specContextReader.ts
+++ b/src/features/specs/specContextReader.ts
@@ -30,31 +30,55 @@ export function getSpecContextSchema(): unknown {
 }
 
 /**
- * Read `.spec-context.json` from a spec directory (or null if absent/invalid).
+ * Read `.spec-context.json` from a spec directory.
+ *
+ * Returns `null` ONLY when the file genuinely does not exist (ENOENT). Any
+ * other failure (EACCES, EBUSY, invalid JSON, encoding error) throws — the
+ * caller MUST distinguish "no file" from "could not read", otherwise a
+ * transient read failure during a concurrent write would let a downstream
+ * "ensure" path silently clobber the real file.
  */
 export async function readSpecContext(specDir: string): Promise<SpecContext | null> {
     const p = path.join(specDir, SPEC_CONTEXT_FILENAME);
+    let raw: string;
     try {
-        const raw = await fs.promises.readFile(p, 'utf-8');
-        const parsed = JSON.parse(raw) as Record<string, unknown>;
-        return normalizeSpecContext(parsed);
-    } catch {
-        return null;
+        raw = await fs.promises.readFile(p, 'utf-8');
+    } catch (err) {
+        if (isEnoent(err)) return null;
+        throw err;
     }
+    return parseAndNormalize(raw, p);
 }
 
 /**
- * Synchronous variant for tree-provider usage.
+ * Synchronous variant for tree-provider usage. Same ENOENT-vs-other contract
+ * as the async reader.
  */
 export function readSpecContextSync(specDir: string): SpecContext | null {
     const p = path.join(specDir, SPEC_CONTEXT_FILENAME);
+    let raw: string;
     try {
-        const raw = fs.readFileSync(p, 'utf-8');
-        const parsed = JSON.parse(raw) as Record<string, unknown>;
-        return normalizeSpecContext(parsed);
-    } catch {
-        return null;
+        raw = fs.readFileSync(p, 'utf-8');
+    } catch (err) {
+        if (isEnoent(err)) return null;
+        throw err;
     }
+    return parseAndNormalize(raw, p);
+}
+
+function isEnoent(err: unknown): boolean {
+    return !!err && typeof err === 'object' && (err as NodeJS.ErrnoException).code === 'ENOENT';
+}
+
+function parseAndNormalize(raw: string, filePath: string): SpecContext {
+    let parsed: Record<string, unknown>;
+    try {
+        parsed = JSON.parse(raw) as Record<string, unknown>;
+    } catch (err) {
+        const reason = err instanceof Error ? err.message : String(err);
+        throw new Error(`spec-context.json exists but is invalid JSON (${filePath}): ${reason}`);
+    }
+    return normalizeSpecContext(parsed);
 }
 
 /**

--- a/src/features/specs/specContextWriter.ts
+++ b/src/features/specs/specContextWriter.ts
@@ -30,12 +30,39 @@ export async function writeSpecContext(
     const target = path.join(specDir, SPEC_CONTEXT_FILENAME);
 
     // Read existing for unknown-field preservation + append-only enforcement.
+    //
+    // Belt-and-suspenders: distinguish "file genuinely missing" (ENOENT on
+    // stat) from "file present but read/parse failed". The former is a
+    // legitimate first-write; the latter would be a silent clobber of real
+    // lifecycle history, so we refuse to write at all and let the caller
+    // surface the error.
     let existing: Record<string, unknown> | null = null;
+    let fileExists = true;
     try {
-        const raw = await fs.promises.readFile(target, 'utf-8');
-        existing = JSON.parse(raw);
-    } catch {
-        existing = null;
+        await fs.promises.stat(target);
+    } catch (err) {
+        if ((err as NodeJS.ErrnoException)?.code === 'ENOENT') {
+            fileExists = false;
+        } else {
+            throw err;
+        }
+    }
+    if (fileExists) {
+        let raw: string;
+        try {
+            raw = await fs.promises.readFile(target, 'utf-8');
+        } catch (err) {
+            throw new Error(
+                `refusing to write spec-context.json: existing file at ${target} is unreadable (${(err as Error)?.message ?? err}). Aborting to avoid clobbering lifecycle history.`,
+            );
+        }
+        try {
+            existing = JSON.parse(raw);
+        } catch (err) {
+            throw new Error(
+                `refusing to write spec-context.json: existing file at ${target} is not valid JSON (${(err as Error)?.message ?? err}). Aborting to avoid clobbering lifecycle history.`,
+            );
+        }
     }
 
     if (existing) {

--- a/src/features/workflows/workflowManager.ts
+++ b/src/features/workflows/workflowManager.ts
@@ -299,16 +299,21 @@ export async function getFeatureWorkflow(
 
     for (const dir of dirsToCheck) {
         const contextPath = path.join(dir, FEATURE_CONTEXT_FILE);
+        let content: string;
         try {
-            const content = await fs.promises.readFile(contextPath, 'utf-8');
-            const context = JSON.parse(content) as FeatureWorkflowContext;
-
+            content = await fs.promises.readFile(contextPath, 'utf-8');
+        } catch (err) {
+            if ((err as NodeJS.ErrnoException)?.code === 'ENOENT') continue;
+            throw err;
+        }
+        try {
             // Return context even if workflow name is unrecognized —
             // callers can fall back to the default workflow for display
             // without overwriting the user's context data.
-            return context;
-        } catch {
-            // File doesn't exist or is invalid, try next
+            return JSON.parse(content) as FeatureWorkflowContext;
+        } catch (err) {
+            const reason = err instanceof Error ? err.message : String(err);
+            throw new Error(`spec-context.json exists but is invalid JSON (${contextPath}): ${reason}`);
         }
     }
 
@@ -326,17 +331,37 @@ export async function saveFeatureWorkflow(
 ): Promise<void> {
     const contextPath = path.join(featureDir, FEATURE_CONTEXT_FILE);
 
-    let context: FeatureWorkflowContext;
+    // Read-modify-write that distinguishes ENOENT (legitimate first write —
+    // emit minimal context) from any other failure (refuse to write so a
+    // transient read error can't wipe lifecycle history).
+    let content: string | null = null;
     try {
-        const content = await fs.promises.readFile(contextPath, 'utf-8');
-        const existing = JSON.parse(content);
+        content = await fs.promises.readFile(contextPath, 'utf-8');
+    } catch (err) {
+        if ((err as NodeJS.ErrnoException)?.code !== 'ENOENT') {
+            throw new Error(
+                `refusing to save workflow selection: existing ${FEATURE_CONTEXT_FILE} at ${contextPath} is unreadable (${(err as Error)?.message ?? err}).`,
+            );
+        }
+    }
+
+    let context: FeatureWorkflowContext;
+    if (content === null) {
         context = {
-            ...existing,
             workflow: workflowName,
             selectedAt: new Date().toISOString(),
         };
-    } catch {
+    } else {
+        let existing: Record<string, unknown>;
+        try {
+            existing = JSON.parse(content);
+        } catch (err) {
+            throw new Error(
+                `refusing to save workflow selection: existing ${FEATURE_CONTEXT_FILE} at ${contextPath} is not valid JSON (${(err as Error)?.message ?? err}).`,
+            );
+        }
         context = {
+            ...(existing as unknown as FeatureWorkflowContext),
             workflow: workflowName,
             selectedAt: new Date().toISOString(),
         };

--- a/src/features/workflows/workflowSelector.ts
+++ b/src/features/workflows/workflowSelector.ts
@@ -32,8 +32,15 @@ export async function selectWorkflow(featureDir: string): Promise<WorkflowConfig
         return workflows[0];
     }
 
-    // Check if feature already has a workflow selected
-    const existingContext = await getFeatureWorkflow(featureDir);
+    // Check if feature already has a workflow selected. Tolerate transient
+    // read failures (treat as "no existing selection") so the user can still
+    // pick a workflow rather than seeing a crash.
+    let existingContext: Awaited<ReturnType<typeof getFeatureWorkflow>>;
+    try {
+        existingContext = await getFeatureWorkflow(featureDir);
+    } catch {
+        existingContext = undefined;
+    }
     if (existingContext) {
         const existingWorkflow = getWorkflow(existingContext.workflow);
         if (existingWorkflow) {
@@ -136,8 +143,17 @@ function buildWorkflowDetail(workflow: WorkflowConfig): string {
  * Returns the workflow config without any side effects (no disk writes).
  */
 async function resolveDefaultWorkflow(featureDir: string, outputChannel?: vscode.OutputChannel): Promise<WorkflowConfig | undefined> {
-    // Check if feature has existing workflow
-    const existingContext = await getFeatureWorkflow(featureDir);
+    // Check if feature has existing workflow. Same tolerance for transient
+    // read failures as the interactive picker above.
+    let existingContext: Awaited<ReturnType<typeof getFeatureWorkflow>>;
+    try {
+        existingContext = await getFeatureWorkflow(featureDir);
+    } catch (err) {
+        outputChannel?.appendLine(
+            `[workflowSelector] resolveDefaultWorkflow: getFeatureWorkflow failed — ${err instanceof Error ? err.message : String(err)}`,
+        );
+        existingContext = undefined;
+    }
     if (existingContext) {
         const workflow = getWorkflow(existingContext.workflow);
         if (workflow) {


### PR DESCRIPTION
## Summary

A user's `.spec-context.json` for spec 118 was wiped from a full `implemented` state (8 history entries, `task_summaries`, human-readable `specName: \"Sidebar Icon Cleanup\"`) to a bare `draft` shell (`history: []`, `specName: \"118-sidebar-icon-cleanup\"` — the raw directory basename) **30 seconds after the AI's last write**, immediately after clicking the **Tasks** tab in the spec viewer.

Root cause: a transient read failure (concurrent CLI write → partial JSON → `JSON.parse` throws) was conflated with \"file doesn't exist\" at every layer of the read/write stack. The spec viewer's `ensureSpecContext` then wrote a fresh `backfillMinimalContext` — which produces *exactly* the wiped shape — over the real file. The append-only guard in the writer was bypassed because its own read of the existing file failed for the same reason.

## What changed

- **Readers** (`specContextReader.ts`, `workflowManager.ts:getFeatureWorkflow`) return `null` ONLY for `ENOENT`; parse/IO errors throw with a clear message.
- **Writer** (`specContextWriter.ts:writeSpecContext`) stat-guards the target. If the file exists but is unreadable/unparseable → throw rather than blind-merge over a \"null\" prior.
- **Spec viewer** (`specViewerProvider.ts:ensureSpecContext`) returns an in-memory backfill on read failure and does NOT touch disk; only the genuine-ENOENT path writes.
- **Spec viewer** (`specViewerProvider.ts:updateContent`) gates `ensureSpecContext` on a new `firstOpenComplete` panel flag — subsequent tab clicks are strictly read-only. This was the trigger.
- **Workflow saver** (`workflowManager.ts:saveFeatureWorkflow`) only emits a minimal context on `ENOENT`; refuses on unparseable existing files.
- **Read-only callsites** (`messageHandlers.ts`, `workflowSelector.ts`, viewer's `sendContentUpdateMessage`) wrap the now-throwing readers with try/catch + `outputChannel` logging so a transient failure degrades gracefully instead of crashing the panel.

## Test plan

- [x] `npm test` — 692/692 passing including new `specContextWipeGuard.test.ts` regression suite.
- [x] `npx tsc -p ./ --noEmit` clean.
- [ ] Manual repro of the original bug:
  - Open the spec viewer on `specs/_02_demo-tasked/` (baseline fixture with populated context).
  - In another terminal, overwrite `.spec-context.json` with malformed JSON (`echo '{ partia' > specs/_02_demo-tasked/.spec-context.json`).
  - Click between **Spec**, **Plan**, **Tasks** tabs.
  - **Expected**: file on disk is unchanged after every click. Output channel logs the read failure. Viewer renders without crashing.
  - **Restore**: `git restore specs/_02_demo-tasked` per CLAUDE.md.
- [ ] Happy-path smoke: open viewer on a real spec, navigate tabs, confirm `.spec-context.json` is read but never modified by navigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)