### PR TITLE
chore(specs): mark finished specs completed; keep only demo fixtures active

### DIFF
--- a/specs/109-prompt-advance-step/.spec-context.json
+++ b/specs/109-prompt-advance-step/.spec-context.json
@@ -20,7 +20,7 @@
       "key_finding": "promptBuilder.ts already centralizes preamble rendering through renderPreamble + renderLifecycleBody, and has COMPLETED_STATUS_BY_STEP / DONE_PHRASE_BY_STEP step-keyed maps — the next-step map fits the same pattern."
     }
   },
-  "status": "implementing",
+  "status": "completed",
   "task_summaries": {
     "T001": {
       "status": "DONE",

--- a/specs/111-history-entry-kind/.spec-context.json
+++ b/specs/111-history-entry-kind/.spec-context.json
@@ -4,7 +4,7 @@
   "branch": "fix/spec-context-state-progression",
   "selectedAt": "2026-05-27T00:00:00.000Z",
   "currentStep": "plan",
-  "status": "planning",
+  "status": "completed",
   "history": [
     {
       "step": "specify",

--- a/specs/120-reorder-sidebar-icons/.spec-context.json
+++ b/specs/120-reorder-sidebar-icons/.spec-context.json
@@ -4,7 +4,7 @@
   "branch": "120-reorder-sidebar-icons",
   "selectedAt": "2026-05-28T14:22:56.118Z",
   "currentStep": "implement",
-  "status": "implemented",
+  "status": "completed",
   "history": [
     {
       "step": "specify",

--- a/specs/121-sidebar-icon-order/.spec-context.json
+++ b/specs/121-sidebar-icon-order/.spec-context.json
@@ -4,27 +4,35 @@
   "branch": "120-reorder-sidebar-icons",
   "selectedAt": "2026-05-28T14:54:48.205Z",
   "currentStep": "implement",
-  "status": "implemented",
+  "status": "completed",
   "task_summaries": {
     "T001": {
       "status": "DONE",
       "did": "Verified speckit.create is pinned to navigation@0 in the explorer title bar — already correct, no change needed.",
-      "files": ["package.json"]
+      "files": [
+        "package.json"
+      ]
     },
     "T002": {
       "status": "DONE",
       "did": "Confirmed no speckit.refresh contribution exists in the explorer view/title menu (only speckit.steering.refresh on the steering view).",
-      "files": ["package.json"]
+      "files": [
+        "package.json"
+      ]
     },
     "T003": {
       "status": "DONE",
       "did": "Sidebar reference doc title-bar action list reads Create → Filter → (Clear Filter) → Sort → Collapse/Expand with no Refresh mention.",
-      "files": ["docs/sidebar.md"]
+      "files": [
+        "docs/sidebar.md"
+      ]
     },
     "T004": {
       "status": "DONE",
       "did": "Audited README — Sidebar at a Glance has no Specs-view refresh mention; only hit is unrelated 'refreshed screenshots' changelog line.",
-      "files": ["README.md"]
+      "files": [
+        "README.md"
+      ]
     }
   },
   "history": [

--- a/specs/122-fix-upgrade-ai-agent/.spec-context.json
+++ b/specs/122-fix-upgrade-ai-agent/.spec-context.json
@@ -4,7 +4,7 @@
   "branch": "122-fix-upgrade-ai-agent",
   "selectedAt": "2026-06-04T21:00:59.162Z",
   "currentStep": "implement",
-  "status": "implemented",
+  "status": "completed",
   "history": [
     {
       "step": "specify",
@@ -116,52 +116,72 @@
     "T002": {
       "status": "DONE",
       "did": "Extracted `detectHostIde()` into a standalone exported function and made the instance method delegate, with `HostIde` now exported.",
-      "files": ["src/ai-providers/ideChatProvider.ts"]
+      "files": [
+        "src/ai-providers/ideChatProvider.ts"
+      ]
     },
     "T003": {
       "status": "DONE",
       "did": "Created the pure total `resolveSpecKitAgent` resolver, the `PROVIDER_TO_AGENT` map, and the impure `getConfiguredSpecKitAgent` wrapper.",
-      "files": ["src/speckit/specKitAgent.ts"]
+      "files": [
+        "src/speckit/specKitAgent.ts"
+      ]
     },
     "T004": {
       "status": "DONE",
       "did": "Routed both `upgradeProject` and `upgradeAll` dispatch sites through `getConfiguredSpecKitAgent()`, removing the hardcoded `claude-code`.",
-      "files": ["src/speckit/detector.ts"]
+      "files": [
+        "src/speckit/detector.ts"
+      ]
     },
     "T005": {
       "status": "DONE",
       "did": "Added resolver tests asserting gemini/copilot/codex/qwen/opencode each map to their own agent.",
-      "files": ["src/speckit/specKitAgent.test.ts"]
+      "files": [
+        "src/speckit/specKitAgent.test.ts"
+      ]
     },
     "T006": {
       "status": "DONE",
       "did": "Added an `upgradeProject` dispatch test asserting the terminal text contains `--ai codex` and no `claude-code`.",
-      "files": ["src/speckit/detector.test.ts"]
+      "files": [
+        "src/speckit/detector.test.ts"
+      ]
     },
     "T007": {
       "status": "DONE",
       "did": "Added tests for `claude`→`claude` and a guard that no provider/host combination ever yields `claude-code`.",
-      "files": ["src/speckit/specKitAgent.test.ts"]
+      "files": [
+        "src/speckit/specKitAgent.test.ts"
+      ]
     },
     "T008": {
       "status": "DONE",
       "did": "Added default-provider dispatch tests for both upgrade paths plus the same-`--ai`-value (FR-006) check.",
-      "files": ["src/speckit/detector.test.ts"]
+      "files": [
+        "src/speckit/detector.test.ts"
+      ]
     },
     "T009": {
       "status": "DONE",
       "did": "Added tests for `claude-vscode`, each `ide-chat` host, unknown-host, and undefined/empty/unrecognized fallback.",
-      "files": ["src/speckit/specKitAgent.test.ts"]
+      "files": [
+        "src/speckit/specKitAgent.test.ts"
+      ]
     },
     "T010": {
       "status": "DONE",
       "did": "Removed both `speckit.workflowEditor.enabled` references (config-keys block and troubleshooting item) from the docs.",
-      "files": ["docs/how-it-works.md"]
+      "files": [
+        "docs/how-it-works.md"
+      ]
     },
     "T011": {
       "status": "DONE",
       "did": "Deleted the unused `ConfigKeys.workflowEditorEnabled` constant.",
-      "files": ["src/core/constants.ts"]
+      "files": [
+        "src/core/constants.ts"
+      ]
     },
     "T012": {
       "status": "DONE",

--- a/specs/124-fix-footer-button-visibility/.spec-context.json
+++ b/specs/124-fix-footer-button-visibility/.spec-context.json
@@ -4,7 +4,7 @@
   "branch": "124-fix-footer-button-visibility",
   "selectedAt": "2026-06-05T17:54:56.690Z",
   "currentStep": "implement",
-  "status": "implemented",
+  "status": "completed",
   "history": [
     {
       "step": "specify",
@@ -123,125 +123,185 @@
     "T001": {
       "status": "DONE",
       "did": "Encoded the footer-button-matrix oracle as a typed, reusable fixture (rows + zone partitions) for the determinism tests.",
-      "files": ["src/features/spec-viewer/__tests__/footerMatrix.fixtures.ts"]
+      "files": [
+        "src/features/spec-viewer/__tests__/footerMatrix.fixtures.ts"
+      ]
     },
     "T002": {
       "status": "DONE",
       "did": "Added runningStepArtifactReady/runningStepStartedAt/runningStepLabel to the core ViewerState interface.",
-      "files": ["src/core/types/specContext.ts"]
+      "files": [
+        "src/core/types/specContext.ts"
+      ]
     },
     "T003": {
       "status": "DONE",
       "did": "Added the viewerStateUpdated message (complete viewerState + complete NavState) to the extension ExtensionToViewerMessage union.",
-      "files": ["src/features/spec-viewer/types.ts"]
+      "files": [
+        "src/features/spec-viewer/types.ts"
+      ]
     },
     "T004": {
       "status": "DONE",
       "did": "Mirrored the new ViewerState fields in the webview types and made viewerStateUpdated.navState a complete (non-partial) NavState.",
-      "files": ["webview/src/spec-viewer/types.ts"]
+      "files": [
+        "webview/src/spec-viewer/types.ts"
+      ]
     },
     "T005": {
       "status": "DONE",
       "did": "Populated the run-step/generating fields in deriveViewerState (startedAt/label from the running step; artifact-ready injected by the provider since the pure function can't probe disk).",
-      "files": ["src/features/spec-viewer/stateDerivation.ts"]
+      "files": [
+        "src/features/spec-viewer/stateDerivation.ts"
+      ]
     },
     "T006": {
       "status": "DONE",
       "did": "Extracted one shared buildViewerPayload builder; both sendContentUpdateMessage and refreshContextIfDisplaying now emit a COMPLETE viewerState + navState (no more 3-field partial).",
-      "files": ["src/features/spec-viewer/specViewerProvider.ts"]
+      "files": [
+        "src/features/spec-viewer/specViewerProvider.ts"
+      ]
     },
     "T007": {
       "status": "DONE",
       "did": "Replaced the 4-source status fallback chain with status = viewerState.status only.",
-      "files": ["webview/src/spec-viewer/components/FooterActions.tsx"]
+      "files": [
+        "webview/src/spec-viewer/components/FooterActions.tsx"
+      ]
     },
     "T008": {
       "status": "DONE",
       "did": "Deleted the legacy navState.footerState render branch so exactly two shapes remain (CatalogFooter, GeneratingFooter).",
-      "files": ["webview/src/spec-viewer/components/FooterActions.tsx"]
+      "files": [
+        "webview/src/spec-viewer/components/FooterActions.tsx"
+      ]
     },
     "T009": {
       "status": "DONE",
       "did": "Computed the generating/run-step gate from viewerState and removed all navState footer-decision reads (only enhancementButtons remain, the documented carve-out).",
-      "files": ["webview/src/spec-viewer/components/FooterActions.tsx"]
+      "files": [
+        "webview/src/spec-viewer/components/FooterActions.tsx"
+      ]
     },
     "T010": {
       "status": "DONE",
       "did": "Sourced GeneratingFooter's running-step label from viewerState instead of navState.",
-      "files": ["webview/src/spec-viewer/components/footer/GeneratingFooter.tsx"]
+      "files": [
+        "webview/src/spec-viewer/components/footer/GeneratingFooter.tsx"
+      ]
     },
     "T011": {
       "status": "DONE",
       "did": "Confirmed the viewerState signal is the footer's sole reactive input; the footer no longer depends on the navState signal for any decision.",
-      "files": ["webview/src/spec-viewer/signals.ts", "webview/src/spec-viewer/components/FooterActions.tsx"]
+      "files": [
+        "webview/src/spec-viewer/signals.ts",
+        "webview/src/spec-viewer/components/FooterActions.tsx"
+      ]
     },
     "T012": {
       "status": "DONE",
       "did": "viewerStateUpdated now fully replaces navState (complete payload), closing the early-arrival race and the stale/partial read.",
-      "files": ["webview/src/spec-viewer/index.tsx"]
+      "files": [
+        "webview/src/spec-viewer/index.tsx"
+      ]
     },
     "T013": {
       "status": "DONE",
       "did": "Added footer determinism tests (idempotence, state-preserving re-derivation, viewed-tab independence, external-change re-derivation, implemented gate).",
-      "files": ["src/features/spec-viewer/__tests__/footerActions.test.ts"]
+      "files": [
+        "src/features/spec-viewer/__tests__/footerActions.test.ts"
+      ]
     },
     "T014": {
       "status": "DONE",
       "did": "Rewrote the webview FooterActions test for the single-source model (stale navState can't hide a button; generating reverts on artifact-ready and on timeout).",
-      "files": ["webview/src/spec-viewer/components/__tests__/FooterActions.test.tsx"]
+      "files": [
+        "webview/src/spec-viewer/components/__tests__/FooterActions.test.tsx"
+      ]
     },
     "T015": {
       "status": "DONE",
       "did": "Verified the serialized approve label resolves to the next step at each pause stage and is hidden on implement; no gating change was needed.",
-      "files": ["src/features/spec-viewer/stateDerivation.ts", "src/features/spec-viewer/footerActions.ts"]
+      "files": [
+        "src/features/spec-viewer/stateDerivation.ts",
+        "src/features/spec-viewer/footerActions.ts"
+      ]
     },
     "T016": {
       "status": "DONE",
       "did": "Verified the closure controls surface per matrix (Mark Completed+Archive at implemented, Reactivate+Archive at completed, Reactivate at archived) via the oracle test rows.",
-      "files": ["src/features/spec-viewer/footerActions.ts", "src/features/spec-viewer/__tests__/footerMatrix.test.ts"]
+      "files": [
+        "src/features/spec-viewer/footerActions.ts",
+        "src/features/spec-viewer/__tests__/footerMatrix.test.ts"
+      ]
     },
     "T017": {
       "status": "DONE",
       "did": "Added pause-stage oracle tests asserting the derived footer equals the matrix Left+Right set for each canonical pause status.",
-      "files": ["src/features/spec-viewer/__tests__/footerMatrix.test.ts"]
+      "files": [
+        "src/features/spec-viewer/__tests__/footerMatrix.test.ts"
+      ]
     },
     "T018": {
       "status": "DONE",
       "did": "Confirmed step-tab class derivation reads from the refreshed viewerState/navState snapshot; the complete-payload refresh keeps tabs in sync (no stale read).",
-      "files": ["webview/src/spec-viewer/components/StepTab.tsx", "webview/src/spec-viewer/components/NavigationBar.tsx"]
+      "files": [
+        "webview/src/spec-viewer/components/StepTab.tsx",
+        "webview/src/spec-viewer/components/NavigationBar.tsx"
+      ]
     },
     "T019": {
       "status": "DONE",
       "did": "Verified a workflow-advancing action updates the step-tab indicator without a reopen — it rides the same complete-payload refresh, with no tab-only state path.",
-      "files": ["webview/src/spec-viewer/components/StepTab.tsx"]
+      "files": [
+        "webview/src/spec-viewer/components/StepTab.tsx"
+      ]
     },
     "T020": {
       "status": "DONE",
       "did": "Added step-tab sync tests (enabled/checkmark match true per-step state; indicator updates after an advancing action).",
-      "files": ["webview/src/spec-viewer/components/__tests__/StepTab.test.tsx"],
-      "concerns": ["Plan named webview/src/spec-viewer/navigation.ts, which doesn't exist; tab-class derivation lives in StepTab.tsx, so the tests live there instead."]
+      "files": [
+        "webview/src/spec-viewer/components/__tests__/StepTab.test.tsx"
+      ],
+      "concerns": [
+        "Plan named webview/src/spec-viewer/navigation.ts, which doesn't exist; tab-class derivation lives in StepTab.tsx, so the tests live there instead."
+      ]
     },
     "T021": {
       "status": "DONE",
       "did": "Updated docs/viewer-states.md to the single-source (viewerState-only) footer model and replaced the stale legacy matrix with the canonical contract matrix.",
-      "files": ["docs/viewer-states.md"]
+      "files": [
+        "docs/viewer-states.md"
+      ]
     },
     "T022": {
       "status": "DONE",
       "did": "Rewrote FooterActions.stories.tsx and mockData to drive only viewerState; removed the legacy-fallback story variants and added the generating/artifact-ready/timeout states.",
-      "files": ["webview/src/spec-viewer/components/FooterActions.stories.tsx", "webview/src/spec-viewer/components/__stories__/mockData.ts"]
+      "files": [
+        "webview/src/spec-viewer/components/FooterActions.stories.tsx",
+        "webview/src/spec-viewer/components/__stories__/mockData.ts"
+      ]
     },
     "T023": {
       "status": "DONE_WITH_CONCERNS",
       "did": "Removed the dead footer duplicates (footerState interface, runningStep* fields) from NavState and the initial-HTML generator + generateHtml signature.",
-      "files": ["webview/src/spec-viewer/types.ts", "src/features/spec-viewer/types.ts", "src/features/spec-viewer/html/generator.ts", "src/features/spec-viewer/specViewerProvider.ts"],
-      "concerns": ["Kept NavState.activeStep (read by StepTab/NavigationBar for in-flight visuals) and NavState.specStatus (header badge fallback) — these are not footer-only, so removing them was out of scope."]
+      "files": [
+        "webview/src/spec-viewer/types.ts",
+        "src/features/spec-viewer/types.ts",
+        "src/features/spec-viewer/html/generator.ts",
+        "src/features/spec-viewer/specViewerProvider.ts"
+      ],
+      "concerns": [
+        "Kept NavState.activeStep (read by StepTab/NavigationBar for in-flight visuals) and NavState.specStatus (header badge fallback) — these are not footer-only, so removing them was out of scope."
+      ]
     },
     "T024": {
       "status": "DONE_WITH_CONCERNS",
       "did": "Ran npm run compile + compile-web + jest — all green (810 tests, 68 suites); demo fixtures left untouched.",
       "files": [],
-      "concerns": ["The manual issue #193 repro in quickstart.md (driving the live VS Code viewer) is a user-side step I cannot perform headlessly."]
+      "concerns": [
+        "The manual issue #193 repro in quickstart.md (driving the live VS Code viewer) is a user-side step I cannot perform headlessly."
+      ]
     }
   },
   "updated": "2026-06-05"

--- a/specs/125-clarify-setup-components/.spec-context.json
+++ b/specs/125-clarify-setup-components/.spec-context.json
@@ -4,20 +4,40 @@
   "branch": "124-fix-footer-button-visibility",
   "selectedAt": "2026-06-05T19:24:41.188Z",
   "currentStep": "implement",
-  "status": "implemented",
+  "status": "completed",
   "type": "docs",
   "next": "done",
   "auto": false,
   "workingBranch": "docs/clarify-setup-components",
   "loadedDomains": [],
-  "files_modified": ["README.md"],
+  "files_modified": [
+    "README.md"
+  ],
   "prUrl": "https://github.com/alfredoperez/speckit-companion/pull/198",
   "prNumber": 198,
   "last_action": "PR #198 opened — docs: clarify required components and extension-vs-CLI relationship.",
   "task_summaries": {
-    "T001": { "status": "DONE", "did": "Added '## Setup & Components' section after Getting Started with a 4-row Required/Optional component table.", "files": ["README.md"] },
-    "T002": { "status": "DONE", "did": "Wrote extension-dispatch-vs-terminal and shared-files ownership prose; linked the providers section and docs/how-it-works.md.", "files": ["README.md"] },
-    "T003": { "status": "DONE", "did": "Cross-checked against IDE Chat / Claude in VS Code notes for consistency; npm test (790 tests, docs-consistency) green and no hard wraps.", "files": ["README.md"] }
+    "T001": {
+      "status": "DONE",
+      "did": "Added '## Setup & Components' section after Getting Started with a 4-row Required/Optional component table.",
+      "files": [
+        "README.md"
+      ]
+    },
+    "T002": {
+      "status": "DONE",
+      "did": "Wrote extension-dispatch-vs-terminal and shared-files ownership prose; linked the providers section and docs/how-it-works.md.",
+      "files": [
+        "README.md"
+      ]
+    },
+    "T003": {
+      "status": "DONE",
+      "did": "Cross-checked against IDE Chat / Claude in VS Code notes for consistency; npm test (790 tests, docs-consistency) green and no hard wraps.",
+      "files": [
+        "README.md"
+      ]
+    }
   },
   "approach": "Add one README 'Setup & Components' section after Getting Started with a Required/Optional table plus prose on extension dispatch vs. terminal spec-kit and shared-files ownership.",
   "step_summaries": {
@@ -30,7 +50,9 @@
     "plan": {
       "approach_summary": "Add one README 'Setup & Components' section after Getting Started with a Required/Optional table plus prose on extension dispatch vs. terminal spec-kit and shared-files ownership.",
       "files_planned": 1,
-      "risks": ["Wording must stay consistent with existing IDE Chat / Claude in VS Code provider notes (one-way dispatch, spec-kit-must-be-initialized)."],
+      "risks": [
+        "Wording must stay consistent with existing IDE Chat / Claude in VS Code provider notes (one-way dispatch, spec-kit-must-be-initialized)."
+      ],
       "principles_concerns": 0,
       "domain_concerns": 0,
       "significance_score": 0
@@ -41,7 +63,10 @@
       "step": "specify",
       "substep": null,
       "kind": "start",
-      "from": { "step": null, "substep": null },
+      "from": {
+        "step": null,
+        "substep": null
+      },
       "by": "extension",
       "at": "2026-06-05T19:24:41.188Z"
     },
@@ -56,7 +81,10 @@
       "step": "plan",
       "substep": null,
       "kind": "start",
-      "from": { "step": "specify", "substep": null },
+      "from": {
+        "step": "specify",
+        "substep": null
+      },
       "by": "ai",
       "at": "2026-06-05T19:38:14Z"
     },
@@ -71,7 +99,10 @@
       "step": "tasks",
       "substep": null,
       "kind": "start",
-      "from": { "step": "plan", "substep": null },
+      "from": {
+        "step": "plan",
+        "substep": null
+      },
       "by": "ai",
       "at": "2026-06-05T19:39:15Z"
     },
@@ -86,7 +117,10 @@
       "step": "implement",
       "substep": "phase1",
       "kind": "start",
-      "from": { "step": "tasks", "substep": null },
+      "from": {
+        "step": "tasks",
+        "substep": null
+      },
       "by": "ai",
       "at": "2026-06-05T19:41:14Z"
     },

--- a/specs/130-status-and-resume/.spec-context.json
+++ b/specs/130-status-and-resume/.spec-context.json
@@ -3,7 +3,7 @@
   "specName": "Status + Resume (v1 boundary)",
   "branch": "130-status-and-resume",
   "currentStep": "implement",
-  "status": "implemented",
+  "status": "completed",
   "updated": "2026-06-07",
   "history": [
     {

--- a/specs/131-fix-opencode-prompt-flag/.spec-context.json
+++ b/specs/131-fix-opencode-prompt-flag/.spec-context.json
@@ -4,7 +4,7 @@
   "branch": "131-fix-opencode-prompt-flag",
   "selectedAt": "2026-06-08T02:09:08.437Z",
   "currentStep": "implement",
-  "status": "implemented",
+  "status": "completed",
   "history": [
     {
       "step": "specify",
@@ -147,17 +147,23 @@
     "T001": {
       "status": "DONE",
       "did": "Added the failing-first regression test asserting OpenCode dispatches `opencode run \"…\"` (no `-p`) while Qwen/Copilot keep their `-p ` prompt flag.",
-      "files": ["src/ai-providers/__tests__/openCodeDispatch.test.ts"]
+      "files": [
+        "src/ai-providers/__tests__/openCodeDispatch.test.ts"
+      ]
     },
     "T002": {
       "status": "DONE",
       "did": "Overrode `cliPromptFlag()` to return `'run '` in OpenCodeProvider and corrected its class doc comment to the `opencode run` form.",
-      "files": ["src/ai-providers/openCodeProvider.ts"]
+      "files": [
+        "src/ai-providers/openCodeProvider.ts"
+      ]
     },
     "T003": {
       "status": "DONE",
       "did": "Corrected the base-class `cliPromptFlag()` doc comment to drop OpenCode from the `-p ` default note and explain OpenCode's positional `run ` override.",
-      "files": ["src/ai-providers/cliTerminalProvider.ts"]
+      "files": [
+        "src/ai-providers/cliTerminalProvider.ts"
+      ]
     },
     "T004": {
       "status": "DONE",

--- a/specs/132-sdd-lean-pipeline/.spec-context.json
+++ b/specs/132-sdd-lean-pipeline/.spec-context.json
@@ -3,7 +3,7 @@
   "specName": "Pipeline + the sdd-lean Preset",
   "branch": "132-sdd-lean-pipeline",
   "currentStep": "implement",
-  "status": "implementing",
+  "status": "completed",
   "updated": "2026-06-08",
   "history": [
     {


### PR DESCRIPTION
Flips the 10 non-terminal specs (2 implementing, 1 planning, 7 implemented) to `status: completed` so the spec sidebar shows only the `_NN_demo-*` fixtures as active.

- **Untouched:** 117 already-`completed`, 4 `archived`, and the 3 demo fixtures (`_00_demo-specified`, `_01_demo-planned`, `_02_demo-tasked`).
- **Changed:** only the top-level `status` value per file (verified identical keys/values otherwise; larger line-deltas are whitespace normalized to canonical indent-2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)