### PR TITLE
fix(spec-viewer): looping-arrows in-progress glyph + lock in-flight clearing (#229)

### DIFF
--- a/docs/viewer-states.md
+++ b/docs/viewer-states.md
@@ -144,12 +144,20 @@
 > pulse remain the ambient "AI is working" cues; the sidebar's
 > per-row Archive remains as an escape hatch.
 >
-> **Step-tab in-flight pill size**: The active step's
-> `.step-status` badge stays at the same 16×16 size as the
-> completed checkmark while empty, only widening to a pill when
-> there's a `taskCompletionPercent` to show on the implement step.
-> Implemented via `:not(:empty)` in
-> `webview/styles/spec-viewer/_navigation.css`.
+> **Step-tab in-flight indicator (spec 147, #229)**: While a
+> specify / plan / tasks step is running, its `.step-status`
+> renders a spinning `sync` codicon (looping arrows) — a
+> `<span class="codicon codicon-sync step-status__sync">` colored
+> with the `--purple` theme var and spun via the shared `spin`
+> keyframe. This replaced the earlier filled-circle dot: looping
+> arrows read as "actively working" at a glance. The glyph is
+> rendered only when `canonicalState === 'in-flight'` and there is
+> no percentage to show, so it **disappears the instant the step
+> completes** (a `completedAt` is recorded or `activeStep` moves
+> off the step — no manual refresh). The implement step keeps its
+> `taskCompletionPercent` pill (the `:not(:empty)` widening path) —
+> the glyph applies only to the empty in-flight case. Implemented
+> in `StepTab.tsx` + `webview/styles/spec-viewer/_navigation.css`.
 >
 > **Footer overflow note (future-proofing)**: After this redesign
 > the right-side bar typically holds 1–3 buttons. If more lifecycle
@@ -415,7 +423,7 @@ stateDiagram-v2
 |-------|---------|--------|
 | `exists` | File exists on disk | Green checkmark dot + bright label (normal weight) |
 | `viewing` | Currently displayed in viewer | Accent-tinted fill + inset accent ring wrapping the whole tab + bold bright label |
-| `working` | Step being worked on (from `spec-context.step`, only if not completed) | Pulsing green glow on dot + live elapsed timer (e.g. `3m 22s`) rendered via `.step-tab__elapsed` |
+| `working` | Step being worked on (from `spec-context.step`, only if not completed) | Spinning `sync` codicon (looping arrows, `.step-status__sync`) + live elapsed timer (e.g. `3m 22s`) via `.step-tab__elapsed`; both clear the moment the step completes |
 | `tasks-active` | Viewing tasks with 0-100% progress | Percentage badge in dot |
 | `in-progress` | Tasks have progress but not viewing | Percentage in dot (subtle) |
 | `workflow` | Current workflow phase (not viewing) | Bright label |

--- a/specs/147-step-tab-sync-glyph/.spec-context.json
+++ b/specs/147-step-tab-sync-glyph/.spec-context.json
@@ -1,0 +1,143 @@
+{
+  "workflow": "speckit",
+  "specName": "step tab sync glyph",
+  "branch": "147-step-tab-sync-glyph",
+  "currentStep": "implement",
+  "status": "implemented",
+  "history": [
+    {
+      "step": "specify",
+      "substep": null,
+      "kind": "start",
+      "by": "extension",
+      "at": "2026-06-11T10:13:18.408Z"
+    },
+    {
+      "step": "specify",
+      "substep": null,
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-06-11T10:13:58.148Z"
+    },
+    {
+      "step": "plan",
+      "substep": null,
+      "kind": "start",
+      "by": "extension",
+      "at": "2026-06-11T10:14:06.971Z"
+    },
+    {
+      "step": "plan",
+      "substep": "research",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-11T10:14:42Z"
+    },
+    {
+      "step": "plan",
+      "substep": "design",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-11T10:14:43Z"
+    },
+    {
+      "step": "plan",
+      "substep": null,
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-11T10:14:50Z"
+    },
+    {
+      "step": "tasks",
+      "substep": null,
+      "kind": "start",
+      "by": "extension",
+      "at": "2026-06-11T10:14:57.480Z"
+    },
+    {
+      "step": "tasks",
+      "substep": "generate",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-11T10:15:20Z"
+    },
+    {
+      "step": "tasks",
+      "substep": null,
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-11T10:15:21Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "kind": "start",
+      "by": "extension",
+      "at": "2026-06-11T10:15:28.405Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T001",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-11T10:16:15.824Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T002",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-11T10:16:16.903Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T003",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-11T10:17:58.571Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T004",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-11T10:17:59.661Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T005",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-11T10:18:00.748Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T006",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-11T10:18:01.831Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T007",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-11T10:18:55.091Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-06-11T10:19:05.080Z"
+    }
+  ],
+  "currentTask": "T007"
+}

--- a/specs/147-step-tab-sync-glyph/checklists/requirements.md
+++ b/specs/147-step-tab-sync-glyph/checklists/requirements.md
@@ -1,0 +1,32 @@
+# Specification Quality Checklist: Step tab sync glyph + locked in-flight clearing
+
+**Purpose**: Validate turbo specification completeness before planning
+**Created**: 2026-06-11
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs) — FRs name the user-visible glyph + behavior; codicon `sync` is the issue's explicit ask, not an incidental detail
+- [x] Focused on user/business value and the change's intent
+- [x] Overview states what is delivered and why in 1–3 sentences
+- [x] All four sections present (Overview, Functional Requirements, Success Criteria, Assumptions)
+
+## Requirement Completeness
+
+- [x] Any [NEEDS CLARIFICATION] markers are genuine ambiguities (≤3) deferred to clarify — none needed
+- [x] Each Functional Requirement is a single, testable MUST/SHOULD statement
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic where possible (compile/test gates are objective pass/fail)
+- [x] Edge cases are folded into Functional Requirements or Assumptions (percentage pill: FR-008; ai vs extension: FR-004)
+- [x] Scope is clearly bounded (glyph swap + regression locks; no rework of correct derivation)
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] Every Functional Requirement maps to at least one Success Criterion
+- [x] Overview intent is reflected by the FR list (no orphan goals)
+- [x] No implementation details leak into the specification
+
+## Notes
+
+- Investigation confirmed the state-clearing bug (a)/(b) is already fixed in `main`; the real outstanding deliverable is the icon swap (FR-001..003) plus regression tests (SC-001/SC-002) and docs/stories.

