### PR TITLE
fix(companion): capture hooks invoke the installed script path, not the dev-source path

### DIFF
--- a/speckit-extension/commands/speckit.companion.capture-implement.md
+++ b/speckit-extension/commands/speckit.companion.capture-implement.md
@@ -20,7 +20,7 @@ runs as the `after_implement` lifecycle hook. It uses the writer's **TASK-SYNC m
 Run the writer script from the repository root, passing the active feature's `tasks.md` path:
 
 ```bash
-python3 speckit-extension/scripts/write-context.py --step implement --status implemented --by extension --tasks-file specs/<NNN>-<slug>/tasks.md
+python3 .specify/extensions/companion/scripts/write-context.py --step implement --status implemented --by extension --tasks-file specs/<NNN>-<slug>/tasks.md
 ```
 
 Pass the active feature's `tasks.md` path to `--tasks-file`. If feature resolution is unambiguous the script resolves the feature directory on its own (in this order: `--feature-dir` → `SPECIFY_FEATURE_DIRECTORY` env → `SPECIFY_FEATURE` env → `.specify/feature.json` → current git branch prefix), but `--tasks-file` must still point at that feature's `tasks.md`. The `--status implemented` value is the terminal status applied only when all task markers are checked; partial completion records `implementing` automatically.

--- a/speckit-extension/commands/speckit.companion.capture-plan.md
+++ b/speckit-extension/commands/speckit.companion.capture-plan.md
@@ -21,7 +21,7 @@ document is created by the core `/speckit.plan` workflow.
 Run the writer script from the repository root:
 
 ```bash
-python3 speckit-extension/scripts/write-context.py --step plan --status planned --by extension
+python3 .specify/extensions/companion/scripts/write-context.py --step plan --status planned --by extension
 ```
 
 The script resolves the active feature directory on its own, in this order:
@@ -32,7 +32,7 @@ If you already know the feature directory (e.g. the one `/speckit.plan` just
 wrote into), pass it explicitly so resolution is unambiguous:
 
 ```bash
-python3 speckit-extension/scripts/write-context.py --feature-dir specs/<NNN>-<slug> --step plan --status planned --by extension
+python3 .specify/extensions/companion/scripts/write-context.py --feature-dir specs/<NNN>-<slug> --step plan --status planned --by extension
 ```
 
 ## Graceful Degradation

--- a/speckit-extension/commands/speckit.companion.capture-tasks.md
+++ b/speckit-extension/commands/speckit.companion.capture-tasks.md
@@ -21,7 +21,7 @@ document is created by the core `/speckit.tasks` workflow.
 Run the writer script from the repository root:
 
 ```bash
-python3 speckit-extension/scripts/write-context.py --step tasks --status ready-to-implement --by extension
+python3 .specify/extensions/companion/scripts/write-context.py --step tasks --status ready-to-implement --by extension
 ```
 
 The script resolves the active feature directory on its own, in this order:
@@ -32,7 +32,7 @@ If you already know the feature directory (e.g. the one `/speckit.tasks` just
 wrote into), pass it explicitly so resolution is unambiguous:
 
 ```bash
-python3 speckit-extension/scripts/write-context.py --feature-dir specs/<NNN>-<slug> --step tasks --status ready-to-implement --by extension
+python3 .specify/extensions/companion/scripts/write-context.py --feature-dir specs/<NNN>-<slug> --step tasks --status ready-to-implement --by extension
 ```
 
 ## Graceful Degradation

--- a/speckit-extension/commands/speckit.companion.capture.md
+++ b/speckit-extension/commands/speckit.companion.capture.md
@@ -21,7 +21,7 @@ directory and files are created by the core `/speckit.specify` workflow.
 Run the writer script from the repository root:
 
 ```bash
-python3 speckit-extension/scripts/write-context.py --step specify --status specified --by extension
+python3 .specify/extensions/companion/scripts/write-context.py --step specify --status specified --by extension
 ```
 
 The script resolves the active feature directory on its own, in this order:
@@ -32,7 +32,7 @@ If you already know the feature directory (e.g. the one `/speckit.specify` just
 created), pass it explicitly so resolution is unambiguous:
 
 ```bash
-python3 speckit-extension/scripts/write-context.py --feature-dir specs/<NNN>-<slug> --step specify --status specified --by extension
+python3 .specify/extensions/companion/scripts/write-context.py --feature-dir specs/<NNN>-<slug> --step specify --status specified --by extension
 ```
 
 ## Graceful Degradation

--- a/speckit-extension/commands/speckit.companion.resume.md
+++ b/speckit-extension/commands/speckit.companion.resume.md
@@ -21,7 +21,7 @@ implement step it continues at the next unchecked task.
 1. Resolve the next action from the repository root:
 
    ```bash
-   python3 speckit-extension/scripts/status-context.py
+   python3 .specify/extensions/companion/scripts/status-context.py
    ```
 
    (Pass `--feature-dir specs/<NNN>-<slug>` when you already know it.) The script

