### PR TITLE
refactor(ai-providers): remove CLI path override settings

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -90,7 +90,8 @@ User-visible settings are declared in `package.json` under `contributes.configur
 
 - `speckit.aiProvider` — selects the active provider. Its enum is the canonical provider list; the README "Supported AI Providers" matrix and this document's prose are checked against it on every `npm test`.
 - `speckit.specDirectories` — list of directories the spec sidebar reads from.
-- Per-provider path overrides (`speckit.geminiPath`, `speckit.copilotPath`, etc.) and timing knobs (`speckit.geminiInitDelay`).
+
+Each CLI provider invokes its binary by bare name from `PATH` (`claude`, `gemini`, `copilot`, `qwen`, `opencode`); there are no per-provider path-override settings.
 
 User data is stored under the workspace `.claude/` and `specs/` directories, plus the user's home `~/.claude/`. None of these are shipped in the `.vsix`; the extension only reads them at runtime.
 

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -350,8 +350,9 @@ speckit.views.settings.visible        // boolean
 
 | Constant | Value | Purpose |
 |----------|-------|---------|
-| `terminalVenvActivationDelay` | 800 | Wait for venv activation |
+| `shellReadyTimeoutMs` | 5000 | Wait for shell integration readiness |
 | `tempFileCleanupDelay` | 30000 | Clean prompt temp files |
+| `terminalDisposeDelay` | 1000 | Delay terminal disposal after execution |
 | `fileWatcherDebounce` | 1000 | Batch file change events |
 
 ---

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -336,11 +336,6 @@ const debouncedRefresh = (event: string, uri: vscode.Uri) => {
 
 ```typescript
 speckit.aiProvider                    // 'claude' | 'claude-vscode' | 'gemini' | 'copilot' | 'codex' | 'qwen' | 'opencode' | 'ide-chat'
-speckit.claudePath                    // Custom Claude CLI path
-speckit.geminiPath                    // Custom Gemini CLI path
-speckit.copilotPath                   // Custom Copilot CLI path
-speckit.qwenPath                      // Custom Qwen CLI path
-speckit.geminiInitDelay               // Gemini startup delay (ms)
 speckit.permissionMode                // Permission bypass mode
 speckit.specDirectories               // Additional spec directories
 speckit.customCommands                // Custom command definitions
@@ -358,7 +353,6 @@ speckit.views.settings.visible        // boolean
 | `terminalVenvActivationDelay` | 800 | Wait for venv activation |
 | `tempFileCleanupDelay` | 30000 | Clean prompt temp files |
 | `fileWatcherDebounce` | 1000 | Batch file change events |
-| `geminiInitDelay` | 8000 | Gemini CLI startup time |
 
 ---
 

--- a/docs/providers/qwen-setup.md
+++ b/docs/providers/qwen-setup.md
@@ -69,15 +69,15 @@ Open VS Code Settings (`Cmd/Ctrl + ,`) and search for **SpecKit AI Provider**, t
 
 | Setting | Default | Description |
 |---|---|---|
-| `speckit.qwenPath` | `"qwen"` | Path to the Qwen Code CLI executable. Change this if `qwen` is not on your `PATH`. |
 | `speckit.qwenYoloMode` | `false` | Enable `--yolo` mode to auto-approve all Qwen actions without prompts. |
+
+The extension invokes the `qwen` binary from your `PATH`; make sure `qwen` is on it (see Troubleshooting below).
 
 Example `settings.json`:
 
 ```json
 {
   "speckit.aiProvider": "qwen",
-  "speckit.qwenPath": "qwen",
   "speckit.qwenYoloMode": false
 }
 ```
@@ -116,7 +116,7 @@ The **Steering** panel in SpecKit will show the global and project `QWEN.md` fil
 
 - Make sure the npm global bin directory is on your `PATH`.
 - Run `npm bin -g` to find the directory and add it to your shell profile.
-- Or set `speckit.qwenPath` to the absolute path of the `qwen` binary.
+- The extension calls `qwen` by bare name, so it must be resolvable on the `PATH` of the shell VS Code launches.
 
 ### Authentication errors
 

--- a/package.json
+++ b/package.json
@@ -677,13 +677,6 @@
             "order": 0,
             "description": "Show a notification when a dispatched spec step completes."
           },