--- a/specs/147-step-tab-sync-glyph/plan.md
+++ b/specs/147-step-tab-sync-glyph/plan.md
@@ -1,0 +1,42 @@
+# Plan: Step tab sync glyph + locked in-flight clearing (#229)
+
+## Summary
+
+Swap the empty in-flight step-tab indicator from a filled pulsing circle to a spinning VS Code `sync` codicon, and lock the already-correct "in-flight clears on completion" behavior with regression tests. The state-clearing path (`stepHistoryDerivation` → `deriveViewerState` / `findRunningStep` → `refreshContextIfDisplaying` → `viewerStateUpdated` → NavigationBar re-render) was verified correct in `main` during investigation, including for `by: "ai"` completes; the only code defect is the missing glyph.
+
+## Technical Context
+
+- **Language**: TypeScript (extension `src/`) + Preact/TSX (webview `webview/src/`).
+- **Styling**: plain CSS partials under `webview/styles/spec-viewer/`; codicon font already loaded; `spin` keyframe already in `_animations.css`.
+- **Testing**: Jest (`npm test`) for both extension and webview (jsdom) suites. Compile gates: `npm run compile` (extension) + `npm run compile-web` (webview bundle).
+- **Constraints**: No runtime deps on `.claude/**` or `.specify/**` from `src/`/`webview/`. Derive in-flight from the full discriminator. Guard `e.target instanceof Element` in delegated handlers (no new handlers added here).
+
+## Approach & Structure
+
+Order of attack:
+
+1. **Glyph render — `webview/src/spec-viewer/components/StepTab.tsx`**
+   The empty in-flight indicator currently renders `<span class="step-status">{statusIcon}</span>` where `statusIcon` is `''` for non-percentage in-flight. Render a `codicon-sync` element inside `.step-status` when `canonicalState === 'in-flight'` and there is no percentage string (i.e. not the implement `inProgress` pill). Keep the percentage pill path (`statusIcon` = `NN%`) unchanged (FR-008).
+
+2. **Glyph styling — `webview/styles/spec-viewer/_navigation.css`**
+   For the empty in-flight `.step-status`: drop the filled circle (transparent background/border, no border) and color the `codicon-sync` with a VS Code theme var; apply `animation: spin 1.5s linear infinite` (reuse the existing `spin` keyframe). Leave `.step-tab.in-flight .step-status:not(:empty)` (the percentage pill) untouched.
+
+3. **Stories — `webview/src/spec-viewer/components/StepTab.stories.tsx`**
+   Ensure an in-flight story exists/updates to surface the sync glyph (FR-009).
+
+4. **Regression tests (lock the clearing behavior — SC-001/SC-002)**
+   - Extension: `src/features/specs/__tests__/stepHistoryDerivation.test.ts` (or a focused new test) — assert a `by: "ai"` step-level `complete` sets `completedAt` and `findRunningStep` returns null; assert a genuinely-running step (start, no complete) stays in flight. Use the `specs/_01_demo-planned` shape inline (no `.specify` runtime dep).
+   - Webview: `webview/src/spec-viewer/components/__tests__/StepTab.test.tsx` — assert the in-flight tab renders the `codicon-sync` glyph; assert the tab flips in-flight → done (and the glyph disappears) when re-rendered with a completed `stepHistory` + null `activeStep`.
+
+5. **Docs — `docs/viewer-states.md`** — document the sync-glyph in-flight visual and when in-flight clears.
+
+## Out of Scope
+
+- Reworking the derivation or refresh path — verified correct; only regression coverage is added.
+- The implement-step percentage pill visual (kept as-is).
+- Any change to `.spec-context.json` write scripts or capture commands.
+- The genuinely-still-running case "C" (substep completes with no step-level complete) — that is correct in-flight behavior, not a bug.
+
+## Constitution Check
+
+No constitution gates defined for this repo affect a webview-visual + test change. Isolation rule (no `src/`/`webview/` deps on `.claude`/`.specify`) is honored — tests inline their fixtures.

