### PR TITLE
chore: gitignore locally-installed preset copies (.specify/presets/)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,9 @@ storybook-static/
 # every machine; never hand-edited. (The non-companion `specify init --ai`
 # scaffolding under these dirs stays tracked as IDE-chat test fixtures.)
 .specify/extensions/companion/
+# Locally-installed preset copies + catalog cache/registry from `specify preset
+# add --dev` (source of truth is speckit-extension/presets/; never hand-edited).
+.specify/presets/
 .claude/skills/speckit-companion-*/
 .cursor/skills/speckit-companion-*/
 .agents/skills/speckit-companion-*/


### PR DESCRIPTION
`specify preset add --dev` writes the installed preset copies + a catalog `.cache/`/`.registry` into `.specify/presets/` — machine-local install artifacts (source of truth is `speckit-extension/presets/`). They were showing as ~24 untracked files; this ignores them, matching how `.specify/extensions/companion/` is already handled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)