### PR TITLE
Fix: dispatch New Spec as a slash command, not a piped prompt

### DIFF
--- a/src/features/spec-editor/specEditorProvider.ts
+++ b/src/features/spec-editor/specEditorProvider.ts
@@ -275,8 +275,8 @@ export class SpecEditorProvider {
             const prompt = `${command} ${tempFileSet.markdownFilePath}`;
             this.outputChannel.appendLine(`[SpecEditor] Using command: ${command} (temp file: ${tempFileSet.markdownFilePath})`);
 
-            // Execute in terminal
-            await provider.executeInTerminal(prompt, 'SpecKit - New Spec');
+            // Slash-command dispatch (like Resume/advance) — piping the whole "/speckit-specify <file>" as a prompt makes Claude Code reject it as an unknown command.
+            await provider.executeSlashCommand(prompt, 'SpecKit - New Spec');
 
             // Mark as submitted
             await this.tempFileManager.markSubmitted(tempFileSet.id);


### PR DESCRIPTION
Closes #219.

Create New Spec built `/speckit-specify <spec.md>` and dispatched it via `executeInTerminal` — i.e. `claude "$(cat prompt)"` — so the leading slash landed inside the piped initial message and Claude Code rejected it as `Unknown command: /speckit-specify`. Resume and phase-advance don't hit this because they use `executeSlashCommand` (the slash sits on the command line where the host resolves it).

This routes New Spec through `executeSlashCommand` too, so the host resolves `/speckit.*` as its skill/command — provider-agnostic, so IDE-chat/Copilot reformatting is unchanged.

- One-line change in `src/features/spec-editor/specEditorProvider.ts`.
- `tsc` clean; `spec-editor` + `ai-providers` suites green (136 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)