--- a/speckit-extension/commands/speckit.companion.status.md
+++ b/speckit-extension/commands/speckit.companion.status.md
@@ -18,7 +18,7 @@ Summarize the active feature's position in the spec-driven pipeline so you can s
 Run the resolver from the repository root:
 
 ```bash
-python3 speckit-extension/scripts/status-context.py
+python3 .specify/extensions/companion/scripts/status-context.py
 ```
 
 The script resolves the active feature directory on its own, in this order:
@@ -28,7 +28,7 @@ The script resolves the active feature directory on its own, in this order:
 Pass the directory explicitly when you already know it:
 
 ```bash
-python3 speckit-extension/scripts/status-context.py --feature-dir specs/<NNN>-<slug>
+python3 .specify/extensions/companion/scripts/status-context.py --feature-dir specs/<NNN>-<slug>
 ```
 
 The script reads `.spec-context.json`. When that file is missing or malformed, it

--- a/speckit-extension/docs/commands.md
+++ b/speckit-extension/docs/commands.md
@@ -26,7 +26,7 @@ The first command. It carries no business logic itself — it resolves the activ
 **What the agent runs:**
 
 ```bash
-python3 speckit-extension/scripts/write-context.py --step specify --status specified --by extension
+python3 .specify/extensions/companion/scripts/write-context.py --step specify --status specified --by extension
 ```
 
 **Flags** (`scripts/write-context.py`):
@@ -48,7 +48,7 @@ Runs after `/speckit.plan`. Resolves the active feature and records plan complet
 **What the agent runs:**
 
 ```bash
-python3 speckit-extension/scripts/write-context.py --step plan --status planned --by extension
+python3 .specify/extensions/companion/scripts/write-context.py --step plan --status planned --by extension
 ```
 
 ## `speckit.companion.capture-tasks`
@@ -58,7 +58,7 @@ Runs after `/speckit.tasks`. Resolves the active feature and records tasks compl
 **What the agent runs:**
 
 ```bash
-python3 speckit-extension/scripts/write-context.py --step tasks --status ready-to-implement --by extension
+python3 .specify/extensions/companion/scripts/write-context.py --step tasks --status ready-to-implement --by extension
 ```
 
 ## `speckit.companion.capture-implement`
@@ -70,37 +70,37 @@ Runs after `/speckit.implement` in task-sync mode: it appends one transition per
 **What the agent runs:**
 
 ```bash
-python3 speckit-extension/scripts/write-context.py --step implement --status implemented --by extension --tasks-file specs/<NNN>-<slug>/tasks.md
+python3 .specify/extensions/companion/scripts/write-context.py --step implement --status implemented --by extension --tasks-file specs/<NNN>-<slug>/tasks.md
 ```
 
 ## Derive-from-files fallback
 
-`speckit-extension/scripts/derive-from-files.py` reconstructs `.spec-context.json` from on-disk artifacts when a hook never fired. Stdlib-only; reuses `write-context.py`'s feature-dir resolution and its no-backward-clobber guard, so it never drags an already-advanced or terminal spec backward. It writes the same canonical schema, tagged `by: "derive"`.
+`.specify/extensions/companion/scripts/derive-from-files.py` reconstructs `.spec-context.json` from on-disk artifacts when a hook never fired. Stdlib-only; reuses `write-context.py`'s feature-dir resolution and its no-backward-clobber guard, so it never drags an already-advanced or terminal spec backward. It writes the same canonical schema, tagged `by: "derive"`.
 
 It infers the lifecycle from what's present: `spec.md` → `specify`/`specified`, `plan.md` → `plan`/`planned`, `tasks.md` → `tasks`/`ready-to-implement`, and all task markers checked → `implement`/`implemented`, plus git as a signal.
 
 **Invocation:**
 
 ```bash
-python3 speckit-extension/scripts/derive-from-files.py
+python3 .specify/extensions/companion/scripts/derive-from-files.py
 # or target an explicit dir:
-python3 speckit-extension/scripts/derive-from-files.py --feature-dir specs/<NNN>-<slug>
+python3 .specify/extensions/companion/scripts/derive-from-files.py --feature-dir specs/<NNN>-<slug>
 ```
 
 See [how-it-works.md](./how-it-works.md) for what the writer guarantees (atomic, append-only, no-regress) and the canonical schema.
 
 ## Read commands: status & resume
 