--- a/specs/147-step-tab-sync-glyph/spec.md
+++ b/specs/147-step-tab-sync-glyph/spec.md
@@ -1,0 +1,32 @@
+# Spec: Step tab sync glyph + locked in-flight clearing (#229)
+
+## Overview
+
+The spec-viewer header shows a step tab as "in progress" while the AI is running that step. Issue #229 asks for two things: (1) confirm the in-flight indicator clears the moment a step's completion lands in `.spec-context.json` — no manual refresh, with the timer stopping and the badge advancing — and (2) replace the in-flight visual from a filled circle to a looping-arrows / sync glyph that communicates "actively working" and disappears when the step completes. Investigation found the state-clearing behavior already works in `main` (derivation + re-render both correct); this change therefore locks that behavior with regression tests and delivers the outstanding icon swap.
+
+## Functional Requirements
+
+- **FR-001** The in-flight step-tab indicator MUST render a looping-arrows / sync glyph (VS Code codicon `sync`) with a continuous spin animation while a step is running, instead of the previous filled circle.
+- **FR-002** The sync glyph MUST use VS Code theme variables for its color so it adapts to light/dark/high-contrast themes.
+- **FR-003** The sync glyph MUST disappear the moment the step completes — when the tab's canonical state is no longer `in-flight` (i.e. `completedAt` is recorded or `activeStep` no longer points at the step).
+- **FR-004** A step whose completion is recorded in `.spec-context.json` (status advanced, a `kind: "complete"` entry written) MUST render as done (checkmark) without any manual refresh, reopen, or reload — regardless of whether the completing entry's `by` is `"ai"` or `"extension"`.
+- **FR-005** The step's elapsed timer MUST stop (unmount) when the step completes; it MUST keep counting only while the step is genuinely in flight.
+- **FR-006** The header status badge MUST advance to the completed wording (e.g. PLANNING → PLANNED) as soon as the completion lands, driven by the same refreshed viewer state as the tabs.
+- **FR-007** A step that is genuinely still running (started, no completion recorded) MUST continue to show the in-flight sync glyph and running timer — no regression to live feedback.
+- **FR-008** The implement-step percentage pill (e.g. `60%`) MUST retain its existing in-flight pill styling; the sync glyph applies to the empty (non-percentage) in-flight indicator used by specify/plan/tasks.
+- **FR-009** The StepTab stories MUST include an in-flight state that demonstrates the new sync glyph.
+- **FR-010** `docs/viewer-states.md` MUST document the step-tab in-flight visual (sync glyph) and when in-flight clears.
+
+## Success Criteria
+
+- **SC-001** Given a `.spec-context.json` with an AI-authored step-level `complete` entry for a step and `currentStep` still pointing at it, the derived per-step history records a non-null `completedAt` and `findRunningStep` returns no running step for that step (100% of such fixtures).
+- **SC-002** Re-rendering the NavigationBar with a fresh navState carrying that completion flips the affected tab from `in-flight` to `done` with a checkmark, with no reopen.
+- **SC-003** The in-flight tab renders an element bearing the `codicon-sync` class (or equivalent sync-glyph marker) and no longer renders the filled-circle-only indicator for empty in-flight steps.
+- **SC-004** A genuinely-running step (started, no completion) still renders the in-flight sync glyph and the elapsed timer.
+- **SC-005** `npm run compile`, `npm run compile-web`, and `npm test` all pass clean.
+
+## Assumptions
+
+- The state-clearing logic in `stepHistoryDerivation.ts` / `stateDerivation.ts` / `specViewerProvider.refreshContextIfDisplaying` is already correct (verified during investigation); the only code defect to fix is the missing sync-glyph visual. Regression tests are added to lock the clearing behavior so a future change can't silently break it.
+- The webview already loads the VS Code codicon font (SpecHeader uses `codicon codicon-git-branch`) and `_animations.css` already defines a `spin` keyframe, so the glyph + spin need no new asset.
+- The sync glyph replaces only the empty in-flight `.step-status` content; the implement-step percentage pill path is left unchanged.

