### PR TITLE
refactor(spec-context): centralize step-level vs per-task history discriminator

### DIFF
--- a/.claude/skills/eval-speckit-extension/check_capture.py
+++ b/.claude/skills/eval-speckit-extension/check_capture.py
@@ -316,16 +316,21 @@ def run_checks(spec_dir: Path) -> Report:
     return r
 
 
+def _is_step_level(e: dict) -> bool:
+    """A step-level boundary entry: no substep and no per-task id. The single
+    Python expression of the rule TypeScript's `isStepLevelEntry` owns; per-task
+    finishes (substep None but `task` set) are excluded from step start/complete."""
+    return e.get("substep") is None and e.get("task") is None
+
+
 def _step_span(history: list, step: str):
     """(start_at, complete_at, seconds) for a step's start→complete at the step
     level (substep None); None when either boundary is missing or unparseable."""
     start = next((e for e in history if e.get("step") == step
-                  and e.get("substep") is None and e.get("task") is None
+                  and _is_step_level(e)
                   and e.get("kind") == "start"), None)
-    # Exclude per-task finishes (substep None, but `task` set) — only the step-level
-    # boundary (substep None AND task None) marks start/complete.
     completes = [e for e in history if e.get("step") == step
-                 and e.get("substep") is None and e.get("task") is None
+                 and _is_step_level(e)
                  and e.get("kind") == "complete"]
     if not start or not completes:
         return None

--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/138-harden-capture-shape"
+  "feature_directory": "specs/139-centralize-entry-discriminator"
 }

--- a/speckit-extension/scripts/write-context.py
+++ b/speckit-extension/scripts/write-context.py
@@ -277,6 +277,17 @@ def _entry_kind(e: dict) -> str:
     return "start"
 
 
