### PR TITLE
fix(webview): brighten secondary/muted tokens for WCAG AA on dark

### DIFF
--- a/specs/148-contrast-secondary-muted-tokens/.spec-context.json
+++ b/specs/148-contrast-secondary-muted-tokens/.spec-context.json
@@ -1,0 +1,151 @@
+{
+  "workflow": "speckit",
+  "specName": "contrast secondary muted tokens",
+  "branch": "148-contrast-secondary-muted-tokens",
+  "currentStep": "implement",
+  "status": "implemented",
+  "history": [
+    {
+      "step": "specify",
+      "substep": null,
+      "kind": "start",
+      "by": "extension",
+      "at": "2026-06-11T12:46:21.141Z"
+    },
+    {
+      "step": "specify",
+      "substep": null,
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-06-11T12:47:06.100Z"
+    },
+    {
+      "step": "plan",
+      "substep": null,
+      "kind": "start",
+      "by": "extension",
+      "at": "2026-06-11T12:47:18.012Z"
+    },
+    {
+      "step": "plan",
+      "substep": "research",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-11T12:47:42.998Z"
+    },
+    {
+      "step": "plan",
+      "substep": "design",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-11T12:47:44.134Z"
+    },
+    {
+      "step": "plan",
+      "substep": null,
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-11T12:47:45.249Z"
+    },
+    {
+      "step": "tasks",
+      "substep": null,
+      "kind": "start",
+      "by": "extension",
+      "at": "2026-06-11T12:47:54.455Z"
+    },
+    {
+      "step": "tasks",
+      "substep": "generate",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-11T12:48:14.453Z"
+    },
+    {
+      "step": "tasks",
+      "substep": null,
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-11T12:48:15.546Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "kind": "start",
+      "by": "extension",
+      "at": "2026-06-11T12:48:27.732Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T001",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-11T12:48:41.493Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T002",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-11T12:48:42.595Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T003",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-11T12:49:05.244Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T004",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-11T12:49:06.325Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T005",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-11T12:49:27.511Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T006",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-11T12:49:45.407Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T007",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-11T12:49:46.496Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T008",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-11T12:50:04.407Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-06-11T12:50:27.516Z"
+    }
+  ],
+  "currentTask": "T008"
+}

--- a/specs/148-contrast-secondary-muted-tokens/checklists/requirements.md
+++ b/specs/148-contrast-secondary-muted-tokens/checklists/requirements.md
@@ -1,0 +1,33 @@
+# Specification Quality Checklist: Contrast secondary/muted text + ghost buttons
+
+**Purpose**: Validate turbo specification completeness before planning
+**Created**: 2026-06-11
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user/business value and the change's intent
+- [x] Overview states what is delivered and why in 1–3 sentences
+- [x] All four sections present (Overview, Functional Requirements, Success Criteria, Assumptions)
+
+## Requirement Completeness
+
+- [x] Any [NEEDS CLARIFICATION] markers are genuine ambiguities (≤3) deferred to clarify — not unresolved guesses
+- [x] Each Functional Requirement is a single, testable MUST/SHOULD statement
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] Edge cases are folded into Functional Requirements or Assumptions
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] Every Functional Requirement maps to at least one Success Criterion
+- [x] Overview intent is reflected by the FR list (no orphan goals)
+- [x] No implementation details leak into the specification
+
+## Notes
+
+- Items marked incomplete require spec updates before clarify or plan.
+- Note: this spec names concrete CSS token/value details because the fix (Option B) was pre-decided in the issue and is the testable subject of the change; the FRs remain stated as outcomes/values rather than procedural steps.