--- a/specs/147-step-tab-sync-glyph/tasks.md
+++ b/specs/147-step-tab-sync-glyph/tasks.md
@@ -1,0 +1,22 @@
+# Tasks: Step tab sync glyph + locked in-flight clearing (#229)
+
+Feature dir: `specs/147-step-tab-sync-glyph/`. Ordered by dependency. `[P]` = parallelizable.
+
+## Implementation
+
+- [x] **T001** Render the sync glyph in the empty in-flight indicator — `webview/src/spec-viewer/components/StepTab.tsx`. When `canonicalState === 'in-flight'` and there is no percentage string, render a `<span class="codicon codicon-sync step-status__sync" aria-hidden="true">` inside `.step-status` (keep the `NN%` pill path for implement `inProgress` unchanged). Satisfies FR-001, FR-003, FR-008.
+- [x] **T002** Style the glyph — `webview/styles/spec-viewer/_navigation.css`. For the empty in-flight `.step-status`: remove the filled-circle look (transparent bg/border, no `working-pulse`), color the `codicon-sync` with a VS Code theme var, and spin it via the existing `spin` keyframe. Leave `.step-tab.in-flight .step-status:not(:empty)` (percentage pill) intact. Satisfies FR-001, FR-002, FR-008.
+
+## Regression tests
+
+- [x] **T003 [P]** Extension derivation lock — `src/features/specs/__tests__/stepHistoryDerivation.test.ts`. Add: a `by: "ai"` step-level `complete` (currentStep still on that step, status advanced) sets a non-null `completedAt` and `findRunningStep` returns null; a started-but-not-completed step stays in flight. Satisfies SC-001, FR-004, FR-007.
+- [x] **T004 [P]** Webview tab lock — `webview/src/spec-viewer/components/__tests__/StepTab.test.tsx`. Add: an in-flight tab renders the `codicon-sync` glyph; re-rendering with completed `stepHistory` + null `activeStep` flips the tab to `done`, shows the checkmark, and the sync glyph is gone; the elapsed timer is present while running and absent when done. Satisfies SC-002, SC-003, SC-004, FR-005.
+
+## Stories + docs
+
+- [x] **T005 [P]** Update StepTab stories — `webview/src/spec-viewer/components/StepTab.stories.tsx`. Ensure an in-flight story surfaces the new sync glyph. Satisfies FR-009.
+- [x] **T006 [P]** Update `docs/viewer-states.md` — document the step-tab in-flight sync glyph and when in-flight clears. Satisfies FR-010.
+
+## Verification
+
+- [x] **T007** Run `npm run compile`, `npm run compile-web`, and `npm test` — all clean. Satisfies SC-005.