-Two user-invokable commands turn the captured state into something actionable. Both are **read-only** with respect to `.spec-context.json` (resume writes state only indirectly, via the `after_*` hook of the command it dispatches). Both run `speckit-extension/scripts/status-context.py`, which reads the canonical state — or derives it from on-disk files when the state file is missing/malformed (`source: derived`) — and emits a human summary plus a final machine line `RESOLUTION: { … }`.
+Two user-invokable commands turn the captured state into something actionable. Both are **read-only** with respect to `.spec-context.json` (resume writes state only indirectly, via the `after_*` hook of the command it dispatches). Both run `.specify/extensions/companion/scripts/status-context.py`, which reads the canonical state — or derives it from on-disk files when the state file is missing/malformed (`source: derived`) — and emits a human summary plus a final machine line `RESOLUTION: { … }`.
 
 ### `speckit.companion.status`
 
 Prints the active spec's current step, status, recorded `decisions[]`, and the next action/command. Falls back to file-derivation when no state file exists.
 
 ```bash
-python3 speckit-extension/scripts/status-context.py
+python3 .specify/extensions/companion/scripts/status-context.py
 # or target an explicit dir:
-python3 speckit-extension/scripts/status-context.py --feature-dir specs/<NNN>-<slug>
+python3 .specify/extensions/companion/scripts/status-context.py --feature-dir specs/<NNN>-<slug>
 ```
 
 ### `speckit.companion.resume`

--- a/speckit-extension/docs/how-it-works.md
+++ b/speckit-extension/docs/how-it-works.md
@@ -38,7 +38,7 @@ The migration rests on one agent-mediated chain: *spec-kit command → agent run
 
 ```bash
 mkdir -p specs/_zzz-proof-demo && printf '# Spec: Proof Demo\n' > specs/_zzz-proof-demo/spec.md
-python3 speckit-extension/scripts/write-context.py --feature-dir specs/_zzz-proof-demo \
+python3 .specify/extensions/companion/scripts/write-context.py --feature-dir specs/_zzz-proof-demo \
   --step specify --status specified --by extension
 cat specs/_zzz-proof-demo/.spec-context.json   # currentStep=specify, status=specified, history[].by=extension
 rm -rf specs/_zzz-proof-demo

--- a/speckit-extension/docs/install.md
+++ b/speckit-extension/docs/install.md
@@ -47,3 +47,5 @@ specify extension list        # companion present
 ```
 
 Then run a real `/speckit.specify` and confirm `specs/<NNN>-<slug>/.spec-context.json` is written — see [how-it-works.md](./how-it-works.md#end-to-end-proof) for the full check.
+
+> The capture hook invokes the script at its **installed** path, `.specify/extensions/companion/scripts/write-context.py` (mirroring the `git` extension's `.specify/extensions/git/scripts/…` convention) — not the source-repo `speckit-extension/scripts/…`. That's why it runs cleanly on any install. If you ever see `No such file or directory` for `speckit-extension/scripts/…`, the command-markdown drifted back to the dev-source path.


### PR DESCRIPTION
## The bug
Dogfooding the `companion` extension on a real repo (`command-center`) surfaced this: the `after_specify` hook ran

```
python3 speckit-extension/scripts/write-context.py …
→ No such file or directory
```

The command-markdown hardcoded the **dev-source repo path** (`speckit-extension/scripts/…`), which only exists in *this* repo. On a real install the script lives at `.specify/extensions/companion/scripts/…`. The capture only succeeded because the agent improvised and found the installed path — on a clean run with a less capable agent, the hook silently fails.

## The fix
Mirror the bundled `git` / `agent-context` extensions and reference the **installed** location: `.specify/extensions/companion/scripts/<script>.py`. spec-kit intentionally does **not** rewrite `.specify/extensions/*` paths at install (`specify_cli/agents.py` → `rewrite_project_relative_paths`), so the author must write the installed path directly.

- 6 command files (`speckit.companion.capture` / `-plan` / `-tasks` / `-implement` / `status` / `resume`) — invocations now use the installed path.
- Docs (`commands.md`, `how-it-works.md`) — example invocations updated; `install.md` gains a verify note.
- The scripts **don't move** — install already copies `scripts/` → `.specify/extensions/companion/scripts/`. Minimal path-reference fix only.
- Historical `specs/106|129|130/…` records left untouched (they reference the repo file location correctly; #106 is the origin of the convention slip). The `eval-speckit-extension` skill keeps its dev-repo reference (it runs in this repo; kaiju-sourced).

## Verify (gate)
```
grep -rn "speckit-extension/scripts/write-context" . --include=*.md | grep -v "/specs/"   # → zero
```
End-to-end: reinstall into a real repo (`specify extension add … --dev --force`), run `/speckit.specify`, confirm the hook runs `.specify/extensions/companion/scripts/write-context.py` on the **first** try and writes `.spec-context.json` — no error, no improvisation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)