--- a/specs/148-contrast-secondary-muted-tokens/plan.md
+++ b/specs/148-contrast-secondary-muted-tokens/plan.md
@@ -1,0 +1,30 @@
+# Implementation Plan: Contrast secondary/muted text + ghost buttons
+
+## Summary
+
+Re-derive the `--text-secondary` and `--text-muted` design tokens from the theme's own `--vscode-editor-foreground` via `color-mix` (70% and 50% respectively) instead of VS Code's intentionally low-contrast `descriptionForeground`/`disabledForeground`. Apply the derivation in the `:root` block and in each per-theme body block that redefines these tokens, so secondary/muted body text and the secondary/ghost buttons that inherit from it clear WCAG AA (≥4.5:1) / ≥3:1 on dark while staying theme-adaptive on light and high-contrast.
+
+## Technical Context
+
+- **Language/runtime**: CSS custom properties consumed by VS Code webviews (Chromium/Electron).
+- **Primary file**: `webview/styles/tokens.css` — the single source of truth for all webviews.
+- **Consumers (read-only verification)**: `webview/styles/spec-viewer/_buttons.css` (secondary/ghost tiers), `webview/styles/spec-viewer/_content.css` and `_navigation.css` (metadata rules: `.meta-date`, `.spec-file-ref`, `.meta-label`, nav subsection label).
+- **Testing**: `npm run compile` (tsc) + `npm test` (jest). No CSS contrast/a11y test exists today, so verification of derived hex values is by reasoning; the suite confirms nothing else regressed.
+- **Constraint**: `color-mix(in srgb, …, transparent)` already used in this file (`--accent-subtle`), so runtime support is established.
+
+## Approach & Structure
+
+`webview/styles/tokens.css` — four edit sites, same two-token derivation in each, with a per-block fallback foreground matching that block's existing `--text-primary` fallback:
+
+1. `:root` (lines ~44–45): fallback `#d4d4d4`.
+2. `body.vscode-light` (lines ~141–144): fallback `#333333`.
+3. `body.vscode-dark` (lines ~171–173): fallback `#d4d4d4`.
+4. `body.vscode-high-contrast` (lines ~183–186): fallback `#ffffff`. High-contrast intentionally keeps full-strength foreground for `--text-secondary` today (`#ffffff`); to avoid regressing its mandated maximal contrast, keep its `--text-secondary` at the foreground (no dilution) and leave `--text-muted` as-is or derive at 50% only if it does not drop below the existing value. Treat high-contrast conservatively — it must not lose contrast.
+
+Order of attack: edit `:root` first (the base), then dark, then light, then high-contrast. Leave all other tokens (primary button, `--accent*`, status colors) untouched.
+
+## Out of Scope
+
+- The optional button polish from the issue (bumping secondary-button border to `--border-hover`, or giving Regenerate/Archive an explicit `--text-body` at rest) — the token re-derivation alone satisfies the acceptance criteria; border polish is deferred unless review shows it's still needed.
+- Any change to the primary button, `--accent`/`--accent-*`, or status (`--success`/`--warning`/`--error`) tokens.
+- Adding a new automated contrast/a11y test harness (none exists; out of scope for this fix).

--- a/specs/148-contrast-secondary-muted-tokens/spec.md
+++ b/specs/148-contrast-secondary-muted-tokens/spec.md
@@ -1,0 +1,29 @@
+# Contrast: secondary/muted text + ghost buttons blend on dark theme
+
+## Overview
+
+Secondary and muted body text — and the secondary/ghost buttons that inherit their rest color from it — blend into the dark editor background because the design tokens pull straight from VS Code's intentionally low-contrast description/disabled foregrounds. This change re-derives the two tokens from the theme's own (brighter) editor foreground so secondary/muted text meets WCAG AA on dark while staying clearly subordinate to primary content, and the Archive (secondary) and Regenerate (ghost) buttons read as clearly clickable at rest. The derivation stays theme-adaptive, so light and high-contrast themes are not regressed.
+
+## Functional Requirements
+
+- **FR-001**: `--text-secondary` MUST be re-derived as `color-mix(in srgb, var(--vscode-editor-foreground) 70%, transparent)` instead of the raw `var(--vscode-descriptionForeground)`.
+- **FR-002**: `--text-muted` MUST be re-derived as `color-mix(in srgb, var(--vscode-editor-foreground) 50%, transparent)` instead of the raw `var(--vscode-disabledForeground)`.
+- **FR-003**: The re-derivation MUST be applied in every block where these tokens are (re)defined — the `:root` block AND each per-theme body block that redefines them (`body.vscode-dark`, `body.vscode-light`, `body.vscode-high-contrast`) — so the value is consistent regardless of which theme cascade wins.
+- **FR-004**: Each per-theme `color-mix` MUST keep a sensible fallback foreground matching that theme's existing `--text-primary` fallback (dark `#d4d4d4`, light `#333333`, high-contrast `#ffffff`, `:root` `#d4d4d4`) so the token degrades gracefully when `--vscode-editor-foreground` is unavailable.
+- **FR-005**: The change MUST NOT alter the primary button styling, `--accent` / `--accent-*`, or any `--success` / `--warning` / `--error` / status token.
+- **FR-006**: The change MUST NOT introduce a new token name or rename `--text-secondary` / `--text-muted`; downstream consumers in `_buttons.css`, `_content.css`, and `_navigation.css` continue to reference the same names.
+
+## Success Criteria
+
+- **SC-001**: On the default dark theme, `--text-secondary` resolves to approximately `#bdbdbd`, yielding a contrast ratio ≥ 4.5:1 against the `#1e1e1e` editor background (WCAG AA for body text).
+- **SC-002**: On the default dark theme, `--text-muted` resolves to approximately `#a0a0a0`, yielding a contrast ratio ≥ 3:1 against the `#1e1e1e` editor background.
+- **SC-003**: The secondary (Archive) and ghost (Regenerate) buttons render with a rest-state text color that reads as clearly clickable (≥ 3:1 against background), not disabled, while remaining visually subordinate to the primary button.
+- **SC-004**: Light and high-contrast themes show no contrast regression — the derived secondary/muted values remain legible and subordinate on those backgrounds.
+- **SC-005**: The full test suite and TypeScript compile pass with the change applied.
+
+## Assumptions
+
+- VS Code exposes `--vscode-editor-foreground` in all themed webviews; the per-block fallbacks cover the rare case it is absent.
+- `color-mix(in srgb, … N%, transparent)` is supported by the Electron/Chromium runtime that ships with currently supported VS Code versions (already used elsewhere in `tokens.css`, e.g. `--accent-subtle`).
+- Mixing the foreground with `transparent` over the known editor background produces the intended ~70%/50% effective luminance; this is the same approach the issue's accepted Option B specifies.
+- No automated contrast/a11y test currently exists in the suite; correctness of the derived hex values is verified by manual reasoning and the existing CSS being unit-test-free.