--- a/src/features/specs/__tests__/stepHistoryDerivation.test.ts
+++ b/src/features/specs/__tests__/stepHistoryDerivation.test.ts
@@ -1,4 +1,5 @@
 import { deriveStepHistory } from '../stepHistoryDerivation';
+import { findRunningStep } from '../../spec-viewer/stateDerivation';
 import type { Transition } from '../../../core/types/specContext';
 
 const tx = (overrides: Partial<Transition>): Transition => ({
@@ -347,6 +348,39 @@ describe('deriveStepHistory', () => {
             expect(out.specify.substeps![0].name).toBe('outline');
             expect(out.specify.substeps![0].startedAt).toBe('2026-04-29T00:01:00Z');
             expect(out.specify.substeps![0].completedAt).toBe('2026-04-29T00:02:00Z');
+        });
+    });
+
+    // Regression for #229: an AI-authored step-level completion must clear
+    // in-flight exactly like an extension-authored one. The viewer's tab
+    // in-flight visual is gated on `completedAt` + `findRunningStep`; if a
+    // `by: "ai"` complete didn't register, the tab would spin forever after
+    // the AI finished the step (the original #229 symptom).
+    describe('regression #229: ai-authored completion clears in-flight', () => {
+        it('records completedAt and stops the running step for a by:"ai" step-level complete', () => {
+            // currentStep still 'plan' (the AI self-closed before the user
+            // advanced), status flipped to 'planned'. Mirrors the
+            // specs/_01_demo-planned fixture inline (no .specify dependency).
+            const history: Transition[] = [
+                tx({ step: 'specify', kind: 'complete', by: 'ai', at: '2026-05-20T20:05:00Z' }),
+                tx({ step: 'plan', kind: 'start', by: 'extension', at: '2026-05-20T20:05:00Z' }),
+                tx({ step: 'plan', kind: 'complete', by: 'ai', at: '2026-05-20T20:10:00Z' }),
+            ];
+            const sh = deriveStepHistory(history, 'plan', 'planned');
+            expect(sh.plan.completedAt).toBe('2026-05-20T20:10:00Z');
+            expect(findRunningStep(sh)).toBeNull();
+        });
+
+        it('keeps a genuinely-running step in flight (started, no completion)', () => {
+            const history: Transition[] = [
+                tx({ step: 'specify', kind: 'complete', by: 'ai', at: '2026-05-20T20:05:00Z' }),
+                tx({ step: 'plan', kind: 'start', by: 'extension', at: '2026-05-20T20:05:00Z' }),
+                // Substep finishes recorded, but no step-level complete yet.
+                tx({ step: 'plan', substep: 'research', kind: 'complete', by: 'ai', at: '2026-05-20T20:07:00Z' }),
+            ];
+            const sh = deriveStepHistory(history, 'plan', 'planning');
+            expect(sh.plan.completedAt).toBeNull();
+            expect(findRunningStep(sh)).toEqual({ step: 'plan', startedAt: '2026-05-20T20:05:00Z' });
         });
     });
 });

--- a/webview/src/spec-viewer/components/StepTab.stories.tsx
+++ b/webview/src/spec-viewer/components/StepTab.stories.tsx
@@ -40,6 +40,21 @@ export const InFlight: Story = {
     args: { ...base, doc: mockDoc('tasks', true, 'Tasks'), index: 2, taskCompletionPercent: 72 },
 };
 
