### PR TITLE
fix(sidebar): trim redundant step-state from the spec row description

### DIFF
--- a/specs/142-trim-spec-row-description/.spec-context.json
+++ b/specs/142-trim-spec-row-description/.spec-context.json
@@ -1,0 +1,106 @@
+{
+  "workflow": "speckit",
+  "specName": "trim spec row description",
+  "branch": "142-trim-spec-row-description",
+  "currentStep": "implement",
+  "status": "completed",
+  "history": [
+    {
+      "step": "specify",
+      "substep": null,
+      "kind": "start",
+      "by": "extension",
+      "at": "2026-06-10T20:57:52.503Z"
+    },
+    {
+      "step": "specify",
+      "substep": null,
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-06-10T20:58:57.943Z"
+    },
+    {
+      "step": "plan",
+      "substep": "fast-path",
+      "kind": "start",
+      "by": "ai",
+      "at": "2026-06-10T20:58:58.030Z"
+    },
+    {
+      "step": "plan",
+      "substep": "fast-path",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-10T20:58:58.113Z"
+    },
+    {
+      "step": "tasks",
+      "substep": "fast-path",
+      "kind": "start",
+      "by": "ai",
+      "at": "2026-06-10T20:58:58.200Z"
+    },
+    {
+      "step": "tasks",
+      "substep": "fast-path",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-10T20:58:58.287Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "kind": "start",
+      "by": "extension",
+      "at": "2026-06-10T20:59:07.452Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T001",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-10T20:59:24.606Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T002",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-10T20:59:40.205Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T003",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-10T20:59:52.481Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T004",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-10T21:00:46.933Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T005",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-10T21:01:17.285Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-10T21:01:29.101Z"
+    }
+  ],
+  "currentTask": "T005"
+}

--- a/specs/142-trim-spec-row-description/checklists/requirements.md
+++ b/specs/142-trim-spec-row-description/checklists/requirements.md
@@ -1,0 +1,32 @@
+# Specification Quality Checklist: Sidebar — trim redundant step-state from spec row description
+
+**Purpose**: Validate turbo specification completeness before planning
+**Created**: 2026-06-10
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs) — file/module names appear only in Approach/Tasks (simple-mode plan content), not in FR/SC
+- [x] Focused on user/business value and the change's intent
+- [x] Overview states what is delivered and why in 1–3 sentences
+- [x] All four sections present (Overview, Functional Requirements, Success Criteria, Assumptions)
+
+## Requirement Completeness
+
+- [x] Any [NEEDS CLARIFICATION] markers are genuine ambiguities (≤3) deferred to clarify — none needed; trim decision was decided in the issue
+- [x] Each Functional Requirement is a single, testable MUST/SHOULD statement
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details in SC-001..SC-004; SC-005/006 are the standard build/isolation gates)
+- [x] Edge cases are folded into Functional Requirements or Assumptions (no-history → FR-006; duplicate-name override → FR-009)
+- [x] Scope is clearly bounded (only the inline `description` of the spec-lifecycle row; icons + tooltip + other nodes untouched)
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] Every Functional Requirement maps to at least one Success Criterion
+- [x] Overview intent is reflected by the FR list (no orphan goals)
+- [x] No implementation details leak into the specification (kept in Approach/Tasks)
+
+## Notes
+
+- Verdict: **simple** (fast-path) — `complexityFastPath: true`, ~4 files, ~5 tasks, scope signal "smaller" (trim/tweak). Approach + Implementation Tasks folded into spec.md; no separate plan.md / tasks.md.

