### PR TITLE
fix(package): ship the extension, not the workspace (66.6MB → 1.17MB vsix)

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -34,9 +34,30 @@ jest.config.js
 tsconfig.test.json
 coverage/**
 dist/__tests__/**
-docs/screenshots/**
+docs/**
 webpack.config.js
 *.log
 **/*.ts
-!**/*.d.ts
 src/**/*.js
+
+# Dev workspace — never runtime code (vsce ignores .gitignore when this file exists,
+# so gitignored caches/build output must be listed here too)
+.codex/**
+examples/**
+specs/**
+bench/**
+speckit-extension/**
+.specify/**
+.opencode/**
+.serena/**
+.cursor/**
+.agents/**
+.gemini/**
+.qwen/**
+.windsurf/**
+.storybook/**
+storybook-static/**
+**/*.stories.tsx
+assets/mascot/**
+AGENTS.md
+package-lock.json


### PR DESCRIPTION
## Summary
Installing the extension downloaded a 66.6 MB package containing the entire dev workspace — example sandboxes, AI-CLI scaffolding, caches, spec folders. The package now ships only the extension itself: **1.17 MB, 384 files** (down from 9,119).

## Technical
- `.vscodeignore` predated the bench sandbox (`examples/`, 107 MB), the AI-CLI dirs (`.opencode/`, `.serena/`, `.codex/`), `storybook-static/`, and the spec/preset fixtures — added all of them. Note: vsce ignores `.gitignore` entirely when `.vscodeignore` exists, so gitignored caches were being packaged.
- Removed the boilerplate `!**/*.d.ts` negation — it re-included 1,340 type declarations from inside excluded dirs; runtime needs no `.d.ts`.
- Downscaled `icon.png` from 1786 px / 5.4 MB to 512 px (marketplace renders ≤256 px; overwritten in place, filename stable).

## Review checklist
- ✅ **VS Code extension** — affected
    - packaging: `.vscodeignore` additions + dropped `.d.ts` negation
    - assets: `icon.png` downscaled in place (same filename — Marketplace URL rules respected)
    - runtime payload unchanged: `dist/` + webview + manifest + media/icons still packaged
- — **SpecKit extension** — not touched
- — **Changelog** — n/a (packaging hygiene; no behavior change — but the next release's install gets ~60x smaller, can add a note at release time)
- ✅ **Verify**
    - repackaged: 9,119 files / 66.6 MB → 384 files / 1.17 MB
    - `dist/`, `webview/`, `package.json`, `assets/media|icons` confirmed present in the new package
    - regression context: 0.21.1 shipped at 60 MB, 0.21.2–3 at ~10 MB, 0.22.x regressed to 66 MB — this also removes the residue that kept 0.21.x at 10 MB

## Gaps / how to see it
- The published Marketplace listing still serves the old fat package until the next `/publish`.
- Try: `npm run package` → the vsix is ~1.2 MB; `unzip -l speckit-companion-*.vsix` shows only `dist/`, `webview/`, manifest, and media/icons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