+// #229: the empty (non-implement) in-flight indicator is a spinning `sync`
+// codicon — looping arrows that read as "actively working". The implement
+// step keeps its percentage pill (see InFlight above). The glyph disappears
+// the moment the step completes (activeStep moves off / completedAt set).
+export const InFlightSyncGlyph: Story = {
+    args: {
+        ...base,
+        doc: mockDoc('plan', true, 'Plan'),
+        index: 1,
+        activeStep: 'plan',
+        currentStep: 'plan',
+        stepHistory: { plan: { startedAt: new Date(Date.now() - 18_000).toISOString() } },
+    },
+};
+
 export const Locked: Story = {
     args: {
         ...base,

--- a/webview/src/spec-viewer/components/StepTab.tsx
+++ b/webview/src/spec-viewer/components/StepTab.tsx
@@ -82,10 +82,18 @@ export function StepTab(props: StepTabProps) {
         isStale && 'stale',
     ].filter(Boolean).join(' ');
 
-    // Status content: percentage in-flight, ✓ done, empty otherwise.
+    // Status content: percentage in-flight (implement), ✓ done, empty otherwise.
     const statusIcon = canonicalState === 'in-flight' && inProgress
         ? `${taskCompletionPercent}%`
         : (canonicalState === 'done' ? '✓' : '');
+
+    // The empty in-flight indicator (specify / plan / tasks — anything that
+    // isn't the implement-step percentage pill) renders a spinning `sync`
+    // codicon: looping arrows that read as "actively working" at a glance.
+    // It vanishes the instant `canonicalState` is no longer `in-flight`
+    // (completion recorded or activeStep moved on), so a done step never
+    // keeps the glyph.
+    const showSyncGlyph = canonicalState === 'in-flight' && !inProgress;
 
     const baseTooltip = STEP_TOOLTIPS[phase] ?? doc.label;
     const tooltip = isLocked
@@ -113,7 +121,11 @@ export function StepTab(props: StepTabProps) {
             disabled={!isClickable}
             onClick={() => isClickable && phase !== 'done' && onClick(phase)}
         >
-            <span class="step-status">{statusIcon}</span>
+            <span class="step-status">
+                {showSyncGlyph
+                    ? <span class="codicon codicon-sync step-status__sync" aria-hidden="true" />
+                    : statusIcon}
+            </span>
             <span class="step-label">{doc.label}</span>
             {vsSubstep && <span class="step-tab__substep">{vsSubstep}</span>}
             {runningStartedAt && <ElapsedTimer startedAt={runningStartedAt} />}

--- a/webview/src/spec-viewer/components/__tests__/StepTab.test.tsx
+++ b/webview/src/spec-viewer/components/__tests__/StepTab.test.tsx
@@ -121,3 +121,86 @@ describe('StepTab — reflects true per-step state', () => {
         }
     });
 });