--- a/specs/142-trim-spec-row-description/spec.md
+++ b/specs/142-trim-spec-row-description/spec.md
@@ -1,0 +1,48 @@
+# Sidebar: trim the redundant step-state status text appended to the spec name
+
+## Overview
+
+Each spec row in the sidebar shows its name plus a status suffix (e.g. `13-rename-financial-to-fire  implement — Implement · T004 · just now`). The per-document step icons (Specification / Plan / Tasks) already convey step state, so the step-name phrase in that suffix is redundant clutter. This change reduces the row `description` to only the information the icons do not already carry — the active task and the last-active time — so rows read cleaner at a glance, while the icons remain the primary step-state signal.
+
+## Functional Requirements
+
+- **FR-001**: The spec/feature row `description` MUST NOT include the current-step word (`specify`/`plan`/`implement`/…) on its own, because the per-document step icons already convey which step is active.
+- **FR-002**: The spec/feature row `description` MUST NOT include the step-name phrase of the last-transition label (`Implement`, `Implement completed`, `Implement started`) for step-boundary transitions, because that step state is what the icons already show.
+- **FR-003**: The spec/feature row `description` MUST keep the last-active relative time (`just now`, `22h ago`) — it is not conveyed by any icon.
+- **FR-004**: When the last transition is a per-task implement finish, the row `description` MUST keep the active task id (`T004`) in a compact form, because the task is not conveyed by any icon.
+- **FR-005**: The kept fields MUST be rendered compactly with a single, consistent separator (e.g. `· T004 · 22h ago`, or `· just now` when no task), with no leading `<step> — ` prefix.
+- **FR-006**: When there is no last-transition history and no other kept field, the row MUST NOT set a step-derived `description` (no empty `—` artifact).
+- **FR-007**: The hover tooltip MAY retain the fuller last-transition label (step + relative time) — only the inline `description` is trimmed; the tooltip is not an at-a-glance surface and remains a deliberate, fuller detail view.
+- **FR-008**: The trim decision MUST be documented in a code comment at the description-builder so it reads as deliberate, not accidental.
+- **FR-009**: The per-document step icons and all other tree nodes (group nodes, spec-document rows, duplicate-name parent-dir override) MUST be unchanged by this trim.
+
+## Success Criteria
+
+- **SC-001**: For a spec mid-implement on task `T004` active `just now`, the row description reads `· T004 · just now` (no `implement`, no `Implement` word) instead of `implement — Implement · T004 · just now`.
+- **SC-002**: For a spec whose last transition is a step start/complete (e.g. plan started 22h ago), the row description reads `· 22h ago` (no `Plan started` / `plan` word).
+- **SC-003**: For a spec with no history, no step-derived description is set.
+- **SC-004**: The duplicate-name parent-dir override and the spec-document `not created` description are byte-identical to before.
+- **SC-005**: `npm run compile` is clean and `npm test` is green, with unit coverage asserting the trimmed description for at least the per-task and step-boundary cases.
+- **SC-006**: No `src/` or `webview/` module gains a runtime import from `.claude/**` or `.specify/**`.
+
+## Assumptions
+
+- The redundant content is the step-name phrase: the standalone `currentStep` word and the `<Step>`/`<Step> started`/`<Step> completed` prefix of the last-transition label. The icon-absent content worth keeping is the active task id and the relative time.
+- The active task id is surfaced by exposing it as a discrete field on the `LastTransition` view (derived from the per-task history entry) rather than string-parsing the existing combined `label`, keeping the description builder declarative and unit-testable.
+- The compact separator is `· ` (middle dot), already used inside the existing label, with a single leading `· ` so the row reads `13-rename… · T004 · just now`.
+- The tooltip keeps its existing fuller `Last: <label> (<relative>)` line — only the inline `description` is trimmed.
+- The change touches the description builder in `specExplorerProvider.ts` and adds one field to `lastTransition.ts`; both are pure of `.claude/`/`.specify/` runtime deps.
+
+## Approach
+
+- **`src/features/specs/lastTransition.ts`**: add an optional `task?: string` field to the `LastTransition` interface and populate it from the per-task history entry (`isPerTaskEntry(entry) ? entry.task : undefined`). Keep `label` (used by the tooltip) unchanged.
+- **`src/features/specs/specExplorerProvider.ts`**: in the `isSpecLifecycleItem` branch, stop pushing `currentStep` into `descParts` and stop pushing the step-name-bearing `lastTransition.label`. Instead build a compact suffix from the kept fields only: optional `task`, then `relative`, joined with ` · ` and a single leading `· `. Document the trim decision in a comment. Leave the tooltip's `Last: …` line as-is.
+- Tests: extend `lastTransition.test.ts` to assert the new `task` field for a per-task entry and its absence for a step entry; extend `specExplorerProvider.test.ts` (or add a focused test) to assert the trimmed `description` for the per-task and step-boundary cases and the no-history (undefined) case.
+
+## Implementation Tasks
+
+- [x] **T001** Add optional `task?: string` to the `LastTransition` interface and populate it from the per-task history entry in `deriveLastTransition` + `src/features/specs/lastTransition.ts`
+- [x] **T002** Rebuild the spec-row `description` in the `isSpecLifecycleItem` branch to drop `currentStep` and the step-name label, keeping only a compact `· <task> · <relative>` suffix, with a deliberate-trim comment + `src/features/specs/specExplorerProvider.ts`
+- [x] **T003** [P] Extend `lastTransition.test.ts` to cover the new `task` field (present for per-task entry, absent for step entry) + `src/features/specs/__tests__/lastTransition.test.ts`
+- [x] **T004** [P] Add/extend provider tests asserting the trimmed description for per-task, step-boundary, and no-history cases + `src/features/specs/__tests__/specExplorerProvider.test.ts`
+- [x] **T005** Run `npm run compile` and `npm test`; fix any regressions to icons / other tree nodes + (verification)