+def _is_step_level(e: dict) -> bool:
+    """A step-level boundary entry: no substep and no per-task id. The single
+    Python expression of the rule TypeScript's `isStepLevelEntry` owns."""
+    return e.get("substep") is None and e.get("task") is None
+
+
+def _is_per_task(e: dict) -> bool:
+    """A per-task implement finish: carries a `task` id (`isPerTaskEntry`)."""
+    return e.get("task") is not None
+
+
 def _has_step_start(log: list, step: str, substep: object = None) -> bool:
     """True if a `start` for `(step, substep)` already exists. A step (or a folded
     substep entry) is started once; this collapses every redundant start — the
@@ -289,7 +300,7 @@ def _has_step_start(log: list, step: str, substep: object = None) -> bool:
         isinstance(e, dict)
         and e.get("step") == step
         and e.get("substep") == substep
-        and e.get("task") is None
+        and not _is_per_task(e)
         and _entry_kind(e) == "start"
         for e in log
     )
@@ -309,7 +320,7 @@ def _has_complete(log: list, step: str, task: object = None) -> bool:
             # (the id lives in `task`), so it must NOT count as the step's complete —
             # otherwise the first task finish would skip the real step close and leave
             # the step permanently in-flight.
-            return e.get("substep") is None and e.get("task") is None
+            return _is_step_level(e)
         return e.get("task") == task or e.get("substep") == task
     return any(
         isinstance(e, dict)

--- a/specs/139-centralize-entry-discriminator/.spec-context.json
+++ b/specs/139-centralize-entry-discriminator/.spec-context.json
@@ -1,0 +1,243 @@
+{
+  "workflow": "speckit",
+  "specName": "centralize entry discriminator",
+  "branch": "main",
+  "currentStep": "implement",
+  "status": "completed",
+  "history": [
+    {
+      "step": "specify",
+      "substep": null,
+      "kind": "start",
+      "by": "extension",
+      "at": "2026-06-10T10:24:34.504Z"
+    },
+    {
+      "step": "specify",
+      "substep": null,
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-06-10T10:25:20.076Z"
+    },
+    {
+      "step": "plan",
+      "substep": null,
+      "kind": "start",
+      "by": "extension",
+      "at": "2026-06-10T10:31:36.572Z"
+    },
+    {
+      "step": "plan",
+      "substep": "research",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-10T10:34:42Z"
+    },
+    {
+      "step": "plan",
+      "substep": "design",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-10T10:35:29Z"
+    },
+    {
+      "step": "plan",
+      "substep": null,
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-10T10:35:48Z"
+    },
+    {
+      "step": "tasks",
+      "substep": null,
+      "kind": "start",
+      "by": "extension",
+      "at": "2026-06-10T10:40:08.693Z"
+    },
+    {
+      "step": "tasks",
+      "substep": "generate",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-10T10:41:01Z"
+    },
+    {
+      "step": "tasks",
+      "substep": null,
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-10T10:41:02Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "kind": "start",
+      "by": "extension",
+      "at": "2026-06-10T10:48:20.999Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T001",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-10T10:49:49.595Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T002",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-10T10:49:49.674Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T003",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-10T10:56:25.186Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T004",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-10T10:56:25.259Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T005",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-10T10:56:25.335Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T006",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-10T10:56:25.404Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T007",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-10T10:56:25.481Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T008",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-10T10:56:25.550Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T009",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-10T10:56:25.644Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T010",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-10T10:56:25.713Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-10T11:10:55Z"
+    }
+  ],
+  "profile": "turbo",
+  "currentTask": "T010",
+  "task_summaries": {
+    "T001": {
+      "status": "DONE",
+      "did": "Added and exported isStepLevelEntry/isPerTaskEntry predicates with a minimal structural param shape.",
+      "files": [
+        "src/features/specs/historyHelpers.ts"
+      ]
+    },
+    "T002": {
+      "status": "DONE",
+      "did": "Rewrote lastEntryIsCompletionFor's loop to use the new predicates, making it the single source.",
+      "files": [
+        "src/features/specs/historyHelpers.ts"
+      ]
+    },
+    "T003": {
+      "status": "DONE",
+      "did": "Deleted the duplicate lastEntryIsCompletionFor, imported the shared one, and routed stepHasBeenStarted through isStepLevelEntry.",
+      "files": [
+        "src/features/specs/specContextManager.ts"
+      ]
+    },
+    "T004": {
+      "status": "DONE",
+      "did": "Replaced the inline step-level check in deriveStepHistory with isStepLevelEntry; kept dedupe field-equality and rowName display logic untouched.",
+      "files": [
+        "src/features/specs/stepHistoryDerivation.ts"
+      ]
+    },
+    "T005": {
+      "status": "DONE",
+      "did": "Routed entryLabel's per-task branch through isPerTaskEntry and replaced HistoryEntryLike with a minimal Pick off canonical HistoryEntry.",
+      "files": [
+        "src/features/specs/lastTransition.ts"
+      ]
+    },
+    "T006": {
+      "status": "DONE_WITH_CONCERNS",
+      "did": "Left normalizeHistoryKind's backfill keyed on substep alone (task-aware predicate would alter legacy per-task backfilled kinds) and added a one-line note.",
+      "files": [
+        "src/features/specs/specContextReader.ts"
+      ],
+      "concerns": [
+        "Backfill intentionally not routed through isStepLevelEntry to preserve exact legacy kind semantics (FR-006)."
+      ]
+    },
+    "T007": {
+      "status": "DONE",
+      "did": "Confirmed HistoryEntry.task is canonical and the predicate param accepts both canonical and legacy reader shapes; no type change needed.",
+      "files": [
+        "src/core/types/specContext.ts"
+      ]
+    },
+    "T008": {
+      "status": "DONE",
+      "did": "Added local webview predicates and routed buildHistoryIndex/mergeStepEvents through them without crossing the extension boundary.",
+      "files": [
+        "webview/src/spec-viewer/timelineEvents.ts"
+      ]
+    },
+    "T009": {
+      "status": "DONE",
+      "did": "Added _is_step_level/_is_per_task helpers and routed inline checks through them in write-context.py (+ mirror) and check_capture.py.",
+      "files": [
+        "speckit-extension/scripts/write-context.py",
+        ".specify/extensions/companion/scripts/write-context.py",
+        ".claude/skills/eval-speckit-extension/check_capture.py"
+      ]
+    },
+    "T010": {
+      "status": "DONE",
+      "did": "Compiled both tsconfigs and ran the suite (75 suites/899 tests pass incl. golden contract); grep confirmed SC-001/SC-002.",
+      "files": []
+    }
+  }
+}

--- a/specs/139-centralize-entry-discriminator/checklists/requirements.md
+++ b/specs/139-centralize-entry-discriminator/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Centralize the step-level vs per-task entry discriminator
+
+**Purpose**: Validate turbo specification completeness before planning
+**Created**: 2026-06-10
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user/business value and the change's intent
+- [x] Overview states what is delivered and why in 1–3 sentences
+- [x] All four sections present (Overview, Functional Requirements, Success Criteria, Assumptions)
+
+## Requirement Completeness
+
+- [x] Any [NEEDS CLARIFICATION] markers are genuine ambiguities (≤3) deferred to clarify — not unresolved guesses
+- [x] Each Functional Requirement is a single, testable MUST/SHOULD statement
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] Edge cases are folded into Functional Requirements or Assumptions
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] Every Functional Requirement maps to at least one Success Criterion
+- [x] Overview intent is reflected by the FR list (no orphan goals)
+- [x] No implementation details leak into the specification
+
+## Notes
+
+- This is a maintainability/internal-refactor feature, so "user/business value" is read as developer-facing value (one place to change the history-shape rule, no bug-class regression). FRs reference structural concepts (history entries, `substep`/`task` fields) because those ARE the domain vocabulary of the change, not incidental implementation choices.
+- No [NEEDS CLARIFICATION] markers: the issue's acceptance criteria are concrete. The TypeScript-vs-Python split is resolved via an informed default (TS primary, Python best-effort) rather than a clarification marker.
+- Self-check pass: all items pass. No spec rewrites needed.

--- a/specs/139-centralize-entry-discriminator/plan.md
+++ b/specs/139-centralize-entry-discriminator/plan.md
@@ -1,0 +1,56 @@
+# Plan — Centralize the step-level vs per-task entry discriminator
+
+## Summary
+
+The rule that classifies a `.spec-context.json` history entry as a step-level boundary (`substep == null && task == null`) vs a per-task implement finish (`task != null`) is re-derived inline across ~6 TypeScript call-sites, and `lastEntryIsCompletionFor` exists as two copies. This refactor adds two shared predicates — `isStepLevelEntry` and `isPerTaskEntry` — to `historyHelpers.ts`, routes every reader/derivation/manager check through them, collapses the duplicate `lastEntryIsCompletionFor` to the single exported one, and folds `HistoryEntryLike` into the canonical `HistoryEntry` (which already carries optional `task`). It is behavior-preserving: the golden-history contract test and full suite must pass unchanged.
+
+## Technical Context
+
+- **Language**: TypeScript 5.3+ (ES2022, strict). Python 3 for the capture scripts (best-effort, FR-008).
+- **Primary deps**: VS Code Extension API; Preact (webview). No new deps.
+- **Storage**: `.spec-context.json` per spec dir — read-only shape concern here; no schema change.
+- **Testing**: Jest (`ts-jest`). The golden contract is `src/features/specs/__tests__/readerShapeContract.test.ts`.
+- **Target**: Both the extension (`src/`) and webview (`webview/src/`) compile paths; both import from `historyHelpers`/types.
+- **Constraints**: Zero observable behavior change (FR-006); no test assertions weakened (FR-007); no new public extension API (Assumptions). Webview must not import extension-only modules — verify the shared predicate location is importable from both sides, or duplicate the trivial predicate webview-side rather than cross a module boundary that isn't already crossed.
+
+## Approach & Structure
+
+Order of attack — predicates first, then swap call-sites, then types, then Python, then verify.
+
+1. **`src/features/specs/historyHelpers.ts`** — add and export two predicates:
+   - `isStepLevelEntry(e): boolean` → `e.substep == null && e.task == null`
+   - `isPerTaskEntry(e): boolean` → `e.task != null`
+   Rewrite the existing `lastEntryIsCompletionFor` loop to use them (line ~33 currently inlines `e.substep != null || e.task != null`). This file's `lastEntryIsCompletionFor` becomes the single source.
+
+2. **`src/features/specs/specContextManager.ts`** — delete the local duplicate `lastEntryIsCompletionFor` (lines ~245-256); import it from `historyHelpers` (line ~218 call-site stays). Route `stepHasBeenStarted` (line ~262) and the completion skip (line ~252) through `isStepLevelEntry`/`isPerTaskEntry`.
+
+3. **`src/features/specs/stepHistoryDerivation.ts`** — replace the inline `t.substep == null && t.task == null` at line ~276 with `isStepLevelEntry`. Check `dedupeConsecutive` (lines ~140-148) and `rowName` (lines ~159-163) — route the per-task/substep distinction through the predicates where it's the same rule (keep `rowName`'s `substep ?? task` naming fallback as-is; that's display logic, not the discriminator).
+
+4. **`src/features/specs/lastTransition.ts`** — `entryLabel` (lines ~45-57) uses `entry.task`/`entry.substep` for labeling; route the per-task branch through `isPerTaskEntry`. Then **remove `HistoryEntryLike`** (lines ~16-23) and retype against canonical `HistoryEntry` (or a shared minimal pick that includes `task`) per FR-005.
+
+5. **`src/features/specs/specContextReader.ts`** — `normalizeHistoryKind` (lines ~228-239) branches on `e.substep == null`; align with `isStepLevelEntry` only if it preserves the existing kind-backfill semantics exactly (it currently keys on `substep` alone — verify substituting the task-aware predicate doesn't change backfilled kinds for legacy entries; if it would, leave the backfill as-is and note why).
+
+6. **`src/core/types/specContext.ts`** — confirm `HistoryEntry.task?: string` is the canonical field (it is, line ~93). Ensure the predicates' parameter type accepts the reader shapes (canonical + legacy duck-type). Mirror nothing new into `webview/src/spec-viewer/types.ts` unless a type moves.
+
+7. **Webview (`webview/src/spec-viewer/timelineEvents.ts`)** — `buildHistoryIndex` (line ~53) and `mergeStepEvents` (line ~89) inline `substep`/`task`. If `historyHelpers` is not already imported webview-side, add a tiny local `isStepLevelEntry`/`isPerTaskEntry` (or shared util under `webview/src/`) rather than importing across the extension boundary. Decision recorded below.
+
+8. **Python (FR-008, best-effort)** — `speckit-extension/scripts/write-context.py` and its installed mirror `.specify/extensions/companion/scripts/write-context.py` (`_has_complete` ~307-312, `_has_step_start` ~280-295), plus `.claude/skills/eval-speckit-extension/check_capture.py` (`_step_span` ~322-329). Add a module-level `_is_step_level(e)` / `_is_per_task(e)` helper in each script and route the inline checks through it. The two languages share the *rule*, not code. Edit the source script under `speckit-extension/scripts/`; the `.specify/...` copy is generated on install — change both to keep the working tree consistent but treat the source as authoritative.
+
+9. **Verify** — `npm run compile` (both tsconfigs), then `npm test`. The golden test (`readerShapeContract.test.ts`) and `messageHandlers.spec.ts` mock must pass with no edits. Grep for residual inline `substep == null`/`substep === null` discriminators at reader call-sites (SC-001) — only the predicate bodies should retain the comparison.
+
+## Decisions
+
+- **Webview duplication over cross-boundary import.** The extension's `historyHelpers.ts` lives under `src/`; webview code must not import from `src/`. If no shared util already bridges them, define the two one-line predicates locally in webview rather than introduce a new cross-boundary dependency. The rule is trivial and the duplication is intentional and symmetric (same as how `HistoryEntry` is already mirrored in `webview/src/spec-viewer/types.ts`).
+- **Predicate param type.** Accept a minimal structural shape (`{ substep?: string | null; task?: string | null }`) so both canonical `HistoryEntry` and the former `HistoryEntryLike` callers pass without casts — this is what lets FR-005 collapse `HistoryEntryLike` cleanly.
+
+## Out of Scope
+
+- No change to the `.spec-context.json` on-disk schema, status vocabulary, or history-shape rule itself.
+- No new public extension API, setting, command, or user-facing surface.
+- No timeline/badge/footer rendering behavior change; webview edits are mechanical predicate swaps.
+- No README/CHANGELOG entry (pure internal refactor); `docs/architecture.md` only if a module boundary actually moves (it should not — predicates land in the existing `historyHelpers.ts`).
+- Python is not required to share code with TypeScript — only the same rule.
+
+## Constitution Check
+
+Pass. No principle is at risk: this is a pure internal consolidation. Principle IV (Modular Architecture / avoid duplication) is directly advanced — collapsing two `lastEntryIsCompletionFor` copies and ~6 inline discriminators into shared predicates. No new provider, no pipeline change, no user-facing surface, so Principles I–III are untouched. No complexity violation to justify.

--- a/specs/139-centralize-entry-discriminator/spec.md
+++ b/specs/139-centralize-entry-discriminator/spec.md
@@ -1,0 +1,31 @@
+# Centralize the step-level vs per-task entry discriminator
+
+## Overview
+
+Every reader of a spec's `.spec-context.json` history must distinguish a step-level boundary entry from a per-task implement finish, but that rule (`substep == null && task == null`) is currently re-derived inline in ~6 places and the `lastEntryIsCompletionFor` helper is duplicated across two files. This delivers a single shared predicate so the same off-by-one bug class (steps reading as in-flight forever, or a per-task finish mislabeled as a step completion) cannot silently reappear and a future history-shape change touches one function instead of N.
+
+## Functional Requirements
+
+- **FR-001** The system MUST expose a single shared predicate that answers "is this history entry a step-level boundary?" defined as `substep == null && task == null`.
+- **FR-002** The system MUST expose a single shared predicate that answers "is this history entry a per-task entry?" defined as `task != null`.
+- **FR-003** Every history reader and derivation that currently inlines a step-level or per-task check MUST route through the shared predicates instead of an inline `substep`/`task` comparison. This covers, at minimum: step-history derivation (completion detection and row/label logic), the last-transition entry label, the spec-context reader normalization, and the spec-context manager's start/completion checks.
+- **FR-004** The `lastEntryIsCompletionFor` helper, currently duplicated in two files, MUST collapse to a single implementation that all callers import.
+- **FR-005** The structural history-entry type used by readers MUST model the `task` field; the duplicate `HistoryEntryLike` shape that omits `task` MUST be reconciled to the canonical `HistoryEntry` (or a shared minimal shape that includes `task`).
+- **FR-006** The refactor MUST NOT change any observable behavior: the same entries are classified the same way before and after, including the regression cases where a backstop per-task finish lands after the step-level completion and where a per-task finish must not be labeled as "Implement completed".
+- **FR-007** The existing golden-history reader contract test and the full test suite MUST pass unchanged (no test assertions weakened or removed to accommodate the refactor).
+- **FR-008** The Python capture scripts (`write-context.py`, `check_capture.py`) SHOULD adopt an equivalent shared step-level/per-task helper where it removes duplication; if a shared Python helper does not cleanly fit, their inline checks MUST at least be made consistent with the canonical rule.
+- **FR-009** A reader added later for a new entry shape MUST be able to rely on the shared predicate without re-deriving the step-level vs per-task rule.
+
+## Success Criteria
+
+- **SC-001** Exactly one definition each of the step-level predicate and the per-task predicate exists in the codebase; a search for inline `substep == null` / `substep === null` discriminators across the reader call-sites returns zero (only the shared predicate retains the comparison).
+- **SC-002** `lastEntryIsCompletionFor` is defined exactly once (down from two copies).
+- **SC-003** The full test suite, including the golden-history reader contract test, passes with no behavior change.
+- **SC-004** Changing the history-shape rule in the future requires editing a single function, not multiple call-sites.
+
+## Assumptions
+
+- The shared predicates live alongside the existing history helpers (`historyHelpers.ts`) or in a small dedicated module; no new public extension API is introduced.
+- The canonical `HistoryEntry` type (with optional `task`) is the source of truth; `HistoryEntryLike` is folded into it or a shared minimal shape that includes `task`.
+- The Python adoption (FR-008) is best-effort: TypeScript consolidation is the primary deliverable, and the two languages are not required to share code, only the same rule.
+- This is a pure internal refactor with no user-facing behavior, settings, or documentation surface change beyond the architecture doc if module boundaries shift.

--- a/specs/139-centralize-entry-discriminator/tasks.md
+++ b/specs/139-centralize-entry-discriminator/tasks.md
@@ -1,0 +1,42 @@
+# Tasks — Centralize the step-level vs per-task entry discriminator
+
+Dependency-ordered, organized by file/layer. Behavior-preserving refactor (FR-006/FR-007). Each task names the concrete file it edits.
+
+## Foundational (blocking — every later task depends on these)
+
+- [x] **T001** Add and export two predicates in `src/features/specs/historyHelpers.ts`: `isStepLevelEntry(e)` → `e.substep == null && e.task == null` (FR-001) and `isPerTaskEntry(e)` → `e.task != null` (FR-002). Type the param as a minimal structural shape `{ substep?: string | null; task?: string | null }` so canonical `HistoryEntry` and former `HistoryEntryLike` callers pass without casts.
+- [x] **T002** In `src/features/specs/historyHelpers.ts`, rewrite the existing `lastEntryIsCompletionFor` loop (~line 33) to use `isStepLevelEntry`/`isPerTaskEntry` instead of the inline `e.substep != null || e.task != null`. This becomes the single source for FR-004.
+
+## Core work (one file per task; depends on T001/T002)
+
+- [x] **T003**  [P] `src/features/specs/specContextManager.ts` — delete the local duplicate `lastEntryIsCompletionFor` (~lines 245-256) and import it from `historyHelpers`; route `stepHasBeenStarted` (~line 262) and the completion skip (~line 252) through `isStepLevelEntry`/`isPerTaskEntry` (FR-003, FR-004).
+- [x] **T004**  [P] `src/features/specs/stepHistoryDerivation.ts` — replace the inline `t.substep == null && t.task == null` (~line 276) with `isStepLevelEntry`; route the per-task/substep distinction in `dedupeConsecutive` (~lines 140-148) through the predicates where it is the same rule. Keep `rowName`'s `substep ?? task` naming fallback (~lines 159-163) as-is — display logic, not the discriminator (FR-003).
+- [x] **T005**  [P] `src/features/specs/lastTransition.ts` — route the per-task branch of `entryLabel` (~lines 45-57) through `isPerTaskEntry`; then remove `HistoryEntryLike` (~lines 16-23) and retype against canonical `HistoryEntry` / shared minimal pick that includes `task` (FR-003, FR-005).
+- [x] **T006**  [P] `src/features/specs/specContextReader.ts` — align `normalizeHistoryKind` (~lines 228-239) with `isStepLevelEntry` ONLY if it preserves the existing kind-backfill semantics exactly. It currently keys on `substep` alone; verify the task-aware predicate does not change backfilled kinds for legacy entries. If it would, leave the backfill as-is and add a one-line note why (FR-003, FR-006).
+
+## Integration (types — after the call-sites that consume them)
+
+- [x] **T007**  `src/core/types/specContext.ts` — confirm `HistoryEntry.task?: string` is the canonical field (~line 93) and that the predicates' param type accepts the reader shapes (canonical + legacy duck-type). No new type mirrored into `webview/src/spec-viewer/types.ts` unless a type actually moves (FR-005). Depends on T005.
+
+## Webview (separate compile boundary; do not import from `src/`)
+
+- [x] **T008**  `webview/src/spec-viewer/timelineEvents.ts` — replace inline `substep`/`task` checks in `buildHistoryIndex` (~line 53) and `mergeStepEvents` (~line 89). Per the plan decision, define tiny local `isStepLevelEntry`/`isPerTaskEntry` (or a shared util under `webview/src/`) rather than crossing the extension boundary (FR-003, FR-009).
+
+## Polish (Python best-effort, then verify)
+
+- [x] **T009**  [P] Python (FR-008, best-effort) — add a module-level `_is_step_level(e)`/`_is_per_task(e)` helper and route inline checks through it in `speckit-extension/scripts/write-context.py` (`_has_complete` ~307-312, `_has_step_start` ~280-295), its installed mirror `.specify/extensions/companion/scripts/write-context.py`, and `.claude/skills/eval-speckit-extension/check_capture.py` (`_step_span` ~322-329). Edit the source script under `speckit-extension/scripts/` as authoritative; keep the `.specify/...` mirror consistent.
+- [x] **T010**  Verify — run `npm run compile` (both tsconfigs) then `npm test`. The golden contract `src/features/specs/__tests__/readerShapeContract.test.ts` and `messageHandlers.spec.ts` mock MUST pass with no edits (FR-007, SC-003). Grep for residual inline `substep == null` / `substep === null` discriminators at reader call-sites — only the predicate bodies should retain the comparison (SC-001, SC-002). Depends on all prior tasks.
+
+## Dependencies
+
+- T001 → T002 (the rewrite uses the new predicates).
+- T002 blocks all of T003–T008 (every call-site imports/uses the shared predicates).
+- T005 → T007 (the type reconciliation follows the `HistoryEntryLike` removal in `lastTransition.ts`).
+- T009 is independent of the TypeScript chain (shares only the rule, not code).
+- T010 depends on everything (final compile + full-suite verification).
+
+## Parallel
+
+- After T002 lands, T003, T004, T005, T006 are `[P]` — distinct files, no shared incomplete dependency.
+- T009 `[P]` can run anytime (separate language/files).
+- T007 and T008 are not `[P]` with each other only by ordering preference; T008 has no TS-side dependency and may run alongside the T003–T006 batch.

--- a/src/features/specs/historyHelpers.ts
+++ b/src/features/specs/historyHelpers.ts
@@ -9,6 +9,26 @@
 import type { HistoryEntry, StepName } from '../../core/types/specContext';
 
 /**
+ * Minimal structural shape both predicates accept, so canonical `HistoryEntry`
+ * and the looser reader/`HistoryEntryLike` shapes pass without casts.
+ */
+type DiscriminatorEntry = { substep?: string | null; task?: string | null };
+
+/**
+ * True iff `e` is a step-level boundary entry (a step start/complete), not a
+ * substep marker or a per-task implement finish. The single source of the
+ * `substep == null && task == null` rule.
+ */
+export function isStepLevelEntry(e: DiscriminatorEntry): boolean {
+    return e.substep == null && e.task == null;
+}
+
+/** True iff `e` is a per-task implement finish (carries a `task` id). */
+export function isPerTaskEntry(e: DiscriminatorEntry): boolean {
+    return e.task != null;
+}
+
+/**
  * Walk `history` from newest to oldest and report whether the most recent
  * entry for `step` is a completion.
  *
@@ -26,11 +46,11 @@ export function lastEntryIsCompletionFor(
     for (let i = history.length - 1; i >= 0; i--) {
         const e = history[i];
         if (e.step !== step) continue;
-        // Per-task implement finishes (substep null + a task id) and substep entries
-        // aren't the step boundary — skip them and keep searching. The backstop can
-        // append task finishes AFTER the step-level complete, so returning here would
-        // report the step incomplete forever.
-        if (e.substep != null || e.task != null) continue;
+        // Per-task implement finishes and substep entries aren't the step boundary —
+        // skip them and keep searching. The backstop can append task finishes AFTER
+        // the step-level complete, so returning here would report the step
+        // incomplete forever.
+        if (!isStepLevelEntry(e)) continue;
         if (e.kind === 'complete') return true;
         if (e.kind == null && e.from?.step === step) return true;
         return false;

--- a/src/features/specs/lastTransition.ts
+++ b/src/features/specs/lastTransition.ts
@@ -1,4 +1,5 @@
-import { StepName } from '../../core/types/specContext';
+import { HistoryEntry, StepName } from '../../core/types/specContext';
+import { isPerTaskEntry } from './historyHelpers';
 
 export interface LastTransition {
     /** Human label for the most recent history entry, e.g. "Plan started". */
@@ -10,20 +11,16 @@ export interface LastTransition {
 }
 
 /**
- * Minimal structural shape of a history entry. Accepts both the canonical
- * `HistoryEntry` (has `kind`) and the reader's `TransitionEntry` (no `kind`).
+ * Minimal reader-facing view of a canonical `HistoryEntry`: the fields this
+ * module reads, all optional with `step` widened so the legacy `TransitionEntry`
+ * (no `kind`) also assigns.
  */
-interface HistoryEntryLike {
+type HistoryEntryView = Partial<Pick<HistoryEntry, 'substep' | 'task' | 'kind' | 'at'>> & {
     step?: string | null;
-    substep?: string | null;
-    /** Per-task id on implement finishes (substep is null on these). */
-    task?: string | null;
-    kind?: string;
-    at?: string;
-}
+};
 
 interface HistoryHolder {
-    history?: ReadonlyArray<HistoryEntryLike> | null;
+    history?: ReadonlyArray<HistoryEntryView> | null;
 }
 
 const STEP_LABELS: Record<StepName, string> = {
@@ -42,10 +39,10 @@ function stepLabel(step: StepName | string | null | undefined): string {
     return STEP_LABELS[step as StepName] ?? String(step);
 }
 
-function entryLabel(entry: HistoryEntryLike): string {
-    // A per-task implement finish (substep null + a task id) must read as that task,
-    // not as the step's completion — otherwise "T004 done" renders "Implement completed".
-    if (entry.task) {
+function entryLabel(entry: HistoryEntryView): string {
+    // A per-task implement finish must read as that task, not as the step's
+    // completion — otherwise "T004 done" renders "Implement completed".
+    if (isPerTaskEntry(entry)) {
         return `${stepLabel(entry.step)} · ${entry.task}`;
     }
     if (entry.substep) {

--- a/src/features/specs/specContextManager.ts
+++ b/src/features/specs/specContextManager.ts
@@ -33,6 +33,7 @@ import {
 } from './specContextWriter';
 import { normalizeSpecContext } from './specContextReader';
 import { seedProfileForNewSpec } from './profileDispatch';
+import { isStepLevelEntry, lastEntryIsCompletionFor } from './historyHelpers';
 
 /**
  * Try reading a JSON file, return parsed content or undefined.
@@ -242,24 +243,11 @@ export async function updateStepProgress(
     });
 }
 
-function lastEntryIsCompletionFor(history: HistoryEntry[], step: StepName): boolean {
-    for (let i = history.length - 1; i >= 0; i--) {
-        const e = history[i];
-        if (e.step !== step) continue;
-        // Per-task finishes are now `substep: null` with `task` set — they are NOT
-        // the step boundary, so skip them and look for the last step-level entry.
-        // Otherwise a mid-implement task finish reads as the step's completion.
-        if (e.task != null) continue;
-        return e.kind === 'complete' && e.substep == null;
-    }
-    return false;
-}
-
 /** True iff `history` contains any *start* entry for `step` (not a completion). */
 function stepHasBeenStarted(history: HistoryEntry[], step: StepName): boolean {
     for (const e of history) {
         if (e.step !== step) continue;
-        if (e.substep != null || e.task != null) continue;
+        if (!isStepLevelEntry(e)) continue;
         if (e.kind === 'start') return true;
     }
     return false;

--- a/src/features/specs/specContextReader.ts
+++ b/src/features/specs/specContextReader.ts
@@ -229,6 +229,9 @@ function normalizeHistoryKind(entries: HistoryEntry[]): HistoryEntry[] {
     return entries.map(e => {
         if (e.kind) return e;
         let kind: HistoryEntryKind;
+        // Keyed on `substep` alone (not the task-aware isStepLevelEntry): a legacy
+        // per-task entry must keep using the step self-loop rule, so substituting
+        // the predicate would change its backfilled kind.
         if (e.substep == null) {
             kind = e.from?.step === e.step ? 'complete' : 'start';
         } else {

--- a/src/features/specs/stepHistoryDerivation.ts
+++ b/src/features/specs/stepHistoryDerivation.ts
@@ -42,6 +42,7 @@ import {
     SubstepEntry,
 } from '../../core/types/specContext';
 import { SpecStatuses } from '../../core/constants';
+import { isStepLevelEntry } from './historyHelpers';
 
 /**
  * Canonical spec-status derivation. Single entry point for "given a context
@@ -273,7 +274,7 @@ export function deriveStepHistory(
         // otherwise a trailing task finish hides the real completion and the step
         // renders in-flight forever.
         const lastStepLevel = [...g.transitions].reverse()
-            .find(t => t.substep == null && t.task == null);
+            .find(isStepLevelEntry);
         const lastOwnIsCompletion = lastStepLevel?.kind === 'complete';
 
         if (g.nextStepFirstIdx !== -1) {

--- a/webview/src/spec-viewer/timelineEvents.ts
+++ b/webview/src/spec-viewer/timelineEvents.ts
@@ -17,6 +17,16 @@ import type { HistoryEntry, StepHistoryEntry, SubstepEntry } from './types';
 export type TimelineEventSource = 'tracked' | 'logged';
 
 /**
+ * Step-level vs per-task discriminators. Intentionally duplicated from the
+ * extension's `historyHelpers` (the webview must not import from `src/`); the
+ * rule is trivial and kept symmetric with the extension side.
+ */
+type DiscriminatorEntry = { substep?: string | null; task?: string | null };
+const isStepLevelEntry = (e: DiscriminatorEntry): boolean =>
+    e.substep == null && e.task == null;
+const isPerTaskEntry = (e: DiscriminatorEntry): boolean => e.task != null;
+
+/**
  * Substeps land on disk in two shapes:
  *   - array form: `Array<{name, startedAt, completedAt}>`
  *   - record form: `Record<name, {startedAt, completedAt}>`
@@ -48,8 +58,10 @@ export function buildHistoryIndex(
 ): Map<string, HistoryEntry> {
     const map = new Map<string, HistoryEntry>();
     for (const t of history) {
-        // Per-task implement entries carry a null `substep` + a `task` id; index
-        // them by task so the tracked row (named after the task) resolves its actor.
+        // Skip step-level boundaries; index substep and per-task entries. Per-task
+        // entries carry a null `substep` + a `task` id, so they index by task —
+        // the tracked row (named after the task) resolves its actor.
+        if (isStepLevelEntry(t)) continue;
         const name = t.substep || t.task;
         if (!name) continue;
         const key = `${t.step}:${name}`;
@@ -86,6 +98,9 @@ export function mergeStepEvents(
 
     for (const tx of history) {
         if (tx.step !== step) continue;
+        // Logged-only events are substep-bearing; skip step-level boundaries and
+        // per-task finishes (both substep null) — they surface via tracked rows.
+        if (isStepLevelEntry(tx) || isPerTaskEntry(tx)) continue;
         if (!tx.substep) continue;
         if (trackedNames.has(tx.substep)) continue;
         // A completion entry's `from.substep === substep` (self-loop). Skip;


### PR DESCRIPTION
## Summary
Every reader of a spec's `.spec-context.json` history has to tell a step boundary apart from a per-task implement finish, and that rule was copy-pasted inline in ~6 places (with a helper duplicated across two files). This consolidates it into one shared predicate pair so the same off-by-one bug class can't silently reappear and a future history-shape change touches one function instead of N. Pure internal refactor — no observable behavior change.

## Technical
- New `isStepLevelEntry` (`substep == null && task == null`) and `isPerTaskEntry` (`task != null`) exported from `src/features/specs/historyHelpers.ts`; `lastEntryIsCompletionFor` rewritten to use them and now the single definition.
- Call-sites rerouted: `specContextManager` (deleted its duplicate helper, imports the shared one), `stepHistoryDerivation`, `lastTransition` (and `HistoryEntryLike` folded into a minimal `Pick` off canonical `HistoryEntry`).
- Webview `timelineEvents.ts` gets local symmetric predicates — intentionally duplicated rather than importing across the `src/` → webview boundary.
- Python capture scripts (`write-context.py` + installed mirror, `check_capture.py`) get an equivalent `_is_step_level`/`_is_per_task` helper.
- `normalizeHistoryKind`'s legacy kind-backfill is **intentionally** left keyed on `substep` alone — substituting the task-aware predicate would change backfilled kinds for legacy per-task entries (FR-006). Noted inline.

## Review checklist
- ✅ **VS Code extension (viewer/spec-context)** — affected
    - reader helpers: `historyHelpers`, `specContextManager`, `specContextReader`, `stepHistoryDerivation`, `lastTransition`
    - webview: `timelineEvents.ts` predicate swap (local, no boundary cross)
- ✅ **SpecKit extension (scripts) + eval** — affected
    - `speckit-extension/scripts/write-context.py` + installed mirror
    - `.claude/skills/eval-speckit-extension/check_capture.py`
- ✅ **Changelog** — n/a
    - pure internal refactor, no user-facing behavior (per CLAUDE.md Out of Scope)
- ⚠️ **Docs** — `docs/capture-and-timing.md` not touched
    - docs-map flags it for `write-context.py`/`check_capture.py` changes, but this is a behavior-preserving helper extraction — the doc's capture model, install paths, and eval assertions are all still accurate, so no content change was warranted
- ✅ **Verify**
    - `npm run compile` (extension tsconfig) clean
    - `npm run compile-web` (webpack) clean
    - `npm test` — 75 suites / 899 tests pass, golden `readerShapeContract` + `messageHandlers` mock unchanged
    - grep confirms SC-001/SC-002: residual `substep` comparisons only in predicate bodies + the noted backfill + `rowName` display
    - no version bump

## Gaps / how to see it
- No follow-up scope — single-function future history-shape changes are now possible (SC-004).
- Try: open any spec in the viewer and confirm the timeline/last-transition still label per-task implement finishes by task (not "Implement completed"), and steps still resolve as complete.

Closes #240

🤖 Generated with [Claude Code](https://claude.com/claude-code)