+
+describe('StepTab — #229 in-flight sync glyph', () => {
+    afterEach(() => {
+        viewerState.value = null;
+    });
+
+    it('renders a spinning sync codicon (not a checkmark) while the step is in flight', () => {
+        viewerState.value = { highlights: ['specify'], activeSubstep: null } as any;
+        const c = renderTab(baseProps({
+            doc: doc('plan', false, 'Plan'),
+            index: 1,
+            activeStep: 'plan',
+            currentStep: 'plan',
+            stepHistory: { plan: { startedAt: '2026-05-20T20:05:00Z', completedAt: null } },
+        }));
+        try {
+            expect(c.querySelector('button')!.className).toContain('in-flight');
+            expect(c.querySelector('.step-status__sync')).not.toBeNull();
+            expect(c.querySelector('.step-status__sync')!.classList.contains('codicon-sync')).toBe(true);
+            // No checkmark while running.
+            expect(c.querySelector('.step-status')!.textContent).not.toContain('✓');
+            // The live elapsed timer is mounted while running.
+            expect(c.querySelector('.step-tab__elapsed')).not.toBeNull();
+        } finally {
+            cleanup(c);
+        }
+    });
+
+    it('drops the sync glyph and shows the checkmark + stops the timer when the step completes', () => {
+        // Before: plan running, glyph + timer present.
+        viewerState.value = { highlights: ['specify'], activeSubstep: null } as any;
+        const c = renderTab(baseProps({
+            doc: doc('plan', false, 'Plan'),
+            index: 1,
+            activeStep: 'plan',
+            currentStep: 'plan',
+            stepHistory: { plan: { startedAt: '2026-05-20T20:05:00Z', completedAt: null } },
+        }));
+        try {
+            expect(c.querySelector('.step-status__sync')).not.toBeNull();
+            expect(c.querySelector('.step-tab__elapsed')).not.toBeNull();
+
+            // After: AI completion lands — doc now exists, completedAt set,
+            // activeStep moved off plan. The tab flips to done.
+            viewerState.value = { highlights: ['specify', 'plan'], activeSubstep: null } as any;
+            rerender(c, baseProps({
+                doc: doc('plan', true, 'Plan'),
+                index: 1,
+                activeStep: null,
+                currentStep: 'tasks',
+                stepHistory: { plan: { startedAt: '2026-05-20T20:05:00Z', completedAt: '2026-05-20T20:10:00Z' } },
+            }));
+
+            expect(c.querySelector('button')!.className).toContain('done');
+            expect(c.querySelector('.step-status')!.textContent).toContain('✓');
+            // Glyph gone, timer unmounted.
+            expect(c.querySelector('.step-status__sync')).toBeNull();
+            expect(c.querySelector('.step-tab__elapsed')).toBeNull();
+        } finally {
+            cleanup(c);
+        }
+    });
+
+    it('renders the percentage pill (not the sync glyph) for the implement in-progress step', () => {
+        viewerState.value = { highlights: ['specify', 'plan'], activeSubstep: null } as any;
+        const c = renderTab(baseProps({
+            doc: doc('tasks', true, 'Tasks'),
+            index: 2,
+            totalSteps: 3,
+            currentStep: 'implement',
+            taskCompletionPercent: 60,
+            currentDoc: 'tasks',
+            stepHistory: {},
+        }));
+        try {
+            expect(c.querySelector('button')!.className).toContain('in-flight');
+            expect(c.querySelector('.step-status__sync')).toBeNull();
+            expect(c.querySelector('.step-status')!.textContent).toContain('60%');
+        } finally {
+            cleanup(c);
+        }
+    });
+});