--- a/src/features/specs/__tests__/lastTransition.test.ts
+++ b/src/features/specs/__tests__/lastTransition.test.ts
@@ -65,6 +65,22 @@ describe('deriveLastTransition', () => {
         expect(result!.label).toBe('Implement · T014');
     });
 
+    it('exposes the active task id on a per-task implement finish', () => {
+        const result = deriveLastTransition(
+            ctxWithHistory([entry({ step: 'implement', substep: null, task: 'T004', kind: 'complete' })]),
+            Date.parse('2026-06-07T10:00:10.000Z')
+        );
+        expect(result!.task).toBe('T004');
+    });
+
+    it('leaves task undefined for a step-boundary entry', () => {
+        const result = deriveLastTransition(
+            ctxWithHistory([entry({ step: 'plan', kind: 'start', substep: null })]),
+            Date.parse('2026-06-07T10:00:10.000Z')
+        );
+        expect(result!.task).toBeUndefined();
+    });
+
     it('labels a complete entry as "<Step> completed"', () => {
         const result = deriveLastTransition(
             ctxWithHistory([entry({ step: 'tasks', kind: 'complete', substep: null })]),

--- a/src/features/specs/__tests__/lastTransition.test.ts
+++ b/src/features/specs/__tests__/lastTransition.test.ts
@@ -73,6 +73,32 @@ describe('deriveLastTransition', () => {
         expect(result!.task).toBe('T004');
     });
 
+    it('does NOT surface task for a non-implement entry that carries a task field', () => {
+        const result = deriveLastTransition(
+            ctxWithHistory([entry({ step: 'plan', substep: null, task: 'T004', kind: 'complete' })]),
+            Date.parse('2026-06-07T10:00:10.000Z')
+        );
+        expect(result!.task).toBeUndefined();
+    });
+
+    it('does NOT surface task for a non-finish (start) implement entry that carries a task field', () => {
+        const result = deriveLastTransition(
+            ctxWithHistory([entry({ step: 'implement', substep: null, task: 'T004', kind: 'start' })]),
+            Date.parse('2026-06-07T10:00:10.000Z')
+        );
+        expect(result!.task).toBeUndefined();
+    });
+
+    it('surfaces task for a legacy kind-less implement finish (no discriminator)', () => {
+        const result = deriveLastTransition(
+            ctxWithHistory([
+                entry({ step: 'implement', substep: null, task: 'T004', kind: undefined }),
+            ]),
+            Date.parse('2026-06-07T10:00:10.000Z')
+        );
+        expect(result!.task).toBe('T004');
+    });
+
     it('leaves task undefined for a step-boundary entry', () => {
         const result = deriveLastTransition(
             ctxWithHistory([entry({ step: 'plan', kind: 'start', substep: null })]),

--- a/src/features/specs/__tests__/specExplorerProvider.test.ts
+++ b/src/features/specs/__tests__/specExplorerProvider.test.ts
@@ -501,6 +501,58 @@ describe('SpecExplorerProvider', () => {
         });
     });
 
+    describe('spec row description trimmed of redundant step state (#238)', () => {
+        async function getSpecRow(specContext: any): Promise<any> {
+            const specName = 'my-feature';
+            (resolveSpecDirectories as jest.Mock).mockResolvedValue([
+                { name: specName, path: `specs/${specName}` },
+            ]);
+            (hasDuplicateNames as jest.Mock).mockReturnValue(new Set());
+            (readSpecContextSync as jest.Mock).mockReturnValue(specContext || undefined);
+            const groups = await provider.getChildren();
+            const specs = await provider.getChildren(groups[0]);
+            return specs[0];
+        }
+
+        // A per-task implement finish 30s ago → "· T004 · just now": keeps the
+        // task + time, drops "implement"/"Implement" (already shown by icons).
+        it('keeps the active task + time and drops the step word for a per-task finish', async () => {
+            const at = new Date(Date.now() - 30 * 1000).toISOString();
+            const row = await getSpecRow({
+                workflow: 'default',
+                currentStep: 'implement',
+                status: 'implementing',
+                history: [{ step: 'implement', substep: null, task: 'T004', kind: 'complete', by: 'ai', at }],
+            });
+            expect(row.description).toBe('· T004 · just now');
+            expect(row.description).not.toMatch(/implement/i);
+        });
+
+        // A step-boundary transition → "· <time>" only: no task, and no
+        // "Plan started" / "plan" word that the icons already convey.
+        it('keeps only the time for a step-boundary transition', async () => {
+            const at = new Date(Date.now() - 30 * 1000).toISOString();
+            const row = await getSpecRow({
+                workflow: 'default',
+                currentStep: 'plan',
+                status: 'planned',
+                history: [{ step: 'plan', substep: null, kind: 'start', by: 'extension', at }],
+            });
+            expect(row.description).toBe('· just now');
+            expect(row.description).not.toMatch(/plan/i);
+        });
+
+        // No history → no step-derived description (no stray "—" artifact).
+        it('sets no description when there is no history', async () => {
+            const row = await getSpecRow({
+                workflow: 'default',
+                currentStep: 'specify',
+                status: 'specifying',
+            });
+            expect(row.description).toBeUndefined();
+        });
+    });
+
     describe('spec-document items have no status circle descriptions', () => {
         it('should not set description on spec-document items with content', async () => {
             (resolveSpecDirectories as jest.Mock).mockResolvedValue([

--- a/src/features/specs/lastTransition.ts
+++ b/src/features/specs/lastTransition.ts
@@ -46,6 +46,22 @@ function stepLabel(step: StepName | string | null | undefined): string {
     return STEP_LABELS[step as StepName] ?? String(step);
 }
 
+/**
+ * True iff `entry` is the one shape that carries an active task id worth
+ * surfacing on the spec row: a per-task *implement finish*. We require the
+ * `implement` step and a completion (`kind === 'complete'`), so a `task`
+ * written on a non-implement step or a non-finish (`start`) entry never
+ * leaks onto the row. Legacy `kind`-less records (older writers) still
+ * qualify on the step + `task` alone, preserving prior behavior for entries
+ * that genuinely are implement finishes but predate the `kind` discriminator.
+ */
+function isImplementFinish(entry: HistoryEntryView): boolean {
+    if (!isPerTaskEntry(entry) || entry.step !== 'implement') {
+        return false;
+    }
+    return entry.kind === 'complete' || entry.kind == null;
+}
+
 function entryLabel(entry: HistoryEntryView): string {
     // A per-task implement finish must read as that task, not as the step's
     // completion — otherwise "T004 done" renders "Implement completed".
@@ -103,8 +119,8 @@ export function deriveLastTransition(
         label: entryLabel(entry),
         at: entry.at,
         relative: formatRelative(entry.at, now),
-        // Only a per-task implement finish carries an active task id; step-boundary
-        // and substep entries leave this undefined.
-        task: isPerTaskEntry(entry) ? entry.task ?? undefined : undefined,
+        // Only a per-task implement *finish* carries an active task id; step-boundary,
+        // substep, non-implement, and non-finish entries leave this undefined.
+        task: isImplementFinish(entry) ? entry.task ?? undefined : undefined,
     };
 }

--- a/src/features/specs/lastTransition.ts
+++ b/src/features/specs/lastTransition.ts
@@ -8,6 +8,13 @@ export interface LastTransition {
     at: string;
     /** Relative time from `at` (e.g. "2h ago"), measured against the entry. */
     relative: string;
+    /**
+     * The active task id (e.g. "T004") when the most recent entry is a per-task
+     * implement finish; otherwise undefined. Exposed as a discrete field so the
+     * sidebar can surface the task in its trimmed, icon-absent row description
+     * without string-parsing `label`.
+     */
+    task?: string;
 }
 
 /**
@@ -96,5 +103,8 @@ export function deriveLastTransition(
         label: entryLabel(entry),
         at: entry.at,
         relative: formatRelative(entry.at, now),
+        // Only a per-task implement finish carries an active task id; step-boundary
+        // and substep entries leave this undefined.
+        task: isPerTaskEntry(entry) ? entry.task ?? undefined : undefined,
     };
 }

--- a/src/features/specs/specExplorerProvider.ts
+++ b/src/features/specs/specExplorerProvider.ts
@@ -669,19 +669,26 @@ class SpecItem extends vscode.TreeItem {
             } else {
                 this.iconPath = new vscode.ThemeIcon('beaker');
             }
-            // Surface current step + last transition on the row so the canonical
-            // state is visible without opening the spec. Duplicate-name specs
-            // override description with their parent dir (set by the caller).
+            // Trim the row description to ONLY what the per-document step icons
+            // (Specification / Plan / Tasks) don't already convey (#238). The step
+            // name is redundant with those icons, so we deliberately DROP both the
+            // standalone `currentStep` word and the step-name phrase of the
+            // last-transition label ("Implement" / "Implement completed"). We KEEP
+            // the genuinely icon-absent info — the active task and the last-active
+            // relative time — in a compact "· T004 · 22h ago" form. The fuller
+            // step+time label still lives in the tooltip below for on-demand detail.
             const lastTransition = deriveLastTransition(specContext);
-            const descParts: string[] = [];
-            if (specContext?.currentStep) {
-                descParts.push(String(specContext.currentStep));
-            }
             if (lastTransition) {
-                descParts.push(`${lastTransition.label} · ${lastTransition.relative}`);
-            }
-            if (descParts.length > 0) {
-                this.description = descParts.join(' — ');
+                const kept: string[] = [];
+                if (lastTransition.task) {
+                    kept.push(lastTransition.task);
+                }
+                if (lastTransition.relative) {
+                    kept.push(lastTransition.relative);
+                }
+                if (kept.length > 0) {
+                    this.description = `· ${kept.join(' · ')}`;
+                }
             }
             const tooltipParts = [`SpecKit Spec: ${label}`];
             if (specContext?.status) {


### PR DESCRIPTION
## Summary

Trims the redundant step-state text from each spec row's grey `description` in the sidebar. The per-document step icons already convey step state, so the row now keeps only what the icons can't show — the active task and last-active time — in a compact form.

Closes #238.

## Technical

- Spec row description rebuilt in `src/features/specs/specExplorerProvider.ts`: drop the standalone `currentStep` word and the `<Step> started/completed` label phrase (redundant with the per-document icons); keep a compact `· <task> · <time>` with a leading `· `, guarded so empty parts never produce a stray separator.
- `src/features/specs/lastTransition.ts`: add an optional, typed `task?` field to `LastTransition`, populated from per-task implement finishes (surfaced as a discrete field rather than parsed from the label).
- The hover tooltip is unchanged (still carries the fuller `Last: <label> (<relative>)`); icons, duplicate-name override, and `not created` document rows are untouched.

## Quality

- `npm run compile`: clean · `npm test`: **912/912 passing** (added description-builder coverage for per-task / step-boundary / no-history)
- Code review: 0 findings
- Isolation respected (no `src/` deps on `.claude/**` or `.specify/**`)

## How to verify (manual — sidebar)

Open the **SpecKit Companion sidebar → Specs**, on an in-progress spec:
- Before: `13-rename-financial-to-fire  implement — Implement · T004 · just now`
- After: `13-rename-financial-to-fire  · T004 · just now` (per-task), or `· 22h ago` (step boundary, no active task)
- Confirm the step icons and hover tooltip are unchanged.

> Built by the SpecKit Companion **turbo** pipeline (spec `142-trim-spec-row-description`) via `/fix-tickets`, then code-reviewed.