-          "speckit.claudePath": {
-            "type": "string",
-            "default": "claude",
-            "scope": "machine",
-            "order": 1,
-            "description": "Path to Claude Code CLI executable"
-          },
           "speckit.aiProvider": {
             "type": "string",
             "default": "claude",
@@ -752,43 +745,6 @@
             "scope": "machine",
             "order": 3,
             "description": "Controls how the AI CLI handles permission prompts. 'interactive' is honored only by providers whose CLI supports interactive prompting (Claude, Gemini, Codex, Qwen, OpenCode). Copilot's CLI cannot surface prompts in -p mode and is auto-switched to auto-approve at dispatch time, regardless of this setting — dismissing the startup warning will not re-enable interactive mode for Copilot."
-          },
-          "speckit.geminiPath": {
-            "type": "string",
-            "default": "gemini",
-            "scope": "machine",
-            "order": 3,
-            "description": "Path to Gemini CLI executable"
-          },
-          "speckit.copilotPath": {
-            "type": "string",
-            "default": "copilot",
-            "scope": "machine",
-            "order": 4,
-            "description": "Path to GitHub Copilot CLI executable"
-          },
-          "speckit.geminiInitDelay": {
-            "type": "number",
-            "default": 8000,
-            "minimum": 3000,
-            "maximum": 30000,
-            "scope": "machine",
-            "order": 5,
-            "description": "Delay in milliseconds before sending prompt to Gemini CLI (allows time for initialization)"
-          },
-          "speckit.qwenPath": {
-            "type": "string",
-            "default": "qwen",
-            "scope": "machine",
-            "order": 6,
-            "description": "Path to Qwen Code CLI executable"
-          },
-          "speckit.opencodePath": {
-            "type": "string",
-            "default": "opencode",
-            "scope": "machine",
-            "order": 7,
-            "description": "Path to OpenCode CLI executable"
           },
           "speckit.specDirectories": {
             "type": "array",

--- a/specs/127-remove-cli-path-settings/.spec-context.json
+++ b/specs/127-remove-cli-path-settings/.spec-context.json
@@ -1,0 +1,81 @@
+{
+  "workflow": "sdd",
+  "currentStep": "done",
+  "currentTask": null,
+  "progress": null,
+  "next": "done",
+  "status": "completed",
+  "checkpointStatus": { "commit": true, "pr": true },
+  "updated": "2026-06-05",
+  "selectedAt": "2026-06-05T21:30:55Z",
+  "specName": "Remove CLI Path Override Settings",
+  "branch": "main",
+  "workingBranch": "refactor/remove-cli-path-settings",
+  "type": "refactor",
+  "createdAt": "2026-06-05T21:30:55Z",
+  "auto": true,
+  "loadedDomains": [],
+  "approach": "Remove the path-override config surface and collapse every provider onto its bare CLI binary name by dropping the cliPathSettingKey abstraction.",
+  "last_action": "Phase 1 complete — 10 tasks done, compile + 810 tests pass, sweep clean",
+  "files_modified": [
+    "src/ai-providers/cliTerminalProvider.ts",
+    "src/ai-providers/geminiCliProvider.ts",
+    "src/ai-providers/copilotCliProvider.ts",
+    "src/ai-providers/qwenCliProvider.ts",
+    "src/ai-providers/openCodeProvider.ts",
+    "src/ai-providers/claudeCodeProvider.ts",
+    "src/ai-providers/codexCliProvider.ts",
+    "src/core/constants.ts",
+    "package.json",
+    "docs/how-it-works.md",
+    "docs/architecture.md",
+    "docs/providers/qwen-setup.md"
+  ],
+  "task_summaries": {
+    "T001": { "status": "DONE", "did": "Removed cliPathSettingKey field + getCliPath() from base provider; prepareDispatch uses this.cliBinary", "files": ["src/ai-providers/cliTerminalProvider.ts"], "concerns": [] },
+    "T002": { "status": "DONE", "did": "Removed cliPathSettingKey='copilotPath' from Copilot provider", "files": ["src/ai-providers/copilotCliProvider.ts"], "concerns": [] },
+    "T003": { "status": "DONE", "did": "Removed cliPathSettingKey='qwenPath' from Qwen provider", "files": ["src/ai-providers/qwenCliProvider.ts"], "concerns": [] },
+    "T004": { "status": "DONE", "did": "Removed cliPathSettingKey='opencodePath' from OpenCode provider", "files": ["src/ai-providers/openCodeProvider.ts"], "concerns": [] },
+    "T005": { "status": "DONE", "did": "Removed cliPathSettingKey=null from Claude provider", "files": ["src/ai-providers/claudeCodeProvider.ts"], "concerns": [] },
+    "T006": { "status": "DONE", "did": "Removed cliPathSettingKey=null from Codex provider", "files": ["src/ai-providers/codexCliProvider.ts"], "concerns": [] },
+    "T007": { "status": "DONE", "did": "Dropped getCliPath + geminiInitDelay reads in Gemini provider; bare 'gemini' binary + hard-coded 8000ms INIT_DELAY_MS", "files": ["src/ai-providers/geminiCliProvider.ts"], "concerns": [] },
+    "T008": { "status": "DONE", "did": "Removed claudePath, geminiPath, copilotPath, qwenPath, opencodePath, geminiInitDelay properties from package.json contributes.configuration", "files": ["package.json"], "concerns": [] },
+    "T009": { "status": "DONE", "did": "Removed claudePath/qwenPath/geminiInitDelay from ConfigKeys and geminiInitDelay from Timing in constants.ts", "files": ["src/core/constants.ts"], "concerns": [] },
+    "T010": { "status": "DONE", "did": "Swept src/webview/tests for stragglers (clean), compile passed, 810 tests passed; README has no doc section for these settings", "files": [], "concerns": [] }
+  },
+  "step_summaries": {
+    "specify": {
+      "complexity": "normal",
+      "requirements": 6,
+      "scenarios": 3,
+      "key_finding": "claudePath is dead config (never read; Claude provider uses cliPathSettingKey=null); getCliPath() already falls back to the bare binary name, so removing path settings makes every provider invoke its CLI from PATH"
+    },
+    "plan": {
+      "approach_summary": "Remove the path-override config surface and collapse every provider onto its bare CLI binary name by dropping the cliPathSettingKey abstraction.",
+      "files_planned": 8,
+      "risks": ["A test or provider file may reference cliPathSettingKey/getCliPath beyond the listed files — the compile step catches stragglers"],
+      "principles_concerns": 0,
+      "domain_concerns": 0,
+      "significance_score": 0
+    }
+  },
+  "transitions": [
+    { "step": "specify", "substep": "parsing", "from": null, "by": "sdd", "at": "2026-06-05T21:30:55Z" },
+    { "step": "specify", "substep": "exploring", "from": "parsing", "by": "sdd", "at": "2026-06-05T21:31:10Z" },
+    { "step": "specify", "substep": "detecting", "from": "exploring", "by": "sdd", "at": "2026-06-05T21:31:40Z" },
+    { "step": "specify", "substep": "writing-spec", "from": "detecting", "by": "sdd", "at": "2026-06-05T21:32:00Z" },
+    { "step": "specify", "substep": null, "from": "writing-spec", "by": "sdd", "at": "2026-06-05T21:32:30Z" },
+    { "step": "specify", "substep": "auto-marked", "from": null, "by": "sdd", "at": "2026-06-05T21:32:45Z" },
+    { "step": "plan", "substep": "loading", "from": "specify", "by": "sdd", "at": "2026-06-05T21:33:30Z" },
+    { "step": "plan", "substep": "writing-plan", "from": "loading", "by": "sdd", "at": "2026-06-05T21:33:50Z" },
+    { "step": "plan", "substep": null, "from": "writing-plan", "by": "sdd", "at": "2026-06-05T21:34:10Z" },
+    { "step": "tasks", "substep": "loading", "from": "plan", "by": "sdd", "at": "2026-06-05T21:34:40Z" },
+    { "step": "tasks", "substep": "writing-tasks", "from": "loading", "by": "sdd", "at": "2026-06-05T21:35:00Z" },
+    { "step": "tasks", "substep": null, "from": "writing-tasks", "by": "sdd", "at": "2026-06-05T21:35:20Z" },
+    { "step": "implement", "substep": "phase1", "from": "tasks", "by": "sdd", "at": "2026-06-05T21:36:00Z" },
+    { "step": "implement", "substep": "hooks", "from": "phase1", "by": "sdd", "at": "2026-06-05T21:40:00Z" },
+    { "step": "implement", "substep": "code-review", "from": "hooks", "by": "sdd", "at": "2026-06-05T21:40:30Z" },
+    { "step": "implement", "substep": "commit-review", "from": "code-review", "by": "sdd", "at": "2026-06-05T21:45:00Z" },
+    { "step": "done", "substep": null, "from": "commit-review", "by": "sdd", "at": "2026-06-05T21:45:30Z" }
+  ]
+}

--- a/specs/127-remove-cli-path-settings/.spec-context.json
+++ b/specs/127-remove-cli-path-settings/.spec-context.json
@@ -16,7 +16,9 @@
   "auto": true,
   "loadedDomains": [],
   "approach": "Remove the path-override config surface and collapse every provider onto its bare CLI binary name by dropping the cliPathSettingKey abstraction.",
-  "last_action": "Phase 1 complete — 10 tasks done, compile + 810 tests pass, sweep clean",
+  "prUrl": "https://github.com/alfredoperez/speckit-companion/pull/200",
+  "prNumber": 200,
+  "last_action": "PR #200 opened — refactor(ai-providers): remove CLI path override settings",
   "files_modified": [
     "src/ai-providers/cliTerminalProvider.ts",
     "src/ai-providers/geminiCliProvider.ts",

--- a/specs/127-remove-cli-path-settings/.spec-context.json
+++ b/specs/127-remove-cli-path-settings/.spec-context.json
@@ -13,7 +13,7 @@
   "workingBranch": "refactor/remove-cli-path-settings",
   "type": "refactor",
   "createdAt": "2026-06-05T21:30:55Z",
-  "auto": true,
+  "auto": false,
   "loadedDomains": [],
   "approach": "Remove the path-override config surface and collapse every provider onto its bare CLI binary name by dropping the cliPathSettingKey abstraction.",
   "prUrl": "https://github.com/alfredoperez/speckit-companion/pull/200",

--- a/specs/127-remove-cli-path-settings/plan.md
+++ b/specs/127-remove-cli-path-settings/plan.md
@@ -11,7 +11,7 @@ Delete the path-override config surface and collapse every provider onto its bar
 ```mermaid
 graph LR
   A[package.json config] -->|removed| X[gone]
-  B[cliPathSettingKey field] -->|removed| C[getCliPath returns cliBinary]
+  B[cliPathSettingKey + getCliPath] -->|removed| C[dispatch uses cliBinary directly]
   C --> D[provider invokes bare binary on PATH]
 ```
 

--- a/specs/127-remove-cli-path-settings/plan.md
+++ b/specs/127-remove-cli-path-settings/plan.md
@@ -1,0 +1,40 @@
+# Plan: Remove CLI Path Override Settings
+
+**Spec**: [spec.md](./spec.md)
+
+## Approach
+
+Delete the path-override config surface and collapse every provider onto its bare CLI binary name. `getCliPath()` in the base `CliTerminalProvider` already falls back to `cliBinary` when `cliPathSettingKey` is `null`, so the cleanest cut is to remove the `cliPathSettingKey` abstraction entirely: drop the field from the base class and all subclasses, and have dispatch use `this.cliBinary` directly. The standalone Gemini provider (which sits outside the `CliTerminalProvider` hierarchy) loses its own `getCliPath` override and `geminiInitDelay` read, hard-coding the former 8000ms default. Finally strip the six properties from `package.json` and the orphaned keys from `constants.ts`.
+
+## Architecture
+
+```mermaid
+graph LR
+  A[package.json config] -->|removed| X[gone]
+  B[cliPathSettingKey field] -->|removed| C[getCliPath returns cliBinary]
+  C --> D[provider invokes bare binary on PATH]
+```
+
+## Files
+
+### Modify
+
+- `package.json` — remove `speckit.claudePath`, `speckit.geminiPath`, `speckit.copilotPath`, `speckit.qwenPath`, `speckit.opencodePath`, and `speckit.geminiInitDelay` from `contributes.configuration` properties.
+- `src/core/constants.ts` — remove `claudePath`, `qwenPath`, `geminiInitDelay` from `ConfigKeys`; remove `geminiInitDelay` from `Timing`.
+- `src/ai-providers/cliTerminalProvider.ts` — remove the abstract `cliPathSettingKey` field and the `getCliPath()` method; have `prepareDispatch` resolve `cliPath` from `this.cliBinary` directly.
+- `src/ai-providers/geminiCliProvider.ts` — remove the `getCliPath()` override and the `geminiInitDelay` config read; use the bare `gemini` binary and a hard-coded 8000ms init delay.
+- `src/ai-providers/copilotCliProvider.ts` — remove `cliPathSettingKey = 'copilotPath'`.
+- `src/ai-providers/qwenCliProvider.ts` — remove `cliPathSettingKey = 'qwenPath'`.
+- `src/ai-providers/openCodeProvider.ts` — remove `cliPathSettingKey = 'opencodePath'`.
+- `src/ai-providers/claudeCodeProvider.ts` — remove `cliPathSettingKey = null` (field no longer exists on base).
+- `src/ai-providers/codexCliProvider.ts` — remove `cliPathSettingKey = null` (field no longer exists on base).
+
+## Testing Strategy
+
+- **Build**: `npm run compile` must pass — removing the abstract field surfaces any subclass that still declares it.
+- **Unit**: `npm test` — update/remove any provider test that stubs a path setting or asserts on `cliPathSettingKey` / `getCliPath`.
+- **Edge cases**: a persisted `speckit.geminiPath` in user settings is silently ignored after removal (VS Code drops unknown keys); dispatch still resolves `gemini` from `PATH`.
+
+## Risks
+
+- A test or provider file may reference `cliPathSettingKey` / `getCliPath` beyond the listed files — the compile step will catch any stragglers; grep before finalizing.

--- a/specs/127-remove-cli-path-settings/spec.md
+++ b/specs/127-remove-cli-path-settings/spec.md
@@ -4,12 +4,12 @@
 
 ## Summary
 
-The extension exposes five per-CLI executable-path override settings (`speckit.claudePath`, `speckit.geminiPath`, `speckit.copilotPath`, `speckit.qwenPath`, `speckit.opencodePath`) plus a `speckit.geminiInitDelay` timing knob. These are rarely-needed power-user tuning options that clutter the configuration surface — and `claudePath` is already dead config (defined in `package.json` but never read, since the Claude provider declares `cliPathSettingKey = null`). This change removes the path overrides so every provider simply invokes its CLI by bare binary name from `PATH` (already the default fallback in `getCliPath()`), and removes the adjacent `geminiInitDelay` knob.
+The extension exposed five per-CLI executable-path override settings (`speckit.claudePath`, `speckit.geminiPath`, `speckit.copilotPath`, `speckit.qwenPath`, `speckit.opencodePath`) plus a `speckit.geminiInitDelay` timing knob. These were rarely-needed power-user tuning options that cluttered the configuration surface — and `claudePath` was already dead config (defined in `package.json` but never read). This change removes the path overrides so every provider simply invokes its CLI by bare binary name from `PATH`, and removes the adjacent `geminiInitDelay` knob.
 
 ## Requirements
 
 - **R001** (MUST): Remove the `speckit.claudePath`, `speckit.geminiPath`, `speckit.copilotPath`, `speckit.qwenPath`, and `speckit.opencodePath` configuration properties from `package.json` `contributes.configuration`.
-- **R002** (MUST): Every CLI provider resolves its executable to the bare binary name (`claude`, `gemini`, `copilot`, `qwen`, `opencode`) — i.e. `cliPathSettingKey` becomes `null` for all providers and the per-provider `getCliPath` override in `geminiCliProvider.ts` is dropped in favor of the bare binary.
+- **R002** (MUST): Every CLI provider resolves its executable to the bare binary name (`claude`, `gemini`, `copilot`, `qwen`, `opencode`) by removing per-provider path-setting lookups and removing the `getCliPath` override in `geminiCliProvider.ts`.
 - **R003** (MUST): Remove the now-unused path keys (`claudePath`, `qwenPath`) from `ConfigKeys` in `src/core/constants.ts`, plus any other now-orphaned path key references.
 - **R004** (SHOULD): Remove the `speckit.geminiInitDelay` setting and its `Timing.geminiInitDelay` default + read site, hard-coding the existing 8000ms default in the Gemini provider.
 - **R005** (MUST): Extension activation and provider dispatch continue to work with no path settings present — no crash, no broken command, providers invoke their binary from `PATH`.

--- a/specs/127-remove-cli-path-settings/spec.md
+++ b/specs/127-remove-cli-path-settings/spec.md
@@ -1,0 +1,39 @@
+# Spec: Remove CLI Path Override Settings
+
+**Slug**: 127-remove-cli-path-settings | **Date**: 2026-06-05
+
+## Summary
+
+The extension exposes five per-CLI executable-path override settings (`speckit.claudePath`, `speckit.geminiPath`, `speckit.copilotPath`, `speckit.qwenPath`, `speckit.opencodePath`) plus a `speckit.geminiInitDelay` timing knob. These are rarely-needed power-user tuning options that clutter the configuration surface — and `claudePath` is already dead config (defined in `package.json` but never read, since the Claude provider declares `cliPathSettingKey = null`). This change removes the path overrides so every provider simply invokes its CLI by bare binary name from `PATH` (already the default fallback in `getCliPath()`), and removes the adjacent `geminiInitDelay` knob.
+
+## Requirements
+
+- **R001** (MUST): Remove the `speckit.claudePath`, `speckit.geminiPath`, `speckit.copilotPath`, `speckit.qwenPath`, and `speckit.opencodePath` configuration properties from `package.json` `contributes.configuration`.
+- **R002** (MUST): Every CLI provider resolves its executable to the bare binary name (`claude`, `gemini`, `copilot`, `qwen`, `opencode`) — i.e. `cliPathSettingKey` becomes `null` for all providers and the per-provider `getCliPath` override in `geminiCliProvider.ts` is dropped in favor of the bare binary.
+- **R003** (MUST): Remove the now-unused path keys (`claudePath`, `qwenPath`) from `ConfigKeys` in `src/core/constants.ts`, plus any other now-orphaned path key references.
+- **R004** (SHOULD): Remove the `speckit.geminiInitDelay` setting and its `Timing.geminiInitDelay` default + read site, hard-coding the existing 8000ms default in the Gemini provider.
+- **R005** (MUST): Extension activation and provider dispatch continue to work with no path settings present — no crash, no broken command, providers invoke their binary from `PATH`.
+- **R006** (SHOULD): If any README/docs section documents these settings, remove it (current grep shows none documented, so this is likely a no-op).
+
+## Scenarios
+
+### Dispatching to a CLI provider after removal
+
+**When** the user runs a spec step against any CLI provider (Gemini, Copilot, Qwen, OpenCode, Claude) with no path settings configured
+**Then** the provider invokes its binary by bare name from `PATH`, exactly as it did when the path setting was left at its default
+
+### Stale path setting persisted in user settings
+
+**When** a user who previously set `speckit.geminiPath` upgrades to the version that removed it
+**Then** the now-unknown setting is silently ignored by VS Code and dispatch falls back to the bare `gemini` binary — no activation error
+
+### Gemini initialization delay
+
+**When** the Gemini provider starts interactively and waits before sending the prompt
+**Then** it uses the hard-coded 8000ms delay (the former default) with no configurable override
+
+## Out of Scope
+
+- Removing `speckit.commandFormat`, `speckit.permissionMode`, `speckit.claudePermissionMode`, or `speckit.qwenYoloMode` — these are behavioral, not path/tuning clutter, and are left untouched unless the user widens scope at the review gate.
+- Any migration/notification telling users their path override was removed (VS Code's silent-ignore of unknown keys is sufficient).
+- Changing how CLI installation is detected (`isInstalled()` already uses the bare binary).

--- a/specs/127-remove-cli-path-settings/tasks.md
+++ b/specs/127-remove-cli-path-settings/tasks.md
@@ -1,0 +1,48 @@
+# Tasks: Remove CLI Path Override Settings
+
+**Plan**: [plan.md](./plan.md)
+
+> Format reference: `[P]` markers and parallel groups — see `skills/tasks/SKILL.md` § Phase rules.
+
+## Phase 1: Core Implementation
+
+- [x] **T001** Drop the path-override abstraction from the base provider — `src/ai-providers/cliTerminalProvider.ts` | R002
+  - **Do**: Remove the abstract `cliPathSettingKey` field and the `getCliPath()` method. In `prepareDispatch`, resolve `cliPath` from `this.cliBinary` directly instead of `this.getCliPath()`.
+  - **Verify**: File no longer references `cliPathSettingKey` or `getCliPath`; `prepareDispatch` uses `this.cliBinary`.
+  - **Leverage**: existing `cliBinary` field already used by `isInstalled()`.
+
+- [x] **T002** [P] Remove path key from Copilot provider *(depends on T001)* — `src/ai-providers/copilotCliProvider.ts` | R002
+  - **Do**: Delete the `protected readonly cliPathSettingKey = 'copilotPath';` line.
+  - **Verify**: No `cliPathSettingKey` reference remains.
+
+- [x] **T003** [P] Remove path key from Qwen provider *(depends on T001)* — `src/ai-providers/qwenCliProvider.ts` | R002
+  - **Do**: Delete the `protected readonly cliPathSettingKey = 'qwenPath';` line.
+  - **Verify**: No `cliPathSettingKey` reference remains.
+
+- [x] **T004** [P] Remove path key from OpenCode provider *(depends on T001)* — `src/ai-providers/openCodeProvider.ts` | R002
+  - **Do**: Delete the `protected readonly cliPathSettingKey = 'opencodePath';` line.
+  - **Verify**: No `cliPathSettingKey` reference remains.
+
+- [x] **T005** [P] Remove null path key from Claude provider *(depends on T001)* — `src/ai-providers/claudeCodeProvider.ts` | R001, R002
+  - **Do**: Delete the `protected readonly cliPathSettingKey = null;` line (field no longer exists on base).
+  - **Verify**: No `cliPathSettingKey` reference remains.
+
+- [x] **T006** [P] Remove null path key from Codex provider *(depends on T001)* — `src/ai-providers/codexCliProvider.ts` | R002
+  - **Do**: Delete the `protected readonly cliPathSettingKey = null;` line.
+  - **Verify**: No `cliPathSettingKey` reference remains.
+
+- [x] **T007** [P] Collapse Gemini provider to bare binary + hard-coded delay — `src/ai-providers/geminiCliProvider.ts` | R002, R004
+  - **Do**: Remove the `getCliPath()` override (use the bare `gemini` binary) and the `geminiInitDelay` config read; hard-code the 8000ms init delay.
+  - **Verify**: No `geminiPath` or `geminiInitDelay` reference remains; init delay is a literal `8000`.
+
+- [x] **T008** [P] Strip path + delay settings from manifest — `package.json` | R001, R004
+  - **Do**: Remove the `speckit.claudePath`, `speckit.geminiPath`, `speckit.copilotPath`, `speckit.qwenPath`, `speckit.opencodePath`, and `speckit.geminiInitDelay` properties from `contributes.configuration`.
+  - **Verify**: `grep -E "claudePath|geminiPath|copilotPath|qwenPath|opencodePath|geminiInitDelay" package.json` returns nothing.
+
+- [x] **T009** [P] Remove orphaned keys from constants — `src/core/constants.ts` | R003, R004
+  - **Do**: Remove `claudePath`, `qwenPath`, `geminiInitDelay` from `ConfigKeys`; remove `geminiInitDelay` (field + comment) from `Timing`.
+  - **Verify**: No `claudePath` / `qwenPath` / `geminiInitDelay` reference remains in the file.
+
+- [x] **T010** Build, sweep for stragglers, and run tests *(depends on T002, T003, T004, T005, T006, T007, T008, T009)* — `(repo-wide)` | R005, R006
+  - **Do**: `grep -rn "cliPathSettingKey\|getCliPath\|geminiInitDelay\|claudePath\|geminiPath\|copilotPath\|qwenPath\|opencodePath" src/ webview/src/` and clean any remaining references (incl. tests). Run `npm run compile` then `npm test`. Confirm README has no doc section for these settings (grep already shows none).
+  - **Verify**: Compile passes, tests pass, grep returns no stragglers.

--- a/src/ai-providers/claudeCodeProvider.ts
+++ b/src/ai-providers/claudeCodeProvider.ts
@@ -41,7 +41,6 @@ export class ClaudeCodeProvider extends CliTerminalProvider {
     public readonly type = AIProviders.CLAUDE;
 
     protected readonly cliBinary = 'claude';
-    protected readonly cliPathSettingKey = null;
     // Claude is so commonly pre-installed that the install-hint path adds
     // noise — keep it null. (The base class skips the check when this is null.)
     protected readonly installHint = null;

--- a/src/ai-providers/cliTerminalProvider.ts
+++ b/src/ai-providers/cliTerminalProvider.ts
@@ -66,10 +66,8 @@ export abstract class CliTerminalProvider implements IAIProvider {
     public abstract readonly name: string;
     public abstract readonly type: AIProviderType;
 
-    /** The bare CLI binary name used for install verification and the default `cliPath`. */
+    /** The bare CLI binary name used for install verification and dispatch. */
     protected abstract readonly cliBinary: string;
-    /** Settings key for an optional user-supplied path override. `null` if the binary name is the only path. */
-    protected abstract readonly cliPathSettingKey: string | null;
     /** `displayName` shown when the CLI isn't found, plus the install command to suggest. `null` skips the install check entirely. */
     protected abstract readonly installHint: { displayName: string; installCommand: string } | null;
     /** Default title for the visible terminal. */
@@ -134,7 +132,7 @@ export abstract class CliTerminalProvider implements IAIProvider {
      * this entirely.
      */
     protected async prepareDispatch(ctx: Omit<DispatchContext, 'cliPath' | 'permissionFlag'>): Promise<DispatchPlan> {
-        const cliPath = this.getCliPath();
+        const cliPath = this.cliBinary;
         const permissionFlag = this.getPermissionFlag();
         const promptText = this.preprocessPrompt(ctx);
         const filePrefix = ctx.mode === 'headless' ? 'background-prompt' : 'prompt';
@@ -174,15 +172,6 @@ export abstract class CliTerminalProvider implements IAIProvider {
      */
     protected cliPromptFlag(): string {
         return '-p ';
-    }
-
-    /**
-     * Resolve the active CLI path (settings override → default to `cliBinary`).
-     */
-    protected getCliPath(): string {
-        if (!this.cliPathSettingKey) return this.cliBinary;
-        const cfg = vscode.workspace.getConfiguration('speckit');
-        return cfg.get<string>(this.cliPathSettingKey, this.cliBinary);
     }
 
     // ─── Shared workflow ────────────────────────────────────────────────────

--- a/src/ai-providers/codexCliProvider.ts
+++ b/src/ai-providers/codexCliProvider.ts
@@ -29,7 +29,6 @@ export class CodexCliProvider extends CliTerminalProvider {
     public readonly type = AIProviders.CODEX;
 
     protected readonly cliBinary = 'codex';
-    protected readonly cliPathSettingKey = null;
     protected readonly installHint = {
         displayName: 'Codex CLI',
         installCommand: 'npm install -g @openai/codex',

--- a/src/ai-providers/copilotCliProvider.ts
+++ b/src/ai-providers/copilotCliProvider.ts
@@ -14,7 +14,6 @@ export class CopilotCliProvider extends CliTerminalProvider {
     public readonly type = AIProviders.COPILOT;
 
     protected readonly cliBinary = CLIDefaults.copilot;
-    protected readonly cliPathSettingKey = 'copilotPath';
     protected readonly installHint = {
         displayName: 'GitHub Copilot CLI',
         installCommand: 'gh extension install github/gh-copilot',

--- a/src/ai-providers/geminiCliProvider.ts
+++ b/src/ai-providers/geminiCliProvider.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 import { exec } from 'child_process';
 import { promisify } from 'util';
 import { ConfigManager } from '../core/utils/configManager';
-import { AIProviders, Timing } from '../core/constants';
+import { AIProviders } from '../core/constants';
 import { waitForShellReady, executeCommandInHiddenTerminal } from '../core/utils/terminalUtils';
 import { createTempFile } from '../core/utils/tempFileUtils';
 import { ensureCliInstalled } from '../core/utils/installUtils';
@@ -47,21 +47,8 @@ export class GeminiCliProvider implements IAIProvider {
         }
     }
 
-    /**
-     * Get the CLI command path
-     */
-    private getCliPath(): string {
-        const config = vscode.workspace.getConfiguration('speckit');
-        return config.get<string>('geminiPath', 'gemini');
-    }
-
-    /**
-     * Get the Gemini CLI initialization delay from settings
-     */
-    private getInitDelay(): number {
-        const config = vscode.workspace.getConfiguration('speckit');
-        return config.get<number>('geminiInitDelay', Timing.geminiInitDelay);
-    }
+    /** Delay before sending the prompt to the interactive Gemini CLI. */
+    private static readonly INIT_DELAY_MS = 8000;
 
     /**
      * Check if Gemini CLI is installed and show helpful error if not
@@ -82,7 +69,6 @@ export class GeminiCliProvider implements IAIProvider {
     async executeInTerminal(prompt: string, title: string = 'SpecKit - Gemini'): Promise<vscode.Terminal> {
         try {
             await this.ensureInstalled();
-            const cliPath = this.getCliPath();
 
             const terminal = vscode.window.createTerminal({
                 name: title,
@@ -94,11 +80,11 @@ export class GeminiCliProvider implements IAIProvider {
 
             terminal.show();
 
-            const initDelay = this.getInitDelay();
+            const initDelay = GeminiCliProvider.INIT_DELAY_MS;
 
             // Wait for shell to be ready, then start Gemini in interactive mode
             await waitForShellReady(terminal);
-            terminal.sendText(cliPath, true);
+            terminal.sendText('gemini', true);
 
             // After Gemini initializes, send the prompt then Enter separately
             setTimeout(() => {
@@ -132,10 +118,9 @@ export class GeminiCliProvider implements IAIProvider {
 
         const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
         const cwd = workspaceFolder?.uri.fsPath;
-        const cliPath = this.getCliPath();
 
         const promptFilePath = await createTempFile(this.context, prompt, 'background-prompt', false);
-        const commandLine = `cat "${promptFilePath}" | ${cliPath}`;
+        const commandLine = `cat "${promptFilePath}" | gemini`;
 
         return executeCommandInHiddenTerminal({
             commandLine,

--- a/src/ai-providers/openCodeProvider.ts
+++ b/src/ai-providers/openCodeProvider.ts
@@ -12,7 +12,6 @@ export class OpenCodeProvider extends CliTerminalProvider {
     public readonly type = AIProviders.OPENCODE;
 
     protected readonly cliBinary = 'opencode';
-    protected readonly cliPathSettingKey = 'opencodePath';
     protected readonly installHint = {
         displayName: 'OpenCode CLI',
         installCommand: 'npm install -g opencode-ai',

--- a/src/ai-providers/qwenCliProvider.ts
+++ b/src/ai-providers/qwenCliProvider.ts
@@ -14,7 +14,6 @@ export class QwenCliProvider extends CliTerminalProvider {
     public readonly type = AIProviders.QWEN;
 
     protected readonly cliBinary = 'qwen';
-    protected readonly cliPathSettingKey = 'qwenPath';
     protected readonly installHint = {
         displayName: 'Qwen Code CLI',
         installCommand: 'npm install -g @qwen-code/qwen-code@latest',

--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -58,12 +58,9 @@ export const Commands = {
  */
 export const ConfigKeys = {
     namespace: 'speckit',
-    claudePath: 'speckit.claudePath',
     aiProvider: 'speckit.aiProvider',
     claudePermissionMode: 'speckit.claudePermissionMode',
-    geminiInitDelay: 'speckit.geminiInitDelay',
     customCommands: 'speckit.customCommands',
-    qwenPath: 'speckit.qwenPath',
     qwenYoloMode: 'speckit.qwenYoloMode',
     specDirectories: 'speckit.specDirectories',
     customWorkflows: 'speckit.customWorkflows',
@@ -117,8 +114,6 @@ export const Timing = {
     terminalDisposeDelay: 1000,
     /** Debounce delay for file watcher refresh */
     fileWatcherDebounce: 1000,
-    /** Delay for Gemini CLI to initialize before sending prompt (configurable via settings) */
-    geminiInitDelay: 8000,
 } as const;
 
 /**


### PR DESCRIPTION
## What

- Remove the five per-CLI executable-path settings (`speckit.claudePath`, `speckit.geminiPath`, `speckit.copilotPath`, `speckit.qwenPath`, `speckit.opencodePath`) and the `speckit.geminiInitDelay` knob from `contributes.configuration`.
- Drop the `cliPathSettingKey` abstraction from the base `CliTerminalProvider`; every provider now invokes its CLI by bare binary name from `PATH`.
- Hard-code Gemini's former 8000ms init delay; remove its `getCliPath`/`getInitDelay` reads.
- Remove the orphaned keys from `ConfigKeys` and `Timing` in `constants.ts`.
- Update docs that documented the removed settings (`how-it-works.md`, `architecture.md`, `providers/qwen-setup.md`).

## Why

These were rarely-needed power-user tuning options cluttering the configuration surface — and `speckit.claudePath` was already dead config (defined in `package.json` but never read, since the Claude provider used `cliPathSettingKey = null`). `getCliPath()` already fell back to the bare binary name, so removal is behavior-preserving for anyone who left the settings at their defaults.

## Testing

- `npm run compile` — clean.
- `npm test` — 810 passing.
- Grep sweep confirms no orphaned references to the removed settings across `src/`, `webview/`, `tests/`, and `docs/`.