--- a/webview/styles/spec-viewer/_navigation.css
+++ b/webview/styles/spec-viewer/_navigation.css
@@ -101,8 +101,8 @@
 
 /* In-flight (canonical): purple badge + working-pulse glow.
    Distinct from done-green so the active step is unmistakable.
-   Default size matches the completed checkmark (16×16); only the
-   implement-step % pill widens via :not(:empty) below. */
+   Used by the implement-step % pill; the specify/plan/tasks in-flight
+   indicator is the spinning sync glyph styled below. */
 .step-tab.in-flight .step-status {
     background: var(--purple);
     border-color: var(--purple);
@@ -113,14 +113,32 @@
 }
 
 /* The pill grows wider only when there's a percent string to show
-   (the implement-step inProgress case). Empty in-flight steps keep
-   the default 16×16 circle defined on .step-status — same size as
-   the completed checkmark, just pulsing. */
+   (the implement-step inProgress case). */
 .step-tab.in-flight .step-status:not(:empty) {
     width: auto;
     min-width: 32px;
     padding: 0 6px;
     border-radius: 10px;
+}
+
+/* Sync-glyph in-flight (specify / plan / tasks): looping-arrows codicon
+   that spins while the step is actively running. Reads as "working" far
+   better than a static filled dot. The glyph is theme-colored; the badge
+   chrome (filled circle + working-pulse) is dropped so only the arrows
+   show. The whole indicator vanishes the moment the step is no longer
+   in-flight — `.step-status__sync` is rendered only for `canonicalState
+   === 'in-flight'` && !inProgress, so a done step has no glyph. */
+.step-tab.in-flight .step-status:has(.step-status__sync) {
+    background: transparent;
+    border-color: transparent;
+    animation: none;
+}
+
+.step-tab.in-flight .step-status__sync {
+    color: var(--purple);
+    font-size: 14px;
+    line-height: 1;
+    animation: spin 1.5s linear infinite;
 }
 
 /* Extra left padding when the pill is widened, so the working-pulse

--- a/webview/styles/spec-viewer/_navigation.css
+++ b/webview/styles/spec-viewer/_navigation.css
@@ -113,8 +113,10 @@
 }
 
 /* The pill grows wider only when there's a percent string to show
-   (the implement-step inProgress case). */
-.step-tab.in-flight .step-status:not(:empty) {
+   (the implement-step inProgress case). The sync-glyph badge is also
+   non-empty (it wraps a <span>), so explicitly exclude it — it keeps
+   the default 16×16 geometry, not the percentage pill. */
+.step-tab.in-flight .step-status:not(:empty):not(:has(.step-status__sync)) {
     width: auto;
     min-width: 32px;
     padding: 0 6px;
@@ -143,8 +145,9 @@
 
 /* Extra left padding when the pill is widened, so the working-pulse
    glow doesn't crash into the preceding connector line. The default
-   16×16 in-flight badge needs no extra padding. */
-.step-tab.in-flight:has(.step-status:not(:empty)) {
+   16×16 in-flight badge (and the sync-glyph badge) needs no extra
+   padding, so scope this to the percentage pill only. */
+.step-tab.in-flight:has(.step-status:not(:empty):not(:has(.step-status__sync))) {
     padding-left: 20px;
 }
 


### PR DESCRIPTION
## Summary

The step tab's in-progress indicator is now a **spinning looping-arrows (sync) glyph** instead of a static filled circle — it reads as "actively working" at a glance and disappears the moment the step completes. Plus regression tests that lock the behavior where a step tab clears in-flight as soon as an AI-authored completion lands.

Closes #229.

## What was already correct (verified, now test-locked)

The "tab stays in-progress after completion" half of #229 **already works on `main`** — verified three ways:
- The derivation records `completedAt` on any step-level `kind: "complete"` entry, **`by: "ai"` or `by: "extension"` alike** (`lastOwnIsCompletion` keys on `kind`, not `by`), so `findRunningStep` returns null and in-flight clears.
- The file watcher's `refreshContextIfDisplaying` re-posts a **full navState + viewerState**, so the header (tab + timer + badge) re-renders, not just the footer.

So the tab flips to a checkmark, the timer stops, and the badge advances (`Planning → Planned`) with no manual refresh. New tests guard against regression.

## What this PR changes

- `StepTab.tsx` — render a spinning `codicon-sync` glyph for the empty in-flight state (specify/plan/tasks); the implement step keeps its `NN%` percentage pill.
- `_navigation.css` — sync-glyph styling (transparent chrome, themed glyph, reuses the existing `spin` keyframe). Code review caught + fixed a scoping bug: the `:not(:empty)` percentage-pill rules were matching the glyph badge and applying pill geometry to it — now scoped `:not(:has(.step-status__sync))` so they target only the implement pill.
- Tests: `StepTab.test.tsx` (glyph while running; gone + checkmark on completion; implement still shows %), `stepHistoryDerivation.test.ts` (`by:"ai"` complete clears in-flight; started-uncompleted stays in-flight). New `InFlightSyncGlyph` story. `docs/viewer-states.md` updated.

## Quality

- `npm run compile` + `npm run compile-web`: clean · `npm test`: **959/959**
- Code review caught + fixed the CSS pill-scoping bug.

## How to verify (manual)

Run a spec's Plan step to completion in the terminal. **While running:** the Plan tab shows a spinning looping-arrows glyph + live timer. **The moment** the AI writes the plan-complete entry (`status → planned`): the tab flips to a green checkmark, glyph + timer disappear, badge reads "Planned" — no reopen. The implement step still shows its `NN%` pill.

> Built by the SpecKit Companion **turbo** pipeline (spec `147-step-tab-sync-glyph`) via `/fix-tickets`, then code-reviewed.
