### PR TITLE
feat(speckit-extension): add full lifecycle capture + derive-from-files fallback

### DIFF
--- a/.specify/extensions.yml
+++ b/.specify/extensions.yml
@@ -115,6 +115,14 @@ hooks:
     prompt: Commit plan changes?
     description: Auto-commit after implementation planning
     condition: null
+  - extension: companion
+    command: speckit.companion.capture-plan
+    enabled: true
+    optional: false
+    prompt: Execute speckit.companion.capture-plan?
+    description: Record plan completion (currentStep=plan, status=planned) into
+      .spec-context.json
+    condition: null
   after_tasks:
   - extension: git
     command: speckit.git.commit
@@ -123,6 +131,14 @@ hooks:
     prompt: Commit task changes?
     description: Auto-commit after task generation
     condition: null
+  - extension: companion
+    command: speckit.companion.capture-tasks
+    enabled: true
+    optional: false
+    prompt: Execute speckit.companion.capture-tasks?
+    description: Record tasks completion (currentStep=tasks, status=ready-to-implement)
+      into .spec-context.json
+    condition: null
   after_implement:
   - extension: git
     command: speckit.git.commit
@@ -130,6 +146,14 @@ hooks:
     optional: true
     prompt: Commit implementation changes?
     description: Auto-commit after implementation
+    condition: null
+  - extension: companion
+    command: speckit.companion.capture-implement
+    enabled: true
+    optional: false
+    prompt: Execute speckit.companion.capture-implement?
+    description: Per-task journaling on implement (currentStep=implement; status=implemented
+      when all tasks checked) into .spec-context.json
     condition: null
   after_checklist:
   - extension: git

--- a/.specify/extensions/companion/commands/speckit.companion.capture-implement.md
+++ b/.specify/extensions/companion/commands/speckit.companion.capture-implement.md
@@ -1,0 +1,40 @@
+---
+description: "Capture per-task implement progress (currentStep=implement) into .spec-context.json for the Companion GUI"
+---
+
+# Capture Implement Context
+
+Record the active feature's implementation progress into `.spec-context.json` so the
+SpecKit Companion GUI re-renders with the correct step and status. This command
+runs as the `after_implement` lifecycle hook. It uses the writer's **TASK-SYNC mode**: it reads the completed task markers in the feature's `tasks.md` and appends one transition per completed task (idempotent — already-recorded tasks are skipped), ending at `status=implemented` when every marker is checked, otherwise `status=implementing`.
+
+## Prerequisites
+
+- Verify Python is available by running `python3 --version`.
+- If `python3` is not available, warn the user and skip the capture:
+  `[companion] Warning: python3 not detected; skipped .spec-context.json capture`.
+  Do not fail the host command.
+
+## Execution
+
+Run the writer script from the repository root, passing the active feature's `tasks.md` path:
+
+```bash
+python3 speckit-extension/scripts/write-context.py --step implement --status implemented --by extension --tasks-file specs/<NNN>-<slug>/tasks.md
+```
+
+Pass the active feature's `tasks.md` path to `--tasks-file`. If feature resolution is unambiguous the script resolves the feature directory on its own (in this order: `--feature-dir` → `SPECIFY_FEATURE_DIRECTORY` env → `SPECIFY_FEATURE` env → `.specify/feature.json` → current git branch prefix), but `--tasks-file` must still point at that feature's `tasks.md`. The `--status implemented` value is the terminal status applied only when all task markers are checked; partial completion records `implementing` automatically.
+
+## Graceful Degradation
+
+The script is best-effort and never fails the host command:
+- If `python3` is missing, skip with the warning above.
+- If the active feature directory cannot be resolved, the script prints a warning
+  to stderr and exits 0 without writing.
+
+## Output
+
+On success the script prints the path it updated and the values written, e.g.:
+`[companion] Updated specs/<NNN>-<slug>/.spec-context.json (currentStep=implement, status=implementing, by=extension)`.
+The write is atomic (temp file + rename) and appends to `transitions` without
+rewriting existing history.

--- a/.specify/extensions/companion/commands/speckit.companion.capture-plan.md
+++ b/.specify/extensions/companion/commands/speckit.companion.capture-plan.md
@@ -1,0 +1,50 @@
+---
+description: "Capture plan completion (currentStep=plan, status=planned) into .spec-context.json for the Companion GUI"
+---
+
+# Capture Plan Context
+
+Record the active feature's plan completion into `.spec-context.json` so the
+SpecKit Companion GUI re-renders with the correct step and status. This command
+runs as the `after_plan` lifecycle hook — **state-writing only**; the plan
+document is created by the core `/speckit.plan` workflow.
+
+## Prerequisites
+
+- Verify Python is available by running `python3 --version`.
+- If `python3` is not available, warn the user and skip the capture:
+  `[companion] Warning: python3 not detected; skipped .spec-context.json capture`.
+  Do not fail the host command.
+
+## Execution
+
+Run the writer script from the repository root:
+
+```bash
+python3 speckit-extension/scripts/write-context.py --step plan --status planned --by extension
+```
+
+The script resolves the active feature directory on its own, in this order:
+`--feature-dir` → `SPECIFY_FEATURE_DIRECTORY` env → `SPECIFY_FEATURE` env →
+`.specify/feature.json` → current git branch prefix.
+
+If you already know the feature directory (e.g. the one `/speckit.plan` just
+wrote into), pass it explicitly so resolution is unambiguous:
+
+```bash
+python3 speckit-extension/scripts/write-context.py --feature-dir specs/<NNN>-<slug> --step plan --status planned --by extension
+```
+
+## Graceful Degradation
+
+The script is best-effort and never fails the host command:
+- If `python3` is missing, skip with the warning above.
+- If the active feature directory cannot be resolved, the script prints a warning
+  to stderr and exits 0 without writing.
+
+## Output
+
+On success the script prints the path it updated and the values written, e.g.:
+`[companion] Updated specs/<NNN>-<slug>/.spec-context.json (currentStep=plan, status=planned, by=extension)`.
+The write is atomic (temp file + rename) and appends to `transitions` without
+rewriting existing history.

--- a/.specify/extensions/companion/commands/speckit.companion.capture-tasks.md
+++ b/.specify/extensions/companion/commands/speckit.companion.capture-tasks.md
@@ -1,0 +1,50 @@
+---
+description: "Capture tasks completion (currentStep=tasks, status=ready-to-implement) into .spec-context.json for the Companion GUI"
+---
+
+# Capture Tasks Context
+
+Record the active feature's tasks completion into `.spec-context.json` so the
+SpecKit Companion GUI re-renders with the correct step and status. This command
+runs as the `after_tasks` lifecycle hook — **state-writing only**; the tasks
+document is created by the core `/speckit.tasks` workflow.
+
+## Prerequisites
+
+- Verify Python is available by running `python3 --version`.
+- If `python3` is not available, warn the user and skip the capture:
+  `[companion] Warning: python3 not detected; skipped .spec-context.json capture`.
+  Do not fail the host command.
+
+## Execution
+
+Run the writer script from the repository root:
+
+```bash
+python3 speckit-extension/scripts/write-context.py --step tasks --status ready-to-implement --by extension
+```
+
+The script resolves the active feature directory on its own, in this order:
+`--feature-dir` → `SPECIFY_FEATURE_DIRECTORY` env → `SPECIFY_FEATURE` env →
+`.specify/feature.json` → current git branch prefix.
+
+If you already know the feature directory (e.g. the one `/speckit.tasks` just
+wrote into), pass it explicitly so resolution is unambiguous:
+
+```bash
+python3 speckit-extension/scripts/write-context.py --feature-dir specs/<NNN>-<slug> --step tasks --status ready-to-implement --by extension
+```
+
+## Graceful Degradation
+
+The script is best-effort and never fails the host command:
+- If `python3` is missing, skip with the warning above.
+- If the active feature directory cannot be resolved, the script prints a warning
+  to stderr and exits 0 without writing.
+
+## Output
+
+On success the script prints the path it updated and the values written, e.g.:
+`[companion] Updated specs/<NNN>-<slug>/.spec-context.json (currentStep=tasks, status=ready-to-implement, by=extension)`.
+The write is atomic (temp file + rename) and appends to `transitions` without
+rewriting existing history.

--- a/.specify/extensions/companion/extension.yml
+++ b/.specify/extensions/companion/extension.yml
@@ -23,12 +23,33 @@ provides:
     - name: speckit.companion.capture
       file: commands/speckit.companion.capture.md
       description: "Capture the current spec-kit step into .spec-context.json for the Companion GUI"
+    - name: speckit.companion.capture-plan
+      file: commands/speckit.companion.capture-plan.md
+      description: "Capture plan completion (currentStep=plan, status=planned) into .spec-context.json"
+    - name: speckit.companion.capture-tasks
+      file: commands/speckit.companion.capture-tasks.md
+      description: "Capture tasks completion (currentStep=tasks, status=ready-to-implement) into .spec-context.json"
+    - name: speckit.companion.capture-implement
+      file: commands/speckit.companion.capture-implement.md
+      description: "Capture per-task implement progress (currentStep=implement) into .spec-context.json"
 
 hooks:
   after_specify:
     command: speckit.companion.capture
     optional: false
     description: "Record specify completion (currentStep=specify, status=specified) into .spec-context.json"
+  after_plan:
+    command: speckit.companion.capture-plan
+    optional: false
+    description: "Record plan completion (currentStep=plan, status=planned) into .spec-context.json"
+  after_tasks:
+    command: speckit.companion.capture-tasks
+    optional: false
+    description: "Record tasks completion (currentStep=tasks, status=ready-to-implement) into .spec-context.json"
+  after_implement:
+    command: speckit.companion.capture-implement
+    optional: false
+    description: "Per-task journaling on implement (currentStep=implement; status=implemented when all tasks checked)"
 
 tags:
   - "spec-driven-development"

--- a/.specify/extensions/companion/scripts/derive-from-files.py
+++ b/.specify/extensions/companion/scripts/derive-from-files.py
@@ -34,7 +34,10 @@ def _infer(feature_dir: Path) -> tuple[str, str] | None:
 
     if tasks_md.is_file():
         all_ids, done_ids = wc.parse_task_markers(tasks_md)
-        if all_ids and len(done_ids) == len(all_ids):
+        # Distinct-id + set-coverage, matching write-context.py sync_tasks, so a
+        # duplicated marker id can't make derive and task-sync disagree on "done".
+        distinct_all = set(all_ids)
+        if distinct_all and set(done_ids) >= distinct_all:
             return "implement", "implemented"
         return "tasks", "ready-to-implement"
     if plan_md.is_file():
@@ -69,30 +72,19 @@ def derive(feature_dir: Path, by: str = "derive") -> Path | None:
     now = wc._now_iso()
     branch = wc._git_branch(wc._repo_root()) or "main"
 
-    transitions = ctx.get("transitions")
-    if not isinstance(transitions, list):
-        transitions = []
-
-    prior = wc.prior_from(transitions)
+    log = wc.canonical_log(ctx)
+    from_ = wc.step_from(ctx.get("currentStep"), step)
     wc.fill_required(ctx, feature_dir, branch)
 
     ctx["currentStep"] = step
     ctx["status"] = status
     ctx["updated"] = wc._today()
 
