### PR TITLE
fix(upgrade): derive --ai from configured provider, consolidate actions behind one picker (#190)

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,1 +1,3 @@
-{"feature_directory": "specs/120-reorder-sidebar-icons"}
+{
+  "feature_directory": "specs/122-fix-upgrade-ai-agent"
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -238,5 +238,5 @@ They exist so the viewer can be opened against a known state during development.
 - 044-context-driven-badges: Added TypeScript 5.3+ (ES2022 target, strict mode) + VS Code Extension API (`@types/vscode ^1.84.0`)
 
 <!-- SPECKIT START -->
-For additional context about technologies to be used, project structure, shell commands, and other important information, read the current plan: `specs/115-footer-generating-status/plan.md`
+For additional context about technologies to be used, project structure, shell commands, and other important information, read the current plan: `specs/122-fix-upgrade-ai-agent/plan.md`
 <!-- SPECKIT END -->

--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ Specs are grouped into three collapsible sections, each with a count in the head
 
 When a step command is running, the spec shows a spinner and a live elapsed timer; a step-complete notification fires when it finishes (toggle via `speckit.notifications.stepComplete`).
 
+The spec-kit upgrade commands are consolidated behind a single **Upgrade…** icon in the Specs view title bar. Clicking it opens a picker with **Upgrade All**, **Upgrade Project**, and **Upgrade CLI** — each upgrades for your configured AI provider. All three remain available individually from the Command Palette.
+
 The sidebar is visible alongside the viewer in the screenshot above. For the full reference (lifecycle button matrix, badge tier mapping, transition logging, all icon meanings), see [`docs/sidebar.md`](./docs/sidebar.md).
 
 ### Offline-First UI

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Specs are grouped into three collapsible sections, each with a count in the head
 
 When a step command is running, the spec shows a spinner and a live elapsed timer; a step-complete notification fires when it finishes (toggle via `speckit.notifications.stepComplete`).
 
-The spec-kit upgrade commands are consolidated behind a single **Upgrade…** icon in the Specs view title bar. Clicking it opens a picker with **Upgrade All**, **Upgrade Project**, and **Upgrade CLI** — each upgrades for your configured AI provider. All three remain available individually from the Command Palette.
+The spec-kit upgrade commands are consolidated behind a single **Upgrade…** icon in the Specs view title bar. Clicking it opens a picker with **Upgrade All**, **Upgrade Project**, and **Upgrade CLI** — the project-scaffolding actions use your configured AI provider, while **Upgrade CLI** updates only the global CLI. All three remain available individually from the Command Palette.
 
 The sidebar is visible alongside the viewer in the screenshot above. For the full reference (lifecycle button matrix, badge tier mapping, transition logging, all icon meanings), see [`docs/sidebar.md`](./docs/sidebar.md).
 

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -336,7 +336,6 @@ const debouncedRefresh = (event: string, uri: vscode.Uri) => {
 
 ```typescript
 speckit.aiProvider                    // 'claude' | 'gemini' | 'copilot' | 'codex' | 'qwen'
-speckit.workflowEditor.enabled        // boolean
 speckit.claudePath                    // Custom Claude CLI path
 speckit.geminiPath                    // Custom Gemini CLI path
 speckit.copilotPath                   // Custom Copilot CLI path
@@ -593,8 +592,7 @@ All extension logging goes to the "SpecKit Companion" output channel:
 
 1. **Tree view not updating**: Check file watcher debounce (1 second delay)
 2. **Provider not configured**: Check `speckit.aiProvider` setting
-3. **Workflow editor not showing**: Check `speckit.workflowEditor.enabled`
-4. **Permission flow triggered**: Claude Code only, check bypass mode
+3. **Permission flow triggered**: Claude Code only, check bypass mode
 
 ### Extension Development
 

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -335,7 +335,7 @@ const debouncedRefresh = (event: string, uri: vscode.Uri) => {
 ### Configuration Keys
 
 ```typescript
-speckit.aiProvider                    // 'claude' | 'gemini' | 'copilot' | 'codex' | 'qwen'
+speckit.aiProvider                    // 'claude' | 'claude-vscode' | 'gemini' | 'copilot' | 'codex' | 'qwen' | 'opencode' | 'ide-chat'
 speckit.claudePath                    // Custom Claude CLI path
 speckit.geminiPath                    // Custom Gemini CLI path
 speckit.copilotPath                   // Custom Copilot CLI path

--- a/docs/sidebar.md
+++ b/docs/sidebar.md
@@ -10,7 +10,7 @@ Specs are grouped into three collapsible sections based on their status (stored 
 - **Completed** — Specs marked as done, collapsed by default.
 - **Archived** — Specs moved to archive, collapsed by default.
 
-The Specs view title bar exposes **Filter**, **Sort**, a **collapse/expand all** toggle, and **Create New Spec** (rightmost). A **clear filter** icon appears only while a filter is active. The collapse/expand icon swaps to reflect the next action; state is in-memory only and is not persisted across sessions.
+The Specs view title bar exposes **Filter**, an **Upgrade…** picker, a **collapse/expand all** toggle, and **Create New Spec** (rightmost). A **clear filter** icon appears only while a filter is active. The collapse/expand icon swaps to reflect the next action; state is in-memory only and is not persisted across sessions. The spec-kit upgrade commands are consolidated behind a single icon — see [Maintenance actions](#maintenance-actions) below.
 
 ## Filter and sort
 
@@ -25,6 +25,16 @@ The Specs view title bar exposes **Filter**, **Sort**, a **collapse/expand all**
 - **Status** (by workflow step)
 
 Ties fall back to numeric prefix then name so output is deterministic. The chosen mode is persisted to workspace state; group order (Active → Completed → Archived) is fixed.
+
+## Maintenance actions
+
+The spec-kit upgrade commands are consolidated behind a single **Upgrade…** icon (`$(cloud-download)`) in the Specs view title bar. Clicking it opens a picker with three options; each resolves the `--ai` agent from your configured `speckit.aiProvider` (see [`docs/how-it-works.md`](how-it-works.md)) and re-scaffolds with `specify init --here --force`.
+
+- **Upgrade All** (`speckit.upgradeAll`) — upgrades the spec-kit CLI, then re-scaffolds the project. The "just do it" choice.
+- **Upgrade Project** (`speckit.upgradeProject`) — re-runs `specify init` in place to refresh this workspace's scaffolding only.
+- **Upgrade CLI** (`speckit.upgradeCli`) — upgrades only the globally installed spec-kit CLI.
+
+The icon is visible when either spec-kit is detected in the workspace or the CLI is installed. All three individual commands remain available from the Command Palette under `SpecKit: Upgrade …`.
 
 ## Right-click and multi-select
 

--- a/docs/sidebar.md
+++ b/docs/sidebar.md
@@ -10,7 +10,7 @@ Specs are grouped into three collapsible sections based on their status (stored 
 - **Completed** — Specs marked as done, collapsed by default.
 - **Archived** — Specs moved to archive, collapsed by default.
 
-The Specs view title bar exposes **Filter**, an **Upgrade…** picker, a **collapse/expand all** toggle, and **Create New Spec** (rightmost). A **clear filter** icon appears only while a filter is active. The collapse/expand icon swaps to reflect the next action; state is in-memory only and is not persisted across sessions. The spec-kit upgrade commands are consolidated behind a single icon — see [Maintenance actions](#maintenance-actions) below.
+The Specs view title bar exposes **Filter**, **Sort**, an **Upgrade…** picker, a **collapse/expand all** toggle, and **Create New Spec** (rightmost). A **clear filter** icon appears only while a filter is active. The collapse/expand icon swaps to reflect the next action; state is in-memory only and is not persisted across sessions. The spec-kit upgrade commands are consolidated behind a single icon — see [Maintenance actions](#maintenance-actions) below.
 
 ## Filter and sort
 
@@ -28,7 +28,7 @@ Ties fall back to numeric prefix then name so output is deterministic. The chose
 
 ## Maintenance actions
 
-The spec-kit upgrade commands are consolidated behind a single **Upgrade…** icon (`$(cloud-download)`) in the Specs view title bar. Clicking it opens a picker with three options; each resolves the `--ai` agent from your configured `speckit.aiProvider` (see [`docs/how-it-works.md`](how-it-works.md)) and re-scaffolds with `specify init --here --force`.
+The spec-kit upgrade commands are consolidated behind a single **Upgrade…** icon (`$(cloud-download)`) in the Specs view title bar. Clicking it opens a picker with three options. **Upgrade All** and **Upgrade Project** resolve the `--ai` agent from your configured `speckit.aiProvider` (see [`docs/how-it-works.md`](how-it-works.md)) and re-scaffold with `specify init --here --force`; **Upgrade CLI** only upgrades the globally installed spec-kit CLI.
 
 - **Upgrade All** (`speckit.upgradeAll`) — upgrades the spec-kit CLI, then re-scaffolds the project. The "just do it" choice.
 - **Upgrade Project** (`speckit.upgradeProject`) — re-runs `specify init` in place to refresh this workspace's scaffolding only.

--- a/package.json
+++ b/package.json
@@ -360,6 +360,12 @@
         "icon": "$(sync)"
       },
       {
+        "command": "speckit.upgrade",
+        "title": "Upgrade…",
+        "category": "SpecKit",
+        "icon": "$(cloud-download)"
+      },
+      {
         "command": "speckit.workflowEditor.editSource",
         "title": "Edit Source",
         "category": "SpecKit",
@@ -480,6 +486,11 @@
         {
           "command": "speckit.steering.refresh",
           "when": "view == speckit.views.steering",
+          "group": "navigation@2"
+        },
+        {
+          "command": "speckit.upgrade",
+          "when": "view == speckit.views.explorer && (speckit.detected || speckit.cliInstalled)",
           "group": "navigation@2"
         }
       ],

--- a/specs/122-fix-upgrade-ai-agent/.spec-context.json
+++ b/specs/122-fix-upgrade-ai-agent/.spec-context.json
@@ -1,0 +1,182 @@
+{
+  "workflow": "speckit",
+  "specName": "Fix Upgrade Agent & Stale Setting Docs",
+  "branch": "122-fix-upgrade-ai-agent",
+  "selectedAt": "2026-06-04T21:00:59.162Z",
+  "currentStep": "implement",
+  "status": "implemented",
+  "history": [
+    {
+      "step": "specify",
+      "substep": null,
+      "kind": "start",
+      "from": {
+        "step": null,
+        "substep": null
+      },
+      "by": "extension",
+      "at": "2026-06-04T21:00:59.162Z"
+    },
+    {
+      "step": "specify",
+      "substep": null,
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-06-04T21:08:17Z"
+    },
+    {
+      "step": "plan",
+      "substep": null,
+      "kind": "start",
+      "from": {
+        "step": "specify",
+        "substep": null
+      },
+      "by": "extension",
+      "at": "2026-06-04T21:26:31.509Z"
+    },
+    {
+      "step": "plan",
+      "substep": "research",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-04T21:31:32Z"
+    },
+    {
+      "step": "plan",
+      "substep": "design",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-04T21:35:07Z"
+    },
+    {
+      "step": "plan",
+      "substep": null,
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-04T21:35:07Z"
+    },
+    {
+      "step": "tasks",
+      "substep": null,
+      "kind": "start",
+      "from": {
+        "step": "plan",
+        "substep": null
+      },
+      "by": "extension",
+      "at": "2026-06-04T21:38:23.840Z"
+    },
+    {
+      "step": "tasks",
+      "substep": "generate",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-04T21:56:04Z"
+    },
+    {
+      "step": "tasks",
+      "substep": null,
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-04T21:56:04Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "kind": "start",
+      "from": {
+        "step": "tasks",
+        "substep": null
+      },
+      "by": "extension",
+      "at": "2026-06-04T22:01:46.238Z"
+    },
+    {
+      "step": "implement",
+      "substep": "run-tests",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-04T22:41:28Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-04T22:41:28Z"
+    }
+  ],
+  "task_summaries": {
+    "T001": {
+      "status": "DONE",
+      "did": "Confirmed a green baseline (761 tests) and the two `--ai claude-code` literals plus the `detectHostIde` instance method before changing anything.",
+      "files": []
+    },
+    "T002": {
+      "status": "DONE",
+      "did": "Extracted `detectHostIde()` into a standalone exported function and made the instance method delegate, with `HostIde` now exported.",
+      "files": ["src/ai-providers/ideChatProvider.ts"]
+    },
+    "T003": {
+      "status": "DONE",
+      "did": "Created the pure total `resolveSpecKitAgent` resolver, the `PROVIDER_TO_AGENT` map, and the impure `getConfiguredSpecKitAgent` wrapper.",
+      "files": ["src/speckit/specKitAgent.ts"]
+    },
+    "T004": {
+      "status": "DONE",
+      "did": "Routed both `upgradeProject` and `upgradeAll` dispatch sites through `getConfiguredSpecKitAgent()`, removing the hardcoded `claude-code`.",
+      "files": ["src/speckit/detector.ts"]
+    },
+    "T005": {
+      "status": "DONE",
+      "did": "Added resolver tests asserting gemini/copilot/codex/qwen/opencode each map to their own agent.",
+      "files": ["src/speckit/specKitAgent.test.ts"]
+    },
+    "T006": {
+      "status": "DONE",
+      "did": "Added an `upgradeProject` dispatch test asserting the terminal text contains `--ai codex` and no `claude-code`.",
+      "files": ["src/speckit/detector.test.ts"]
+    },
+    "T007": {
+      "status": "DONE",
+      "did": "Added tests for `claude`→`claude` and a guard that no provider/host combination ever yields `claude-code`.",
+      "files": ["src/speckit/specKitAgent.test.ts"]
+    },
+    "T008": {
+      "status": "DONE",
+      "did": "Added default-provider dispatch tests for both upgrade paths plus the same-`--ai`-value (FR-006) check.",
+      "files": ["src/speckit/detector.test.ts"]
+    },
+    "T009": {
+      "status": "DONE",
+      "did": "Added tests for `claude-vscode`, each `ide-chat` host, unknown-host, and undefined/empty/unrecognized fallback.",
+      "files": ["src/speckit/specKitAgent.test.ts"]
+    },
+    "T010": {
+      "status": "DONE",
+      "did": "Removed both `speckit.workflowEditor.enabled` references (config-keys block and troubleshooting item) from the docs.",
+      "files": ["docs/how-it-works.md"]
+    },
+    "T011": {
+      "status": "DONE",
+      "did": "Deleted the unused `ConfigKeys.workflowEditorEnabled` constant.",
+      "files": ["src/core/constants.ts"]
+    },
+    "T012": {
+      "status": "DONE",
+      "did": "Ran the quickstart greps — zero `claude-code` in detector and zero `workflowEditor.enabled` repo-wide.",
+      "files": []
+    },
+    "T013": {
+      "status": "DONE",
+      "did": "Ran `npm run compile` then `npm test` — both green (782 tests across 64 suites).",
+      "files": []
+    },
+    "T014": {
+      "status": "DONE",
+      "did": "Confirmed README needs no change for this fix and contains no `workflowEditor.enabled` reference.",
+      "files": []
+    }
+  }
+}

--- a/specs/122-fix-upgrade-ai-agent/checklists/requirements.md
+++ b/specs/122-fix-upgrade-ai-agent/checklists/requirements.md
@@ -1,0 +1,37 @@
+# Specification Quality Checklist: Fix Upgrade AI Agent
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-06-04
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Issue #190 bundled five problems. This spec covers two value-correctness defects that share a root theme (the extension emitting/documenting a value the rest of the system doesn't recognize): the upgrade-agent `--ai claude-code` bug, and the stale `speckit.workflowEditor.enabled` setting docs.
+- The remaining three problems were split into their own tracked issues — #192 (setup clarity), #193 (button appear/disappear), #194 (`analyze` not updating context) — and are listed under "Out of Scope."
+- The one genuinely ambiguous area (which spec-kit agent the "IDE Chat" provider maps to) is resolved with a documented default-plus-host-detection assumption rather than a blocking clarification, since a reasonable default exists (always send a recognized identifier).
+- Items marked incomplete require spec updates before `/speckit.clarify` or `/speckit.plan`. All items currently pass.

--- a/specs/122-fix-upgrade-ai-agent/contracts/agent-resolution.md
+++ b/specs/122-fix-upgrade-ai-agent/contracts/agent-resolution.md
@@ -1,0 +1,65 @@
+# Contract: Spec-kit agent resolution
+
+The extension exposes one internal contract for this feature: a pure function that maps the configured provider (plus host, for IDE Chat) to a spec-kit agent identifier, and an impure wrapper that supplies those inputs from the environment. Both upgrade dispatch paths consume the wrapper.
+
+## `resolveSpecKitAgent(provider, host)` — pure
+
+**Input**
+
+- `provider: string | undefined` — raw value of `speckit.aiProvider` (may be undefined/empty/stale).
+- `host: HostIde` — `'vscode' | 'cursor' | 'windsurf' | 'antigravity' | 'unknown'`; only consulted when `provider === 'ide-chat'`.
+
+**Output**
+
+- `agent: string` — always a member of the spec-kit CLI accepted set. Never `claude-code`.
+
+**Contract table**
+
+| provider        | host          | → agent        |
+|-----------------|---------------|----------------|
+| `claude`        | *(any)*       | `claude`       |
+| `claude-vscode` | *(any)*       | `claude`       |
+| `gemini`        | *(any)*       | `gemini`       |
+| `copilot`       | *(any)*       | `copilot`      |
+| `codex`         | *(any)*       | `codex`        |
+| `qwen`          | *(any)*       | `qwen`         |
+| `opencode`      | *(any)*       | `opencode`     |
+| `ide-chat`      | `vscode`      | `copilot`      |
+| `ide-chat`      | `cursor`      | `cursor-agent` |
+| `ide-chat`      | `windsurf`    | `windsurf`     |
+| `ide-chat`      | `antigravity` | `agy`          |
+| `ide-chat`      | `unknown`     | `copilot`      |
+| `undefined`/`''`/unknown value | *(any)* | `claude` |
+
+**Guarantees**
+
+- Total: no input throws; every input returns a valid agent.
+- Pure: no config reads, no `vscode` API calls, no side effects.
+- `claude-code` never appears in any output.
+
+## `getConfiguredSpecKitAgent()` — impure wrapper
+
+**Behavior**
+
+1. Read `speckit.aiProvider` from `vscode.workspace.getConfiguration`.
+2. Detect the host via the shared `detectHostIde()` (only meaningful for `ide-chat`).
+3. Return `resolveSpecKitAgent(provider, host)`.
+
+**Consumers**: `SpecKitDetector.upgradeProject()` and `SpecKitDetector.upgradeAll()` build their terminal command as
+`specify init --here --force --ai ${getConfiguredSpecKitAgent()}`.
+
+## Test contract (BDD)
+
+Pure-function tests (`describe('resolveSpecKitAgent')`):
+
+- maps every direct provider to its agent (one `it` per row).
+- maps `claude-vscode` to `claude`.
+- resolves each `ide-chat` host to the right agent (vscode→copilot, cursor→cursor-agent, windsurf→windsurf, antigravity→agy).
+- falls back to `copilot` for `ide-chat` with `unknown` host.
+- falls back to `claude` for undefined / empty / unrecognized provider values.
+- never returns the string `claude-code` for any input in the table.
+
+Dispatch tests (`describe('upgradeProject' / 'upgradeAll')`):
+
+- the dispatched terminal text contains `--ai <resolved>` and does **not** contain `claude-code`, for at least the default (`claude`) and one non-Claude (`codex`) provider.
+- both upgrade paths produce the same `--ai` value for the same provider.

--- a/specs/122-fix-upgrade-ai-agent/data-model.md
+++ b/specs/122-fix-upgrade-ai-agent/data-model.md
@@ -1,0 +1,57 @@
+# Data Model: Fix Upgrade Agent & Stale Setting Docs
+
+**Branch**: `122-fix-upgrade-ai-agent` | **Date**: 2026-06-04
+
+This feature introduces no persisted state and no new storage. The "entities" are in-memory value mappings and the inputs/outputs of a pure resolution function. They are documented here so the contract is unambiguous.
+
+## Entities
+
+### AI Provider setting
+
+The user's configured assistant, read from `speckit.aiProvider` (VS Code settings). Domain is the `AIProviders` enum:
+
+| Value           | Meaning                          |
+|-----------------|----------------------------------|
+| `claude`        | Claude terminal CLI (default)    |
+| `claude-vscode` | Claude Code VS Code panel        |
+| `gemini`        | Gemini CLI                       |
+| `copilot`       | GitHub Copilot CLI               |
+| `codex`         | Codex CLI                        |
+| `qwen`          | Qwen Code CLI                    |
+| `opencode`      | OpenCode CLI                     |
+| `ide-chat`      | Host editor's built-in chat      |
+
+Validation: any value outside this set (missing, empty, stale/renamed enum) is treated as **unrecognized** and resolves to the safe default agent.
+
+### Host IDE
+
+The detected host editor, used only when the provider is `ide-chat`. Domain (`HostIde`), produced from `vscode.env.uriScheme` with `vscode.env.appName` fallback:
+
+`vscode` | `cursor` | `windsurf` | `antigravity` | `unknown`
+
+### Spec-kit agent identifier
+
+The output value passed to the CLI as `specify init … --ai <agent>`. Must always be a member of the CLI's accepted set (see research.md §1). The extension only emits: `claude`, `gemini`, `copilot`, `codex`, `qwen`, `opencode`, `cursor-agent`, `windsurf`, `agy`.
+
+## Mapping rules (the resolution function)
+
+`resolveSpecKitAgent(provider, host) → agent`
+
+1. **Direct providers** — `claude`/`claude-vscode` → `claude`; `gemini` → `gemini`; `copilot` → `copilot`; `codex` → `codex`; `qwen` → `qwen`; `opencode` → `opencode`.
+2. **IDE Chat** — when `provider === 'ide-chat'`, resolve by `host`: `vscode` → `copilot`; `cursor` → `cursor-agent`; `windsurf` → `windsurf`; `antigravity` → `agy`; `unknown` → `copilot`.
+3. **Fallback** — any unrecognized/missing provider → `claude`.
+
+Invariants:
+
+- The function is **total**: every possible input yields a valid agent; it never returns `claude-code` or any non-CLI value.
+- The function is **pure**: no I/O, no config reads — inputs in, agent out. The impure wrapper (`getConfiguredSpecKitAgent()`) reads the provider setting and detects the host, then calls this function.
+
+## Removed entity
+
+### `speckit.workflowEditor.enabled` (deleted)
+
+A configuration key constant (`ConfigKeys.workflowEditorEnabled`) and two documentation references describing a setting the extension no longer contributes. No runtime reads exist. Status after this change: **absent everywhere** — not declared in `package.json`, not named in docs, not present as a constant.
+
+## State transitions
+
+None. The resolution is stateless and recomputed on each upgrade dispatch.

--- a/specs/122-fix-upgrade-ai-agent/plan.md
+++ b/specs/122-fix-upgrade-ai-agent/plan.md
@@ -1,0 +1,107 @@
+# Implementation Plan: Fix Upgrade Agent & Stale Setting Docs
+
+**Branch**: `122-fix-upgrade-ai-agent` | **Date**: 2026-06-04 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `specs/122-fix-upgrade-ai-agent/spec.md`
+
+## Summary
+
+Two value-correctness defects from issue #190. (1) The "Upgrade Project" action hardcodes `specify init --here --force --ai claude-code`; `claude-code` is not a valid spec-kit agent (the CLI errors `Unknown agent 'claude-code'`), and it ignores the user's configured provider. (2) The docs and one code constant still reference a removed `speckit.workflowEditor.enabled` setting.
+
+Technical approach: introduce one pure resolver, `resolveSpecKitAgent(provider, host)`, mapping the `speckit.aiProvider` value (and, for `ide-chat`, the detected host) to a valid CLI agent identifier, with `claude` as the unrecognized-provider fallback. Route both upgrade dispatch sites (`upgradeProject`, `upgradeAll`) through an impure wrapper `getConfiguredSpecKitAgent()` so neither can reintroduce a hardcoded value. Separately, delete the phantom setting from `docs/how-it-works.md` (two spots) and the unused `ConfigKeys.workflowEditorEnabled` constant.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.3+ (ES2022, strict mode)
+**Primary Dependencies**: VS Code Extension API (`@types/vscode ^1.84.0`); spec-kit CLI (`specify`) invoked via terminal
+**Storage**: N/A — stateless, no persisted data
+**Testing**: Jest + ts-jest (`tsconfig.test.json`); VS Code mocked via `tests/__mocks__/vscode.ts`
+**Target Platform**: VS Code 1.84+ (and forks: Cursor, Windsurf, Antigravity)
+**Project Type**: Single project (VS Code extension)
+**Performance Goals**: N/A (synchronous string resolution at command-dispatch time)
+**Constraints**: Extension must only ever emit a spec-kit `--ai` value from the CLI's accepted set; resolver must be total (never throws, never emits an invalid identifier)
+**Scale/Scope**: 8 providers + 5 host buckets; 2 upgrade dispatch sites; 3 stale-setting references
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-checked after Phase 1 design.*
+
+| Principle | Assessment |
+|-----------|------------|
+| I. Extensibility & Configuration | **Pass** — fix removes a hardcode and derives behavior from the `speckit.aiProvider` setting; new mapping is a single, extensible table. |
+| II. Spec-Driven Workflow | **Pass** — no change to the Specify→Plan→Tasks→Implement pipeline or spec lifecycle. |
+| III. Visual & Interactive | **Pass** — no UI surface change; corrects what an existing command dispatches. |
+| IV. Modular Architecture | **Pass** — resolver lives in a small focused module with a pure core and a thin impure wrapper; host detection consolidated to one source. |
+
+No violations. Complexity Tracking table omitted.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/122-fix-upgrade-ai-agent/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/
+│   └── agent-resolution.md
+└── tasks.md             # Phase 2 output (/speckit.tasks — NOT created here)
+```
+
+### Source Code (repository root)
+
+```text
+src/
+├── speckit/
+│   ├── detector.ts            # upgradeProject() + upgradeAll() — route through resolver
+│   ├── specKitAgent.ts        # NEW: resolveSpecKitAgent() + getConfiguredSpecKitAgent()
+│   ├── specKitAgent.test.ts   # NEW: pure-resolution BDD tests
+│   └── detector.test.ts       # EXTEND: dispatched --ai value, no claude-code
+├── ai-providers/
+│   └── ideChatProvider.ts     # extract detectHostIde() to standalone export; method delegates
+└── core/
+    └── constants.ts           # remove ConfigKeys.workflowEditorEnabled
+
+docs/
+└── how-it-works.md            # remove both speckit.workflowEditor.enabled references
+```
+
+**Structure Decision**: Single-project VS Code extension. The new resolver is added under `src/speckit/` alongside the only consumer (`detector.ts`). Host detection (`detectHostIde`) is extracted from `IdeChatProvider` into a standalone exported function in `ideChatProvider.ts` so the resolver and the existing IDE-Chat dispatch share one detector — preventing the kind of duplicated logic that produced the original bug.
+
+## Phase 0: Outline & Research
+
+Complete — see [research.md](./research.md). Resolved: the CLI's authoritative agent list (`claude-code` absent, `claude` correct, Copilot the non-interactive default), the full provider→agent and host→agent tables, the two dispatch sites, and the three stale-setting references (the `ConfigKeys.workflowEditorEnabled` constant has zero other usages, so removal is inert).
+
+## Phase 1: Design & Contracts
+
+Complete. Artifacts:
+
+- [data-model.md](./data-model.md) — provider / host / agent value sets, mapping rules, the removed setting.
+- [contracts/agent-resolution.md](./contracts/agent-resolution.md) — `resolveSpecKitAgent` and `getConfiguredSpecKitAgent` contracts plus the BDD test contract.
+- [quickstart.md](./quickstart.md) — automated + manual verification covering every SC.
+
+Agent context: the `CLAUDE.md` SPECKIT marker block will be updated to point at this plan.
+
+### Implementation notes for /speckit.tasks
+
+- **Resolver module** (`src/speckit/specKitAgent.ts`): export `PROVIDER_TO_AGENT` map keyed by `AIProviders` values, `resolveSpecKitAgent(provider, host)` (pure, total, `claude` default), and `getConfiguredSpecKitAgent()` (reads `speckit.aiProvider`, detects host, calls the pure fn). Reuse `AIProviders` from `core/constants.ts`.
+- **Host detection**: extract the body of `IdeChatProvider.detectHostIde()` into an exported standalone `detectHostIde(): HostIde`; have the instance method delegate. Behavior unchanged for existing IDE-Chat callers.
+- **Dispatch sites**: in `detector.ts`, replace both `--ai claude-code` literals with `--ai ${getConfiguredSpecKitAgent()}` in `upgradeProject()` and `upgradeAll()`.
+- **Docs**: in `docs/how-it-works.md`, drop the `speckit.workflowEditor.enabled // boolean` line from the Configuration Keys block, and remove (or repoint) the "Workflow editor not showing" troubleshooting item — the editor is no longer gated by a user setting, so the entry has no replacement toggle.
+- **Constant**: delete `workflowEditorEnabled` from `ConfigKeys` in `core/constants.ts` (no other references).
+- **README map**: this is a bug fix changing documented behavior; the only user-facing doc affected is `docs/how-it-works.md` (a phantom config key). No README provider-matrix or settings change is needed — no provider added, no live setting removed from the README's Configuration section. Confirm during tasks that README has no `workflowEditor.enabled` reference (grep already shows none).
+
+## Complexity Tracking
+
+No constitution violations — not applicable.
+
+---
+
+## Plan Summary
+
+**The problem.** Two places where the extension states a value the rest of the system rejects. The "Upgrade Project" button always runs `specify init … --ai claude-code` — but `claude-code` isn't a real spec-kit agent, so the CLI errors out for everyone, and it ignores whichever AI provider the user actually picked. Separately, the docs still tell people to check a `speckit.workflowEditor.enabled` setting that was deleted long ago, sending them hunting for a toggle that no longer exists.
+
+**The fix.** Add one small function that turns the user's configured provider into a valid spec-kit agent name (Claude→`claude`, Codex→`codex`, Gemini→`gemini`, and so on; for "IDE Chat" it picks based on the host editor — VS Code→`copilot`, Cursor→`cursor-agent`, Windsurf→`windsurf`, Antigravity→`agy`). Anything unrecognized safely falls back to `claude`. Both upgrade buttons call this one function, so neither can ever send `claude-code` again. Then delete the dead `workflowEditor.enabled` setting from the docs and the one leftover code constant so the configuration reference matches reality.
+
+**Outcome.** Every supported provider can upgrade without an "Unknown agent" error, the upgrade scaffolds for the assistant the user chose, and the docs no longer point at a setting that isn't there.

--- a/specs/122-fix-upgrade-ai-agent/quickstart.md
+++ b/specs/122-fix-upgrade-ai-agent/quickstart.md
@@ -1,0 +1,43 @@
+# Quickstart: Verify the upgrade-agent fix & doc cleanup
+
+**Branch**: `122-fix-upgrade-ai-agent`
+
+How to confirm both defects are fixed after implementation.
+
+## Part A — Upgrade agent (automated)
+
+```bash
+npm test -- detector
+```
+
+Expect the new resolver + dispatch tests to pass: every provider maps to a valid agent, `ide-chat` resolves per host, unrecognized providers fall back to `claude`, and `claude-code` never appears.
+
+```bash
+grep -rn "claude-code" src/speckit/detector.ts
+```
+
+Expect **no matches** (SC-003).
+
+## Part B — Upgrade agent (manual, in Extension Development Host)
+
+1. Press F5 to launch the Extension Development Host.
+2. Set `speckit.aiProvider` to `codex` in settings.
+3. Run the **Upgrade Project** command. Confirm the spawned terminal shows `specify init --here --force --ai codex` and the CLI does **not** print `Unknown agent` (SC-001, SC-002).
+4. Repeat with `gemini` (→ `--ai gemini`) and with the default `claude` (→ `--ai claude`, no `claude-code` anywhere) (SC-004).
+5. Set provider to `ide-chat` and run **Upgrade Project**: in plain VS Code expect `--ai copilot`; in Cursor expect `--ai cursor-agent` (US3).
+6. Set provider to a junk value (e.g. via `settings.json` hand-edit `"speckit.aiProvider": "claude-code"`) and run upgrade: expect fallback `--ai claude`, no error (SC-005).
+7. Repeat step 3 via the **combined CLI + project upgrade** path and confirm it sends the same `--ai` value (FR-006).
+
+## Part C — Stale setting docs
+
+```bash
+grep -rn "workflowEditor.enabled" docs/ README.md src/ webview/
+```
+
+Expect **zero matches** (SC-006, SC-007) — gone from `docs/how-it-works.md` (both the Configuration Keys block and the troubleshooting list) and from `src/core/constants.ts`.
+
+## Done when
+
+- `npm test` is green.
+- `grep` for `claude-code` (in detector) and `workflowEditor.enabled` (repo-wide) both return nothing.
+- A non-Claude provider upgrades without an unknown-agent error.

--- a/specs/122-fix-upgrade-ai-agent/research.md
+++ b/specs/122-fix-upgrade-ai-agent/research.md
@@ -1,0 +1,95 @@
+# Research: Fix Upgrade Agent & Stale Setting Docs
+
+**Branch**: `122-fix-upgrade-ai-agent` | **Date**: 2026-06-04
+
+This is a two-part correctness fix. The research below resolves every unknown the spec raised: what the spec-kit CLI actually accepts as an agent identifier, how each extension provider maps to one of those identifiers, how the IDE-Chat provider resolves to a host-appropriate agent, and exactly where the phantom `speckit.workflowEditor.enabled` setting still lives.
+
+## 1. Spec-kit CLI's real agent list
+
+**Decision**: Treat the CLI's `--ai` accepted set as the authoritative whitelist; the extension only ever emits a value from it.
+
+**Finding**: Running `specify init --help` against the installed CLI prints the accepted `--ai` values:
+
+```
+agy, amp, auggie, bob, claude, codebuddy, codex, copilot, cursor-agent,
+devin, forge, gemini, goose, iflow, junie, kilocode, kimi, kiro-cli,
+lingma, opencode, pi, qodercli, qwen, roo, shai, tabnine, trae, vibe,
+windsurf, or generic
+```
+
+`claude-code` is **not** in this list — that is the root of the bug (`Error: Unknown agent 'claude-code'`). The valid identifier for Claude is `claude`. The help text also states the CLI "default[s] to Copilot in non-interactive sessions," which makes `copilot` the natural fallback for any host we can't otherwise resolve.
+
+**Rationale**: The CLI's own `--help` output is the single source of truth for what it accepts; anchoring the extension's mapping to it guarantees we never originate an identifier we know to be invalid (FR-002, FR-005).
+
+**Alternatives considered**: Hardcoding a curated subset — rejected because it drifts from the CLI; the CLI list already covers every provider we support.
+
+## 2. Provider → spec-kit agent mapping
+
+**Decision**: A single pure mapping from the extension's `AIProviders` enum to a CLI agent identifier, used by every upgrade path.
+
+| Extension provider (`speckit.aiProvider`) | spec-kit `--ai` agent |
+|-------------------------------------------|-----------------------|
+| `claude` (terminal)                       | `claude`              |
+| `claude-vscode` (Claude VS Code panel)    | `claude`              |
+| `gemini`                                  | `gemini`              |
+| `copilot`                                 | `copilot`             |
+| `codex`                                   | `codex`               |
+| `qwen`                                    | `qwen`                |
+| `opencode`                                | `opencode`            |
+| `ide-chat`                                | host-dependent (see §3) |
+| *(missing / empty / unrecognized)*        | `claude` (safe default) |
+
+**Rationale**: Seven of the eight providers have a one-to-one CLI agent; `claude-vscode` shares Claude's scaffolding so it also maps to `claude` (spec assumption confirmed). The unrecognized-value fallback is `claude` because that is already the extension's declared default for `speckit.aiProvider` (package.json `default: "claude"`), so a stale/renamed enum degrades to the same agent a fresh install would use — consistent with the existing PROVIDER_PATHS fallback pattern. (FR-001, FR-003, FR-005, FR-007)
+
+**Alternatives considered**: Reusing the spec-kit metadata written at `specify init` time — rejected per spec: the user's configured provider, not init metadata, is authoritative for the upgrade target.
+
+## 3. IDE-Chat host → agent resolution
+
+**Decision**: When the provider is `ide-chat`, resolve the agent from the detected host editor, reusing the extension's existing host-detection signals (`vscode.env.uriScheme`, falling back to `appName`).
+
+| Detected host (`HostIde`) | spec-kit `--ai` agent |
+|---------------------------|-----------------------|
+| `vscode`                  | `copilot`             |
+| `cursor`                  | `cursor-agent`        |
+| `windsurf`                | `windsurf`            |
+| `antigravity`             | `agy`                 |
+| `unknown`                 | `copilot` (default)   |
+
+**Finding**: `IdeChatProvider.detectHostIde()` already classifies the host into exactly these five buckets from stable `vscode.env` signals. Every bucket has a corresponding CLI agent: VS Code's built-in chat is Copilot, Cursor is `cursor-agent`, Windsurf is `windsurf`, and Antigravity's `agy` identifier is in the CLI list. An unrecognized fork falls back to `copilot`, which matches the CLI's own non-interactive default.
+
+**Rationale**: Host detection already exists and is exercised by the IDE-Chat dispatch path; routing the upgrade through the same detector keeps a single source of truth and guarantees a valid identifier is always sent (FR-004). The current `detectHostIde()` is an instance method on `IdeChatProvider`; to consume it from the upgrade path without constructing a provider, it will be extracted to a standalone exported function with the method delegating to it (behavior-preserving for IDE-Chat dispatch).
+
+**Alternatives considered**: Duplicating the uriScheme/appName check inside the resolver — rejected; duplicated host detection is precisely the kind of drift that produced the original `claude-code` bug. One detector, one truth.
+
+## 4. Where the upgrade agent is emitted
+
+**Decision**: Fix both terminal-emitting paths through the shared resolver.
+
+**Finding**: The literal `--ai claude-code` appears in exactly two dispatch sites, both in `src/speckit/detector.ts`:
+
+- `upgradeProject()` (line 235) — the standalone "Upgrade Project" action.
+- `upgradeAll()` (line 260) — the combined "upgrade CLI + project" action.
+
+`detector.ts` currently reads no configuration. Both sites build a `specify init --here --force --ai <agent>` terminal command. Routing both through one `getConfiguredSpecKitAgent()` helper guarantees neither path can reintroduce a hardcoded identifier (FR-006).
+
+**Rationale**: Two call sites, one resolver — the spec's "every upgrade path uses the same resolution" requirement maps directly onto a single shared function.
+
+## 5. The phantom `speckit.workflowEditor.enabled` setting
+
+**Decision**: Remove every live-setting reference from docs and code; the setting is genuinely gone from the extension's `package.json` contributions.
+
+**Finding**: A repo-wide search locates exactly three references and confirms the setting is **not** declared in `package.json`:
+
+- `docs/how-it-works.md:339` — lists `speckit.workflowEditor.enabled // boolean` in the Configuration Keys block.
+- `docs/how-it-works.md:596` — troubleshooting step "Workflow editor not showing: Check `speckit.workflowEditor.enabled`".
+- `src/core/constants.ts:60` — `workflowEditorEnabled: 'speckit.workflowEditor.enabled'` in `ConfigKeys`. This constant has **zero** other usages anywhere in `src/` or `webview/`, so removing it is safe and inert.
+
+README.md and CHANGELOG.md contain no references. The workflow editor today is not gated by any user setting, so the troubleshooting entry has no valid replacement target and should be removed (or repointed at the actual cause) rather than rewritten to name another toggle.
+
+**Rationale**: The setting key must have a single, consistent (absent) status across docs and code (FR-008, FR-009, FR-010). Since the constant is unreferenced, this is a pure deletion with no runtime behavior change.
+
+**Alternatives considered**: Re-introducing the setting to match the docs — rejected per spec assumption: the removal was intentional; the docs are what's stale.
+
+## Open questions
+
+None. All NEEDS CLARIFICATION from Technical Context are resolved.

--- a/specs/122-fix-upgrade-ai-agent/spec.md
+++ b/specs/122-fix-upgrade-ai-agent/spec.md
@@ -1,0 +1,135 @@
+# Feature Specification: Fix Upgrade Agent & Stale Setting Docs
+
+**Feature Branch**: `122-fix-upgrade-ai-agent`
+**Created**: 2026-06-04
+**Status**: Draft
+**Input**: User description (from issue #190): two correctness defects where the extension emits or documents a value that doesn't exist. (1) `speckit.upgradeProject` always passes `--force --ai claude-code`; it ignores the configured AI provider and `claude-code` is not even a valid spec-kit agent (the CLI rejects it with `Error: Unknown agent 'claude-code'`). (2) The documentation describes a `speckit.workflowEditor.enabled` boolean setting that no longer exists in VS Code settings, so users go looking for a toggle that isn't there.
+
+## Why This Matters
+
+Both defects share a theme: the extension presents a value — to the CLI, or to the user in docs — that the rest of the system does not recognize. Each erodes trust that what the extension says matches what it does.
+
+**Upgrade agent.** The "Upgrade Project" action is supposed to refresh a workspace's spec-kit scaffolding for the AI assistant the user actually works with. Today it ignores the user's configured provider and always asks spec-kit to scaffold for `claude-code` — an identifier the spec-kit CLI does not recognize. The result is a hard failure (`Unknown agent 'claude-code'`) for anyone, and even when it does not error it would scaffold the wrong assistant's command files. A user on Codex (the reporter's case) cannot upgrade their project at all. This makes a one-click maintenance action unusable and erodes trust that the extension respects the provider setting.
+
+**Stale setting docs.** The `speckit.workflowEditor.enabled` setting was removed from the extension in an earlier change, but the documentation still lists it as a configuration key and points users at it for troubleshooting ("Workflow editor not showing: check `speckit.workflowEditor.enabled`"). A user following that guidance searches VS Code settings for a toggle that doesn't exist, then can't tell whether they've misconfigured something or the docs are wrong. The docs are the single source of truth for configuration in this project, so a phantom setting there is a real defect.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Upgrade succeeds for a non-Claude provider (Priority: P1)
+
+A user who has configured a non-Claude AI provider (e.g. Codex) runs the "Upgrade Project" action. The upgrade scaffolds for *their* assistant and completes without error.
+
+**Why this priority**: This is the exact failure in the bug report — the command is completely broken for non-Claude users, who currently cannot upgrade at all. Fixing this restores the core capability and is the minimum viable outcome.
+
+**Independent Test**: Set the provider to Codex, trigger "Upgrade Project," and confirm the dispatched upgrade names the Codex agent and the spec-kit CLI runs without an "Unknown agent" error.
+
+**Acceptance Scenarios**:
+
+1. **Given** the AI provider is set to Codex, **When** the user runs "Upgrade Project," **Then** the upgrade requests spec-kit scaffolding for the Codex agent and the CLI does not report an unknown-agent error.
+2. **Given** the AI provider is set to Gemini, **When** the user runs "Upgrade Project," **Then** the upgrade requests the Gemini agent.
+3. **Given** any supported provider is configured, **When** the user runs "Upgrade Project," **Then** the agent identifier sent to spec-kit is one the CLI recognizes.
+
+---
+
+### User Story 2 - Default Claude path no longer sends an invalid identifier (Priority: P1)
+
+A user on the default Claude provider runs "Upgrade Project." The upgrade names the valid `claude` agent rather than the invalid `claude-code`, so the default experience succeeds too.
+
+**Why this priority**: The invalid `claude-code` value breaks even the out-of-the-box default, not just non-Claude users. Both stories share one root cause, so the default path must be fixed in the same change.
+
+**Independent Test**: Leave the provider at its default, trigger "Upgrade Project," and confirm the dispatched command names `claude` and contains no occurrence of `claude-code`.
+
+**Acceptance Scenarios**:
+
+1. **Given** the provider is left at the default, **When** the user runs "Upgrade Project," **Then** the upgrade names the `claude` agent and the literal string `claude-code` does not appear anywhere in the dispatched command.
+
+---
+
+### User Story 3 - Providers without a direct CLI agent still resolve safely (Priority: P2)
+
+A user whose provider is an editor-surface choice rather than a terminal CLI (the Claude VS Code panel, or "IDE Chat" routed to the host editor) runs "Upgrade Project." The upgrade resolves that choice to a valid spec-kit agent and completes without error.
+
+**Why this priority**: These providers have no obvious one-to-one terminal agent, so without explicit handling they would either fail or silently scaffold the wrong assistant. Important for correctness, but the reported break is the CLI providers in P1.
+
+**Independent Test**: Set the provider to the Claude VS Code panel (and separately to IDE Chat), trigger "Upgrade Project," and confirm a valid agent identifier is sent and the CLI does not error.
+
+**Acceptance Scenarios**:
+
+1. **Given** the provider is the Claude VS Code panel, **When** the user runs "Upgrade Project," **Then** the upgrade resolves to the `claude` agent.
+2. **Given** the provider is IDE Chat, **When** the user runs "Upgrade Project," **Then** the upgrade resolves to a valid agent identifier appropriate to the host editor (defaulting to a recognized agent when the host cannot be determined) and the CLI does not report an unknown-agent error.
+
+---
+
+### User Story 4 - Docs no longer point to a setting that doesn't exist (Priority: P2)
+
+A user troubleshooting the workflow editor follows the documentation, which currently tells them to check a `speckit.workflowEditor.enabled` setting. That setting was removed, so the user must not be sent looking for it. After this change, the documentation no longer references the removed setting anywhere.
+
+**Why this priority**: A phantom setting in the docs wastes user time and undermines confidence in the configuration reference, but unlike the upgrade defect it does not block a workflow. It is a documentation-correctness fix bundled here because it shares the "extension claims a value that doesn't exist" root theme.
+
+**Independent Test**: Search the documentation and the extension's declared configuration for `speckit.workflowEditor.enabled` and confirm there are no remaining references that present it as a usable setting.
+
+**Acceptance Scenarios**:
+
+1. **Given** the `speckit.workflowEditor.enabled` setting is not declared by the extension, **When** a user reads the configuration reference and troubleshooting docs, **Then** they find no instruction to set or check `speckit.workflowEditor.enabled`.
+2. **Given** the setting was removed, **When** the codebase is inspected, **Then** no orphaned reference to the removed setting key remains presented as a live configuration option.
+
+---
+
+### Edge Cases
+
+- **Unknown / unset provider value**: If the stored provider setting is empty, missing, or holds a value the extension does not recognize (e.g. a renamed or stale enum), the upgrade falls back to a safe, valid default agent rather than sending an unrecognized identifier.
+- **Both upgrade entry points**: The defect must be fixed wherever an upgrade is dispatched — the standalone "Upgrade Project" action and the combined "upgrade CLI + project" action must use the same provider-derived agent, so neither path can reintroduce `claude-code`.
+- **Provider valid to the extension but not to the installed CLI**: The extension only sends identifiers from the spec-kit supported list; whether a specific CLI build accepts a given name is outside extension control, but the extension never originates an identifier it knows to be invalid.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The upgrade action MUST derive the spec-kit agent identifier from the user's currently configured AI provider, rather than from a hardcoded value.
+- **FR-002**: The upgrade action MUST NOT pass `claude-code` (or any other identifier outside the spec-kit CLI's supported agent list) to the CLI under any provider setting.
+- **FR-003**: Each supported provider MUST map to a valid spec-kit agent identifier as follows: Claude (terminal) → `claude`; Claude VS Code panel → `claude`; Gemini → `gemini`; GitHub Copilot → `copilot`; Codex → `codex`; Qwen → `qwen`; OpenCode → `opencode`.
+- **FR-004**: For a configured provider that does not correspond to a single terminal CLI agent (IDE Chat), the upgrade action MUST resolve to a valid agent identifier appropriate to the host editor, and MUST fall back to a recognized default agent when the host editor cannot be determined.
+- **FR-005**: If the configured provider value is missing, empty, or unrecognized, the upgrade action MUST fall back to a single, valid default agent so the upgrade can never fail with an unknown-agent error.
+- **FR-006**: Every code path that dispatches an upgrade (the standalone project upgrade and the combined CLI-plus-project upgrade) MUST use the same provider-to-agent resolution, so no path can reintroduce a hardcoded or invalid identifier.
+- **FR-007**: The provider-to-agent mapping MUST remain consistent with the agent identifiers used elsewhere in the extension when scaffolding or dispatching for a given provider, so a project upgraded for a provider matches what that provider expects.
+- **FR-008**: The documentation MUST NOT reference `speckit.workflowEditor.enabled` as a usable configuration setting, since it is no longer declared by the extension. Every place that presents it as a live setting (configuration-key listings and troubleshooting guidance) MUST be corrected or removed.
+- **FR-009**: Any orphaned in-code reference that presents `speckit.workflowEditor.enabled` as a live configuration key (e.g. a constant naming it) MUST be removed so the setting key has a single, consistent (absent) status across docs and code.
+- **FR-010**: If the underlying capability the removed setting once gated is still documented as togglable, the docs MUST be corrected to describe the current actual behavior (the capability is no longer gated by a user setting) rather than pointing at the nonexistent toggle.
+
+### Key Entities
+
+- **AI Provider setting**: The user's chosen assistant (Claude, Claude VS Code panel, Gemini, Copilot, Codex, Qwen, OpenCode, IDE Chat). Source of truth for which assistant the workspace should be scaffolded for.
+- **Spec-kit agent identifier**: The value the spec-kit CLI accepts to scaffold an assistant's command files (e.g. `claude`, `codex`, `gemini`, `copilot`, `qwen`, `opencode`, `windsurf`, `cursor-agent`, `generic`, …). The extension must only ever emit a value from this recognized set.
+- **Upgrade action**: The user-triggered operation that re-runs spec-kit scaffolding against the current workspace for a chosen agent.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: For every provider the extension supports, running "Upgrade Project" completes without an "Unknown agent" error — 0 unknown-agent failures across the supported provider set.
+- **SC-002**: The agent the upgrade scaffolds for matches the user's configured provider in 100% of supported-provider cases (a Codex user's upgrade scaffolds Codex, a Gemini user's scaffolds Gemini, etc.).
+- **SC-003**: The literal identifier `claude-code` is never present in any dispatched upgrade command, under any provider setting.
+- **SC-004**: A user who has never changed the default provider can run "Upgrade Project" successfully, with no regression from the prior default experience.
+- **SC-005**: When the provider value is unrecognized or unset, the upgrade still completes successfully against a valid default agent rather than erroring.
+- **SC-006**: A search of the documentation returns zero references that instruct the user to set or check `speckit.workflowEditor.enabled`.
+- **SC-007**: A search of the codebase returns zero references that present `speckit.workflowEditor.enabled` as a live configuration key.
+
+## Assumptions
+
+- The set of providers the extension supports is: Claude (terminal CLI), Claude VS Code panel, Gemini, GitHub Copilot, Codex, Qwen, OpenCode, and IDE Chat. The mapping in FR-003/FR-004 covers all of them.
+- The spec-kit CLI's recognized agent list includes at least `claude`, `codex`, `copilot`, `gemini`, `qwen`, `opencode`, `windsurf`, `cursor-agent`, and `generic` (per the CLI's own error output and current spec-kit releases). `claude-code` is not in that list; the corresponding value is `claude`.
+- The Claude VS Code panel uses the same spec-kit scaffolding as the Claude terminal CLI, so both map to `claude`.
+- For IDE Chat, the appropriate agent depends on the host editor (e.g. Copilot, Cursor, Windsurf). When the host cannot be identified, a recognized default agent is used so the command never errors. The exact host-detection behavior is an implementation detail; the requirement is only that a valid identifier is always sent.
+- The user's configured provider is the single source of truth for the upgrade's target agent; the value previously stored in any spec-kit init metadata is not authoritative for this action.
+- The `speckit.workflowEditor.enabled` setting was intentionally removed in a prior change; the documentation simply wasn't updated to match. The correct fix is therefore to bring the docs (and any orphaned code reference) in line with the setting's removal — not to re-introduce the setting.
+- The project treats its documentation as the single source of truth for configuration, so a configuration reference that lists a nonexistent setting is a defect even though it changes no runtime behavior.
+
+## Out of Scope
+
+Issue #190 bundled five problems. This spec covers the two value-correctness defects (the upgrade agent and the stale setting docs). The remaining three were split into their own tracked issues and are **not** part of this spec:
+
+- **Setup/onboarding clarity** — which components are required and how the VS Code extension relates to the command-line spec-kit workflow → tracked in #192.
+- **Footer/step buttons** in the viewer appearing or disappearing after other buttons are clicked → tracked in #193.
+- **The `analyze` step** not updating `.spec-context.json` and leaving the viewer asking for regeneration → tracked in #194.
+
+This spec is limited to (a) making the upgrade action send a valid, provider-correct spec-kit agent identifier, and (b) removing the phantom `speckit.workflowEditor.enabled` setting from the docs and code.

--- a/specs/122-fix-upgrade-ai-agent/tasks.md
+++ b/specs/122-fix-upgrade-ai-agent/tasks.md
@@ -1,0 +1,165 @@
+# Tasks: Fix Upgrade Agent & Stale Setting Docs
+
+**Input**: Design documents from `specs/122-fix-upgrade-ai-agent/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/agent-resolution.md, quickstart.md
+
+**Tests**: Included. The plan and `contracts/agent-resolution.md` specify a BDD test contract (`specKitAgent.test.ts` NEW, `detector.test.ts` EXTEND) as explicit deliverables, so test tasks are part of this feature.
+
+**Organization**: Tasks are grouped by user story. Because this fix is one shared resolver consumed by every upgrade path, the resolver itself is foundational; each user-story phase owns the verification that its provider class resolves correctly and is independently testable.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (US1–US4)
+- Exact file paths are included in each task
+
+## Path Conventions
+
+Single-project VS Code extension: source under `src/`, tests colocated as `*.test.ts`, docs under `docs/`.
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: Establish a green baseline and confirm the two defect sites before changing anything.
+
+- [X] T001 Run `npm test` to confirm a green baseline, then confirm the two `--ai claude-code` literals in [src/speckit/detector.ts](src/speckit/detector.ts) (`upgradeProject()` ~L235, `upgradeAll()` ~L260) and the `detectHostIde()` instance method in [src/ai-providers/ideChatProvider.ts](src/ai-providers/ideChatProvider.ts). No code change.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Build the shared, total resolver and route both dispatch sites through it. This is the engine every provider story rides on.
+
+**⚠️ CRITICAL**: US1, US2, and US3 all depend on this phase. (US4 — docs/code cleanup — is independent and may proceed in parallel.)
+
+- [X] T002 [P] Extract the body of `IdeChatProvider.detectHostIde()` into a standalone exported `detectHostIde(): HostIde` in [src/ai-providers/ideChatProvider.ts](src/ai-providers/ideChatProvider.ts); make the instance method delegate to it (behavior-preserving for existing IDE-Chat callers). Export the `HostIde` type if not already exported.
+- [X] T003 Create [src/speckit/specKitAgent.ts](src/speckit/specKitAgent.ts) exporting: `PROVIDER_TO_AGENT` (keyed by `AIProviders` values from [src/core/constants.ts](src/core/constants.ts)), the pure total `resolveSpecKitAgent(provider, host)` (direct providers per the contract table, `ide-chat` resolved by host: vscode→`copilot`, cursor→`cursor-agent`, windsurf→`windsurf`, antigravity→`agy`, unknown→`copilot`; any unrecognized/missing provider → `claude`; never returns `claude-code`), and the impure `getConfiguredSpecKitAgent()` (reads `speckit.aiProvider` via `vscode.workspace.getConfiguration`, calls `detectHostIde()`, returns `resolveSpecKitAgent(provider, host)`). Depends on T002.
+- [X] T004 In [src/speckit/detector.ts](src/speckit/detector.ts), import `getConfiguredSpecKitAgent` and replace both `--ai claude-code` literals (in `upgradeProject()` and `upgradeAll()`) with `--ai ${getConfiguredSpecKitAgent()}`. Depends on T003.
+
+**Checkpoint**: All providers now resolve to valid agents at both dispatch sites; `claude-code` is gone from runtime. User-story verification can begin.
+
+---
+
+## Phase 3: User Story 1 - Upgrade succeeds for a non-Claude provider (Priority: P1) 🎯 MVP
+
+**Goal**: A non-Claude provider (Codex, Gemini, Copilot, Qwen, OpenCode) upgrades for *its own* assistant with no "Unknown agent" error.
+
+**Independent Test**: Set provider to Codex, trigger Upgrade Project, confirm the dispatched command names `codex` and the CLI does not error.
+
+- [X] T005 [P] [US1] In [src/speckit/specKitAgent.test.ts](src/speckit/specKitAgent.test.ts), add `describe('resolveSpecKitAgent')` cases asserting each direct non-Claude provider maps to its agent: `gemini`→`gemini`, `copilot`→`copilot`, `codex`→`codex`, `qwen`→`qwen`, `opencode`→`opencode` (one `it` per row).
+- [X] T006 [US1] In [src/speckit/detector.test.ts](src/speckit/detector.test.ts), add a `describe('upgradeProject')` test: with `speckit.aiProvider` mocked to `codex`, the dispatched terminal text contains `--ai codex` and does not contain `claude-code`.
+
+**Checkpoint**: The reported failure (non-Claude upgrade) is fixed and proven. MVP complete.
+
+---
+
+## Phase 4: User Story 2 - Default Claude path no longer sends an invalid identifier (Priority: P1)
+
+**Goal**: The default provider upgrades with `--ai claude`, never `claude-code`.
+
+**Independent Test**: Leave provider at default, trigger Upgrade Project, confirm the command names `claude` and contains no `claude-code`.
+
+- [X] T007 [US2] In [src/speckit/specKitAgent.test.ts](src/speckit/specKitAgent.test.ts), add cases: `resolveSpecKitAgent('claude')` → `claude`, and a guard asserting no input in the contract table ever yields `claude-code`.
+- [X] T008 [US2] In [src/speckit/detector.test.ts](src/speckit/detector.test.ts), add tests: with the default (`claude`) provider, both `upgradeProject()` and `upgradeAll()` dispatch `--ai claude`, contain no `claude-code`, and emit the same `--ai` value for the same provider (FR-006).
+
+**Checkpoint**: Default experience succeeds; both P1 stories pass.
+
+---
+
+## Phase 5: User Story 3 - Providers without a direct CLI agent still resolve safely (Priority: P2)
+
+**Goal**: `claude-vscode`, `ide-chat` (host-resolved), and any unrecognized/missing provider all resolve to a valid agent.
+
+**Independent Test**: Set provider to the Claude VS Code panel (→`claude`) and to IDE Chat (→host-appropriate, default `copilot`), trigger upgrade, confirm a valid identifier is sent and the CLI does not error.
+
+- [X] T009 [US3] In [src/speckit/specKitAgent.test.ts](src/speckit/specKitAgent.test.ts), add cases: `claude-vscode`→`claude`; each `ide-chat` host (vscode→`copilot`, cursor→`cursor-agent`, windsurf→`windsurf`, antigravity→`agy`); `ide-chat` with `unknown` host →`copilot`; and `undefined`/`''`/unrecognized provider →`claude` (FR-004, FR-005).
+
+**Checkpoint**: Every supported provider plus the unknown-value fallback resolves to a valid agent.
+
+---
+
+## Phase 6: User Story 4 - Docs no longer point to a setting that doesn't exist (Priority: P2)
+
+**Goal**: No remaining reference to `speckit.workflowEditor.enabled` as a live setting in docs or code.
+
+**Independent Test**: `grep -rn "workflowEditor.enabled" docs/ README.md src/ webview/` returns zero matches.
+
+- [X] T010 [US4] In [docs/how-it-works.md](docs/how-it-works.md), remove both `speckit.workflowEditor.enabled` references: the `// boolean` line in the Configuration Keys block (~L339) and the "Workflow editor not showing: check `speckit.workflowEditor.enabled`" troubleshooting item (~L596). The editor is no longer gated by a user setting, so drop the troubleshooting entry rather than repoint it at another toggle (FR-008, FR-010).
+- [X] T011 [P] [US4] Delete the `workflowEditorEnabled: 'speckit.workflowEditor.enabled'` entry from `ConfigKeys` in [src/core/constants.ts](src/core/constants.ts) (~L60). It has zero other usages, so removal is inert (FR-009).
+
+**Checkpoint**: The phantom setting is absent from docs, code, and `package.json`.
+
+---
+
+## Phase 7: Polish & Cross-Cutting Concerns
+
+**Purpose**: Verify the whole change against the quickstart and success criteria.
+
+- [X] T012 [P] Run quickstart greps: `grep -rn "claude-code" src/speckit/detector.ts` (expect zero — SC-003) and `grep -rn "workflowEditor.enabled" docs/ README.md src/ webview/` (expect zero — SC-006, SC-007).
+- [X] T013 Run `npm run compile` then `npm test` and confirm both are green (resolver + dispatch suites pass).
+- [X] T014 [P] Confirm [README.md](README.md) needs no change for this fix (no provider added, no live setting removed from its Configuration section) and contains no `workflowEditor.enabled` reference — per plan, the only user-facing doc touched is `docs/how-it-works.md`.
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies.
+- **Foundational (Phase 2)**: Depends on Setup. Blocks US1, US2, US3. (US4 is independent of Phase 2.)
+- **US1 / US2 / US3 (Phases 3–5)**: All depend on Foundational. Once it's done, their test tasks are independent of one another.
+- **US4 (Phase 6)**: Independent — can start immediately, even before Phase 2.
+- **Polish (Phase 7)**: Depends on all desired stories being complete.
+
+### Task-Level Dependencies
+
+- T002 → T003 → T004 (host detector → resolver → routing).
+- T006, T008 (dispatch tests) depend on T004.
+- T005, T007, T009 (pure-function tests) depend on T003.
+- T010, T011 depend on nothing (US4 is standalone).
+- T012–T014 depend on all implementation/test tasks.
+
+### Parallel Opportunities
+
+- T002 and the entire US4 phase (T010, T011) can run in parallel from the start.
+- T011 is [P] with T010 (different files).
+- Within the test phases, T005 is [P] (its own file region); dispatch tests in `detector.test.ts` (T006, T008) share a file and run sequentially.
+- T012 and T014 are [P] in the polish phase.
+
+---
+
+## Parallel Example
+
+```bash
+# From the start, independent tracks:
+Track A (engine): T002 → T003 → T004
+Track B (docs/code cleanup, US4): T010 (docs/how-it-works.md), T011 (src/core/constants.ts)
+
+# After T003/T004 land, the verification tasks:
+T005 (specKitAgent.test.ts) and T006 (detector.test.ts) can be written in parallel.
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1)
+
+1. Phase 1: Setup (green baseline).
+2. Phase 2: Foundational — build `resolveSpecKitAgent` + `getConfiguredSpecKitAgent`, extract `detectHostIde()`, route both dispatch sites. This alone fixes every provider.
+3. Phase 3: US1 — prove a non-Claude provider (Codex) upgrades cleanly. **STOP and VALIDATE** — this is the exact reported bug.
+
+### Incremental Delivery
+
+1. Foundational (+ US4 in parallel, since it's independent) → core fix + clean docs.
+2. US1 → non-Claude providers proven (MVP).
+3. US2 → default `claude` proven, no `claude-code`.
+4. US3 → `claude-vscode`, IDE-Chat host resolution, and fallback proven.
+5. Polish → quickstart greps + full test run.
+
+### Notes
+
+- The resolver is shared foundational code; the user-story phases differentiate by *verified behavior*, each independently testable via its own `describe`/`it` block.
+- [P] = different files, no dependencies.
+- Commit after each logical group; run `npm test` after T004 and again at T013.

--- a/src/ai-providers/ideChatProvider.ts
+++ b/src/ai-providers/ideChatProvider.ts
@@ -9,7 +9,7 @@ import { splitContextPreamble, cleanCommandArg } from './promptBuilder';
  * `unknown` means the editor was not recognized — we still try the inherited
  * base chat command before giving up.
  */
-type HostIde = 'vscode' | 'cursor' | 'windsurf' | 'antigravity' | 'unknown';
+export type HostIde = 'vscode' | 'cursor' | 'windsurf' | 'antigravity' | 'unknown';
 
 /** Inherited VS Code chat-open command — present in most forks. */
 const BASE_CHAT_OPEN = 'workbench.action.chat.open';
@@ -75,6 +75,33 @@ export function getIdeChatDisplayName(): string {
     return IDE_DISPLAY_NAMES[host];
 }
 
+/**
+ * Detect the host editor from stable `vscode.env` signals. `uriScheme` is the
+ * most reliable (forks set their own), with `appName` as a fallback. Shared by
+ * the IDE-Chat dispatch path and the spec-kit agent resolver so host detection
+ * lives in one place.
+ */
+export function detectHostIde(): HostIde {
+    const scheme = (vscode.env.uriScheme || '').toLowerCase();
+    const appName = (vscode.env.appName || '').toLowerCase();
+
+    if (scheme === 'cursor' || appName.includes('cursor')) {
+        return 'cursor';
+    }
+    if (scheme === 'windsurf' || appName.includes('windsurf')) {
+        return 'windsurf';
+    }
+    if (scheme === 'antigravity' || scheme === 'agy' || appName.includes('antigravity')) {
+        return 'antigravity';
+    }
+    if (scheme === 'vscode' || scheme === 'vscode-insiders' || appName.includes('visual studio code')) {
+        return 'vscode';
+    }
+    // An unrecognized fork falls through to 'unknown', which still tries the
+    // inherited base chat command before giving up.
+    return 'unknown';
+}
+
 /** Common tail for the no-chat-target warnings — keeps the guidance identical. */
 const SWITCH_TO_CLI_HINT =
     'Switch `speckit.aiProvider` to a CLI provider (e.g. Claude, Gemini) to run this command.';
@@ -98,29 +125,8 @@ export class IdeChatProvider implements IAIProvider {
         this.outputChannel = outputChannel;
     }
 
-    /**
-     * Detect the host editor from stable `vscode.env` signals. `uriScheme` is
-     * the most reliable (forks set their own), with `appName` as a fallback.
-     */
     detectHostIde(): HostIde {
-        const scheme = (vscode.env.uriScheme || '').toLowerCase();
-        const appName = (vscode.env.appName || '').toLowerCase();
-
-        if (scheme === 'cursor' || appName.includes('cursor')) {
-            return 'cursor';
-        }
-        if (scheme === 'windsurf' || appName.includes('windsurf')) {
-            return 'windsurf';
-        }
-        if (scheme === 'antigravity' || scheme === 'agy' || appName.includes('antigravity')) {
-            return 'antigravity';
-        }
-        if (scheme === 'vscode' || scheme === 'vscode-insiders' || appName.includes('visual studio code')) {
-            return 'vscode';
-        }
-        // An unrecognized fork falls through to 'unknown', which still tries the
-        // inherited base chat command before giving up.
-        return 'unknown';
+        return detectHostIde();
     }
     /**
      * Resolve the first candidate chat command that is actually registered in

--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -23,6 +23,7 @@ export const Commands = {
     upgradeCli: 'speckit.upgradeCli',
     upgradeProject: 'speckit.upgradeProject',
     upgradeAll: 'speckit.upgradeAll',
+    upgrade: 'speckit.upgrade',
     checkForUpdates: 'speckit.checkForUpdates',
     steering: {
         create: 'speckit.steering.create',
@@ -57,7 +58,6 @@ export const Commands = {
  */
 export const ConfigKeys = {
     namespace: 'speckit',
-    workflowEditorEnabled: 'speckit.workflowEditor.enabled',
     claudePath: 'speckit.claudePath',
     aiProvider: 'speckit.aiProvider',
     claudePermissionMode: 'speckit.claudePermissionMode',

--- a/src/speckit/cliCommands.test.ts
+++ b/src/speckit/cliCommands.test.ts
@@ -1,0 +1,70 @@
+import * as vscode from 'vscode';
+import { registerCliCommands } from './cliCommands';
+import { SpecKitDetector } from './detector';
+
+jest.mock('child_process', () => ({ exec: jest.fn() }));
+jest.mock('fs', () => ({ existsSync: jest.fn().mockReturnValue(false), readFileSync: jest.fn() }));
+
+const mockCommands = vscode.commands as jest.Mocked<typeof vscode.commands>;
+const mockWindow = vscode.window as jest.Mocked<typeof vscode.window>;
+
+type Handler = (...args: unknown[]) => unknown;
+
+function getRegisteredHandler(commandId: string): Handler {
+    const call = mockCommands.registerCommand.mock.calls.find(c => c[0] === commandId);
+    if (!call) {
+        throw new Error(`${commandId} was not registered`);
+    }
+    return call[1] as Handler;
+}
+
+describe('speckit.upgrade QuickPick', () => {
+    let context: vscode.ExtensionContext;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        context = { subscriptions: [] } as unknown as vscode.ExtensionContext;
+        registerCliCommands(context, SpecKitDetector.getInstance());
+    });
+
+    it('offers three options in order: All → Project → CLI', async () => {
+        mockWindow.showQuickPick.mockResolvedValue(undefined as never);
+        await getRegisteredHandler('speckit.upgrade')();
+
+        const [items] = mockWindow.showQuickPick.mock.calls[0];
+        const labels = (items as Array<{ label: string }>).map(i => i.label);
+        expect(labels[0]).toMatch(/Upgrade All/);
+        expect(labels[1]).toMatch(/Upgrade Project/);
+        expect(labels[2]).toMatch(/Upgrade CLI/);
+    });
+
+    it('dispatches speckit.upgradeAll when "Upgrade All" is picked', async () => {
+        mockWindow.showQuickPick.mockImplementation(async (items: unknown) => {
+            return (items as Array<{ label: string }>).find(i => i.label.includes('Upgrade All'));
+        });
+        await getRegisteredHandler('speckit.upgrade')();
+        expect(mockCommands.executeCommand).toHaveBeenCalledWith('speckit.upgradeAll');
+    });
+
+    it('dispatches speckit.upgradeProject when "Upgrade Project" is picked', async () => {
+        mockWindow.showQuickPick.mockImplementation(async (items: unknown) => {
+            return (items as Array<{ label: string }>).find(i => i.label.includes('Upgrade Project'));
+        });
+        await getRegisteredHandler('speckit.upgrade')();
+        expect(mockCommands.executeCommand).toHaveBeenCalledWith('speckit.upgradeProject');
+    });
+
+    it('dispatches speckit.upgradeCli when "Upgrade CLI" is picked', async () => {
+        mockWindow.showQuickPick.mockImplementation(async (items: unknown) => {
+            return (items as Array<{ label: string }>).find(i => i.label.includes('Upgrade CLI'));
+        });
+        await getRegisteredHandler('speckit.upgrade')();
+        expect(mockCommands.executeCommand).toHaveBeenCalledWith('speckit.upgradeCli');
+    });
+
+    it('does nothing when the picker is cancelled', async () => {
+        mockWindow.showQuickPick.mockResolvedValue(undefined as never);
+        await getRegisteredHandler('speckit.upgrade')();
+        expect(mockCommands.executeCommand).not.toHaveBeenCalled();
+    });
+});

--- a/src/speckit/cliCommands.ts
+++ b/src/speckit/cliCommands.ts
@@ -27,6 +27,32 @@ export function registerCliCommands(
 
         vscode.commands.registerCommand('speckit.upgradeAll', async () => {
             await specKitDetector.upgradeAll();
+        }),
+
+        vscode.commands.registerCommand('speckit.upgrade', async () => {
+            const pick = await vscode.window.showQuickPick(
+                [
+                    {
+                        label: '$(sync) Upgrade All',
+                        description: "Refresh the spec-kit CLI and this project's scaffolding",
+                        commandId: 'speckit.upgradeAll',
+                    },
+                    {
+                        label: '$(refresh) Upgrade Project',
+                        description: "Refresh this workspace's scaffolding for your AI provider",
+                        commandId: 'speckit.upgradeProject',
+                    },
+                    {
+                        label: '$(cloud-download) Upgrade CLI',
+                        description: 'Install the latest spec-kit CLI globally',
+                        commandId: 'speckit.upgradeCli',
+                    },
+                ],
+                { title: 'SpecKit: Upgrade', placeHolder: 'Choose what to upgrade' }
+            );
+            if (pick) {
+                await vscode.commands.executeCommand(pick.commandId);
+            }
         })
     );
 }

--- a/src/speckit/detector.test.ts
+++ b/src/speckit/detector.test.ts
@@ -79,4 +79,65 @@ describe('SpecKitDetector', () => {
             expect(a).toBe(b);
         });
     });
+
+    describe('upgrade dispatch (--ai agent resolution)', () => {
+        const getConfig = vscode.workspace.getConfiguration as jest.Mock;
+
+        function mockProvider(value: string | undefined): void {
+            getConfig.mockReturnValue({ get: jest.fn().mockReturnValue(value) });
+        }
+
+        function lastSentText(): string {
+            const results = mockWindow.createTerminal.mock.results;
+            const terminal = results[results.length - 1].value;
+            const calls = terminal.sendText.mock.calls;
+            return calls[calls.length - 1][0];
+        }
+
+        beforeEach(() => {
+            (vscode.workspace as any).workspaceFolders = [{ uri: { fsPath: '/tmp/ws' } }];
+        });
+
+        afterEach(() => {
+            (vscode.workspace as any).workspaceFolders = undefined;
+        });
+
+        describe('upgradeProject', () => {
+            it('dispatches the configured non-Claude agent, never claude-code (US1)', async () => {
+                mockProvider('codex');
+                await SpecKitDetector.getInstance().upgradeProject();
+                const sent = lastSentText();
+                expect(sent).toContain('--ai codex');
+                expect(sent).not.toContain('claude-code');
+            });
+
+            it('dispatches --ai claude for the default provider (US2)', async () => {
+                mockProvider('claude');
+                await SpecKitDetector.getInstance().upgradeProject();
+                const sent = lastSentText();
+                expect(sent).toContain('--ai claude');
+                expect(sent).not.toContain('claude-code');
+            });
+        });
+
+        describe('upgradeAll', () => {
+            it('dispatches --ai claude for the default provider, never claude-code (US2)', async () => {
+                mockProvider('claude');
+                await SpecKitDetector.getInstance().upgradeAll();
+                const sent = lastSentText();
+                expect(sent).toContain('--ai claude');
+                expect(sent).not.toContain('claude-code');
+            });
+        });
+
+        it('both upgrade paths emit the same --ai value for the same provider (FR-006)', async () => {
+            mockProvider('claude');
+            await SpecKitDetector.getInstance().upgradeProject();
+            const projectAgent = lastSentText().match(/--ai (\S+)/)?.[1];
+            await SpecKitDetector.getInstance().upgradeAll();
+            const allAgent = lastSentText().match(/--ai (\S+)/)?.[1];
+            expect(projectAgent).toBe('claude');
+            expect(allAgent).toBe('claude');
+        });
+    });
 });

--- a/src/speckit/detector.ts
+++ b/src/speckit/detector.ts
@@ -4,6 +4,7 @@ import * as fs from 'fs';
 import { exec } from 'child_process';
 import { promisify } from 'util';
 import { CONTEXT_KEYS, setContextKey } from '../core/utils/contextKeys';
+import { getConfiguredSpecKitAgent } from './specKitAgent';
 
 const execAsync = promisify(exec);
 
@@ -232,7 +233,7 @@ export class SpecKitDetector {
 
         const terminal = vscode.window.createTerminal('Upgrade SpecKit Project');
         terminal.show();
-        terminal.sendText(`cd "${workspaceFolder.uri.fsPath}" && specify init --here --force --ai claude-code`);
+        terminal.sendText(`cd "${workspaceFolder.uri.fsPath}" && specify init --here --force --ai ${getConfiguredSpecKitAgent()}`);
 
         const selection = await vscode.window.showInformationMessage(
             'Upgrading project files... Reload window after upgrade completes.',
@@ -257,7 +258,7 @@ export class SpecKitDetector {
         const terminal = vscode.window.createTerminal('Upgrade SpecKit (All)');
         terminal.show();
         terminal.sendText('uv tool install specify-cli --force --from git+https://github.com/github/spec-kit.git && ' +
-            `cd "${workspaceFolder.uri.fsPath}" && specify init --here --force --ai claude-code`);
+            `cd "${workspaceFolder.uri.fsPath}" && specify init --here --force --ai ${getConfiguredSpecKitAgent()}`);
 
         const selection = await vscode.window.showInformationMessage(
             'Upgrading SpecKit CLI and project files... Reload window after upgrade completes.',

--- a/src/speckit/specKitAgent.test.ts
+++ b/src/speckit/specKitAgent.test.ts
@@ -1,0 +1,86 @@
+import { resolveSpecKitAgent, PROVIDER_TO_AGENT } from './specKitAgent';
+import { HostIde } from '../ai-providers/ideChatProvider';
+
+const ANY_HOST: HostIde = 'vscode';
+const ALL_HOSTS: HostIde[] = ['vscode', 'cursor', 'windsurf', 'antigravity', 'unknown'];
+
+describe('resolveSpecKitAgent', () => {
+    describe('direct non-Claude providers (US1)', () => {
+        it('maps gemini → gemini', () => {
+            expect(resolveSpecKitAgent('gemini', ANY_HOST)).toBe('gemini');
+        });
+        it('maps copilot → copilot', () => {
+            expect(resolveSpecKitAgent('copilot', ANY_HOST)).toBe('copilot');
+        });
+        it('maps codex → codex', () => {
+            expect(resolveSpecKitAgent('codex', ANY_HOST)).toBe('codex');
+        });
+        it('maps qwen → qwen', () => {
+            expect(resolveSpecKitAgent('qwen', ANY_HOST)).toBe('qwen');
+        });
+        it('maps opencode → opencode', () => {
+            expect(resolveSpecKitAgent('opencode', ANY_HOST)).toBe('opencode');
+        });
+    });
+
+    describe('Claude providers (US2)', () => {
+        it('maps claude → claude', () => {
+            expect(resolveSpecKitAgent('claude', ANY_HOST)).toBe('claude');
+        });
+        it('maps claude-vscode → claude (US3)', () => {
+            expect(resolveSpecKitAgent('claude-vscode', ANY_HOST)).toBe('claude');
+        });
+    });
+
+    describe('ide-chat resolves by host (US3)', () => {
+        it('vscode host → copilot', () => {
+            expect(resolveSpecKitAgent('ide-chat', 'vscode')).toBe('copilot');
+        });
+        it('cursor host → cursor-agent', () => {
+            expect(resolveSpecKitAgent('ide-chat', 'cursor')).toBe('cursor-agent');
+        });
+        it('windsurf host → windsurf', () => {
+            expect(resolveSpecKitAgent('ide-chat', 'windsurf')).toBe('windsurf');
+        });
+        it('antigravity host → agy', () => {
+            expect(resolveSpecKitAgent('ide-chat', 'antigravity')).toBe('agy');
+        });
+        it('unknown host → copilot', () => {
+            expect(resolveSpecKitAgent('ide-chat', 'unknown')).toBe('copilot');
+        });
+    });
+
+    describe('fallback for unrecognized / missing provider (US3)', () => {
+        it('undefined → claude', () => {
+            expect(resolveSpecKitAgent(undefined, ANY_HOST)).toBe('claude');
+        });
+        it('empty string → claude', () => {
+            expect(resolveSpecKitAgent('', ANY_HOST)).toBe('claude');
+        });
+        it('unrecognized value → claude', () => {
+            expect(resolveSpecKitAgent('totally-made-up-provider', ANY_HOST)).toBe('claude');
+        });
+        it('stale claude-code value → claude', () => {
+            expect(resolveSpecKitAgent('claude-code', ANY_HOST)).toBe('claude');
+        });
+    });
+
+    describe('never emits claude-code (US2 guard)', () => {
+        const PROVIDERS: (string | undefined)[] = [
+            ...Object.keys(PROVIDER_TO_AGENT),
+            'ide-chat',
+            '',
+            'claude-code',
+            'unrecognized',
+            undefined,
+        ];
+
+        it('no provider/host combination in the contract table yields claude-code', () => {
+            for (const provider of PROVIDERS) {
+                for (const host of ALL_HOSTS) {
+                    expect(resolveSpecKitAgent(provider, host)).not.toBe('claude-code');
+                }
+            }
+        });
+    });
+});

--- a/src/speckit/specKitAgent.ts
+++ b/src/speckit/specKitAgent.ts
@@ -1,0 +1,57 @@
+import * as vscode from 'vscode';
+import { AIProviders } from '../core/constants';
+import { detectHostIde, HostIde } from '../ai-providers/ideChatProvider';
+
+/**
+ * The spec-kit CLI accepted agent identifier the upgrade command passes as
+ * `specify init … --ai <agent>`. `claude-code` is NOT a member of this set —
+ * the resolver never emits it.
+ */
+export type SpecKitAgent = string;
+
+/** Safe fallback for any unrecognized / missing provider value. */
+const DEFAULT_AGENT = 'claude';
+
+/**
+ * Direct provider → agent map, keyed by `speckit.aiProvider` values. Excludes
+ * `ide-chat`, which is host-resolved (see IDE_CHAT_HOST_TO_AGENT).
+ */
+export const PROVIDER_TO_AGENT: Record<string, SpecKitAgent> = {
+    [AIProviders.CLAUDE]: 'claude',
+    [AIProviders.CLAUDE_VSCODE]: 'claude',
+    [AIProviders.GEMINI]: 'gemini',
+    [AIProviders.COPILOT]: 'copilot',
+    [AIProviders.CODEX]: 'codex',
+    [AIProviders.QWEN]: 'qwen',
+    [AIProviders.OPENCODE]: 'opencode',
+};
+
+/** `ide-chat` resolves by detected host editor; unknown hosts fall back to Copilot. */
+const IDE_CHAT_HOST_TO_AGENT: Record<HostIde, SpecKitAgent> = {
+    vscode: 'copilot',
+    cursor: 'cursor-agent',
+    windsurf: 'windsurf',
+    antigravity: 'agy',
+    unknown: 'copilot',
+};
+
+/**
+ * Pure, total map from the configured provider (plus host, for `ide-chat`) to a
+ * valid spec-kit CLI agent. Never throws, never reads config, and never returns
+ * `claude-code` — any unrecognized/missing provider resolves to `claude`.
+ */
+export function resolveSpecKitAgent(provider: string | undefined, host: HostIde): SpecKitAgent {
+    if (provider === AIProviders.IDE_CHAT) {
+        return IDE_CHAT_HOST_TO_AGENT[host] ?? IDE_CHAT_HOST_TO_AGENT.unknown;
+    }
+    return PROVIDER_TO_AGENT[provider ?? ''] ?? DEFAULT_AGENT;
+}
+
+/**
+ * Impure wrapper: reads `speckit.aiProvider`, detects the host, and resolves the
+ * agent. Both upgrade dispatch sites call this so neither can hardcode an agent.
+ */
+export function getConfiguredSpecKitAgent(): SpecKitAgent {
+    const provider = vscode.workspace.getConfiguration('speckit').get<string>('aiProvider');
+    return resolveSpecKitAgent(provider, detectHostIde());
+}


### PR DESCRIPTION
## Summary

- **Bug fix.** The upgrade action ignored the configured AI provider and always passed `--ai claude-code` — an identifier the spec-kit CLI rejects with `Unknown agent 'claude-code'`. A new pure resolver maps `speckit.aiProvider` (and the host editor, for `ide-chat`) to a valid CLI agent; both dispatch sites (`upgradeProject`, `upgradeAll`) route through it. Unrecognized providers fall back to `claude`.
- **Doc cleanup.** Remove the phantom `speckit.workflowEditor.enabled` references from `docs/how-it-works.md` and the unused `ConfigKeys.workflowEditorEnabled` constant — the setting is no longer contributed.
- **UI consolidation.** The three separate upgrade title-bar entries are replaced by a single `Upgrade…` icon (\`\$(cloud-download)\`) that opens a QuickPick with **Upgrade All → Upgrade Project → Upgrade CLI** in deliberate order. The individual commands stay in the Command Palette.
- Extracts \`detectHostIde()\` from \`IdeChatProvider\` into a standalone export so the IDE-Chat dispatch path and the new resolver share one host detector.

Closes part of #190 (the two value-correctness defects: upgrade agent + stale setting docs). The remaining three items from #190 are tracked in #192, #193, #194.

## Test plan

- [x] \`npm run compile\` clean
- [x] \`npm test\` — 65 suites / 787 tests green, including new \`specKitAgent.test.ts\` (resolver), \`cliCommands.test.ts\` (picker dispatch), and extended \`detector.test.ts\` (\`--ai\` value at both dispatch sites, FR-006 cross-path consistency)
- [x] \`grep -rn "claude-code" src/speckit/detector.ts\` → 0
- [x] \`grep -rn "workflowEditor.enabled" docs/ README.md src/ webview/\` → 0
- [ ] **Manual (F5)**: Specs view title bar shows the new \`Upgrade…\` icon; clicking it opens a picker with All / Project / CLI in that order
- [ ] **Manual**: with \`speckit.aiProvider\` set to \`codex\`, Upgrade Project dispatches \`specify init --here --force --ai codex\` (no \`Unknown agent\` error)
- [ ] **Manual**: with the default \`claude\` provider, both upgrade paths dispatch \`--ai claude\` (no \`claude-code\` anywhere)
- [ ] **Manual**: Command Palette still lists \`SpecKit: Upgrade CLI\`, \`Upgrade Project Files\`, and \`Upgrade All\` individually

🤖 Generated with [Claude Code](https://claude.com/claude-code)