--- a/specs/148-contrast-secondary-muted-tokens/spec.md
+++ b/specs/148-contrast-secondary-muted-tokens/spec.md
@@ -15,8 +15,8 @@ Secondary and muted body text — and the secondary/ghost buttons that inherit t
 
 ## Success Criteria
 
-- **SC-001**: On the default dark theme, `--text-secondary` resolves to approximately `#bdbdbd`, yielding a contrast ratio ≥ 4.5:1 against the `#1e1e1e` editor background (WCAG AA for body text).
-- **SC-002**: On the default dark theme, `--text-muted` resolves to approximately `#a0a0a0`, yielding a contrast ratio ≥ 3:1 against the `#1e1e1e` editor background.
+- **SC-001**: On the default dark theme, `--text-secondary` (a semi-transparent `color-mix` composited over the editor background) yields a contrast ratio ≥ 4.5:1 against the `#1e1e1e` editor background (WCAG AA for body text).
+- **SC-002**: On the default dark theme, `--text-muted` (semi-transparent, composited over the background) yields a contrast ratio ≥ 3:1 against the `#1e1e1e` editor background.
 - **SC-003**: The secondary (Archive) and ghost (Regenerate) buttons render with a rest-state text color that reads as clearly clickable (≥ 3:1 against background), not disabled, while remaining visually subordinate to the primary button.
 - **SC-004**: Light and high-contrast themes show no contrast regression — the derived secondary/muted values remain legible and subordinate on those backgrounds.
 - **SC-005**: The full test suite and TypeScript compile pass with the change applied.

--- a/specs/148-contrast-secondary-muted-tokens/tasks.md
+++ b/specs/148-contrast-secondary-muted-tokens/tasks.md
@@ -1,0 +1,31 @@
+# Tasks: Contrast secondary/muted text + ghost buttons
+
+Dependency-ordered checklist. All edits land in a single file (`webview/styles/tokens.css`), so the core tasks are sequential (same-file, no `[P]`). Verification tasks follow.
+
+## Setup
+
+- [x] **T001** Confirm the bug reproduces on the current tree: `--text-secondary`/`--text-muted` in `webview/styles/tokens.css` still resolve to raw `descriptionForeground`/`disabledForeground` (not already `color-mix`). (FR-001, FR-002)
+
+## Core work
+
+- [x] **T002** In the `:root` block of `webview/styles/tokens.css`, re-derive `--text-secondary` to `color-mix(in srgb, var(--vscode-editor-foreground, #d4d4d4) 70%, transparent)` and `--text-muted` to `color-mix(in srgb, var(--vscode-editor-foreground, #d4d4d4) 50%, transparent)`. (FR-001, FR-002, FR-003, FR-004)
+- [x] **T003** In the `body.vscode-dark` block of `webview/styles/tokens.css`, apply the same derivation with fallback foreground `#d4d4d4`. (FR-003, FR-004, SC-001, SC-002)
+- [x] **T004** In the `body.vscode-light` block of `webview/styles/tokens.css`, apply the same derivation with fallback foreground `#333333`. (FR-003, FR-004, SC-004)
+- [x] **T005** In the `body.vscode-high-contrast` block of `webview/styles/tokens.css`, keep `--text-secondary` at the full editor foreground (no dilution) so high-contrast's mandated maximal contrast is not regressed; leave `--text-muted` no weaker than its existing value. (FR-003, SC-004)
+
+## Polish / Verification
+
+- [x] **T006** Re-read `webview/styles/spec-viewer/_buttons.css`, `_content.css`, and `_navigation.css` to confirm the secondary/ghost button tiers and metadata rules still reference `--text-secondary`/`--text-muted` (no token rename needed) and now inherit the lifted values. (FR-006, SC-003)
+- [x] **T007** Confirm no change leaked into the primary button, `--accent*`, or status (`--success`/`--warning`/`--error`) tokens. (FR-005)
+- [x] **T008** Run `npm run compile && npm test` and confirm green. (SC-005)
+
+## Dependencies
+
+- T001 (reproduce) precedes all edits.
+- T002 (`:root`) is the base; T003–T005 are the per-theme overrides and depend on the same understanding but edit distinct blocks of the same file.
+- T006–T007 verify the edits from T002–T005.
+- T008 (compile + test) is last.
+
+## Parallel
+
+- None marked `[P]`: T002–T005 all edit `webview/styles/tokens.css`, so they run sequentially to avoid edit conflicts. T006/T007 are read-only and could be reviewed together but are listed sequentially for clarity.

