### PR TITLE
feat(spec-viewer): surface malformed spec-context with reset action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- **Recovery for a malformed `.spec-context.json`** (#144): when a spec's context file exists but is not parseable JSON (truncated write, hand edit, merge-conflict markers), the viewer now surfaces an error notification naming the JSON parse error and the offending file path — instead of silently falling back to a read-only draft render. The notification offers a **Reset context** action that moves the broken file aside to a timestamped backup (`.spec-context.json.bak-<timestamp>`) and writes a fresh minimal skeleton in its place, then reloads the viewer. The original bytes are never overwritten in place (they survive in the backup); dismissing the notification leaves the broken file untouched and reopening the spec re-offers the reset. The reader now throws a typed `SpecContextParseError` (carrying `filePath` + `reason`) so the corrupt-file case is distinguished from a missing file without sniffing message text. JSON-syntax failures only — semantically-off-but-parseable files are still tolerated and coerced.
+
 ### Fixed
 
 - **`analyze` and `clarify` left viewer stuck on "needs regeneration"** (#194): `buildPrompt` short-circuited for these two steps because `CANONICAL_SUBSTEPS` only listed `specify` / `plan` / `tasks` / `implement` — so the bookkeeping preamble was never injected and the AI had no instruction to flip status or append a completion history entry. Added `analyze` and `clarify` to the substep table (single-pass — empty arrays), wired their completed status (`ready-to-implement` / `specified`) and done phrase, and guarded the substep-line renderer for empty arrays. Works in isolation: no edits to `.specify/extensions.yml` or user-local skill files required.

--- a/README.md
+++ b/README.md
@@ -542,6 +542,10 @@ Legacy shapes (`status: "active"`, `status: "tasks-done"`, or files that
 only contain `{ status: "completed" }`) are coerced by
 `normalizeSpecContext` at read time.
 
+### Recovering a malformed context file
+
+A `.spec-context.json` that is *syntactically* broken — a truncated write, a hand edit, or merge-conflict markers — cannot be parsed, so the viewer falls back to a read-only, draft-state render of the spec. Instead of failing silently, it surfaces an error notification naming the JSON parse error and the offending file path, with a **Reset context** action. Choosing **Reset context** moves the broken file aside to a timestamped backup (`.spec-context.json.bak-<timestamp>`) and writes a fresh minimal skeleton in its place, then reloads the viewer. The original bytes are never overwritten in place — they survive in the backup so you can salvage lifecycle history by hand. Dismissing the notification leaves the broken file untouched; reopening the spec re-offers the reset. (This covers JSON-syntax failures only — a file that parses but is semantically off is tolerated and coerced as above.)
+
 ## Development
 
 ### Setup

--- a/specs/128-malformed-context-recovery/.spec-context.json
+++ b/specs/128-malformed-context-recovery/.spec-context.json
@@ -1,0 +1,65 @@
+{
+  "workflow": "sdd",
+  "currentStep": "done",
+  "currentTask": null,
+  "progress": null,
+  "next": "done",
+  "status": "completed",
+  "checkpointStatus": { "commit": true, "pr": true },
+  "last_action": "T001–T004 complete — typed parse error, reset module + tests, viewer toast/reset wiring; compile + 813 tests green",
+  "files_modified": [
+    "src/features/specs/specContextReader.ts",
+    "src/features/specs/specContextReset.ts",
+    "src/features/specs/__tests__/specContextReset.test.ts",
+    "src/features/spec-viewer/specViewerProvider.ts"
+  ],
+  "updated": "2026-06-05",
+  "approach": "Surface JSON parse failures at the viewer's ensureSpecContext chokepoint via a toast, and add a Reset context action that moves the broken file to a .bak-<timestamp> backup before writing a fresh skeleton.",
+  "selectedAt": "2026-06-05T22:19:21Z",
+  "specName": "Malformed Spec-Context Recovery",
+  "branch": "main",
+  "workingBranch": "feat/malformed-context-recovery",
+  "type": "feat",
+  "createdAt": "2026-06-05T22:19:21Z",
+  "auto": true,
+  "loadedDomains": [],
+  "step_summaries": {
+    "specify": {
+      "complexity": "normal",
+      "requirements": 8,
+      "scenarios": 4,
+      "key_finding": "Viewer's ensureSpecContext already catches the reader's parse-error throw and silently falls back to backfillMinimalContext (output-channel log only); the writer refuses to overwrite bad JSON, so the broken file is preserved for backup — both are the natural hooks for surfacing + reset."
+    },
+    "plan": {
+      "approach_summary": "Surface JSON parse failures at the viewer's ensureSpecContext chokepoint via a toast, and add a Reset context action that moves the broken file to a .bak-<timestamp> backup before writing a fresh skeleton.",
+      "files_planned": 4,
+      "risks": ["writeSpecContext wipe-guard refuses to overwrite bad JSON — mitigated by renaming the broken file to .bak before the skeleton write", "File-watcher re-entrancy on the skeleton write — harmless because reload is idempotent"],
+      "principles_concerns": 0,
+      "domain_concerns": 0,
+      "significance_score": 0
+    }
+  },
+  "task_summaries": {
+    "T001": { "status": "DONE", "did": "Added typed SpecContextParseError (filePath + reason) thrown from the reader's parse path", "files": ["src/features/specs/specContextReader.ts"], "concerns": [] },
+    "T002": { "status": "DONE", "did": "Created resetMalformedContext: collision-safe .bak rename then skeleton write via backfill + writeSpecContext", "files": ["src/features/specs/specContextReset.ts"], "concerns": [] },
+    "T003": { "status": "DONE", "did": "Added 3 BDD tests: backup keeps original bytes, valid skeleton written, no-collision, no-op on missing file", "files": ["src/features/specs/__tests__/specContextReset.test.ts"], "concerns": [] },
+    "T004": { "status": "DONE", "did": "Wired ensureSpecContext parse-error callback to a non-blocking showErrorMessage 'Reset context' toast that resets + reloads the panel", "files": ["src/features/spec-viewer/specViewerProvider.ts"], "concerns": [] }
+  },
+  "transitions": [
+    { "step": "specify", "substep": "parsing", "from": null, "by": "sdd", "at": "2026-06-05T22:19:21Z" },
+    { "step": "specify", "substep": "exploring", "from": { "step": "specify", "substep": "parsing" }, "by": "sdd", "at": "2026-06-05T22:19:30Z" },
+    { "step": "specify", "substep": "detecting", "from": { "step": "specify", "substep": "exploring" }, "by": "sdd", "at": "2026-06-05T22:19:40Z" },
+    { "step": "specify", "substep": "writing-spec", "from": { "step": "specify", "substep": "detecting" }, "by": "sdd", "at": "2026-06-05T22:19:50Z" },
+    { "step": "specify", "substep": null, "from": { "step": "specify", "substep": "writing-spec" }, "by": "sdd", "at": "2026-06-05T22:20:00Z" },
+    { "step": "specify", "substep": null, "from": { "step": "specify", "substep": null }, "by": "sdd", "at": "2026-06-05T22:20:10Z" },
+    { "step": "plan", "substep": "loading", "from": { "step": "specify", "substep": null }, "by": "sdd", "at": "2026-06-05T22:21:00Z" },
+    { "step": "plan", "substep": "writing-plan", "from": { "step": "plan", "substep": "loading" }, "by": "sdd", "at": "2026-06-05T22:21:20Z" },
+    { "step": "plan", "substep": null, "from": { "step": "plan", "substep": "writing-plan" }, "by": "sdd", "at": "2026-06-05T22:21:40Z" },
+    { "step": "tasks", "substep": "loading", "from": { "step": "plan", "substep": null }, "by": "sdd", "at": "2026-06-05T22:22:00Z" },
+    { "step": "tasks", "substep": "writing-tasks", "from": { "step": "tasks", "substep": "loading" }, "by": "sdd", "at": "2026-06-05T22:22:20Z" },
+    { "step": "tasks", "substep": null, "from": { "step": "tasks", "substep": "writing-tasks" }, "by": "sdd", "at": "2026-06-05T22:22:40Z" },
+    { "step": "implement", "substep": "phase1", "from": { "step": "tasks", "substep": null }, "by": "sdd", "at": "2026-06-05T22:23:00Z" },
+    { "step": "implement", "substep": "code-review", "from": { "step": "implement", "substep": "phase1" }, "by": "sdd", "at": "2026-06-05T22:30:00Z" },
+    { "step": "done", "substep": null, "from": { "step": "implement", "substep": "code-review" }, "by": "sdd", "at": "2026-06-05T22:35:00Z" }
+  ]
+}

--- a/specs/128-malformed-context-recovery/.spec-context.json
+++ b/specs/128-malformed-context-recovery/.spec-context.json
@@ -6,7 +6,9 @@
   "next": "done",
   "status": "completed",
   "checkpointStatus": { "commit": true, "pr": true },
-  "last_action": "T001–T004 complete — typed parse error, reset module + tests, viewer toast/reset wiring; compile + 813 tests green",
+  "prUrl": "https://github.com/alfredoperez/speckit-companion/pull/201",
+  "prNumber": 201,
+  "last_action": "PR #201 opened — feat(spec-viewer): surface malformed spec-context with reset action",
   "files_modified": [
     "src/features/specs/specContextReader.ts",
     "src/features/specs/specContextReset.ts",

--- a/specs/128-malformed-context-recovery/.spec-context.json
+++ b/specs/128-malformed-context-recovery/.spec-context.json
@@ -23,7 +23,7 @@
   "workingBranch": "feat/malformed-context-recovery",
   "type": "feat",
   "createdAt": "2026-06-05T22:19:21Z",
-  "auto": true,
+  "auto": false,
   "loadedDomains": [],
   "step_summaries": {
     "specify": {
@@ -62,6 +62,7 @@
     { "step": "tasks", "substep": null, "from": { "step": "tasks", "substep": "writing-tasks" }, "by": "sdd", "at": "2026-06-05T22:22:40Z" },
     { "step": "implement", "substep": "phase1", "from": { "step": "tasks", "substep": null }, "by": "sdd", "at": "2026-06-05T22:23:00Z" },
     { "step": "implement", "substep": "code-review", "from": { "step": "implement", "substep": "phase1" }, "by": "sdd", "at": "2026-06-05T22:30:00Z" },
-    { "step": "done", "substep": null, "from": { "step": "implement", "substep": "code-review" }, "by": "sdd", "at": "2026-06-05T22:35:00Z" }
+    { "step": "done", "substep": null, "from": { "step": "implement", "substep": "code-review" }, "by": "sdd", "at": "2026-06-05T22:35:00Z" },
+    { "step": "done", "substep": null, "from": { "step": "done", "substep": null }, "by": "sdd", "at": "2026-06-05T22:36:00Z" }
   ]
 }

--- a/specs/128-malformed-context-recovery/plan.md
+++ b/specs/128-malformed-context-recovery/plan.md
@@ -1,0 +1,31 @@
+# Plan: Malformed Spec-Context Recovery
+
+**Spec**: [spec.md](./spec.md)
+
+## Approach
+
+Surface JSON parse failures at the viewer's single load chokepoint (`ensureSpecContext` in `specViewerProvider.ts`) instead of swallowing them into a silent backfill, and add a **Reset context** recovery that moves the broken file aside before writing a fresh skeleton. The reader already throws a descriptive error on bad JSON; we make that error *typed* (a `SpecContextParseError` carrying the file path + reason) so the provider can reliably distinguish "file is corrupt" from "file is missing" without string-sniffing. On parse failure the viewer still renders today's read-only backfill (non-blocking) and fires a `showErrorMessage(reason, 'Reset context')` toast; choosing Reset moves the bad bytes to `.spec-context.json.bak-<timestamp>` and writes a skeleton via the existing `backfillMinimalContext` + `writeSpecContext` path, then reloads the panel.
+
+The move-aside ordering is forced by an existing invariant: `writeSpecContext` *refuses* to overwrite a file that is present-but-unparseable (the wipe guard). Renaming the broken file to the `.bak` path both satisfies R003 (original bytes survive in the backup) and turns the skeleton write into a clean ENOENT first-write the guard allows.
+
+## Files
+
+### Create
+
+- `src/features/specs/specContextReset.ts` — `resetMalformedContext(specDir, { workflow, specName, branch }, outputChannel?)`: pick a collision-safe `.spec-context.json.bak-<timestamp>` name, `fs.rename` the broken file to it, then write a skeleton via `backfillMinimalContext` + `writeSpecContext`. Returns the backup path. Logs the backup path to the output channel.
+- `src/features/specs/__tests__/specContextReset.test.ts` — BDD tests: backup file contains the original (broken) bytes; original path holds a valid skeleton afterward; backup filename does not collide with an existing `.bak-<timestamp>`; a missing source file is a no-op error (does not fabricate a backup).
+
+### Modify
+
+- `src/features/specs/specContextReader.ts` — introduce an exported `SpecContextParseError extends Error` (fields: `filePath`, `reason`) and throw it from `parseAndNormalize` instead of a plain `Error`, so callers can `instanceof`-detect parse failures vs. other read errors. Message text stays equivalent.
+- `src/features/spec-viewer/specViewerProvider.ts` — in `ensureSpecContext`, when the caught error is a `SpecContextParseError`, signal it to the render caller (via callback/return discriminator) so the provider can show the `showErrorMessage(..., 'Reset context')` toast; on Reset, call `resetMalformedContext(...)` then `refreshContextIfDisplaying(...)` to reload. Missing-file (ENOENT) and healthy paths keep their current behavior. Keep the existing output-channel log line.
+
+## Testing Strategy
+
+- **Unit**: `specContextReset.test.ts` covers backup/skeleton/collision/no-op-on-missing using a temp dir (Node `fs`, no VS Code mock needed for the reset module itself).
+- **Edge cases**: broken file with merge-conflict markers (parse throws); a pre-existing `.bak-<timestamp>` for the same timestamp must not be clobbered (R007); dismissing the toast leaves the broken file on disk (R006 — assert no rename happens without the Reset action).
+
+## Risks
+
+- `writeSpecContext` wipe-guard refuses to overwrite bad JSON: mitigated by moving the broken file to `.bak` *first* so the skeleton write is a fresh ENOENT write, not an overwrite.
+- File-watcher re-entrancy: a reset rewrites `.spec-context.json`, which the watcher observes and triggers `refreshContextIfDisplaying`; reload is idempotent, so a double-refresh is harmless.

--- a/specs/128-malformed-context-recovery/spec.md
+++ b/specs/128-malformed-context-recovery/spec.md
@@ -1,0 +1,52 @@
+# Spec: Malformed Spec-Context Recovery
+
+**Slug**: 128-malformed-context-recovery | **Date**: 2026-06-05
+
+## Summary
+
+`.spec-context.json` drives the entire viewer UI (status badges, step tabs, lifecycle buttons, transition history). Today, when that file is syntactically broken (truncated write, hand edit, merge-conflict markers), the viewer silently falls back to an in-memory backfill and only logs to the output channel — the user sees a viewer that looks "reset" with no explanation, while the real broken file sits on disk. This feature surfaces the JSON parse error (message + file path) to the user when the viewer opens a spec with an unparseable context, and offers a one-click **Reset context** action that backs up the broken file and writes a fresh skeleton inferred from the current step.
+
+## Requirements
+
+- **R001** (MUST): When the viewer opens a spec whose `.spec-context.json` exists but fails `JSON.parse`, surface a user-visible error containing both the parse error message and the absolute file path, using the viewer's existing notification affordance (`vscode.window.showErrorMessage`).
+- **R002** (MUST): The surfaced error MUST offer a **Reset context** action. Choosing it backs up the broken file to a sibling `.spec-context.json.bak-<timestamp>` and writes a fresh skeleton context, then reloads the viewer so it renders from the repaired file.
+- **R003** (MUST): The reset MUST NOT delete or overwrite the broken file in place — the original bytes MUST survive in the `.bak-<timestamp>` copy so the user can recover lifecycle history manually.
+- **R004** (MUST): The fresh skeleton MUST be derived from the same minimal-backfill path already used for missing context (`backfillMinimalContext`), recording only verifiable facts (workflow, specName, branch, `currentStep: "specify"`, `status: "draft"`, empty history) — never inferring step completion from file presence.
+- **R005** (MUST): A spec whose context is simply missing (ENOENT) MUST keep its current behavior — silent backfill, no error toast. Only a parse failure on an existing file triggers the error surface.
+- **R006** (SHOULD): When the viewer falls back to backfill because of a parse failure (e.g. user dismisses the toast without resetting), it MUST still render the spec read-only as it does today; the broken file is left untouched on disk.
+- **R007** (SHOULD): The backup filename MUST be collision-safe — if a `.bak-<timestamp>` already exists for the chosen timestamp, the write MUST NOT clobber the prior backup.
+- **R008** (MAY): The error message copy MAY include a short hint that a backup was/will be made, so the user understands resetting is non-destructive.
+
+## Scenarios
+
+### Opening a spec with a corrupt context file
+
+**When** the user opens a spec in the viewer and its `.spec-context.json` contains invalid JSON (e.g. a merge-conflict marker)
+**Then** the viewer shows an error notification stating the JSON is invalid, including the parse reason and the file path, with a **Reset context** button — and the viewer still renders the spec in a safe backfilled state rather than failing opaquely.
+
+### Resetting a broken context
+
+**When** the user clicks **Reset context** on that notification
+**Then** the broken file is copied to `.spec-context.json.bak-<timestamp>`, a fresh skeleton `.spec-context.json` is written in its place, and the viewer reloads to reflect the repaired (draft / specify) state.
+
+### Healthy or missing context is unaffected
+
+**When** the user opens a spec whose context parses cleanly, or whose context file does not exist at all
+**Then** no error notification appears and behavior is exactly as it is today (normal render, or silent minimal backfill for the missing case).
+
+### Dismissing without resetting
+
+**When** the user dismisses the parse-error notification without choosing **Reset context**
+**Then** the broken file is left on disk untouched and the viewer continues to render the read-only backfill, so the user can still inspect the spec and fix the file by hand later.
+
+## Non-Functional Requirements
+
+- **NFR001** (MUST): Reliability — the reset MUST be atomic from the user's perspective: the backup copy is created before the skeleton is written, so a failure mid-reset never leaves the user with neither the original nor a valid skeleton.
+- **NFR002** (SHOULD): Observability — both the detected parse failure and the reset action (with the backup path) MUST be written to the existing output channel for diagnostics.
+
+## Out of Scope
+
+- Auto-recovery beyond the explicit **Reset context** action (no automatic repair, no silent rewrite of malformed files).
+- Semantic validation of context contents (unknown step IDs, missing transitions, schema-invalid-but-parseable files) — only JSON-syntactic parse failures are in scope.
+- Surfacing parse failures from non-viewer code paths (the Explorer tree's `tryReadJsonSync` and the file watcher) — these may remain silent; this feature targets the viewer open path, which is the highest-pain surface.
+- A bulk "scan all specs for corruption" command.

--- a/specs/128-malformed-context-recovery/tasks.md
+++ b/specs/128-malformed-context-recovery/tasks.md
@@ -1,0 +1,27 @@
+# Tasks: Malformed Spec-Context Recovery
+
+**Plan**: [plan.md](./plan.md)
+
+> Format reference: `[P]` markers and parallel groups — see `skills/tasks/SKILL.md` § Phase rules.
+
+## Phase 1: Core Implementation
+
+- [x] **T001** [P] Add typed `SpecContextParseError` — `src/features/specs/specContextReader.ts` | R001, R005
+  - **Do**: Export a `class SpecContextParseError extends Error` with `filePath: string` and `reason: string` fields. In `parseAndNormalize`, throw it (instead of the plain `Error`) on `JSON.parse` failure; keep the message text equivalent (`spec-context.json exists but is invalid JSON (<path>): <reason>`). ENOENT still returns `null` in the readers — only the parse path throws the typed error.
+  - **Verify**: `npm run compile` passes; `instanceof SpecContextParseError` is true for a bad-JSON read and the error carries `filePath` + `reason`.
+  - **Leverage**: existing throw site at `specContextReader.ts:77-80`.
+
+- [x] **T002** [P] Create reset module — `src/features/specs/specContextReset.ts` | R002, R003, R004, R007, NFR001, NFR002
+  - **Do**: Add `resetMalformedContext(specDir, { workflow, specName, branch }, outputChannel?)`. Compute a collision-safe backup name `.spec-context.json.bak-<timestamp>` (if it exists, suffix `-1`, `-2`, … — R007). `fs.rename` the broken `.spec-context.json` to that path (preserves original bytes — R003; backup created before skeleton write — NFR001). Then build a skeleton via `backfillMinimalContext({ workflow, specName, branch })` and persist with `writeSpecContext(specDir, skeleton)` (now a clean ENOENT first-write the wipe-guard allows — R004). Append the output-channel line `[SpecViewer] Reset malformed context — backed up to <bak path>` (NFR002). Return the backup path.
+  - **Verify**: `npm run compile` passes; calling it against a dir with broken JSON yields a `.bak-<timestamp>` holding the original bytes and a fresh valid skeleton at the original path.
+  - **Leverage**: `src/features/specs/specContextBackfill.ts` (`backfillMinimalContext`), `src/features/specs/specContextWriter.ts` (`writeSpecContext`).
+
+- [x] **T003** [P] Reset-module tests — `src/features/specs/__tests__/specContextReset.test.ts` *(depends on T002)* | R003, R004, R007
+  - **Do**: BDD tests over a temp dir: (a) backup file contains the original broken bytes; (b) original path holds a valid, re-parseable skeleton afterward; (c) a pre-existing `.bak-<timestamp>` is not clobbered — a distinct backup name is chosen (R007); (d) a missing source file is a no-op error and fabricates no backup.
+  - **Verify**: `npm test` green for the new file.
+  - **Leverage**: existing temp-dir test style in `src/features/specs/__tests__/` (e.g. `specContextWipeGuard.test.ts`).
+
+- [x] **T004** [P] Surface error + wire Reset into viewer — `src/features/spec-viewer/specViewerProvider.ts` *(depends on T001, T002)* | R001, R002, R005, R006, NFR002
+  - **Do**: In `ensureSpecContext`, detect `err instanceof SpecContextParseError`; keep the existing read-only backfill render (R006) and existing output-channel log, but signal the parse failure to the render caller (around line 486) so the provider shows `vscode.window.showErrorMessage(<reason incl. file path>, 'Reset context')`. On the `Reset context` choice, call `resetMalformedContext(specDirectory, { workflow, specName, branch })` then `refreshContextIfDisplaying(<contextPath>)` to reload the panel. Missing-file (ENOENT) and healthy loads stay silent (R005); dismissing the toast leaves the broken file untouched (R006).
+  - **Verify**: `npm run compile` passes; opening a spec with corrupt `.spec-context.json` shows the toast with a working **Reset context** button that repairs + reloads; healthy/missing specs show no toast.
+  - **Leverage**: existing `showErrorMessage` usage in `messageHandlers.ts`, `refreshContextIfDisplaying` at `specViewerProvider.ts:293`.

--- a/src/features/spec-viewer/specViewerProvider.ts
+++ b/src/features/spec-viewer/specViewerProvider.ts
@@ -48,10 +48,11 @@ import { ConfigKeys, SpecStatuses, WorkflowSteps } from "../../core/constants";
 import type { CustomCommandConfig } from "../../core/types/config";
 import { deriveChangeRoot } from "../../core/specDirectoryResolver";
 import { deriveSpecName } from "../specs/specContextManager";
-import { readSpecContext, SPEC_CONTEXT_FILENAME } from "../specs/specContextReader";
+import { readSpecContext, SPEC_CONTEXT_FILENAME, SpecContextParseError } from "../specs/specContextReader";
 import { writeSpecContext } from "../specs/specContextWriter";
 import { deriveStepHistory } from "../specs/stepHistoryDerivation";
 import { backfillMinimalContext } from "../specs/specContextBackfill";
+import { resetMalformedContext } from "../specs/specContextReset";
 import { reconcileAndPersist } from "../specs/specContextReconciler";
 import { deriveViewerState, isStepCompleted, findRunningStep } from "./stateDerivation";
 import { hasNonTrivialArtifact } from "./stepArtifact";
@@ -93,6 +94,7 @@ async function ensureSpecContext(
   specDirectory: string,
   workflowName?: string,
   outputChannel?: vscode.OutputChannel,
+  onParseError?: (detail: { filePath: string; reason: string }) => void,
 ): Promise<ReturnType<typeof readSpecContext> extends Promise<infer T> ? T : never> {
   let existing: Awaited<ReturnType<typeof readSpecContext>>;
   try {
@@ -102,6 +104,9 @@ async function ensureSpecContext(
     outputChannel?.appendLine(
       `[SpecViewer] readSpecContext failed for ${specDirectory}: ${msg} — rendering with in-memory backfill, NOT writing.`,
     );
+    if (err instanceof SpecContextParseError) {
+      onParseError?.({ filePath: err.filePath, reason: err.reason });
+    }
     const specName = path.basename(specDirectory);
     return backfillMinimalContext({
       workflow: workflowName || 'speckit-companion',
@@ -313,6 +318,39 @@ export class SpecViewerProvider {
   }
 
   /**
+   * Surface a malformed `.spec-context.json` to the user and offer a one-click
+   * reset. Non-blocking: the viewer has already rendered the read-only backfill;
+   * dismissing the toast leaves the broken file untouched on disk.
+   */
+  private async promptResetMalformedContext(
+    specDirectory: string,
+    workflowName: string,
+    detail: { filePath: string; reason: string },
+  ): Promise<void> {
+    const choice = await vscode.window.showErrorMessage(
+      `Spec context is corrupt and could not be read: ${detail.reason} (${detail.filePath}). Reset backs the file up first.`,
+      'Reset context',
+    );
+    if (choice !== 'Reset context') return;
+    try {
+      const specName = path.basename(specDirectory);
+      const backupPath = await resetMalformedContext(
+        specDirectory,
+        { workflow: workflowName, specName, branch: specName },
+        this.outputChannel,
+      );
+      vscode.window.showInformationMessage(
+        `Spec context reset — original backed up to ${path.basename(backupPath)}.`,
+      );
+      await this.refreshContextIfDisplaying(path.join(specDirectory, SPEC_CONTEXT_FILENAME));
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      this.outputChannel.appendLine(`[SpecViewer] resetMalformedContext failed: ${msg}`);
+      vscode.window.showErrorMessage(`Failed to reset spec context: ${msg}`);
+    }
+  }
+
+  /**
    * Handle file deletion
    */
   public handleFileDeleted(filePath: string): void {
@@ -483,7 +521,9 @@ export class SpecViewerProvider {
       if (!featureCtx && !instance.firstOpenComplete) {
         const workflowName =
           (await resolveWorkflow(specDirectory))?.name ?? DEFAULT_WORKFLOW.name;
-        await ensureSpecContext(specDirectory, workflowName, this.outputChannel);
+        await ensureSpecContext(specDirectory, workflowName, this.outputChannel, detail =>
+          void this.promptResetMalformedContext(specDirectory, workflowName, detail),
+        );
         try {
           featureCtx = await getFeatureWorkflow(specDirectory, changeRoot);
         } catch {

--- a/src/features/specs/__tests__/specContextReset.test.ts
+++ b/src/features/specs/__tests__/specContextReset.test.ts
@@ -54,28 +54,28 @@ describe('resetMalformedContext', () => {
             fs.writeFileSync(target, BROKEN);
 
             // Pre-seed every timestamp-shaped backup name so the first choice collides.
-            const realToISOString = Date.prototype.toISOString;
             const fixed = '2026-06-05T22:30:00.000Z';
-            jest.spyOn(Date.prototype, 'toISOString').mockReturnValue(fixed);
-            const stamp = fixed.replace(/[:.]/g, '-');
-            const firstChoice = path.join(dir, `${SPEC_CONTEXT_FILENAME}.bak-${stamp}`);
-            fs.writeFileSync(firstChoice, 'PRIOR BACKUP — must not be overwritten');
+            const toISOStringSpy = jest.spyOn(Date.prototype, 'toISOString').mockReturnValue(fixed);
+            try {
+                const stamp = fixed.replace(/[:.]/g, '-');
+                const firstChoice = path.join(dir, `${SPEC_CONTEXT_FILENAME}.bak-${stamp}`);
+                fs.writeFileSync(firstChoice, 'PRIOR BACKUP — must not be overwritten');
 
-            const backupPath = await resetMalformedContext(dir, {
-                workflow: 'sdd',
-                specName: 'x',
-                branch: 'x',
-            });
+                const backupPath = await resetMalformedContext(dir, {
+                    workflow: 'sdd',
+                    specName: 'x',
+                    branch: 'x',
+                });
 
-            // The prior backup is untouched and a distinct name was chosen.
-            expect(backupPath).not.toBe(firstChoice);
-            expect(fs.readFileSync(firstChoice, 'utf-8')).toBe(
-                'PRIOR BACKUP — must not be overwritten',
-            );
-            expect(fs.readFileSync(backupPath, 'utf-8')).toBe(BROKEN);
-
-            (Date.prototype.toISOString as jest.Mock).mockRestore?.();
-            Date.prototype.toISOString = realToISOString;
+                // The prior backup is untouched and a distinct name was chosen.
+                expect(backupPath).not.toBe(firstChoice);
+                expect(fs.readFileSync(firstChoice, 'utf-8')).toBe(
+                    'PRIOR BACKUP — must not be overwritten',
+                );
+                expect(fs.readFileSync(backupPath, 'utf-8')).toBe(BROKEN);
+            } finally {
+                toISOStringSpy.mockRestore();
+            }
         } finally {
             fs.rmSync(dir, { recursive: true, force: true });
         }

--- a/src/features/specs/__tests__/specContextReset.test.ts
+++ b/src/features/specs/__tests__/specContextReset.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Tests for malformed-context recovery: a broken `.spec-context.json` is moved
+ * to a timestamped backup and replaced with a fresh, parseable skeleton — and
+ * the original bytes survive in the backup so lifecycle history can be salvaged
+ * by hand.
+ */
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import { SPEC_CONTEXT_FILENAME } from '../specContextReader';
+import { resetMalformedContext } from '../specContextReset';
+
+function makeTmpDir(): string {
+    return fs.mkdtempSync(path.join(os.tmpdir(), 'speckit-reset-'));
+}
+
+const BROKEN = '<<<<<<< HEAD\n{ "currentStep": "plan"\n=======\n{ broken';
+
+describe('resetMalformedContext', () => {
+    it('backs up the original broken bytes and writes a valid skeleton', async () => {
+        const dir = makeTmpDir();
+        try {
+            const target = path.join(dir, SPEC_CONTEXT_FILENAME);
+            fs.writeFileSync(target, BROKEN);
+
+            const backupPath = await resetMalformedContext(dir, {
+                workflow: 'sdd',
+                specName: '128-malformed-context-recovery',
+                branch: '128-malformed-context-recovery',
+            });
+
+            // Backup holds the original (broken) bytes verbatim.
+            expect(path.basename(backupPath)).toMatch(/^\.spec-context\.json\.bak-/);
+            expect(fs.readFileSync(backupPath, 'utf-8')).toBe(BROKEN);
+
+            // Original path now holds a fresh, parseable skeleton.
+            const skeleton = JSON.parse(fs.readFileSync(target, 'utf-8'));
+            expect(skeleton.workflow).toBe('sdd');
+            expect(skeleton.specName).toBe('128-malformed-context-recovery');
+            expect(skeleton.currentStep).toBe('specify');
+            expect(skeleton.status).toBe('draft');
+            expect(skeleton.history).toEqual([]);
+        } finally {
+            fs.rmSync(dir, { recursive: true, force: true });
+        }
+    });
+
+    it('does not clobber an existing backup of the same timestamp', async () => {
+        const dir = makeTmpDir();
+        try {
+            const target = path.join(dir, SPEC_CONTEXT_FILENAME);
+            fs.writeFileSync(target, BROKEN);
+
+            // Pre-seed every timestamp-shaped backup name so the first choice collides.
+            const realToISOString = Date.prototype.toISOString;
+            const fixed = '2026-06-05T22:30:00.000Z';
+            jest.spyOn(Date.prototype, 'toISOString').mockReturnValue(fixed);
+            const stamp = fixed.replace(/[:.]/g, '-');
+            const firstChoice = path.join(dir, `${SPEC_CONTEXT_FILENAME}.bak-${stamp}`);
+            fs.writeFileSync(firstChoice, 'PRIOR BACKUP — must not be overwritten');
+
+            const backupPath = await resetMalformedContext(dir, {
+                workflow: 'sdd',
+                specName: 'x',
+                branch: 'x',
+            });
+
+            // The prior backup is untouched and a distinct name was chosen.
+            expect(backupPath).not.toBe(firstChoice);
+            expect(fs.readFileSync(firstChoice, 'utf-8')).toBe(
+                'PRIOR BACKUP — must not be overwritten',
+            );
+            expect(fs.readFileSync(backupPath, 'utf-8')).toBe(BROKEN);
+
+            (Date.prototype.toISOString as jest.Mock).mockRestore?.();
+            Date.prototype.toISOString = realToISOString;
+        } finally {
+            fs.rmSync(dir, { recursive: true, force: true });
+        }
+    });
+
+    it('is a no-op error when there is no file to reset (fabricates no backup)', async () => {
+        const dir = makeTmpDir();
+        try {
+            await expect(
+                resetMalformedContext(dir, { workflow: 'sdd', specName: 'x', branch: 'x' }),
+            ).rejects.toThrow();
+
+            // No skeleton, no backup left behind.
+            const entries = fs.readdirSync(dir);
+            expect(entries).toHaveLength(0);
+        } finally {
+            fs.rmSync(dir, { recursive: true, force: true });
+        }
+    });
+});

--- a/src/features/specs/specContextReader.ts
+++ b/src/features/specs/specContextReader.ts
@@ -21,6 +21,21 @@ import {
 
 export const SPEC_CONTEXT_FILENAME = '.spec-context.json';
 
+/**
+ * Thrown when `.spec-context.json` exists but is not parseable JSON. Lets
+ * callers distinguish a corrupt file (recoverable via reset) from a missing
+ * one (ENOENT → null) or other read failures, without sniffing message text.
+ */
+export class SpecContextParseError extends Error {
+    constructor(
+        readonly filePath: string,
+        readonly reason: string,
+    ) {
+        super(`spec-context.json exists but is invalid JSON (${filePath}): ${reason}`);
+        this.name = 'SpecContextParseError';
+    }
+}
+
 /** Load canonical schema (bundled via raw require). */
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const SPEC_CONTEXT_SCHEMA = require('../../core/types/spec-context.schema.json');
@@ -76,7 +91,7 @@ function parseAndNormalize(raw: string, filePath: string): SpecContext {
         parsed = JSON.parse(raw) as Record<string, unknown>;
     } catch (err) {
         const reason = err instanceof Error ? err.message : String(err);
-        throw new Error(`spec-context.json exists but is invalid JSON (${filePath}): ${reason}`);
+        throw new SpecContextParseError(filePath, reason);
     }
     return normalizeSpecContext(parsed);
 }

--- a/src/features/specs/specContextReset.ts
+++ b/src/features/specs/specContextReset.ts
@@ -1,0 +1,62 @@
+/**
+ * Recovery for a malformed `.spec-context.json`: move the broken file aside to
+ * a timestamped backup, then write a fresh minimal skeleton in its place.
+ *
+ * The move-aside is mandatory, not cosmetic: `writeSpecContext` refuses to
+ * overwrite a present-but-unparseable file (the wipe guard), so the broken
+ * bytes must leave the canonical path before the skeleton write — which also
+ * preserves the original bytes for manual recovery.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { SPEC_CONTEXT_FILENAME } from './specContextReader';
+import { backfillMinimalContext } from './specContextBackfill';
+import { writeSpecContext } from './specContextWriter';
+
+export interface ResetContextInput {
+    workflow: string;
+    specName: string;
+    branch: string;
+}
+
+/**
+ * Back up the broken `.spec-context.json` and write a fresh skeleton.
+ * Returns the absolute path of the backup file.
+ */
+export async function resetMalformedContext(
+    specDir: string,
+    input: ResetContextInput,
+    outputChannel?: { appendLine(value: string): void },
+): Promise<string> {
+    const target = path.join(specDir, SPEC_CONTEXT_FILENAME);
+    const backupPath = pickBackupPath(specDir);
+
+    await fs.promises.rename(target, backupPath);
+
+    const skeleton = backfillMinimalContext({
+        workflow: input.workflow,
+        specName: input.specName,
+        branch: input.branch,
+    });
+    await writeSpecContext(specDir, skeleton);
+
+    outputChannel?.appendLine(
+        `[SpecViewer] Reset malformed context — backed up to ${backupPath}`,
+    );
+    return backupPath;
+}
+
+/**
+ * Choose a `.spec-context.json.bak-<timestamp>` name that does not collide with
+ * an existing backup. Falls back to a numeric suffix when the timestamp clashes.
+ */
+function pickBackupPath(specDir: string): string {
+    const stamp = new Date().toISOString().replace(/[:.]/g, '-');
+    const base = path.join(specDir, `${SPEC_CONTEXT_FILENAME}.bak-${stamp}`);
+    if (!fs.existsSync(base)) return base;
+    for (let i = 1; ; i++) {
+        const candidate = `${base}-${i}`;
+        if (!fs.existsSync(candidate)) return candidate;
+    }
+}


### PR DESCRIPTION
## What

- Surface a typed parse error (message + file path) when a spec's `.spec-context.json` is unparseable, instead of a silent read-only fallback.
- Add a **Reset context** notification action that backs up the broken file to `.spec-context.json.bak-<timestamp>` and writes a fresh skeleton, then reloads the viewer.
- New `SpecContextParseError` (carrying `filePath` + `reason`) distinguishes a corrupt file from a missing one; new `resetMalformedContext` module + unit tests.

## Why

A malformed `.spec-context.json` (truncated write, hand edit, merge-conflict markers) was the highest-pain silent failure in the viewer — it failed opaquely down the render stack with no surface error and no recovery path. The original bytes are now never overwritten in place: they survive in the timestamped backup so lifecycle history can be salvaged by hand.

## Testing

- `npm run compile` clean; `npm test` → 813 passing (3 new reset tests + 18 reader/wipe-guard).
- Backup holds the original broken bytes; original path holds a valid skeleton; a pre-existing backup is not clobbered; missing-file reset is a no-op (fabricates no backup).
- Healthy / missing (ENOENT) context is unaffected — no toast; dismissing the toast leaves the broken file untouched.

## Scope notes

- JSON-syntax failures only — a file that parses but is semantically off is tolerated and coerced as before (per the issue's out-of-scope).
- Two-level `changeRoot` layouts where only the `changeRoot` context is corrupt are a known limitation, outside the issue's scope.

Closes #144