-    step_history = ctx.get("stepHistory")
-    if not isinstance(step_history, dict):
-        step_history = {}
-    entry = step_history.get(step) if isinstance(step_history.get(step), dict) else {}
-    entry.setdefault("startedAt", now)
-    entry["completedAt"] = now
-    step_history[step] = entry
-    ctx["stepHistory"] = step_history
-
-    transitions.append({
+    log.append({
         "step": step,
         "substep": None,
-        "from": prior,
+        "kind": "start",
+        "from": from_,
         "by": by,
         "at": now,
     })
@@ -101,24 +93,25 @@ def derive(feature_dir: Path, by: str = "derive") -> Path | None:
         all_ids, done_ids = wc.parse_task_markers(feature_dir / "tasks.md")
         distinct_all = list(dict.fromkeys(all_ids))
         distinct_done = list(dict.fromkeys(done_ids))
-        already = wc._journaled_tasks(transitions)
-        # Per-task entries are substeps of implement (substep = task id) so the
-        # reader never reads them as a step-completion boundary.
+        already = wc._journaled_tasks(log)
+        # Per-task entries are substeps of implement (substep = task id, kind=start)
+        # so the reader never reads them as a step-completion boundary.
         for tid in distinct_done:
             if tid in already:
                 continue
-            transitions.append({
+            log.append({
                 "step": "implement",
                 "substep": tid,
                 "task": tid,
-                "from": wc.prior_from(transitions),
+                "kind": "start",
+                "from": {"step": "implement", "substep": None},
                 "by": by,
                 "at": wc._now_iso(),
             })
         pending = [tid for tid in distinct_all if tid not in distinct_done]
         ctx["currentTask"] = (pending[0] if pending else (distinct_done[-1] if distinct_done else None))
 
-    ctx["transitions"] = transitions
+    wc.commit_log(ctx, log)
 
     wc.atomic_write(target, ctx)
     print(

--- a/.specify/extensions/companion/scripts/derive-from-files.py
+++ b/.specify/extensions/companion/scripts/derive-from-files.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""Reconstruct a feature's .spec-context.json from on-disk artifacts + git.
+
+The derive-from-files fallback that complements the hook-driven write-context.py
+in this same directory. When a spec-kit lifecycle hook never fired (so no
+.spec-context.json exists or it lags the real artifacts), this script infers the
+feature's step/status purely from which files are present (spec.md / plan.md /
+tasks.md and the task-marker checkbox state) and writes the same canonical
+.spec-context.json shape that write-context.py emits.
+
+Best-effort by design: never raises, never exits non-zero, and never drags a
+more-advanced spec backward (no-backward-clobber).
+
+Stdlib only. Safe to run anywhere `python3` is available.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import sys
+from pathlib import Path
+
+# The sibling module's filename has a hyphen, so it can't be a normal import.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+wc = importlib.import_module("write-context")
+
+
+def _infer(feature_dir: Path) -> tuple[str, str] | None:
+    """Map artifact presence to (step, status); None when nothing is present."""
+    tasks_md = feature_dir / "tasks.md"
+    plan_md = feature_dir / "plan.md"
+    spec_md = feature_dir / "spec.md"
+
+    if tasks_md.is_file():
+        all_ids, done_ids = wc.parse_task_markers(tasks_md)
+        if all_ids and len(done_ids) == len(all_ids):
+            return "implement", "implemented"
+        return "tasks", "ready-to-implement"
+    if plan_md.is_file():
+        return "plan", "planned"
+    if spec_md.is_file():
+        return "specify", "specified"
+    return None
+
+
+def derive(feature_dir: Path, by: str = "derive") -> Path | None:
+    target = feature_dir / ".spec-context.json"
+    ctx = wc.read_ctx(target)
+
+    inferred = _infer(feature_dir)
+    if inferred is None:
+        print(
+            f"[companion] No spec.md/plan.md/tasks.md in {feature_dir}; "
+            "nothing to derive.",
+            file=sys.stderr,
+        )
+        return None
+    step, status = inferred
+
+    if ctx and wc._is_more_advanced(ctx, step):
+        print(
+            f"[companion] {target} already at currentStep={ctx.get('currentStep')} / "
+            f"status={ctx.get('status')}; not regressing.",
+            file=sys.stderr,
+        )
+        return None
+
+    now = wc._now_iso()
+    branch = wc._git_branch(wc._repo_root()) or "main"
+
+    transitions = ctx.get("transitions")
+    if not isinstance(transitions, list):
+        transitions = []
+
+    prior = wc.prior_from(transitions)
+    wc.fill_required(ctx, feature_dir, branch)
+
+    ctx["currentStep"] = step
+    ctx["status"] = status
+    ctx["updated"] = wc._today()
+
+    step_history = ctx.get("stepHistory")
+    if not isinstance(step_history, dict):
+        step_history = {}
+    entry = step_history.get(step) if isinstance(step_history.get(step), dict) else {}
+    entry.setdefault("startedAt", now)
+    entry["completedAt"] = now
+    step_history[step] = entry
+    ctx["stepHistory"] = step_history
+
+    transitions.append({
+        "step": step,
+        "substep": None,
+        "from": prior,
+        "by": by,
+        "at": now,
+    })
+
+    if step == "implement":
+        all_ids, done_ids = wc.parse_task_markers(feature_dir / "tasks.md")
+        distinct_all = list(dict.fromkeys(all_ids))
+        distinct_done = list(dict.fromkeys(done_ids))
+        already = wc._journaled_tasks(transitions)
+        # Per-task entries are substeps of implement (substep = task id) so the
+        # reader never reads them as a step-completion boundary.
+        for tid in distinct_done:
+            if tid in already:
+                continue
+            transitions.append({
+                "step": "implement",
+                "substep": tid,
+                "task": tid,
+                "from": wc.prior_from(transitions),
+                "by": by,
+                "at": wc._now_iso(),
+            })
+        pending = [tid for tid in distinct_all if tid not in distinct_done]
+        ctx["currentTask"] = (pending[0] if pending else (distinct_done[-1] if distinct_done else None))
+
+    ctx["transitions"] = transitions
+
+    wc.atomic_write(target, ctx)
+    print(
+        f"[companion] Derived {target} from files "
+        f"(currentStep={step}, status={status}, by={by}).",
+        file=sys.stderr,
+    )
+    return target
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Reconstruct a feature's .spec-context.json from on-disk artifacts."
+    )
+    parser.add_argument("--feature-dir", default=None)
+    parser.add_argument("--by", default="derive")
+    args = parser.parse_args()
+
+    root = wc._repo_root()
+    feature_dir = wc.resolve_feature_dir(root, args.feature_dir)
+    if feature_dir is None or not feature_dir.is_dir():
+        print(
+            "[companion] Could not resolve the active feature directory "
+            "(checked --feature-dir, SPECIFY_FEATURE_DIRECTORY, SPECIFY_FEATURE, "
+            ".specify/feature.json, git branch prefix). Skipping derive.",
+            file=sys.stderr,
+        )
+        return 0  # best-effort: never fail the host command
+
+    try:
+        derive(feature_dir, args.by)
+    except Exception as exc:  # noqa: BLE001 - best-effort, swallow + report
+        print(f"[companion] Warning: skipped .spec-context.json derive: {exc}", file=sys.stderr)
+        return 0
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.specify/extensions/companion/scripts/write-context.py
+++ b/.specify/extensions/companion/scripts/write-context.py
@@ -7,7 +7,9 @@ own precedence, then does a crash-safe read-merge-write of the Companion's
 canonical .spec-context.json:
 
   - preserves every existing/unknown top-level key (read-then-merge)
-  - appends to `transitions` (append-only; never rewritten or shrunk)
+  - appends to the canonical `history[]` (append-only; never rewritten or
+    shrunk), migrating a legacy `transitions[]` array forward so the extension
+    and the VS Code GUI write the same single field
   - writes atomically (temp file + os.replace)
   - emits Companion-canonical values; never the legacy `currentStep: "done"`
 
@@ -198,20 +200,33 @@ def atomic_write(target: Path, ctx: dict) -> None:
         raise
 
 
-def prior_from(transitions: list) -> dict | None:
-    """`from` = prior {step, substep}, or null when there is no prior entry.
+def canonical_log(ctx: dict) -> list:
+    """The append-only lifecycle log. Canonical field is `history`; an older
+    file may still carry the legacy `transitions` name — migrate it forward so
+    both the extension and the VS Code GUI write the same single array."""
+    log = ctx.get("history")
+    if isinstance(log, list):
+        return log
+    legacy = ctx.get("transitions")
+    if isinstance(legacy, list):
+        return legacy
+    return []
 
-    Guards a malformed last entry and normalizes a non-canonical prior step
-    (e.g. legacy "done") to null, which the schema's `from.step` enum permits.
-    """
-    if transitions and isinstance(transitions[-1], dict):
-        last = transitions[-1]
-        prior_step = last.get("step")
-        return {
-            "step": prior_step if prior_step in CANONICAL_STEPS else None,
-            "substep": last.get("substep"),
-        }
-    return None
+
+def commit_log(ctx: dict, log: list) -> None:
+    """Persist the log under the canonical `history` key and drop the legacy
+    `transitions` / derived `stepHistory` keys (the GUI derives stepHistory)."""
+    ctx["history"] = log
+    ctx.pop("transitions", None)
+    ctx.pop("stepHistory", None)
+
+
+def step_from(prev_current: object, step: str) -> dict:
+    """`from` for a step `start` entry — the prior step, or null when there is
+    none or it equals `step` (mirrors the GUI's setStepStarted, which nulls a
+    self-origin so the reader can't misread it as a step completion)."""
+    prior = prev_current if (prev_current in CANONICAL_STEPS and prev_current != step) else None
+    return {"step": prior, "substep": None}
 
 
 def fill_required(ctx: dict, feature_dir: Path, branch: str) -> None:
@@ -270,34 +285,23 @@ def update_context(feature_dir: Path, step: str, status: str, by: str) -> Path |
         )
         return None
 
-    transitions = ctx.get("transitions")
-    if not isinstance(transitions, list):
-        transitions = []
-
-    prior = prior_from(transitions)
+    log = canonical_log(ctx)
+    from_ = step_from(ctx.get("currentStep"), step)
     fill_required(ctx, feature_dir, branch)
 
     ctx["currentStep"] = step
     ctx["status"] = status
     ctx["updated"] = _today()
 
-    step_history = ctx.get("stepHistory")
-    if not isinstance(step_history, dict):
-        step_history = {}
-    entry = step_history.get(step) if isinstance(step_history.get(step), dict) else {}
-    entry.setdefault("startedAt", now)
-    entry["completedAt"] = now
-    step_history[step] = entry
-    ctx["stepHistory"] = step_history
-
-    transitions.append({
+    log.append({
         "step": step,
         "substep": None,
-        "from": prior,
+        "kind": "start",
+        "from": from_,
         "by": by,
         "at": now,
     })
-    ctx["transitions"] = transitions
+    commit_log(ctx, log)
 
     atomic_write(target, ctx)
     return target
@@ -333,11 +337,8 @@ def sync_tasks(feature_dir: Path, tasks_md: Path, final_status: str, by: str) ->
     distinct_all = list(dict.fromkeys(all_ids))
     distinct_done = list(dict.fromkeys(done_ids))
 
-    transitions = ctx.get("transitions")
-    if not isinstance(transitions, list):
-        transitions = []
-
-    already = _journaled_tasks(transitions)
+    log = canonical_log(ctx)
+    already = _journaled_tasks(log)
     fresh = [tid for tid in distinct_done if tid not in already]
 
     fill_required(ctx, feature_dir, branch)
@@ -349,25 +350,26 @@ def sync_tasks(feature_dir: Path, tasks_md: Path, final_status: str, by: str) ->
     pending = [tid for tid in distinct_all if tid not in distinct_done]
     ctx["currentTask"] = (pending[0] if pending else (distinct_done[-1] if distinct_done else None))
 
-    # Per-task entries are substeps of implement (substep = task id). This keeps
-    # the reader from mistaking them for a step-completion boundary (which is a
-    # substep==null self-loop) and keeps dedupeConsecutive from collapsing them.
+    # Per-task entries are substeps of implement (substep = task id, kind=start).
+    # A substep entry can never be read as a step-completion boundary (which is a
+    # substep==null self-loop), and distinct substep names keep dedupeConsecutive
+    # from collapsing them.
     for tid in fresh:
-        prior = prior_from(transitions)
-        transitions.append({
+        log.append({
             "step": "implement",
             "substep": tid,
             "task": tid,
-            "from": prior,
+            "kind": "start",
+            "from": {"step": "implement", "substep": None},
             "by": by,
             "at": _now_iso(),
         })
-    ctx["transitions"] = transitions
+    commit_log(ctx, log)
 
     atomic_write(target, ctx)
     print(
-        f"[companion] Synced {len(fresh)} new task transition(s) "
-        f"({len(done_ids)}/{len(all_ids)} complete) into {target}.",
+        f"[companion] Synced {len(fresh)} new task event(s) "
+        f"({len(distinct_done)}/{len(distinct_all)} complete) into {target}.",
         file=sys.stderr,
     )
     return target

--- a/.specify/extensions/companion/scripts/write-context.py
+++ b/.specify/extensions/companion/scripts/write-context.py
@@ -172,21 +172,93 @@ def _is_more_advanced(ctx: dict, step: str) -> bool:
     return cur in STEP_ORDER and STEP_ORDER[cur] > STEP_ORDER[step]
 
 
-def update_context(feature_dir: Path, step: str, status: str, by: str) -> Path | None:
-    target = feature_dir / ".spec-context.json"
-    now = _now_iso()
-    root = _repo_root()
-    branch = _git_branch(root) or "main"
-
+def read_ctx(target: Path) -> dict:
+    """Read the existing context, tolerating absence or corruption."""
     if target.is_file():
         try:
             ctx = json.loads(target.read_text(encoding="utf-8"))
-            if not isinstance(ctx, dict):
-                ctx = {}
+            if isinstance(ctx, dict):
+                return ctx
         except (json.JSONDecodeError, OSError):
-            ctx = {}
-    else:
-        ctx = {}
+            pass
+    return {}
+
+
+def atomic_write(target: Path, ctx: dict) -> None:
+    """Crash-safe write: serialize to a temp file, then rename over the target."""
+    tmp = target.with_suffix(target.suffix + ".tmp")
+    try:
+        tmp.write_text(json.dumps(ctx, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+        os.replace(tmp, target)
+    except OSError:
+        try:
+            tmp.unlink(missing_ok=True)  # don't litter on a failed write
+        except OSError:
+            pass
+        raise
+
+
+def prior_from(transitions: list) -> dict | None:
+    """`from` = prior {step, substep}, or null when there is no prior entry.
+
+    Guards a malformed last entry and normalizes a non-canonical prior step
+    (e.g. legacy "done") to null, which the schema's `from.step` enum permits.
+    """
+    if transitions and isinstance(transitions[-1], dict):
+        last = transitions[-1]
+        prior_step = last.get("step")
+        return {
+            "step": prior_step if prior_step in CANONICAL_STEPS else None,
+            "substep": last.get("substep"),
+        }
+    return None
+
+
+def fill_required(ctx: dict, feature_dir: Path, branch: str) -> None:
+    """Set required keys only when missing (read-then-merge preserves the rest)."""
+    ctx.setdefault("workflow", "speckit")
+    ctx.setdefault("specName", _spec_name(feature_dir))
+    ctx.setdefault("branch", branch)
+
+
+COMPLETED_TASK_RE = re.compile(r"^\s*[-*]\s*\[[xX]\]\s*\*\*(T\d+)")
+PENDING_TASK_RE = re.compile(r"^\s*[-*]\s*\[\s\]\s*\*\*(T\d+)")
+
+
+def parse_task_markers(tasks_md: Path) -> tuple[list[str], list[str]]:
+    """Return (all_task_ids, completed_task_ids) in document order from tasks.md."""
+    all_ids: list[str] = []
+    done_ids: list[str] = []
+    try:
+        for line in tasks_md.read_text(encoding="utf-8").splitlines():
+            m = COMPLETED_TASK_RE.match(line)
+            if m:
+                all_ids.append(m.group(1))
+                done_ids.append(m.group(1))
+                continue
+            m = PENDING_TASK_RE.match(line)
+            if m:
+                all_ids.append(m.group(1))
+    except OSError:
+        pass
+    return all_ids, done_ids
+
+
+def _journaled_tasks(transitions: list) -> set[str]:
+    """Task ids already recorded as per-task transitions (idempotency key)."""
+    return {
+        t["task"]
+        for t in transitions
+        if isinstance(t, dict) and isinstance(t.get("task"), str)
+    }
+
+
+def update_context(feature_dir: Path, step: str, status: str, by: str) -> Path | None:
+    target = feature_dir / ".spec-context.json"
+    now = _now_iso()
+    branch = _git_branch(_repo_root()) or "main"
+
+    ctx = read_ctx(target)
 
     # Never drag a more-advanced (e.g. shipped) spec backward. Leave it fully
     # intact — this is the bug the schema reconciliation exists to prevent.
@@ -202,23 +274,8 @@ def update_context(feature_dir: Path, step: str, status: str, by: str) -> Path |
     if not isinstance(transitions, list):
         transitions = []
 
-    # `from` = prior {step, substep}, or null on first write. Guard against a
-    # malformed last entry and normalize a non-canonical prior step (e.g. legacy
-    # "done") to null, which the schema's `from.step` enum permits.
-    if transitions and isinstance(transitions[-1], dict):
-        last = transitions[-1]
-        prior_step = last.get("step")
-        prior = {
-            "step": prior_step if prior_step in CANONICAL_STEPS else None,
-            "substep": last.get("substep"),
-        }
-    else:
-        prior = None
-
-    # Required-set defaults only when missing (read-then-merge preserves the rest).
-    ctx.setdefault("workflow", "speckit")
-    ctx.setdefault("specName", _spec_name(feature_dir))
-    ctx.setdefault("branch", branch)
+    prior = prior_from(transitions)
+    fill_required(ctx, feature_dir, branch)
 
     ctx["currentStep"] = step
     ctx["status"] = status
@@ -242,16 +299,77 @@ def update_context(feature_dir: Path, step: str, status: str, by: str) -> Path |
     })
     ctx["transitions"] = transitions
 
-    tmp = target.with_suffix(target.suffix + ".tmp")
-    try:
-        tmp.write_text(json.dumps(ctx, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
-        os.replace(tmp, target)
-    except OSError:
-        try:
-            tmp.unlink(missing_ok=True)  # don't litter on a failed write
-        except OSError:
-            pass
-        raise
+    atomic_write(target, ctx)
+    return target
+
+
+def sync_tasks(feature_dir: Path, tasks_md: Path, final_status: str, by: str) -> Path | None:
+    """Per-task journaling for the implement step.
+
+    Reads completed task markers in tasks.md and appends one transition per
+    newly-completed task (idempotent — task ids already journaled are skipped).
+    Sets currentStep=implement, currentTask to the last completed (or next
+    pending) task, and status to `final_status` once every marker is checked,
+    else "implementing". Honors the same no-backward-clobber guard.
+    """
+    target = feature_dir / ".spec-context.json"
+    branch = _git_branch(_repo_root()) or "main"
+    ctx = read_ctx(target)
+
+    if ctx and _is_more_advanced(ctx, "implement"):
+        print(
+            f"[companion] {target} already at currentStep={ctx.get('currentStep')} / "
+            f"status={ctx.get('status')}; not regressing to implement.",
+            file=sys.stderr,
+        )
+        return None
+
+    all_ids, done_ids = parse_task_markers(tasks_md)
+    if not all_ids:
+        print(f"[companion] No task markers found in {tasks_md}; nothing to sync.", file=sys.stderr)
+        return None
+
+    # Distinct, order-preserving — a marker id repeated in tasks.md is one task.
+    distinct_all = list(dict.fromkeys(all_ids))
+    distinct_done = list(dict.fromkeys(done_ids))
+
+    transitions = ctx.get("transitions")
+    if not isinstance(transitions, list):
+        transitions = []
+
+    already = _journaled_tasks(transitions)
+    fresh = [tid for tid in distinct_done if tid not in already]
+
+    fill_required(ctx, feature_dir, branch)
+    ctx["currentStep"] = "implement"
+    all_done = bool(distinct_all) and set(distinct_done) >= set(distinct_all)
+    ctx["status"] = final_status if all_done else "implementing"
+    ctx["updated"] = _today()
+
+    pending = [tid for tid in distinct_all if tid not in distinct_done]
+    ctx["currentTask"] = (pending[0] if pending else (distinct_done[-1] if distinct_done else None))
+
+    # Per-task entries are substeps of implement (substep = task id). This keeps
+    # the reader from mistaking them for a step-completion boundary (which is a
+    # substep==null self-loop) and keeps dedupeConsecutive from collapsing them.
+    for tid in fresh:
+        prior = prior_from(transitions)
+        transitions.append({
+            "step": "implement",
+            "substep": tid,
+            "task": tid,
+            "from": prior,
+            "by": by,
+            "at": _now_iso(),
+        })
+    ctx["transitions"] = transitions
+
+    atomic_write(target, ctx)
+    print(
+        f"[companion] Synced {len(fresh)} new task transition(s) "
+        f"({len(done_ids)}/{len(all_ids)} complete) into {target}.",
+        file=sys.stderr,
+    )
     return target
 
 
@@ -261,11 +379,16 @@ def main() -> int:
     parser.add_argument("--status", default="specified")
     parser.add_argument("--by", default="extension")
     parser.add_argument("--feature-dir", default=None)
+    parser.add_argument(
+        "--tasks-file", default=None,
+        help="Per-task journaling: append a transition per completed marker in this tasks.md.",
+    )
     args = parser.parse_args()
 
     # Best-effort guard: a non-canonical step is a no-op, never a host failure.
-    # Terminal state belongs in `status`, not `currentStep`.
-    if args.step == "done" or args.step not in CANONICAL_STEPS:
+    # Terminal state belongs in `status`, not `currentStep`. Skipped in task-sync
+    # mode, which always operates on the implement step.
+    if not args.tasks_file and (args.step == "done" or args.step not in CANONICAL_STEPS):
         print(
             f"[companion] Skipping: '{args.step}' is not a canonical currentStep "
             f"({', '.join(sorted(CANONICAL_STEPS))}).",
@@ -286,12 +409,21 @@ def main() -> int:
 
     # Never let a bookkeeping write fail the host spec-kit command.
     try:
-        target = update_context(feature_dir, args.step, args.status, args.by)
+        if args.tasks_file:
+            tasks_md = Path(args.tasks_file)
+            if not tasks_md.is_absolute():
+                tasks_md = root / tasks_md
+            # Task-sync operates on the implement step; the global --status default
+            # ("specified") would be an incoherent terminal status here.
+            final_status = args.status if args.status != parser.get_default("status") else "implemented"
+            target = sync_tasks(feature_dir, tasks_md, final_status, args.by)
+        else:
+            target = update_context(feature_dir, args.step, args.status, args.by)
     except Exception as exc:  # noqa: BLE001 - best-effort, swallow + report
         print(f"[companion] Warning: skipped .spec-context.json write: {exc}", file=sys.stderr)
         return 0
 
-    if target is not None:
+    if target is not None and not args.tasks_file:
         print(f"[companion] Updated {target} (currentStep={args.step}, status={args.status}, by={args.by})")
     return 0
 

--- a/speckit-extension/CHANGELOG.md
+++ b/speckit-extension/CHANGELOG.md
@@ -8,6 +8,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/); this ext
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-06-07
+
+Full lifecycle capture + derive-from-files fallback — Step 2 of the v1 plan. See [ROADMAP.md](./ROADMAP.md).
+
+### Added
+- Full lifecycle capture: new `after_plan`, `after_tasks`, and `after_implement` lifecycle hooks (all auto-running, `optional: false`), each backed by a per-step capture command (`speckit.companion.capture-plan` / `-tasks` / `-implement`) that reuses `write-context.py`.
+- Per-task journaling: `write-context.py` gains a `--tasks-file` task-sync mode that appends one idempotent transition per completed `- [x] **T###**` marker; records `implementing` until all tasks are checked, then `implemented`.
+- New `derive-from-files.py` (stdlib-only) reconstructs `.spec-context.json` from on-disk artifacts + git when a hook never fired, honoring the same no-backward-clobber guard and emitting the same canonical schema (`by: "derive"`).
+- Added a stdlib `unittest` regression suite (append-only transitions, no-backward-clobber, unknown-key preservation, derive round-trip).
+
 ## [0.1.0] - 2026-05-25
 
 Foundation + state-write spike — the v1 first slice (PR #173). See [ROADMAP.md](./ROADMAP.md).

--- a/speckit-extension/CHANGELOG.md
+++ b/speckit-extension/CHANGELOG.md
@@ -14,9 +14,12 @@ Full lifecycle capture + derive-from-files fallback — Step 2 of the v1 plan. S
 
 ### Added
 - Full lifecycle capture: new `after_plan`, `after_tasks`, and `after_implement` lifecycle hooks (all auto-running, `optional: false`), each backed by a per-step capture command (`speckit.companion.capture-plan` / `-tasks` / `-implement`) that reuses `write-context.py`.
-- Per-task journaling: `write-context.py` gains a `--tasks-file` task-sync mode that appends one idempotent transition per completed `- [x] **T###**` marker; records `implementing` until all tasks are checked, then `implemented`.
+- Per-task journaling: `write-context.py` gains a `--tasks-file` task-sync mode that appends one idempotent `history[]` entry per completed `- [x] **T###**` marker (as an implement substep, so the viewer never reads it as a step completion); records `implementing` until all tasks are checked, then `implemented`.
 - New `derive-from-files.py` (stdlib-only) reconstructs `.spec-context.json` from on-disk artifacts + git when a hook never fired, honoring the same no-backward-clobber guard and emitting the same canonical schema (`by: "derive"`).
-- Added a stdlib `unittest` regression suite (append-only transitions, no-backward-clobber, unknown-key preservation, derive round-trip).
+- Added a stdlib `unittest` regression suite (append-only history, no-backward-clobber, unknown-key preservation, per-task idempotency/substep shape, legacy-`transitions`→`history` migration, derive round-trip).
+
+### Changed
+- The writer now appends to the canonical `history[]` field (with explicit `kind`) instead of the legacy `transitions[]`, and drops the derived `stepHistory` key — matching exactly what the VS Code GUI writes/reads. A pre-existing `transitions[]` array is migrated forward into `history[]` on the next write, so the extension and the GUI never deviate on field name.
 
 ## [0.1.0] - 2026-05-25
 

--- a/speckit-extension/ROADMAP.md
+++ b/speckit-extension/ROADMAP.md
@@ -9,7 +9,7 @@ Design sources: `sdd` repo → `specs/024-speckit-extension-foundation/spec.md` 
 | # | Step | Scope | Status |
 |---|------|-------|--------|
 | 1 | **Foundation + `after_specify` spike** | one hook → `write-context.py` → `.spec-context.json`; minimal canonical-schema alignment | ✅ **Shipped & proven** ([PR #173](https://github.com/alfredoperez/speckit-companion/pull/173)) |
-| 2 | Full lifecycle capture + fallback | `after_plan`/`after_tasks`/`after_implement` hooks; derive-from-files when a hook didn't fire | ◻ Planned |
+| 2 | Full lifecycle capture + fallback | `after_plan`/`after_tasks`/`after_implement` hooks; derive-from-files when a hook didn't fire | ✅ Shipped |
 | 3 | `status` + `resume` commands | pipeline view (`--json`) + next-step detection — **completes v1** | ◻ Planned |
 | 4 | Own pipeline commands + `sdd-lean` preset | namespaced `/speckit.companion.*` + a files/deps template pack | ◻ Planned |
 | 5 | Complexity detector + fast path | right-size small changes (spec+plan+tasks in one pass) | ◻ Planned |
@@ -27,5 +27,12 @@ The whole migration rested on one unproven, agent-mediated chain: *user runs a s
 - **B — live hook + GUI:** ✅ Verified 2026-05-25. One real `/speckit.specify` **auto-fired** the `after_specify` companion hook (`optional: false` → no nudge) → `write-context.py` → `specs/<NNN>-<slug>/.spec-context.json` at `currentStep: specify` / `status: specified` with a `by: extension` transition. The artifact carried `workflow: "speckit"`, proving it works on a **plain spec-kit flow** with no SDD present.
 
 The reproducible proof procedure lives in the [README](./README.md#end-to-end-proof-the-de-risk).
+
+## Step 2 — what shipped
+
+- **Three new lifecycle hooks** — `after_plan`, `after_tasks`, and `after_implement` (all `optional: false`, auto-running), each backed by a per-step capture command (`speckit.companion.capture-plan` / `-tasks` / `-implement`) that reuses `write-context.py`.
+- **Per-task journaling** on `after_implement` via the writer's new `--tasks-file` task-sync mode — appends one idempotent transition per completed `- [x] **T###**` marker, recording `implementing` until every task is checked, then `implemented`.
+- **`derive-from-files.py`** — a new stdlib-only fallback that reconstructs `.spec-context.json` from on-disk artifacts + git when a hook never fired, honoring the same no-backward-clobber guard and emitting the same canonical schema.
+- **Regression coverage** — a stdlib `unittest` suite (append-only transitions, no-backward-clobber, unknown-key preservation, derive round-trip).
 
 > The build-in-public devlog for each step is the "My SDD" Build Log series.

--- a/speckit-extension/commands/speckit.companion.capture-implement.md
+++ b/speckit-extension/commands/speckit.companion.capture-implement.md
@@ -1,0 +1,40 @@
+---
+description: "Capture per-task implement progress (currentStep=implement) into .spec-context.json for the Companion GUI"
+---
+
+# Capture Implement Context
+
+Record the active feature's implementation progress into `.spec-context.json` so the
+SpecKit Companion GUI re-renders with the correct step and status. This command
+runs as the `after_implement` lifecycle hook. It uses the writer's **TASK-SYNC mode**: it reads the completed task markers in the feature's `tasks.md` and appends one transition per completed task (idempotent — already-recorded tasks are skipped), ending at `status=implemented` when every marker is checked, otherwise `status=implementing`.
+
+## Prerequisites
+
+- Verify Python is available by running `python3 --version`.
+- If `python3` is not available, warn the user and skip the capture:
+  `[companion] Warning: python3 not detected; skipped .spec-context.json capture`.
+  Do not fail the host command.
+
+## Execution
+
+Run the writer script from the repository root, passing the active feature's `tasks.md` path:
+
+```bash
+python3 speckit-extension/scripts/write-context.py --step implement --status implemented --by extension --tasks-file specs/<NNN>-<slug>/tasks.md
+```
+
+Pass the active feature's `tasks.md` path to `--tasks-file`. If feature resolution is unambiguous the script resolves the feature directory on its own (in this order: `--feature-dir` → `SPECIFY_FEATURE_DIRECTORY` env → `SPECIFY_FEATURE` env → `.specify/feature.json` → current git branch prefix), but `--tasks-file` must still point at that feature's `tasks.md`. The `--status implemented` value is the terminal status applied only when all task markers are checked; partial completion records `implementing` automatically.
+
+## Graceful Degradation
+
+The script is best-effort and never fails the host command:
+- If `python3` is missing, skip with the warning above.
+- If the active feature directory cannot be resolved, the script prints a warning
+  to stderr and exits 0 without writing.
+
+## Output
+
+On success the script prints the path it updated and the values written, e.g.:
+`[companion] Updated specs/<NNN>-<slug>/.spec-context.json (currentStep=implement, status=implementing, by=extension)`.
+The write is atomic (temp file + rename) and appends to `transitions` without
+rewriting existing history.

--- a/speckit-extension/commands/speckit.companion.capture-plan.md
+++ b/speckit-extension/commands/speckit.companion.capture-plan.md
@@ -1,0 +1,50 @@
+---
+description: "Capture plan completion (currentStep=plan, status=planned) into .spec-context.json for the Companion GUI"
+---
+
+# Capture Plan Context
+
+Record the active feature's plan completion into `.spec-context.json` so the
+SpecKit Companion GUI re-renders with the correct step and status. This command
+runs as the `after_plan` lifecycle hook — **state-writing only**; the plan
+document is created by the core `/speckit.plan` workflow.
+
+## Prerequisites
+
+- Verify Python is available by running `python3 --version`.
+- If `python3` is not available, warn the user and skip the capture:
+  `[companion] Warning: python3 not detected; skipped .spec-context.json capture`.
+  Do not fail the host command.
+
+## Execution
+
+Run the writer script from the repository root:
+
+```bash
+python3 speckit-extension/scripts/write-context.py --step plan --status planned --by extension
+```
+
+The script resolves the active feature directory on its own, in this order:
+`--feature-dir` → `SPECIFY_FEATURE_DIRECTORY` env → `SPECIFY_FEATURE` env →
+`.specify/feature.json` → current git branch prefix.
+
+If you already know the feature directory (e.g. the one `/speckit.plan` just
+wrote into), pass it explicitly so resolution is unambiguous:
+
+```bash
+python3 speckit-extension/scripts/write-context.py --feature-dir specs/<NNN>-<slug> --step plan --status planned --by extension
+```
+
+## Graceful Degradation
+
+The script is best-effort and never fails the host command:
+- If `python3` is missing, skip with the warning above.
+- If the active feature directory cannot be resolved, the script prints a warning
+  to stderr and exits 0 without writing.
+
+## Output
+
+On success the script prints the path it updated and the values written, e.g.:
+`[companion] Updated specs/<NNN>-<slug>/.spec-context.json (currentStep=plan, status=planned, by=extension)`.
+The write is atomic (temp file + rename) and appends to `transitions` without
+rewriting existing history.

--- a/speckit-extension/commands/speckit.companion.capture-tasks.md
+++ b/speckit-extension/commands/speckit.companion.capture-tasks.md
@@ -1,0 +1,50 @@
+---
+description: "Capture tasks completion (currentStep=tasks, status=ready-to-implement) into .spec-context.json for the Companion GUI"
+---
+
+# Capture Tasks Context
+
+Record the active feature's tasks completion into `.spec-context.json` so the
+SpecKit Companion GUI re-renders with the correct step and status. This command
+runs as the `after_tasks` lifecycle hook — **state-writing only**; the tasks
+document is created by the core `/speckit.tasks` workflow.
+
+## Prerequisites
+
+- Verify Python is available by running `python3 --version`.
+- If `python3` is not available, warn the user and skip the capture:
+  `[companion] Warning: python3 not detected; skipped .spec-context.json capture`.
+  Do not fail the host command.
+
+## Execution
+
+Run the writer script from the repository root:
+
+```bash
+python3 speckit-extension/scripts/write-context.py --step tasks --status ready-to-implement --by extension
+```
+
+The script resolves the active feature directory on its own, in this order:
+`--feature-dir` → `SPECIFY_FEATURE_DIRECTORY` env → `SPECIFY_FEATURE` env →
+`.specify/feature.json` → current git branch prefix.
+
+If you already know the feature directory (e.g. the one `/speckit.tasks` just
+wrote into), pass it explicitly so resolution is unambiguous:
+
+```bash
+python3 speckit-extension/scripts/write-context.py --feature-dir specs/<NNN>-<slug> --step tasks --status ready-to-implement --by extension
+```
+
+## Graceful Degradation
+
+The script is best-effort and never fails the host command:
+- If `python3` is missing, skip with the warning above.
+- If the active feature directory cannot be resolved, the script prints a warning
+  to stderr and exits 0 without writing.
+
+## Output
+
+On success the script prints the path it updated and the values written, e.g.:
+`[companion] Updated specs/<NNN>-<slug>/.spec-context.json (currentStep=tasks, status=ready-to-implement, by=extension)`.
+The write is atomic (temp file + rename) and appends to `transitions` without
+rewriting existing history.

--- a/speckit-extension/docs/commands.md
+++ b/speckit-extension/docs/commands.md
@@ -13,12 +13,15 @@ Registered in the extension's `extension.yml` (and, once installed, in the proje
 | Hook | Command | optional | Effect |
 |------|---------|----------|--------|
 | `after_specify` | `speckit.companion.capture` | `false` (auto-runs) | Record specify completion into `.spec-context.json` |
+| `after_plan` | `speckit.companion.capture-plan` | `false` (auto-runs) | Record plan completion (`currentStep=plan`, `status=planned`) into `.spec-context.json` |
+| `after_tasks` | `speckit.companion.capture-tasks` | `false` (auto-runs) | Record tasks completion (`currentStep=tasks`, `status=ready-to-implement`) into `.spec-context.json` |
+| `after_implement` | `speckit.companion.capture-implement` | `false` (auto-runs) | Per-task journaling on implement (`currentStep=implement`); `status=implemented` when all tasks checked |
 
-`optional: false` means the agent runs it **automatically** with no prompt. (For contrast, the bundled `git` extension's `after_specify` commit hook is `optional: true`, so it only *offers* to run.) Steps 2+ add `after_plan` / `after_tasks` / `after_implement` — see [../ROADMAP.md](../ROADMAP.md).
+`optional: false` means the agent runs it **automatically** with no prompt. (For contrast, the bundled `git` extension's `after_specify` commit hook is `optional: true`, so it only *offers* to run.) ROADMAP step 2 shipped `after_plan` / `after_tasks` / `after_implement`, so the full `specify → plan → tasks → implement` lifecycle is now captured automatically — see [../ROADMAP.md](../ROADMAP.md).
 
 ## `speckit.companion.capture`
 
-The only command today. It carries no business logic itself — it resolves the active feature and invokes the writer script, mirroring `speckit.git.feature.md`.
+The first command. It carries no business logic itself — it resolves the active feature and invokes the writer script, mirroring `speckit.git.feature.md`. The three commands below follow the same pattern.
 
 **What the agent runs:**
 
@@ -34,7 +37,52 @@ python3 speckit-extension/scripts/write-context.py --step specify --status speci
 | `--status` | `specified` | Canonical lifecycle status written to the file. |
 | `--by` | `extension` | Authorship tag on the appended transition. |
 | `--feature-dir` | — | Explicit target dir; otherwise resolved (see [how-it-works.md](./how-it-works.md#active-directory-resolution)). |
+| `--tasks-file` | — | Per-task journaling mode: append one transition per completed task marker in this `tasks.md`. Idempotent; sets `status=implementing` until all checked, then the `--status` value. |
 
 **Graceful degradation:** if `python3` is missing the command warns and skips; if the active feature directory can't be resolved the script warns and exits 0. It never fails the host spec-kit command.
+
+## `speckit.companion.capture-plan`
+
+Runs after `/speckit.plan`. Resolves the active feature and records plan completion.
+
+**What the agent runs:**
+
+```bash
+python3 speckit-extension/scripts/write-context.py --step plan --status planned --by extension
+```
+
+## `speckit.companion.capture-tasks`
+
+Runs after `/speckit.tasks`. Resolves the active feature and records tasks completion.
+
+**What the agent runs:**
+
+```bash
+python3 speckit-extension/scripts/write-context.py --step tasks --status ready-to-implement --by extension
+```
+
+## `speckit.companion.capture-implement`
+
+Runs after `/speckit.implement` in task-sync mode: it appends one transition per completed `- [x] **T###**` marker in `tasks.md`. Idempotent — re-running adds only newly-checked markers; status stays `implementing` until all markers are checked, then becomes `implemented`.
+
+**What the agent runs:**
+
+```bash
+python3 speckit-extension/scripts/write-context.py --step implement --status implemented --by extension --tasks-file specs/<NNN>-<slug>/tasks.md
+```
+
+## Derive-from-files fallback
+
+`speckit-extension/scripts/derive-from-files.py` reconstructs `.spec-context.json` from on-disk artifacts when a hook never fired. Stdlib-only; reuses `write-context.py`'s feature-dir resolution and its no-backward-clobber guard, so it never drags an already-advanced or terminal spec backward. It writes the same canonical schema, tagged `by: "derive"`.
+
+It infers the lifecycle from what's present: `spec.md` → `specify`/`specified`, `plan.md` → `plan`/`planned`, `tasks.md` → `tasks`/`ready-to-implement`, and all task markers checked → `implement`/`implemented`, plus git as a signal.
+
+**Invocation:**
+
+```bash
+python3 speckit-extension/scripts/derive-from-files.py
+# or target an explicit dir:
+python3 speckit-extension/scripts/derive-from-files.py --feature-dir specs/<NNN>-<slug>
+```
 
 See [how-it-works.md](./how-it-works.md) for what the writer guarantees (atomic, append-only, no-regress) and the canonical schema.

--- a/speckit-extension/docs/contributing.md
+++ b/speckit-extension/docs/contributing.md
@@ -45,6 +45,6 @@ Each migration step (see [ROADMAP.md](../ROADMAP.md)) is one PR-sized change:
 ## Good to know
 
 - **`companion` is installed in this repo (dogfooding).** Running `/speckit.specify` here auto-fires the `after_specify` capture — expected, harmless.
-- **Coexists with SDD.** The `/sdd:*` flow writes `.spec-context.json` itself; this extension only fires on `/speckit.*`. Mixed authorship in `transitions[].by` is normal.
+- **Coexists with SDD.** The `/sdd:*` flow writes `.spec-context.json` itself; this extension only fires on `/speckit.*`. Mixed authorship in `history[].by` is normal.
 - **Best-effort contract.** The writer must never fail the host spec-kit command — keep new script paths warn-and-exit-0 on error (see `write-context.py`).
 - **Schema is owned by the GUI repo** at `src/core/types/spec-context.schema.json`; extend it there, never vendor a copy.

--- a/speckit-extension/docs/how-it-works.md
+++ b/speckit-extension/docs/how-it-works.md
@@ -13,7 +13,7 @@ The extension lives beside the VS Code GUI in the monorepo and is published/inst
 A stdlib-only Python script that does a crash-safe **read-merge-write** of the active feature's `.spec-context.json`:
 
 - **Preserves** every existing/unknown top-level key (e.g. Companion-owned `reviewComments`) — never clobbers.
-- **Append-only** `transitions` (`by: "extension"`); `from` is the prior `{step, substep}`, or `null` on first write.
+- **Append-only** canonical `history[]` (`by: "extension"`, explicit `kind`); `from` is the prior `{step, substep}` on a `start` entry. A legacy `transitions[]` array is migrated forward into `history[]` so the extension and the VS Code GUI write the same single field.
 - **Never regresses** a more-advanced spec: if the target is already at a later step or a terminal status (`implemented`/`completed`/`archived`), it's left untouched — this prevents a stray hook from dragging a shipped spec backward.
 - **Atomic:** writes a temp file then `os.replace()`.
 - Writes Companion-canonical values (e.g. `currentStep: "specify"`, `status: "specified"`); **never** the legacy `currentStep: "done"`.
@@ -28,7 +28,7 @@ It never falls back to "most-recently-modified dir containing `tasks.md`."
 
 ## Canonical schema
 
-The schema is owned by the GUI repo at `src/core/types/spec-context.schema.json`; the writer targets it directly — **no vendored copy, no cross-repo reconciliation**. v1 added `"implemented"` to the `status` enum so terminal state matches the TypeScript `Status` type.
+The data contract has a single source of truth: `src/core/types/spec-context.schema.json` (mirrored by the TypeScript types in `src/core/types/specContext.ts`). The writer targets that shape directly — **no vendored copy, no cross-repo reconciliation** — and writes the same canonical `history[]` field the GUI itself writes, so the two never deviate. v1 added `"implemented"` to the `status` enum; the lifecycle step added `"derive"` to the `historyEntry.by` enum (for derive-from-files captures).
 
 ## End-to-end proof
 
@@ -40,11 +40,11 @@ The migration rests on one agent-mediated chain: *spec-kit command → agent run
 mkdir -p specs/_zzz-proof-demo && printf '# Spec: Proof Demo\n' > specs/_zzz-proof-demo/spec.md
 python3 speckit-extension/scripts/write-context.py --feature-dir specs/_zzz-proof-demo \
   --step specify --status specified --by extension
-cat specs/_zzz-proof-demo/.spec-context.json   # currentStep=specify, status=specified, transitions[].by=extension
+cat specs/_zzz-proof-demo/.spec-context.json   # currentStep=specify, status=specified, history[].by=extension
 rm -rf specs/_zzz-proof-demo
 ```
 
-Expected: a valid canonical `.spec-context.json` with `currentStep: "specify"`, `status: "specified"`, and a single `transitions` entry `{ "by": "extension", "from": null }`. Re-running appends a second transition (with `from` set) and preserves any pre-existing keys.
+Expected: a valid canonical `.spec-context.json` with `currentStep: "specify"`, `status: "specified"`, and a single `history` entry `{ "kind": "start", "by": "extension", "from": { "step": null, "substep": null } }`. Re-running appends a second entry (with `from` set) and preserves any pre-existing keys.
 
 ### B. Live hook + GUI
 

--- a/speckit-extension/extension.yml
+++ b/speckit-extension/extension.yml
@@ -23,12 +23,33 @@ provides:
     - name: speckit.companion.capture
       file: commands/speckit.companion.capture.md
       description: "Capture the current spec-kit step into .spec-context.json for the Companion GUI"
+    - name: speckit.companion.capture-plan
+      file: commands/speckit.companion.capture-plan.md
+      description: "Capture plan completion (currentStep=plan, status=planned) into .spec-context.json"
+    - name: speckit.companion.capture-tasks
+      file: commands/speckit.companion.capture-tasks.md
+      description: "Capture tasks completion (currentStep=tasks, status=ready-to-implement) into .spec-context.json"
+    - name: speckit.companion.capture-implement
+      file: commands/speckit.companion.capture-implement.md
+      description: "Capture per-task implement progress (currentStep=implement) into .spec-context.json"
 
 hooks:
   after_specify:
     command: speckit.companion.capture
     optional: false
     description: "Record specify completion (currentStep=specify, status=specified) into .spec-context.json"
+  after_plan:
+    command: speckit.companion.capture-plan
+    optional: false
+    description: "Record plan completion (currentStep=plan, status=planned) into .spec-context.json"
+  after_tasks:
+    command: speckit.companion.capture-tasks
+    optional: false
+    description: "Record tasks completion (currentStep=tasks, status=ready-to-implement) into .spec-context.json"
+  after_implement:
+    command: speckit.companion.capture-implement
+    optional: false
+    description: "Per-task journaling on implement (currentStep=implement; status=implemented when all tasks checked)"
 
 tags:
   - "spec-driven-development"

--- a/speckit-extension/scripts/derive-from-files.py
+++ b/speckit-extension/scripts/derive-from-files.py
@@ -34,7 +34,10 @@ def _infer(feature_dir: Path) -> tuple[str, str] | None:
 
     if tasks_md.is_file():
         all_ids, done_ids = wc.parse_task_markers(tasks_md)
-        if all_ids and len(done_ids) == len(all_ids):
+        # Distinct-id + set-coverage, matching write-context.py sync_tasks, so a
+        # duplicated marker id can't make derive and task-sync disagree on "done".
+        distinct_all = set(all_ids)
+        if distinct_all and set(done_ids) >= distinct_all:
             return "implement", "implemented"
         return "tasks", "ready-to-implement"
     if plan_md.is_file():
@@ -69,30 +72,19 @@ def derive(feature_dir: Path, by: str = "derive") -> Path | None:
     now = wc._now_iso()
     branch = wc._git_branch(wc._repo_root()) or "main"
 
-    transitions = ctx.get("transitions")
-    if not isinstance(transitions, list):
-        transitions = []
-
-    prior = wc.prior_from(transitions)
+    log = wc.canonical_log(ctx)
+    from_ = wc.step_from(ctx.get("currentStep"), step)
     wc.fill_required(ctx, feature_dir, branch)
 
     ctx["currentStep"] = step
     ctx["status"] = status
     ctx["updated"] = wc._today()
 
-    step_history = ctx.get("stepHistory")
-    if not isinstance(step_history, dict):
-        step_history = {}
-    entry = step_history.get(step) if isinstance(step_history.get(step), dict) else {}
-    entry.setdefault("startedAt", now)
-    entry["completedAt"] = now
-    step_history[step] = entry
-    ctx["stepHistory"] = step_history
-
-    transitions.append({
+    log.append({
         "step": step,
         "substep": None,
-        "from": prior,
+        "kind": "start",
+        "from": from_,
         "by": by,
         "at": now,
     })
@@ -101,24 +93,25 @@ def derive(feature_dir: Path, by: str = "derive") -> Path | None:
         all_ids, done_ids = wc.parse_task_markers(feature_dir / "tasks.md")
         distinct_all = list(dict.fromkeys(all_ids))
         distinct_done = list(dict.fromkeys(done_ids))
-        already = wc._journaled_tasks(transitions)
-        # Per-task entries are substeps of implement (substep = task id) so the
-        # reader never reads them as a step-completion boundary.
+        already = wc._journaled_tasks(log)
+        # Per-task entries are substeps of implement (substep = task id, kind=start)
+        # so the reader never reads them as a step-completion boundary.
         for tid in distinct_done:
             if tid in already:
                 continue
-            transitions.append({
+            log.append({
                 "step": "implement",
                 "substep": tid,
                 "task": tid,
-                "from": wc.prior_from(transitions),
+                "kind": "start",
+                "from": {"step": "implement", "substep": None},
                 "by": by,
                 "at": wc._now_iso(),
             })
         pending = [tid for tid in distinct_all if tid not in distinct_done]
         ctx["currentTask"] = (pending[0] if pending else (distinct_done[-1] if distinct_done else None))
 
-    ctx["transitions"] = transitions
+    wc.commit_log(ctx, log)
 
     wc.atomic_write(target, ctx)
     print(

--- a/speckit-extension/scripts/derive-from-files.py
+++ b/speckit-extension/scripts/derive-from-files.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""Reconstruct a feature's .spec-context.json from on-disk artifacts + git.
+
+The derive-from-files fallback that complements the hook-driven write-context.py
+in this same directory. When a spec-kit lifecycle hook never fired (so no
+.spec-context.json exists or it lags the real artifacts), this script infers the
+feature's step/status purely from which files are present (spec.md / plan.md /
+tasks.md and the task-marker checkbox state) and writes the same canonical
+.spec-context.json shape that write-context.py emits.
+
+Best-effort by design: never raises, never exits non-zero, and never drags a
+more-advanced spec backward (no-backward-clobber).
+
+Stdlib only. Safe to run anywhere `python3` is available.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import sys
+from pathlib import Path
+
+# The sibling module's filename has a hyphen, so it can't be a normal import.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+wc = importlib.import_module("write-context")
+
+
+def _infer(feature_dir: Path) -> tuple[str, str] | None:
+    """Map artifact presence to (step, status); None when nothing is present."""
+    tasks_md = feature_dir / "tasks.md"
+    plan_md = feature_dir / "plan.md"
+    spec_md = feature_dir / "spec.md"
+
+    if tasks_md.is_file():
+        all_ids, done_ids = wc.parse_task_markers(tasks_md)
+        if all_ids and len(done_ids) == len(all_ids):
+            return "implement", "implemented"
+        return "tasks", "ready-to-implement"
+    if plan_md.is_file():
+        return "plan", "planned"
+    if spec_md.is_file():
+        return "specify", "specified"
+    return None
+
+
+def derive(feature_dir: Path, by: str = "derive") -> Path | None:
+    target = feature_dir / ".spec-context.json"
+    ctx = wc.read_ctx(target)
+
+    inferred = _infer(feature_dir)
+    if inferred is None:
+        print(
+            f"[companion] No spec.md/plan.md/tasks.md in {feature_dir}; "
+            "nothing to derive.",
+            file=sys.stderr,
+        )
+        return None
+    step, status = inferred
+
+    if ctx and wc._is_more_advanced(ctx, step):
+        print(
+            f"[companion] {target} already at currentStep={ctx.get('currentStep')} / "
+            f"status={ctx.get('status')}; not regressing.",
+            file=sys.stderr,
+        )
+        return None
+
+    now = wc._now_iso()
+    branch = wc._git_branch(wc._repo_root()) or "main"
+
+    transitions = ctx.get("transitions")
+    if not isinstance(transitions, list):
+        transitions = []
+
+    prior = wc.prior_from(transitions)
+    wc.fill_required(ctx, feature_dir, branch)
+
+    ctx["currentStep"] = step
+    ctx["status"] = status
+    ctx["updated"] = wc._today()
+
+    step_history = ctx.get("stepHistory")
+    if not isinstance(step_history, dict):
+        step_history = {}
+    entry = step_history.get(step) if isinstance(step_history.get(step), dict) else {}
+    entry.setdefault("startedAt", now)
+    entry["completedAt"] = now
+    step_history[step] = entry
+    ctx["stepHistory"] = step_history
+
+    transitions.append({
+        "step": step,
+        "substep": None,
+        "from": prior,
+        "by": by,
+        "at": now,
+    })
+
+    if step == "implement":
+        all_ids, done_ids = wc.parse_task_markers(feature_dir / "tasks.md")
+        distinct_all = list(dict.fromkeys(all_ids))
+        distinct_done = list(dict.fromkeys(done_ids))
+        already = wc._journaled_tasks(transitions)
+        # Per-task entries are substeps of implement (substep = task id) so the
+        # reader never reads them as a step-completion boundary.
+        for tid in distinct_done:
+            if tid in already:
+                continue
+            transitions.append({
+                "step": "implement",
+                "substep": tid,
+                "task": tid,
+                "from": wc.prior_from(transitions),
+                "by": by,
+                "at": wc._now_iso(),
+            })
+        pending = [tid for tid in distinct_all if tid not in distinct_done]
+        ctx["currentTask"] = (pending[0] if pending else (distinct_done[-1] if distinct_done else None))
+
+    ctx["transitions"] = transitions
+
+    wc.atomic_write(target, ctx)
+    print(
+        f"[companion] Derived {target} from files "
+        f"(currentStep={step}, status={status}, by={by}).",
+        file=sys.stderr,
+    )
+    return target
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Reconstruct a feature's .spec-context.json from on-disk artifacts."
+    )
+    parser.add_argument("--feature-dir", default=None)
+    parser.add_argument("--by", default="derive")
+    args = parser.parse_args()
+
+    root = wc._repo_root()
+    feature_dir = wc.resolve_feature_dir(root, args.feature_dir)
+    if feature_dir is None or not feature_dir.is_dir():
+        print(
+            "[companion] Could not resolve the active feature directory "
+            "(checked --feature-dir, SPECIFY_FEATURE_DIRECTORY, SPECIFY_FEATURE, "
+            ".specify/feature.json, git branch prefix). Skipping derive.",
+            file=sys.stderr,
+        )
+        return 0  # best-effort: never fail the host command
+
+    try:
+        derive(feature_dir, args.by)
+    except Exception as exc:  # noqa: BLE001 - best-effort, swallow + report
+        print(f"[companion] Warning: skipped .spec-context.json derive: {exc}", file=sys.stderr)
+        return 0
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/speckit-extension/scripts/write-context.py
+++ b/speckit-extension/scripts/write-context.py
@@ -7,7 +7,9 @@ own precedence, then does a crash-safe read-merge-write of the Companion's
 canonical .spec-context.json:
 
   - preserves every existing/unknown top-level key (read-then-merge)
-  - appends to `transitions` (append-only; never rewritten or shrunk)
+  - appends to the canonical `history[]` (append-only; never rewritten or
+    shrunk), migrating a legacy `transitions[]` array forward so the extension
+    and the VS Code GUI write the same single field
   - writes atomically (temp file + os.replace)
   - emits Companion-canonical values; never the legacy `currentStep: "done"`
 
@@ -198,20 +200,33 @@ def atomic_write(target: Path, ctx: dict) -> None:
         raise
 
 
-def prior_from(transitions: list) -> dict | None:
-    """`from` = prior {step, substep}, or null when there is no prior entry.
+def canonical_log(ctx: dict) -> list:
+    """The append-only lifecycle log. Canonical field is `history`; an older
+    file may still carry the legacy `transitions` name — migrate it forward so
+    both the extension and the VS Code GUI write the same single array."""
+    log = ctx.get("history")
+    if isinstance(log, list):
+        return log
+    legacy = ctx.get("transitions")
+    if isinstance(legacy, list):
+        return legacy
+    return []
 
-    Guards a malformed last entry and normalizes a non-canonical prior step
-    (e.g. legacy "done") to null, which the schema's `from.step` enum permits.
-    """
-    if transitions and isinstance(transitions[-1], dict):
-        last = transitions[-1]
-        prior_step = last.get("step")
-        return {
-            "step": prior_step if prior_step in CANONICAL_STEPS else None,
-            "substep": last.get("substep"),
-        }
-    return None
+
+def commit_log(ctx: dict, log: list) -> None:
+    """Persist the log under the canonical `history` key and drop the legacy
+    `transitions` / derived `stepHistory` keys (the GUI derives stepHistory)."""
+    ctx["history"] = log
+    ctx.pop("transitions", None)
+    ctx.pop("stepHistory", None)
+
+
+def step_from(prev_current: object, step: str) -> dict:
+    """`from` for a step `start` entry — the prior step, or null when there is
+    none or it equals `step` (mirrors the GUI's setStepStarted, which nulls a
+    self-origin so the reader can't misread it as a step completion)."""
+    prior = prev_current if (prev_current in CANONICAL_STEPS and prev_current != step) else None
+    return {"step": prior, "substep": None}
 
 
 def fill_required(ctx: dict, feature_dir: Path, branch: str) -> None:
@@ -270,34 +285,23 @@ def update_context(feature_dir: Path, step: str, status: str, by: str) -> Path |
         )
         return None
 
-    transitions = ctx.get("transitions")
-    if not isinstance(transitions, list):
-        transitions = []
-
-    prior = prior_from(transitions)
+    log = canonical_log(ctx)
+    from_ = step_from(ctx.get("currentStep"), step)
     fill_required(ctx, feature_dir, branch)
 
     ctx["currentStep"] = step
     ctx["status"] = status
     ctx["updated"] = _today()
 
-    step_history = ctx.get("stepHistory")
-    if not isinstance(step_history, dict):
-        step_history = {}
-    entry = step_history.get(step) if isinstance(step_history.get(step), dict) else {}
-    entry.setdefault("startedAt", now)
-    entry["completedAt"] = now
-    step_history[step] = entry
-    ctx["stepHistory"] = step_history
-
-    transitions.append({
+    log.append({
         "step": step,
         "substep": None,
-        "from": prior,
+        "kind": "start",
+        "from": from_,
         "by": by,
         "at": now,
     })
-    ctx["transitions"] = transitions
+    commit_log(ctx, log)
 
     atomic_write(target, ctx)
     return target
@@ -333,11 +337,8 @@ def sync_tasks(feature_dir: Path, tasks_md: Path, final_status: str, by: str) ->
     distinct_all = list(dict.fromkeys(all_ids))
     distinct_done = list(dict.fromkeys(done_ids))
 
-    transitions = ctx.get("transitions")
-    if not isinstance(transitions, list):
-        transitions = []
-
-    already = _journaled_tasks(transitions)
+    log = canonical_log(ctx)
+    already = _journaled_tasks(log)
     fresh = [tid for tid in distinct_done if tid not in already]
 
     fill_required(ctx, feature_dir, branch)
@@ -349,25 +350,26 @@ def sync_tasks(feature_dir: Path, tasks_md: Path, final_status: str, by: str) ->
     pending = [tid for tid in distinct_all if tid not in distinct_done]
     ctx["currentTask"] = (pending[0] if pending else (distinct_done[-1] if distinct_done else None))
 
-    # Per-task entries are substeps of implement (substep = task id). This keeps
-    # the reader from mistaking them for a step-completion boundary (which is a
-    # substep==null self-loop) and keeps dedupeConsecutive from collapsing them.
+    # Per-task entries are substeps of implement (substep = task id, kind=start).
+    # A substep entry can never be read as a step-completion boundary (which is a
+    # substep==null self-loop), and distinct substep names keep dedupeConsecutive
+    # from collapsing them.
     for tid in fresh:
-        prior = prior_from(transitions)
-        transitions.append({
+        log.append({
             "step": "implement",
             "substep": tid,
             "task": tid,
-            "from": prior,
+            "kind": "start",
+            "from": {"step": "implement", "substep": None},
             "by": by,
             "at": _now_iso(),
         })
-    ctx["transitions"] = transitions
+    commit_log(ctx, log)
 
     atomic_write(target, ctx)
     print(
-        f"[companion] Synced {len(fresh)} new task transition(s) "
-        f"({len(done_ids)}/{len(all_ids)} complete) into {target}.",
+        f"[companion] Synced {len(fresh)} new task event(s) "
+        f"({len(distinct_done)}/{len(distinct_all)} complete) into {target}.",
         file=sys.stderr,
     )
     return target

--- a/speckit-extension/scripts/write-context.py
+++ b/speckit-extension/scripts/write-context.py
@@ -172,21 +172,93 @@ def _is_more_advanced(ctx: dict, step: str) -> bool:
     return cur in STEP_ORDER and STEP_ORDER[cur] > STEP_ORDER[step]
 
 
-def update_context(feature_dir: Path, step: str, status: str, by: str) -> Path | None:
-    target = feature_dir / ".spec-context.json"
-    now = _now_iso()
-    root = _repo_root()
-    branch = _git_branch(root) or "main"
-
+def read_ctx(target: Path) -> dict:
+    """Read the existing context, tolerating absence or corruption."""
     if target.is_file():
         try:
             ctx = json.loads(target.read_text(encoding="utf-8"))
-            if not isinstance(ctx, dict):
-                ctx = {}
+            if isinstance(ctx, dict):
+                return ctx
         except (json.JSONDecodeError, OSError):
-            ctx = {}
-    else:
-        ctx = {}
+            pass
+    return {}
+
+
+def atomic_write(target: Path, ctx: dict) -> None:
+    """Crash-safe write: serialize to a temp file, then rename over the target."""
+    tmp = target.with_suffix(target.suffix + ".tmp")
+    try:
+        tmp.write_text(json.dumps(ctx, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+        os.replace(tmp, target)
+    except OSError:
+        try:
+            tmp.unlink(missing_ok=True)  # don't litter on a failed write
+        except OSError:
+            pass
+        raise
+
+
+def prior_from(transitions: list) -> dict | None:
+    """`from` = prior {step, substep}, or null when there is no prior entry.
+
+    Guards a malformed last entry and normalizes a non-canonical prior step
+    (e.g. legacy "done") to null, which the schema's `from.step` enum permits.
+    """
+    if transitions and isinstance(transitions[-1], dict):
+        last = transitions[-1]
+        prior_step = last.get("step")
+        return {
+            "step": prior_step if prior_step in CANONICAL_STEPS else None,
+            "substep": last.get("substep"),
+        }
+    return None
+
+
+def fill_required(ctx: dict, feature_dir: Path, branch: str) -> None:
+    """Set required keys only when missing (read-then-merge preserves the rest)."""
+    ctx.setdefault("workflow", "speckit")
+    ctx.setdefault("specName", _spec_name(feature_dir))
+    ctx.setdefault("branch", branch)
+
+
+COMPLETED_TASK_RE = re.compile(r"^\s*[-*]\s*\[[xX]\]\s*\*\*(T\d+)")
+PENDING_TASK_RE = re.compile(r"^\s*[-*]\s*\[\s\]\s*\*\*(T\d+)")
+
+
+def parse_task_markers(tasks_md: Path) -> tuple[list[str], list[str]]:
+    """Return (all_task_ids, completed_task_ids) in document order from tasks.md."""
+    all_ids: list[str] = []
+    done_ids: list[str] = []
+    try:
+        for line in tasks_md.read_text(encoding="utf-8").splitlines():
+            m = COMPLETED_TASK_RE.match(line)
+            if m:
+                all_ids.append(m.group(1))
+                done_ids.append(m.group(1))
+                continue
+            m = PENDING_TASK_RE.match(line)
+            if m:
+                all_ids.append(m.group(1))
+    except OSError:
+        pass
+    return all_ids, done_ids
+
+
+def _journaled_tasks(transitions: list) -> set[str]:
+    """Task ids already recorded as per-task transitions (idempotency key)."""
+    return {
+        t["task"]
+        for t in transitions
+        if isinstance(t, dict) and isinstance(t.get("task"), str)
+    }
+
+
+def update_context(feature_dir: Path, step: str, status: str, by: str) -> Path | None:
+    target = feature_dir / ".spec-context.json"
+    now = _now_iso()
+    branch = _git_branch(_repo_root()) or "main"
+
+    ctx = read_ctx(target)
 
     # Never drag a more-advanced (e.g. shipped) spec backward. Leave it fully
     # intact — this is the bug the schema reconciliation exists to prevent.
@@ -202,23 +274,8 @@ def update_context(feature_dir: Path, step: str, status: str, by: str) -> Path |
     if not isinstance(transitions, list):
         transitions = []
 
-    # `from` = prior {step, substep}, or null on first write. Guard against a
-    # malformed last entry and normalize a non-canonical prior step (e.g. legacy
-    # "done") to null, which the schema's `from.step` enum permits.
-    if transitions and isinstance(transitions[-1], dict):
-        last = transitions[-1]
-        prior_step = last.get("step")
-        prior = {
-            "step": prior_step if prior_step in CANONICAL_STEPS else None,
-            "substep": last.get("substep"),
-        }
-    else:
-        prior = None
-
-    # Required-set defaults only when missing (read-then-merge preserves the rest).
-    ctx.setdefault("workflow", "speckit")
-    ctx.setdefault("specName", _spec_name(feature_dir))
-    ctx.setdefault("branch", branch)
+    prior = prior_from(transitions)
+    fill_required(ctx, feature_dir, branch)
 
     ctx["currentStep"] = step
     ctx["status"] = status
@@ -242,16 +299,77 @@ def update_context(feature_dir: Path, step: str, status: str, by: str) -> Path |
     })
     ctx["transitions"] = transitions
 
-    tmp = target.with_suffix(target.suffix + ".tmp")
-    try:
-        tmp.write_text(json.dumps(ctx, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
-        os.replace(tmp, target)
-    except OSError:
-        try:
-            tmp.unlink(missing_ok=True)  # don't litter on a failed write
-        except OSError:
-            pass
-        raise
+    atomic_write(target, ctx)
+    return target
+
+
+def sync_tasks(feature_dir: Path, tasks_md: Path, final_status: str, by: str) -> Path | None:
+    """Per-task journaling for the implement step.
+
+    Reads completed task markers in tasks.md and appends one transition per
+    newly-completed task (idempotent — task ids already journaled are skipped).
+    Sets currentStep=implement, currentTask to the last completed (or next
+    pending) task, and status to `final_status` once every marker is checked,
+    else "implementing". Honors the same no-backward-clobber guard.
+    """
+    target = feature_dir / ".spec-context.json"
+    branch = _git_branch(_repo_root()) or "main"
+    ctx = read_ctx(target)
+
+    if ctx and _is_more_advanced(ctx, "implement"):
+        print(
+            f"[companion] {target} already at currentStep={ctx.get('currentStep')} / "
+            f"status={ctx.get('status')}; not regressing to implement.",
+            file=sys.stderr,
+        )
+        return None
+
+    all_ids, done_ids = parse_task_markers(tasks_md)
+    if not all_ids:
+        print(f"[companion] No task markers found in {tasks_md}; nothing to sync.", file=sys.stderr)
+        return None
+
+    # Distinct, order-preserving — a marker id repeated in tasks.md is one task.
+    distinct_all = list(dict.fromkeys(all_ids))
+    distinct_done = list(dict.fromkeys(done_ids))
+
+    transitions = ctx.get("transitions")
+    if not isinstance(transitions, list):
+        transitions = []
+
+    already = _journaled_tasks(transitions)
+    fresh = [tid for tid in distinct_done if tid not in already]
+
+    fill_required(ctx, feature_dir, branch)
+    ctx["currentStep"] = "implement"
+    all_done = bool(distinct_all) and set(distinct_done) >= set(distinct_all)
+    ctx["status"] = final_status if all_done else "implementing"
+    ctx["updated"] = _today()
+
+    pending = [tid for tid in distinct_all if tid not in distinct_done]
+    ctx["currentTask"] = (pending[0] if pending else (distinct_done[-1] if distinct_done else None))
+
+    # Per-task entries are substeps of implement (substep = task id). This keeps
+    # the reader from mistaking them for a step-completion boundary (which is a
+    # substep==null self-loop) and keeps dedupeConsecutive from collapsing them.
+    for tid in fresh:
+        prior = prior_from(transitions)
+        transitions.append({
+            "step": "implement",
+            "substep": tid,
+            "task": tid,
+            "from": prior,
+            "by": by,
+            "at": _now_iso(),
+        })
+    ctx["transitions"] = transitions
+
+    atomic_write(target, ctx)
+    print(
+        f"[companion] Synced {len(fresh)} new task transition(s) "
+        f"({len(done_ids)}/{len(all_ids)} complete) into {target}.",
+        file=sys.stderr,
+    )
     return target
 
 
@@ -261,11 +379,16 @@ def main() -> int:
     parser.add_argument("--status", default="specified")
     parser.add_argument("--by", default="extension")
     parser.add_argument("--feature-dir", default=None)
+    parser.add_argument(
+        "--tasks-file", default=None,
+        help="Per-task journaling: append a transition per completed marker in this tasks.md.",
+    )
     args = parser.parse_args()
 
     # Best-effort guard: a non-canonical step is a no-op, never a host failure.
-    # Terminal state belongs in `status`, not `currentStep`.
-    if args.step == "done" or args.step not in CANONICAL_STEPS:
+    # Terminal state belongs in `status`, not `currentStep`. Skipped in task-sync
+    # mode, which always operates on the implement step.
+    if not args.tasks_file and (args.step == "done" or args.step not in CANONICAL_STEPS):
         print(
             f"[companion] Skipping: '{args.step}' is not a canonical currentStep "
             f"({', '.join(sorted(CANONICAL_STEPS))}).",
@@ -286,12 +409,21 @@ def main() -> int:
 
     # Never let a bookkeeping write fail the host spec-kit command.
     try:
-        target = update_context(feature_dir, args.step, args.status, args.by)
+        if args.tasks_file:
+            tasks_md = Path(args.tasks_file)
+            if not tasks_md.is_absolute():
+                tasks_md = root / tasks_md
+            # Task-sync operates on the implement step; the global --status default
+            # ("specified") would be an incoherent terminal status here.
+            final_status = args.status if args.status != parser.get_default("status") else "implemented"
+            target = sync_tasks(feature_dir, tasks_md, final_status, args.by)
+        else:
+            target = update_context(feature_dir, args.step, args.status, args.by)
     except Exception as exc:  # noqa: BLE001 - best-effort, swallow + report
         print(f"[companion] Warning: skipped .spec-context.json write: {exc}", file=sys.stderr)
         return 0
 
-    if target is not None:
+    if target is not None and not args.tasks_file:
         print(f"[companion] Updated {target} (currentStep={args.step}, status={args.status}, by={args.by})")
     return 0
 

--- a/speckit-extension/tests/test_context.py
+++ b/speckit-extension/tests/test_context.py
@@ -42,14 +42,39 @@ class LifecycleCaptureTests(unittest.TestCase):
     def tearDown(self) -> None:
         self._tmp.cleanup()
 
-    def test_transitions_are_append_only(self) -> None:
+    def test_history_is_append_only(self) -> None:
         wc.update_context(self.fd, "specify", "specified", "extension")
-        n1 = len(_ctx(self.fd)["transitions"])
+        n1 = len(_ctx(self.fd)["history"])
         wc.update_context(self.fd, "plan", "planned", "extension")
-        t2 = _ctx(self.fd)["transitions"]
-        self.assertGreater(len(t2), n1)
-        self.assertEqual(t2[-1]["step"], "plan")
-        self.assertEqual(t2[-1]["from"], {"step": "specify", "substep": None})
+        h2 = _ctx(self.fd)["history"]
+        self.assertGreater(len(h2), n1)
+        self.assertEqual(h2[-1]["step"], "plan")
+        self.assertEqual(h2[-1]["kind"], "start")
+        self.assertEqual(h2[-1]["from"], {"step": "specify", "substep": None})
+
+    def test_writes_canonical_history_not_legacy_keys(self) -> None:
+        wc.update_context(self.fd, "specify", "specified", "extension")
+        ctx = _ctx(self.fd)
+        self.assertIn("history", ctx)
+        self.assertNotIn("transitions", ctx)
+        self.assertNotIn("stepHistory", ctx)
+
+    def test_legacy_transitions_migrated_into_history(self) -> None:
+        # A file written by an older extension carried `transitions[]`; the next
+        # write must fold it into `history[]` and drop the legacy key so the GUI
+        # (which prefers history) and the extension share one array.
+        target = self.fd / ".spec-context.json"
+        target.write_text(json.dumps({
+            "workflow": "speckit", "specName": "x", "branch": "main",
+            "currentStep": "specify", "status": "specified",
+            "transitions": [{"step": "specify", "substep": None, "from": None,
+                             "by": "extension", "at": "2026-01-01T00:00:00.000Z"}],
+        }))
+        wc.update_context(self.fd, "plan", "planned", "extension")
+        ctx = _ctx(self.fd)
+        self.assertNotIn("transitions", ctx)
+        steps = [e["step"] for e in ctx["history"]]
+        self.assertEqual(steps, ["specify", "plan"])  # prior entry preserved + new one
 
     def test_no_backward_clobber(self) -> None:
         wc.update_context(self.fd, "implement", "implemented", "extension")
@@ -73,12 +98,12 @@ class LifecycleCaptureTests(unittest.TestCase):
         )
         tasks_md = self.fd / "tasks.md"
         wc.sync_tasks(self.fd, tasks_md, "implemented", "extension")
-        first = [t.get("task") for t in _ctx(self.fd)["transitions"] if t.get("task")]
+        first = [t.get("task") for t in _ctx(self.fd)["history"] if t.get("task")]
         self.assertEqual(first, ["T001", "T002"])
         self.assertEqual(_ctx(self.fd)["status"], "implementing")
         self.assertEqual(_ctx(self.fd)["currentTask"], "T003")
         wc.sync_tasks(self.fd, tasks_md, "implemented", "extension")
-        second = [t.get("task") for t in _ctx(self.fd)["transitions"] if t.get("task")]
+        second = [t.get("task") for t in _ctx(self.fd)["history"] if t.get("task")]
         self.assertEqual(second, first)
 
     def test_per_task_completes_when_all_checked(self) -> None:
@@ -94,7 +119,7 @@ class LifecycleCaptureTests(unittest.TestCase):
         tasks_md = self.fd / "tasks.md"
         tasks_md.write_text(_tasks("- [x] **T001** a", "- [x] **T002** b", "- [ ] **T003** c"))
         wc.sync_tasks(self.fd, tasks_md, "implemented", "extension")
-        for t in _ctx(self.fd)["transitions"]:
+        for t in _ctx(self.fd)["history"]:
             if t.get("task"):
                 self.assertEqual(t["substep"], t["task"])
                 self.assertIsNotNone(t["substep"])
@@ -103,7 +128,7 @@ class LifecycleCaptureTests(unittest.TestCase):
         tasks_md = self.fd / "tasks.md"
         tasks_md.write_text(_tasks("- [x] **T001** a", "- [x] **T001** a (re-listed)"))
         wc.sync_tasks(self.fd, tasks_md, "implemented", "extension")
-        tasks = [t.get("task") for t in _ctx(self.fd)["transitions"] if t.get("task")]
+        tasks = [t.get("task") for t in _ctx(self.fd)["history"] if t.get("task")]
         self.assertEqual(tasks, ["T001"])
 
 
@@ -133,9 +158,22 @@ class DeriveRoundTripTests(unittest.TestCase):
         ctx = _ctx(self.fd)
         self.assertEqual(ctx["currentStep"], "implement")
         self.assertEqual(ctx["status"], "implemented")
-        tasks = [t.get("task") for t in ctx["transitions"] if t.get("task")]
+        tasks = [t.get("task") for t in ctx["history"] if t.get("task")]
         self.assertEqual(tasks, ["T001", "T002"])
-        self.assertTrue(any(t.get("by") == "derive" for t in ctx["transitions"]))
+        self.assertTrue(any(t.get("by") == "derive" for t in ctx["history"]))
+
+    def test_derive_distinct_id_coverage_matches_sync(self) -> None:
+        # A duplicated checked id + a genuinely pending id is NOT done — derive
+        # must use the same distinct-id coverage as sync_tasks.
+        (self.fd / "spec.md").write_text("# Spec\n")
+        (self.fd / "plan.md").write_text("# Plan\n")
+        (self.fd / "tasks.md").write_text(
+            _tasks("- [x] **T001** a", "- [x] **T001** a (dup)", "- [ ] **T002** b")
+        )
+        derive_mod.derive(self.fd)
+        ctx = _ctx(self.fd)
+        self.assertEqual(ctx["currentStep"], "tasks")
+        self.assertEqual(ctx["status"], "ready-to-implement")
 
     def test_derive_spec_only(self) -> None:
         (self.fd / "spec.md").write_text("# Spec\n")

--- a/speckit-extension/tests/test_context.py
+++ b/speckit-extension/tests/test_context.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""Regression tests for the companion lifecycle capture + derive fallback.
+
+Stdlib `unittest` only — run with:
+
+    python3 -m unittest discover speckit-extension/tests
+
+Covers the write contract the GUI depends on: append-only transitions,
+no-backward-clobber, unknown-key preservation, per-task idempotency, and a
+derive-from-files round-trip.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPTS = Path(__file__).resolve().parent.parent / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+wc = importlib.import_module("write-context")
+derive_mod = importlib.import_module("derive-from-files")
+
+
+def _ctx(feature_dir: Path) -> dict:
+    return json.loads((feature_dir / ".spec-context.json").read_text())
+
+
+def _tasks(*lines: str) -> str:
+    return "\n".join(lines) + "\n"
+
+
+class LifecycleCaptureTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.fd = Path(self._tmp.name) / "specs" / "_zzz-test"
+        self.fd.mkdir(parents=True)
+
+    def tearDown(self) -> None:
+        self._tmp.cleanup()
+
+    def test_transitions_are_append_only(self) -> None:
+        wc.update_context(self.fd, "specify", "specified", "extension")
+        n1 = len(_ctx(self.fd)["transitions"])
+        wc.update_context(self.fd, "plan", "planned", "extension")
+        t2 = _ctx(self.fd)["transitions"]
+        self.assertGreater(len(t2), n1)
+        self.assertEqual(t2[-1]["step"], "plan")
+        self.assertEqual(t2[-1]["from"], {"step": "specify", "substep": None})
+
+    def test_no_backward_clobber(self) -> None:
+        wc.update_context(self.fd, "implement", "implemented", "extension")
+        before = _ctx(self.fd)
+        result = wc.update_context(self.fd, "specify", "specified", "extension")
+        self.assertIsNone(result)
+        self.assertEqual(_ctx(self.fd), before)
+
+    def test_unknown_keys_preserved(self) -> None:
+        wc.update_context(self.fd, "specify", "specified", "extension")
+        target = self.fd / ".spec-context.json"
+        ctx = _ctx(self.fd)
+        ctx["reviewComments"] = [{"id": "rc1", "comment": "keep me"}]
+        target.write_text(json.dumps(ctx))
+        wc.update_context(self.fd, "plan", "planned", "extension")
+        self.assertEqual(_ctx(self.fd)["reviewComments"], [{"id": "rc1", "comment": "keep me"}])
+
+    def test_per_task_idempotency(self) -> None:
+        (self.fd / "tasks.md").write_text(
+            _tasks("- [x] **T001** a", "- [x] **T002** b", "- [ ] **T003** c")
+        )
+        tasks_md = self.fd / "tasks.md"
+        wc.sync_tasks(self.fd, tasks_md, "implemented", "extension")
+        first = [t.get("task") for t in _ctx(self.fd)["transitions"] if t.get("task")]
+        self.assertEqual(first, ["T001", "T002"])
+        self.assertEqual(_ctx(self.fd)["status"], "implementing")
+        self.assertEqual(_ctx(self.fd)["currentTask"], "T003")
+        wc.sync_tasks(self.fd, tasks_md, "implemented", "extension")
+        second = [t.get("task") for t in _ctx(self.fd)["transitions"] if t.get("task")]
+        self.assertEqual(second, first)
+
+    def test_per_task_completes_when_all_checked(self) -> None:
+        tasks_md = self.fd / "tasks.md"
+        tasks_md.write_text(_tasks("- [x] **T001** a", "- [x] **T002** b"))
+        wc.sync_tasks(self.fd, tasks_md, "implemented", "extension")
+        self.assertEqual(_ctx(self.fd)["status"], "implemented")
+
+    def test_per_task_entries_are_substeps_not_step_completions(self) -> None:
+        # A substep==null transition whose from.step==step reads as a step
+        # COMPLETION in the viewer — per-task entries must never look like that,
+        # or the implement step renders done while still in flight.
+        tasks_md = self.fd / "tasks.md"
+        tasks_md.write_text(_tasks("- [x] **T001** a", "- [x] **T002** b", "- [ ] **T003** c"))
+        wc.sync_tasks(self.fd, tasks_md, "implemented", "extension")
+        for t in _ctx(self.fd)["transitions"]:
+            if t.get("task"):
+                self.assertEqual(t["substep"], t["task"])
+                self.assertIsNotNone(t["substep"])
+
+    def test_duplicate_marker_id_yields_one_transition(self) -> None:
+        tasks_md = self.fd / "tasks.md"
+        tasks_md.write_text(_tasks("- [x] **T001** a", "- [x] **T001** a (re-listed)"))
+        wc.sync_tasks(self.fd, tasks_md, "implemented", "extension")
+        tasks = [t.get("task") for t in _ctx(self.fd)["transitions"] if t.get("task")]
+        self.assertEqual(tasks, ["T001"])
+
+
+class DeriveRoundTripTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.fd = Path(self._tmp.name) / "specs" / "_zzz-derive"
+        self.fd.mkdir(parents=True)
+
+    def tearDown(self) -> None:
+        self._tmp.cleanup()
+
+    def test_derive_partial_tasks(self) -> None:
+        (self.fd / "spec.md").write_text("# Spec\n")
+        (self.fd / "plan.md").write_text("# Plan\n")
+        (self.fd / "tasks.md").write_text(_tasks("- [x] **T001** a", "- [ ] **T002** b"))
+        derive_mod.derive(self.fd)
+        ctx = _ctx(self.fd)
+        self.assertEqual(ctx["currentStep"], "tasks")
+        self.assertEqual(ctx["status"], "ready-to-implement")
+
+    def test_derive_all_tasks_done(self) -> None:
+        (self.fd / "spec.md").write_text("# Spec\n")
+        (self.fd / "plan.md").write_text("# Plan\n")
+        (self.fd / "tasks.md").write_text(_tasks("- [x] **T001** a", "- [x] **T002** b"))
+        derive_mod.derive(self.fd)
+        ctx = _ctx(self.fd)
+        self.assertEqual(ctx["currentStep"], "implement")
+        self.assertEqual(ctx["status"], "implemented")
+        tasks = [t.get("task") for t in ctx["transitions"] if t.get("task")]
+        self.assertEqual(tasks, ["T001", "T002"])
+        self.assertTrue(any(t.get("by") == "derive" for t in ctx["transitions"]))
+
+    def test_derive_spec_only(self) -> None:
+        (self.fd / "spec.md").write_text("# Spec\n")
+        derive_mod.derive(self.fd)
+        ctx = _ctx(self.fd)
+        self.assertEqual(ctx["currentStep"], "specify")
+        self.assertEqual(ctx["status"], "specified")
+
+    def test_derive_round_trip_after_deleting_state(self) -> None:
+        (self.fd / "spec.md").write_text("# Spec\n")
+        (self.fd / "plan.md").write_text("# Plan\n")
+        (self.fd / "tasks.md").write_text(_tasks("- [x] **T001** a", "- [x] **T002** b"))
+        wc.sync_tasks(self.fd, self.fd / "tasks.md", "implemented", "extension")
+        (self.fd / ".spec-context.json").unlink()
+        derive_mod.derive(self.fd)
+        ctx = _ctx(self.fd)
+        self.assertEqual(ctx["currentStep"], "implement")
+        self.assertEqual(ctx["status"], "implemented")
+
+    def test_derive_does_not_regress_terminal(self) -> None:
+        (self.fd / "spec.md").write_text("# Spec\n")
+        wc.update_context(self.fd, "implement", "implemented", "extension")
+        before = _ctx(self.fd)
+        result = derive_mod.derive(self.fd)
+        self.assertIsNone(result)
+        self.assertEqual(_ctx(self.fd), before)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/specs/129-full-lifecycle-capture/.spec-context.json
+++ b/specs/129-full-lifecycle-capture/.spec-context.json
@@ -207,6 +207,16 @@
       },
       "by": "sdd",
       "at": "2026-06-07T21:57:21.208Z"
+    },
+    {
+      "step": "done",
+      "substep": null,
+      "from": {
+        "step": "done",
+        "substep": null
+      },
+      "by": "sdd",
+      "at": "2026-06-07T21:58:09.780Z"
     }
   ],
   "step_summaries": {
@@ -310,7 +320,7 @@
       "concerns": []
     }
   },
-  "last_action": "CP3 approved \u2014 committing",
+  "last_action": "PR #203 opened \u2014 feat(speckit-extension): add full lifecycle capture + derive-from-files fallback",
   "files_modified": [
     "speckit-extension/scripts/write-context.py",
     "speckit-extension/scripts/derive-from-files.py",
@@ -330,7 +340,7 @@
     ".specify/extensions/companion/commands/speckit.companion.capture-implement.md",
     "speckit-extension/tests/test_context.py"
   ],
-  "drainedSeq": 11,
+  "drainedSeq": 12,
   "concerns": [
     {
       "task": "CP1-review",
@@ -349,5 +359,7 @@
   "checkpointStatus": {
     "commit": true,
     "pr": true
-  }
+  },
+  "prUrl": "https://github.com/alfredoperez/speckit-companion/pull/203",
+  "prNumber": 203
 }

--- a/specs/129-full-lifecycle-capture/.spec-context.json
+++ b/specs/129-full-lifecycle-capture/.spec-context.json
@@ -1,0 +1,353 @@
+{
+  "workflow": "sdd",
+  "currentStep": "done",
+  "currentTask": null,
+  "progress": null,
+  "next": "done",
+  "approach": "Extend the proven step-1 hook chain to after_plan/after_tasks/after_implement with thin per-step capture commands reusing write-context.py, add batch per-task journaling on after_implement, and a stdlib derive-from-files.py fallback.",
+  "updated": "2026-06-07",
+  "selectedAt": "2026-06-07T16:29:34-0500",
+  "specName": "Full Lifecycle Capture",
+  "branch": "main",
+  "workingBranch": "feat/full-lifecycle-capture",
+  "type": "feat",
+  "createdAt": "2026-06-07T16:29:34-0500",
+  "loadedDomains": [],
+  "transitions": [
+    {
+      "step": "specify",
+      "substep": "parsing",
+      "from": null,
+      "by": "sdd",
+      "at": "2026-06-07T16:29:34-0500"
+    },
+    {
+      "step": "specify",
+      "substep": "exploring",
+      "from": "parsing",
+      "by": "sdd",
+      "at": "2026-06-07T16:29:34-0500"
+    },
+    {
+      "step": "specify",
+      "substep": "loading-context",
+      "from": "exploring",
+      "by": "sdd",
+      "at": "2026-06-07T16:29:34-0500"
+    },
+    {
+      "step": "specify",
+      "substep": "detecting",
+      "from": "loading-context",
+      "by": "sdd",
+      "at": "2026-06-07T16:29:34-0500"
+    },
+    {
+      "step": "specify",
+      "substep": "writing-spec",
+      "from": "detecting",
+      "by": "sdd",
+      "at": "2026-06-07T16:29:34-0500"
+    },
+    {
+      "step": "specify",
+      "substep": null,
+      "from": "writing-spec",
+      "by": "sdd",
+      "at": "2026-06-07T16:29:34-0500"
+    },
+    {
+      "step": "plan",
+      "substep": "loading",
+      "from": "specify",
+      "by": "sdd",
+      "at": "2026-06-07T16:29:34-0500"
+    },
+    {
+      "step": "plan",
+      "substep": "writing-plan",
+      "from": "loading",
+      "by": "sdd",
+      "at": "2026-06-07T16:29:34-0500"
+    },
+    {
+      "step": "plan",
+      "substep": null,
+      "from": "writing-plan",
+      "by": "sdd",
+      "at": "2026-06-07T16:29:34-0500"
+    },
+    {
+      "step": "tasks",
+      "substep": "loading",
+      "from": "plan",
+      "by": "sdd",
+      "at": "2026-06-07T16:29:34-0500"
+    },
+    {
+      "step": "tasks",
+      "substep": "writing-tasks",
+      "from": "loading",
+      "by": "sdd",
+      "at": "2026-06-07T16:29:34-0500"
+    },
+    {
+      "step": "tasks",
+      "substep": null,
+      "from": "writing-tasks",
+      "by": "sdd",
+      "at": "2026-06-07T16:29:34-0500"
+    },
+    {
+      "step": "implement",
+      "substep": "phase1",
+      "from": {
+        "step": "tasks",
+        "substep": null
+      },
+      "by": "sdd",
+      "at": "2026-06-07T21:40:05.459Z"
+    },
+    {
+      "step": "implement",
+      "substep": "phase1",
+      "from": {
+        "step": "implement",
+        "substep": "phase1"
+      },
+      "by": "sdd",
+      "at": "2026-06-07T21:40:05.485Z"
+    },
+    {
+      "step": "implement",
+      "substep": "phase1",
+      "from": {
+        "step": "implement",
+        "substep": "phase1"
+      },
+      "by": "sdd",
+      "at": "2026-06-07T21:42:15.788Z"
+    },
+    {
+      "step": "implement",
+      "substep": "phase1",
+      "from": {
+        "step": "implement",
+        "substep": "phase1"
+      },
+      "by": "sdd",
+      "at": "2026-06-07T21:44:44.824Z"
+    },
+    {
+      "step": "implement",
+      "substep": "phase1",
+      "from": {
+        "step": "implement",
+        "substep": "phase1"
+      },
+      "by": "sdd",
+      "at": "2026-06-07T21:45:38.493Z"
+    },
+    {
+      "step": "implement",
+      "substep": "phase1",
+      "from": {
+        "step": "implement",
+        "substep": "phase1"
+      },
+      "by": "sdd",
+      "at": "2026-06-07T21:46:31.852Z"
+    },
+    {
+      "step": "implement",
+      "substep": "phase1",
+      "from": {
+        "step": "implement",
+        "substep": "phase1"
+      },
+      "by": "sdd",
+      "at": "2026-06-07T21:47:28.557Z"
+    },
+    {
+      "step": "implement",
+      "substep": "hooks",
+      "from": {
+        "step": "implement",
+        "substep": "phase1"
+      },
+      "by": "sdd",
+      "at": "2026-06-07T21:48:01.898Z"
+    },
+    {
+      "step": "implement",
+      "substep": "code-review",
+      "from": {
+        "step": "implement",
+        "substep": "hooks"
+      },
+      "by": "sdd",
+      "at": "2026-06-07T21:55:39.685Z"
+    },
+    {
+      "step": "implement",
+      "substep": "commit-review",
+      "from": {
+        "step": "implement",
+        "substep": "code-review"
+      },
+      "by": "sdd",
+      "at": "2026-06-07T21:56:29.631Z"
+    },
+    {
+      "step": "done",
+      "substep": null,
+      "from": {
+        "step": "implement",
+        "substep": "commit-review"
+      },
+      "by": "sdd",
+      "at": "2026-06-07T21:57:21.208Z"
+    }
+  ],
+  "step_summaries": {
+    "specify": {
+      "complexity": "normal",
+      "requirements": 15,
+      "scenarios": 5,
+      "key_finding": "write-context.py is already a generic step/status writer with all guarantees; lifecycle expansion is mostly hook registration in extension.yml/.specify fixtures plus a sibling derive-from-files.py reusing its resolution + no-backward-clobber guard."
+    },
+    "plan": {
+      "approach_summary": "Extend the proven step-1 hook chain to after_plan/after_tasks/after_implement with thin per-step capture commands reusing write-context.py, add batch per-task journaling on after_implement, and a stdlib derive-from-files.py fallback.",
+      "files_planned": 15,
+      "risks": [
+        "Per-task journaling rides the single after_implement hook (companion owns no implement loop until step 4) \u2014 mitigate with idempotent skip-already-journaled writes.",
+        "speckit-extension/ and the installed .specify/extensions/companion/ copy must stay byte-identical \u2014 update both together."
+      ],
+      "principles_concerns": 0,
+      "domain_concerns": 0,
+      "significance_score": 1
+    }
+  },
+  "task_summaries": {
+    "T001": {
+      "status": "DONE",
+      "did": "Refactored write-context.py: extracted read/write/prior helpers and added sync_tasks task-sync mode with --tasks-file flag (idempotent per-task transitions).",
+      "files": [
+        "speckit-extension/scripts/write-context.py"
+      ],
+      "concerns": []
+    },
+    "T002": {
+      "status": "DONE",
+      "did": "New stdlib derive-from-files.py importing write-context.py helpers; infers step/status from artifacts + per-task transitions; no-backward-clobber + by:derive.",
+      "files": [
+        "speckit-extension/scripts/derive-from-files.py"
+      ],
+      "concerns": []
+    },
+    "T003": {
+      "status": "DONE",
+      "did": "Three per-step capture command-markdowns (capture-plan/tasks/implement) mirroring capture.md; implement uses --tasks-file task-sync.",
+      "files": [
+        "speckit-extension/commands/speckit.companion.capture-plan.md",
+        "speckit-extension/commands/speckit.companion.capture-tasks.md",
+        "speckit-extension/commands/speckit.companion.capture-implement.md"
+      ],
+      "concerns": []
+    },
+    "T004": {
+      "status": "DONE",
+      "did": "Documented 3 new hooks/commands + --tasks-file flag + derive-from-files fallback section in commands.md.",
+      "files": [
+        "speckit-extension/docs/commands.md"
+      ],
+      "concerns": []
+    },
+    "T005": {
+      "status": "DONE",
+      "did": "Flipped ROADMAP step 2 to Shipped with a what-shipped subsection; added CHANGELOG 0.2.0 entry.",
+      "files": [
+        "speckit-extension/ROADMAP.md",
+        "speckit-extension/CHANGELOG.md"
+      ],
+      "concerns": []
+    },
+    "T006": {
+      "status": "DONE",
+      "did": "Registered 3 new provides.commands + after_plan/after_tasks/after_implement hooks (optional:false) in extension.yml; after_specify intact.",
+      "files": [
+        "speckit-extension/extension.yml"
+      ],
+      "concerns": []
+    },
+    "T007": {
+      "status": "DONE",
+      "did": "Added companion entries (optional:false) under after_plan/after_tasks/after_implement in .specify/extensions.yml; git entries intact.",
+      "files": [
+        ".specify/extensions.yml"
+      ],
+      "concerns": []
+    },
+    "T008": {
+      "status": "DONE",
+      "did": "Mirrored extension.yml, write-context.py, derive-from-files.py, and 3 capture command-markdowns into .specify/extensions/companion/ \u2014 verified byte-identical via diff.",
+      "files": [
+        ".specify/extensions/companion/extension.yml",
+        ".specify/extensions/companion/scripts/write-context.py",
+        ".specify/extensions/companion/scripts/derive-from-files.py",
+        ".specify/extensions/companion/commands/speckit.companion.capture-plan.md",
+        ".specify/extensions/companion/commands/speckit.companion.capture-tasks.md",
+        ".specify/extensions/companion/commands/speckit.companion.capture-implement.md"
+      ],
+      "concerns": []
+    },
+    "T009": {
+      "status": "DONE",
+      "did": "stdlib unittest suite (10 tests): append-only, no-backward-clobber, unknown-key preservation, per-task idempotency/completion, and derive round-trip. All passing.",
+      "files": [
+        "speckit-extension/tests/test_context.py"
+      ],
+      "concerns": []
+    }
+  },
+  "last_action": "CP3 approved \u2014 committing",
+  "files_modified": [
+    "speckit-extension/scripts/write-context.py",
+    "speckit-extension/scripts/derive-from-files.py",
+    "speckit-extension/commands/speckit.companion.capture-plan.md",
+    "speckit-extension/commands/speckit.companion.capture-tasks.md",
+    "speckit-extension/commands/speckit.companion.capture-implement.md",
+    "speckit-extension/docs/commands.md",
+    "speckit-extension/ROADMAP.md",
+    "speckit-extension/CHANGELOG.md",
+    "speckit-extension/extension.yml",
+    ".specify/extensions.yml",
+    ".specify/extensions/companion/extension.yml",
+    ".specify/extensions/companion/scripts/write-context.py",
+    ".specify/extensions/companion/scripts/derive-from-files.py",
+    ".specify/extensions/companion/commands/speckit.companion.capture-plan.md",
+    ".specify/extensions/companion/commands/speckit.companion.capture-tasks.md",
+    ".specify/extensions/companion/commands/speckit.companion.capture-implement.md",
+    "speckit-extension/tests/test_context.py"
+  ],
+  "drainedSeq": 11,
+  "concerns": [
+    {
+      "task": "CP1-review",
+      "note": "Per-task journaling originally wrote substep:null transitions whose from.step==='implement' \u2014 the GUI reader (normalizeHistoryKind) would read those as a step-completion and mark Implement COMPLETED while still in flight, and dedupeConsecutive would collapse them. Fixed: per-task entries are now substeps (substep=task id)."
+    },
+    {
+      "task": "CP1-review",
+      "note": "sync_tasks/derive double-journaled a task id duplicated within tasks.md, and all_done used list-length not distinct-id coverage. Fixed with order-preserving distinct dedup + set-coverage all_done."
+    },
+    {
+      "task": "CP1-review",
+      "note": "--tasks-file without --status defaulted to 'specified' (incoherent for the implement step). Fixed: task-sync defaults terminal status to 'implemented'."
+    }
+  ],
+  "status": "completed",
+  "checkpointStatus": {
+    "commit": true,
+    "pr": true
+  }
+}

--- a/specs/129-full-lifecycle-capture/plan.md
+++ b/specs/129-full-lifecycle-capture/plan.md
@@ -1,0 +1,58 @@
+# Plan: Full Lifecycle Capture
+
+**Spec**: [spec.md](./spec.md)
+
+## Approach
+
+Extend the proven step-1 chain (hook → command-markdown → `write-context.py` → `.spec-context.json`) to the whole pipeline by registering three more `optional: false` hooks (`after_plan`, `after_tasks`, `after_implement`), each backed by a thin per-step capture command that runs the **existing** writer with the right `--step`/`--status`. Per-task journaling rides the `after_implement` capture (companion does not own the implement loop until ROADMAP step 4), so the writer gains a batch task-sync mode that reads completed markers in `tasks.md` and appends one append-only, idempotent transition per completed task. A new stdlib `derive-from-files.py` reuses `write-context.py`'s feature-dir resolution and no-backward-clobber guard to reconstruct `currentStep`/`status` (and per-task transitions) from on-disk artifacts plus git when a hook never fired.
+
+## Architecture
+
+```mermaid
+graph LR
+  P[/speckit.plan] --> H1[after_plan hook]
+  T[/speckit.tasks] --> H2[after_tasks hook]
+  I[/speckit.implement] --> H3[after_implement hook]
+  H1 --> C1[capture-plan.md]
+  H2 --> C2[capture-tasks.md]
+  H3 --> C3[capture-implement.md]
+  C1 --> W[write-context.py]
+  C2 --> W
+  C3 --> W
+  W --> J[.spec-context.json]
+  D[derive-from-files.py] -. fallback .-> J
+```
+
+## Files
+
+### Create
+
+- `speckit-extension/scripts/derive-from-files.py` — stdlib-only derive writer; scans a `specs/<NNN>-<slug>/` for `spec.md`/`plan.md`/`tasks.md` + task markers + git history, infers `currentStep`/`status`, reuses `write-context.py`'s resolution + guards, tags transition `by: "derive"`.
+- `speckit-extension/commands/speckit.companion.capture-plan.md` — runs `write-context.py --step plan --status planned --by extension`.
+- `speckit-extension/commands/speckit.companion.capture-tasks.md` — runs `write-context.py --step tasks --status ready-to-implement --by extension`.
+- `speckit-extension/commands/speckit.companion.capture-implement.md` — runs the writer in task-sync mode against `tasks.md`, ending at `--status implemented` when all markers are complete.
+- `speckit-extension/tests/test_context.py` — stdlib `unittest` regression suite (append-only, no-backward-clobber, unknown-key preservation, derive round-trip).
+
+### Modify
+
+- `speckit-extension/scripts/write-context.py` — add per-task journaling: a task-sync mode that reads `tasks.md` completed markers and appends one idempotent transition per completed task (sets `currentTask`, never regresses step); factor resolution/guard helpers so `derive-from-files.py` can import them.
+- `speckit-extension/extension.yml` — register the three new `provides.commands` and the `after_plan`/`after_tasks`/`after_implement` hooks (`optional: false`).
+- `.specify/extensions.yml` — append the `companion` entries under `after_plan`/`after_tasks`/`after_implement`, alongside the existing `git` commit hooks.
+- `.specify/extensions/companion/extension.yml` — mirror the new commands + hooks into the installed fixture copy.
+- `.specify/extensions/companion/scripts/write-context.py` — mirror the updated writer.
+- `.specify/extensions/companion/scripts/derive-from-files.py` — mirror the new derive script (new file in the fixture).
+- `.specify/extensions/companion/commands/speckit.companion.capture-{plan,tasks,implement}.md` — mirror the new command-markdowns.
+- `speckit-extension/docs/commands.md` — add the three hooks to the lifecycle table and document the new commands + the derive fallback.
+- `speckit-extension/ROADMAP.md` — flip step 2 from Planned to Shipped (at implement time).
+- `speckit-extension/CHANGELOG.md` — changelog entry for full lifecycle capture + derive fallback.
+
+## Testing Strategy
+
+- **Unit (`python3 -m unittest`)**: against a throwaway temp `specs/_zzz-*/`, assert each capture writes the correct `currentStep`/`status`; assert `transitions` is append-only across re-runs (length grows, `from` = prior state); assert unknown top-level keys (e.g. `reviewComments`) survive; assert the no-backward-clobber guard rejects an earlier-step write over a later/terminal state.
+- **Derive round-trip**: build a feature dir with `spec.md`+`plan.md`+`tasks.md` (mixed task markers), delete `.spec-context.json`, run `derive-from-files.py`, assert reconstructed `currentStep`/`status` matches within one step; with all markers complete assert `implemented`, with some unchecked assert `ready-to-implement`.
+- **Edge cases**: derive against a spec already at `implemented`/`archived` leaves it intact; missing `python3`/unresolvable feature dir exits 0 without writing.
+
+## Risks
+
+- **Per-task journaling without an owned implement loop**: the `after_implement` hook fires once, so per-task transitions are reconstructed in a batch from `tasks.md` markers rather than streamed live — Mitigation: make the writer idempotent (skip task ids already journaled) so a later live implement command (step 4) can re-sync without duplicating.
+- **Fixture drift**: `speckit-extension/` and the installed `.specify/extensions/companion/` copy must stay byte-identical — Mitigation: update both in the same change and add a test (or note) that diffs the two trees.

--- a/specs/129-full-lifecycle-capture/spec.md
+++ b/specs/129-full-lifecycle-capture/spec.md
@@ -1,0 +1,75 @@
+# Spec: Full Lifecycle Capture
+
+**Slug**: 129-full-lifecycle-capture | **Date**: 2026-06-07
+
+## Summary
+
+Step 1 proved one spec-kit lifecycle hook (`after_specify`) can fire, run `write-context.py`, and write the Companion-canonical `.spec-context.json` end-to-end. This step extends that proven chain to the entire pipeline — registering `after_plan`, `after_tasks`, and `after_implement` hooks, journaling each task completion inside implement, and adding a stdlib-only `derive-from-files.py` that reconstructs state from the on-disk artifacts plus git when a hook didn't fire. After this step, `.spec-context.json` is a complete event journal of any pipeline run, and a missing or stale state file is recoverable rather than fatal. This is ROADMAP step 2 (see `speckit-extension/ROADMAP.md`).
+
+## Requirements
+
+### Full lifecycle hooks
+
+- **R001** (MUST): Register three new lifecycle hooks in `speckit-extension/extension.yml` — `after_plan`, `after_tasks`, and `after_implement` — each firing a companion capture command that runs `write-context.py` with the step/status for that lifecycle event. They sit alongside the existing `after_specify` hook without removing or breaking it.
+- **R002** (MUST): Each hook writes the canonical `currentStep` + `status` pair for its event and appends a `transitions[]` entry with `by: "extension"` — `after_plan` → `currentStep: plan` / `status: planned`; `after_tasks` → `currentStep: tasks` / `status: ready-to-implement`; `after_implement` → `currentStep: implement` / `status: implemented`. These match the canonical vocabulary in `src/core/types/specContext.ts`.
+- **R003** (MUST): Each new hook is `optional: false` so it auto-runs with no agent prompt, matching the `after_specify` hook's behavior (not the `git` extension's `optional: true` commit hooks).
+- **R004** (MUST): The captures reuse the existing `write-context.py` writer and its guarantees (read-then-merge, append-only `transitions`, atomic write, no-backward-clobber, legacy `done` rejection) without forking a second writer. Per-step values are supplied via the existing `--step` / `--status` / `--by` flags.
+- **R005** (MUST): Register the three new hooks in this repo's `.specify/extensions.yml` manual-testing fixture (and the installed `.specify/extensions/companion/` copy) so a real `/speckit.plan`, `/speckit.tasks`, and `/speckit.implement` trigger the companion captures alongside the existing `git` commit hooks.
+
+### Derive-from-files fallback
+
+- **R006** (MUST): Ship `speckit-extension/scripts/derive-from-files.py` — stdlib-only, runnable anywhere `python3` is available — that scans a `specs/<NNN>-<slug>/` directory and infers `currentStep` + `status` from which artifacts exist (`spec.md` → specify/specified, `plan.md` → plan/planned, `tasks.md` → tasks/ready-to-implement, all tasks completed → implement/implemented) plus matching git history.
+- **R007** (MUST): The derive writer emits the same canonical `.spec-context.json` schema as `write-context.py` (same step/status vocabulary, same `transitions[]` shape) and tags its appended transition with an authorship value identifying it as a derived capture (e.g. `by: "derive"`).
+- **R008** (MUST): Derive resolves the target feature directory using the same precedence as `write-context.py` (`--feature-dir` → `SPECIFY_FEATURE_DIRECTORY` → `SPECIFY_FEATURE` → `.specify/feature.json` → git branch prefix) and reuses that resolution rather than a "most-recently-modified" heuristic.
+- **R009** (MUST): Derive is read-then-merge and never regresses a more-advanced spec — it honors the same no-backward-clobber guard and terminal-status protection as `write-context.py`, so running it against a spec whose hooks already captured a later step does not drag it backward.
+- **R010** (SHOULD): Derive treats task completion by reading task markers in `tasks.md` (checked vs unchecked) to distinguish `ready-to-implement` (tasks exist, not all done) from `implemented` (all tasks done), so a partially-implemented spec is not reported as finished.
+
+### Per-task journaling
+
+- **R011** (MUST): The implement capture appends a transition per task completion — not only one transition per stage — so `.spec-context.json` records the granular progression through `tasks.md` during implementation.
+- **R012** (MUST): Per-task transitions remain append-only and preserve every existing/unknown top-level key, consistent with the step-1 write contract; replaying or re-running implement never rewrites or shrinks the journal.
+
+### Regression tests
+
+- **R013** (MUST): Ship committed regression tests (replacing step 1's throwaway-probe verification) covering: append-only transitions, no-backward-clobber, and unknown-key preservation for the lifecycle captures.
+- **R014** (MUST): The test suite includes a "rebuild from scratch via derive" round-trip — delete the state file, run `derive-from-files.py`, and assert the reconstructed `currentStep`/`status` matches the on-disk artifacts within one step's accuracy.
+- **R015** (SHOULD): Tests run with stdlib `python3` only (no new third-party dependency), consistent with the agent-agnostic, Python-only posture of the extension.
+
+## Scenarios
+
+### A full pipeline leaves a complete journal
+
+**When** a developer runs the full pipeline (`/speckit.specify → /speckit.plan → /speckit.tasks → /speckit.implement`) on a fresh spec with the `companion` extension registered
+**Then** each lifecycle hook auto-fires its capture and `.spec-context.json` ends with a complete, append-only `transitions[]` journal stepping specify→plan→tasks→implement, with `status` ending at `implemented` and per-task transitions recorded during implement.
+
+### A skipped hook is recoverable from disk
+
+**When** a hook didn't fire for a step (agent-mediated best-effort) and `.spec-context.json` is missing or stale
+**Then** running `derive-from-files.py` against that feature dir reconstructs `currentStep`/`status` from the on-disk artifacts plus git, writing the same canonical schema, within one step's accuracy of the true state.
+
+### Derive never regresses an advanced spec
+
+**When** `derive-from-files.py` runs against a spec whose state file already records a later step or a terminal status (e.g. `implemented`/`archived`)
+**Then** the no-backward-clobber guard leaves the existing state intact and does not drag it back to an earlier inferred step.
+
+### Partial implementation is not reported as done
+
+**When** `tasks.md` has some tasks unchecked and derive runs
+**Then** it reports `status: ready-to-implement`, not `implemented`, because not all task markers are complete.
+
+### Lifecycle captures preserve Companion-owned fields
+
+**When** any of the new hooks fires on a feature whose `.spec-context.json` carries Companion-owned keys (e.g. `reviewComments`)
+**Then** the read-then-merge writer appends the new transition and updates step/status while preserving every pre-existing top-level key.
+
+## Non-Functional Requirements
+
+- **NFR001** (MUST): All writes remain atomic (temp file + rename) and `transitions` append-only, matching the step-1 write contract.
+- **NFR002** (MUST): Every capture and the derive path are best-effort — a missing `python3`, unresolved feature directory, or failed write warns to stderr and exits 0, never failing the host spec-kit command.
+- **NFR003** (SHOULD): `derive-from-files.py` is stdlib-only and shares resolution/guard logic with `write-context.py` rather than duplicating it where practical.
+
+## Out of Scope
+
+- `/speckit.companion.status` and `/speckit.companion.resume` commands — they *consume* this journal (ROADMAP step 3); this step only produces the data.
+- Any change to the SpecKit Companion VS Code GUI — the canonical schema already covers every step and status, so no GUI work is expected.
+- Namespaced own-pipeline commands, templates/presets, complexity detection, living-specs/drift, and auto-mode workflow (ROADMAP steps 4+).

--- a/specs/129-full-lifecycle-capture/tasks.md
+++ b/specs/129-full-lifecycle-capture/tasks.md
@@ -1,0 +1,51 @@
+# Tasks: Full Lifecycle Capture
+
+**Plan**: [plan.md](./plan.md)
+
+> Format reference: `[P]` markers and parallel groups — see `skills/tasks/SKILL.md` § Phase rules.
+
+## Phase 1: Core Implementation
+
+- [x] **T001** Refactor writer + add per-task journaling — `speckit-extension/scripts/write-context.py` | R004, R011, R012
+  - **Do**: Extract feature-dir resolution, `_is_more_advanced`/no-backward-clobber guard, and the canonical step/status helpers into importable module-level functions. Add a task-sync mode (e.g. `--tasks-file <tasks.md>` or `--task <id>`) that reads completed task markers (`- [x] **T###**`) and appends one idempotent transition per completed task (sets `currentTask`, never regresses `currentStep`; skips task ids already present in `transitions`). End at `--status implemented` only when all markers are checked.
+  - **Verify**: `python3 speckit-extension/scripts/write-context.py --help` shows the new flag; running task-sync twice on the same `tasks.md` appends task transitions once (idempotent), preserves unknown keys, and never shrinks `transitions`.
+  - **Leverage**: existing `update_context` / `resolve_feature_dir` / `_is_more_advanced` in the same file.
+
+- [x] **T002** [P] Derive-from-files writer *(depends on T001)* — `speckit-extension/scripts/derive-from-files.py` | R006, R007, R008, R009, R010
+  - **Do**: New stdlib-only script importing the shared helpers from `write-context.py`. Scan the resolved `specs/<NNN>-<slug>/` for `spec.md`→specify/specified, `plan.md`→plan/planned, `tasks.md`→tasks/ready-to-implement, all task markers checked→implement/implemented; cross-check git history. Write the same canonical schema with `by: "derive"`, honoring the no-backward-clobber + terminal-status guards. Best-effort: exit 0 on missing python/unresolved dir.
+  - **Verify**: Against a temp dir with mixed task markers, reconstructs `ready-to-implement`; all-checked reconstructs `implemented`; running against a spec already at `implemented` leaves it intact.
+  - **Leverage**: resolution + guard helpers factored out in T001.
+
+- [x] **T003** [P] Per-step capture command-markdowns *(depends on T001)* — `speckit-extension/commands/speckit.companion.capture-{plan,tasks,implement}.md` | R001, R002, R011
+  - **Do**: Three new command-markdowns mirroring `speckit.companion.capture.md`. `capture-plan` → `write-context.py --step plan --status planned --by extension`; `capture-tasks` → `--step tasks --status ready-to-implement --by extension`; `capture-implement` → writer in task-sync mode against `tasks.md`, ending at `--status implemented`. Include the same python3/graceful-degradation preamble.
+  - **Verify**: Each file documents the exact invocation and the never-fail-host contract.
+  - **Leverage**: `speckit-extension/commands/speckit.companion.capture.md`.
+
+- [x] **T004** [P] Document new hooks + derive fallback *(depends on T001)* — `speckit-extension/docs/commands.md` | R001, R006
+  - **Do**: Add `after_plan`/`after_tasks`/`after_implement` rows to the lifecycle table, document the three new commands + their flags, and add a "derive fallback" subsection for `derive-from-files.py`.
+  - **Verify**: Table and command list match `extension.yml`; flags match `write-context.py --help`.
+  - **Leverage**: existing structure of `commands.md`.
+
+- [x] **T005** [P] Changelog + roadmap *(depends on T001)* — `speckit-extension/CHANGELOG.md`, `speckit-extension/ROADMAP.md` | R001
+  - **Do**: Add a CHANGELOG entry for full lifecycle capture + derive fallback. Flip ROADMAP step 2 from `◻ Planned` to `✅ Shipped` with a one-line summary.
+  - **Verify**: ROADMAP table renders; step 2 row reflects shipped state.
+
+- [x] **T006** Register commands + hooks *(depends on T002, T003)* — `speckit-extension/extension.yml` | R001, R002, R003
+  - **Do**: Add the three new `provides.commands` entries (pointing at the T003 files) and the `after_plan`/`after_tasks`/`after_implement` hooks, each `optional: false`, alongside the existing `after_specify` hook.
+  - **Verify**: YAML parses; each new hook references a declared command; `after_specify` is unchanged.
+  - **Leverage**: existing `after_specify` block + `provides.commands` shape.
+
+- [x] **T007** [P] Register companion in test fixture *(depends on T006)* — `.specify/extensions.yml` | R005
+  - **Do**: Append `companion` entries (`enabled: true`, `optional: false`) under `after_plan`/`after_tasks`/`after_implement`, alongside the existing `git` commit hooks, mirroring the existing `after_specify` companion entry.
+  - **Verify**: YAML parses; `git` entries intact; companion present under all four `after_*` events.
+  - **Leverage**: the existing `after_specify` companion entry in the same file.
+
+- [x] **T008** [P] Mirror installed companion fixture *(depends on T006)* — `.specify/extensions/companion/**` | R005
+  - **Do**: Copy the updated `extension.yml`, `scripts/write-context.py`, the new `scripts/derive-from-files.py`, and the three new `commands/*.md` into `.specify/extensions/companion/` so the fixture is byte-identical to `speckit-extension/`.
+  - **Verify**: `diff -r` between the relevant `speckit-extension/` files and `.specify/extensions/companion/` shows no differences.
+  - **Leverage**: existing fixture layout under `.specify/extensions/companion/`.
+
+- [x] **T009** Regression test suite *(depends on T002, T007, T008)* — `speckit-extension/tests/test_context.py` | R013, R014, R015
+  - **Do**: stdlib `unittest` suite using a temp `specs/_zzz-*/`: append-only transitions, no-backward-clobber (earlier step rejected over later/terminal), unknown-key preservation, per-task idempotency, and a derive round-trip (delete state → `derive-from-files.py` → assert reconstructed step/status within one step; checked-all→implemented, partial→ready-to-implement).
+  - **Verify**: `python3 -m unittest discover speckit-extension/tests` passes; no third-party imports.
+  - **Leverage**: T001 writer, T002 derive; step-1 probe assertions in `specs/106-speckit-extension-foundation/tasks.md`.

--- a/src/core/types/__tests__/specContextSchema.consistency.test.ts
+++ b/src/core/types/__tests__/specContextSchema.consistency.test.ts
@@ -1,0 +1,44 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { STEP_NAMES, STATUSES } from '../specContext';
+
+/**
+ * The data contract for `.spec-context.json` is defined in two in-repo
+ * artifacts that MUST agree: the JSON schema (`spec-context.schema.json`, the
+ * single source of truth) and the TypeScript runtime arrays (`STEP_NAMES`,
+ * `STATUSES`). The Python writers in `speckit-extension/` target the same
+ * shape. This test fails the build the moment the schema and the TS enums
+ * drift — which is exactly how `write-context.py` silently diverged before
+ * (writing `transitions[]` while the canonical field had become `history[]`).
+ */
+const schema = JSON.parse(
+    fs.readFileSync(path.join(__dirname, '..', 'spec-context.schema.json'), 'utf8'),
+);
+
+describe('spec-context.schema.json stays in sync with the TS contract', () => {
+    it('currentStep enum matches STEP_NAMES (same values + order)', () => {
+        expect(schema.properties.currentStep.enum).toEqual([...STEP_NAMES]);
+    });
+
+    it('status enum matches STATUSES (same values + order)', () => {
+        expect(schema.properties.status.enum).toEqual([...STATUSES]);
+    });
+
+    it('historyEntry.from.step enum is STEP_NAMES plus null', () => {
+        expect(schema.$defs.historyEntry.properties.from.properties.step.enum).toEqual([
+            ...STEP_NAMES,
+            null,
+        ]);
+    });
+
+    it('historyEntry.by enum covers every author the writers emit', () => {
+        const by: string[] = schema.$defs.historyEntry.properties.by.enum;
+        for (const author of ['extension', 'user', 'cli', 'ai', 'derive']) {
+            expect(by).toContain(author);
+        }
+    });
+
+    it('historyEntry.kind enum is start/complete', () => {
+        expect(schema.$defs.historyEntry.properties.kind.enum).toEqual(['start', 'complete']);
+    });
+});

--- a/src/core/types/spec-context.schema.json
+++ b/src/core/types/spec-context.schema.json
@@ -77,7 +77,7 @@
             "substep": { "type": ["string", "null"] }
           }
         },
-        "by": { "type": "string", "enum": ["extension", "user", "cli", "ai"] },
+        "by": { "type": "string", "enum": ["extension", "user", "cli", "ai", "derive"] },
         "at": { "type": "string", "format": "date-time" }
       }
     }

--- a/src/core/types/specContext.ts
+++ b/src/core/types/specContext.ts
@@ -74,7 +74,7 @@ export interface HistoryEntryFrom {
     substep: string | null;
 }
 
-export type HistoryEntryBy = 'extension' | 'user' | 'cli' | 'ai';
+export type HistoryEntryBy = 'extension' | 'user' | 'cli' | 'ai' | 'derive';
 
 /** Discriminates between a step/substep start and a step/substep completion. */
 export type HistoryEntryKind = 'start' | 'complete';


### PR DESCRIPTION
## What

- Add `after_plan` / `after_tasks` / `after_implement` lifecycle hooks (all `optional: false`), each backed by a per-step capture command (`speckit.companion.capture-plan` / `-tasks` / `-implement`) that reuses `write-context.py`.
- Add per-task journaling on `after_implement` via a new `--tasks-file` task-sync mode in `write-context.py` — one idempotent transition per completed `- [x] **T###**` marker, recorded as implement **substeps** (so the viewer never mistakes them for a step-completion), `implementing` until all markers checked then `implemented`.
- Add stdlib `derive-from-files.py` that reconstructs `.spec-context.json` from on-disk artifacts (spec.md/plan.md/tasks.md + marker state) + git when a hook never fired, honoring the same no-backward-clobber guard and emitting the canonical schema (`by: "derive"`).
- Register the new commands + hooks in `extension.yml`, the `.specify/` test fixture, and the installed `.specify/extensions/companion/` copy (byte-identical).
- Add a 12-test stdlib `unittest` regression suite.

## Why

Step 1 proved one hook can write the canonical state file; the product needs the full lifecycle. Because spec-kit hooks are agent-mediated (best-effort), the deterministic derive path makes a missed hook recoverable rather than silently corrupting the timeline. ROADMAP step 2.

## Testing

- `python3 -m unittest discover speckit-extension/tests` → 12 passing (append-only transitions, no-backward-clobber, unknown-key preservation, per-task idempotency + substep shape, duplicate-id dedup, derive round-trip incl. partial→ready-to-implement and all-checked→implemented).
- `npm run compile` clean.