--- a/webview/styles/tokens.css
+++ b/webview/styles/tokens.css
@@ -174,8 +174,9 @@ body.vscode-dark {
     --bg-elevated: var(--vscode-editorWidget-background, #252526);
     --bg-hover: var(--vscode-list-hoverBackground, #2a2d2e);
     --text-primary: var(--vscode-editor-foreground, #d4d4d4);
-    /* Derived from the editor foreground so secondary text clears WCAG AA on #1e1e1e
-       (~#bdbdbd ≥4.5:1) and muted clears ~3:1 (~#a0a0a0). See spec 148. */
+    /* Derived from the editor foreground (semi-transparent, so effective color
+       composites over the background) so secondary text clears WCAG AA (≥4.5:1)
+       and muted clears ~3:1 against the dark editor bg. See spec 148. */
     --text-secondary: color-mix(in srgb, var(--vscode-editor-foreground, #d4d4d4) 70%, transparent);
     --text-muted: color-mix(in srgb, var(--vscode-editor-foreground, #d4d4d4) 50%, transparent);
     --border: var(--vscode-panel-border, #3c3c3c);
@@ -189,8 +190,8 @@ body.vscode-high-contrast {
     --bg-hover: var(--vscode-list-hoverBackground, #0a0a0a);
     --text-primary: var(--vscode-editor-foreground, #ffffff);
     /* High-contrast mandates maximal contrast: keep secondary at the full editor
-       foreground (no dilution) and derive muted only mildly (70%) so it never drops
-       below the prior #a0a0a0. See spec 148. */
+       foreground (no dilution) and derive muted only mildly (70%) so it stays
+       strong against the HC background. See spec 148. */
     --text-secondary: var(--vscode-editor-foreground, #ffffff);
     --text-body: var(--vscode-editor-foreground, #ffffff);
     --text-muted: color-mix(in srgb, var(--vscode-editor-foreground, #ffffff) 70%, transparent);

--- a/webview/styles/tokens.css
+++ b/webview/styles/tokens.css
@@ -41,8 +41,11 @@
 
     /* Text colors - mapped to VS Code theme variables */
     --text-primary: var(--vscode-editor-foreground, #d4d4d4);
-    --text-secondary: var(--vscode-descriptionForeground, #858585);
-    --text-muted: var(--vscode-disabledForeground, #6c6c6c);
+    /* Secondary/muted derive from the theme's own foreground (not the intentionally
+       low-contrast description/disabled tokens) so they clear WCAG AA on dark while
+       staying subordinate and theme-adaptive. See spec 148. */
+    --text-secondary: color-mix(in srgb, var(--vscode-editor-foreground, #d4d4d4) 70%, transparent);
+    --text-muted: color-mix(in srgb, var(--vscode-editor-foreground, #d4d4d4) 50%, transparent);
 
     /* Accent colors - mapped to VS Code theme variables */
     --accent: var(--vscode-focusBorder, #007fd4);
@@ -139,9 +142,11 @@ body.vscode-light {
     --bg-elevated: var(--vscode-editorWidget-background, #f3f3f3);
     --bg-hover: var(--vscode-list-hoverBackground, #e8e8e8);
     --text-primary: var(--vscode-editor-foreground, #333333);
-    --text-secondary: var(--vscode-descriptionForeground, #717171);
+    /* Derived from the editor foreground (see spec 148) — keeps secondary/muted
+       theme-adaptive and legible on light backgrounds. */
+    --text-secondary: color-mix(in srgb, var(--vscode-editor-foreground, #333333) 70%, transparent);
     --text-body: #4a4a4a;
-    --text-muted: var(--vscode-disabledForeground, #a0a0a0);
+    --text-muted: color-mix(in srgb, var(--vscode-editor-foreground, #333333) 50%, transparent);
     --border: var(--vscode-panel-border, #e0e0e0);
     --border-hover: var(--vscode-contrastBorder, #c0c0c0);
 
@@ -169,8 +174,10 @@ body.vscode-dark {
     --bg-elevated: var(--vscode-editorWidget-background, #252526);
     --bg-hover: var(--vscode-list-hoverBackground, #2a2d2e);
     --text-primary: var(--vscode-editor-foreground, #d4d4d4);
-    --text-secondary: var(--vscode-descriptionForeground, #858585);
-    --text-muted: var(--vscode-disabledForeground, #6c6c6c);
+    /* Derived from the editor foreground so secondary text clears WCAG AA on #1e1e1e
+       (~#bdbdbd ≥4.5:1) and muted clears ~3:1 (~#a0a0a0). See spec 148. */
+    --text-secondary: color-mix(in srgb, var(--vscode-editor-foreground, #d4d4d4) 70%, transparent);
+    --text-muted: color-mix(in srgb, var(--vscode-editor-foreground, #d4d4d4) 50%, transparent);
     --border: var(--vscode-panel-border, #3c3c3c);
     --border-hover: var(--vscode-contrastBorder, #6c6c6c);
 }
@@ -181,9 +188,12 @@ body.vscode-high-contrast {
     --bg-elevated: var(--vscode-editorWidget-background, #000000);
     --bg-hover: var(--vscode-list-hoverBackground, #0a0a0a);
     --text-primary: var(--vscode-editor-foreground, #ffffff);
-    --text-secondary: var(--vscode-descriptionForeground, #ffffff);
+    /* High-contrast mandates maximal contrast: keep secondary at the full editor
+       foreground (no dilution) and derive muted only mildly (70%) so it never drops
+       below the prior #a0a0a0. See spec 148. */
+    --text-secondary: var(--vscode-editor-foreground, #ffffff);
     --text-body: var(--vscode-editor-foreground, #ffffff);
-    --text-muted: var(--vscode-disabledForeground, #a0a0a0);
+    --text-muted: color-mix(in srgb, var(--vscode-editor-foreground, #ffffff) 70%, transparent);
     --border: var(--vscode-contrastBorder, #ffffff);
     --border-hover: var(--vscode-contrastBorder, #ffffff);
     --accent: var(--vscode-focusBorder, #f38518);


### PR DESCRIPTION
Closes #254

## Summary
Re-derive `--text-secondary` / `--text-muted` in `webview/styles/tokens.css` from the theme's own `--vscode-editor-foreground` via `color-mix` (70% / 50%) instead of VS Code's intentionally low-contrast `descriptionForeground` / `disabledForeground`. Applied in `:root` plus the per-theme `body.vscode-dark` / `vscode-light` / `vscode-high-contrast` blocks.

On dark (`#1e1e1e`) this lifts secondary from ~3.5:1 to ~6.1:1 (clears WCAG AA) and muted to ~3.8:1, and because the Archive (secondary) and Regenerate (ghost) buttons inherit `--text-secondary`, they stop reading as disabled — fixed in the same change. High-contrast keeps secondary at full foreground (no dimming), so it is not regressed.

## Technical notes
- Tokens stay **theme-adaptive** — they derive from the foreground, so light/HC adapt automatically.
- No change to the primary button, `--accent`, or status colors.
- `color-mix(..., transparent)` yields a semi-transparent color; the only opaque-ish consumers (priority dots, callout border) are decorative and degrade harmlessly.

## How to verify
- Dark theme spec viewer: FR descriptions, `.meta-date`, `.spec-file-ref` chips, `.meta-label`, nav subsection label read clearly (≥AA).
- Footer: Archive + Regenerate read as clearly clickable at rest, still subordinate to Mark Completed.
- Light + high-contrast: secondary/muted still legible and subordinate, no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)