### PR TITLE
fix(ui): distinct install icon + grouped sidebar actions; Create-Spec cleanup

### DIFF
--- a/docs/screenshots/CAPTURE.md
+++ b/docs/screenshots/CAPTURE.md
@@ -81,7 +81,7 @@ chip, step tabs, children rail, TOC, footer state machine).
 | `viewer.png` | `_01_demo-planned` viewer, Plan tab — **sidebar visible** | Specs sidebar + viewer together; title-leading header + `Planned` badge + `demo/planned` chip + date pill; Spec/Plan/Tasks tabs; children-rail chips (data-model / research / quickstart); the architecture/mermaid diagram; next-step **Tasks** footer |
 | `comments.png` | `_01_demo-planned` viewer, hover a line, click `+` | GitHub-style comment card mid-use: context header, textarea with text, footer (secondary action left / Cancel + Add Comment right) |
 | `activity.png` | `_02_demo-tasked`, toggle **Activity** | Phases timeline + Approach / Tasks / Review-comments cards |
-| `create-spec.png` | `+` New Spec | Title, **Load Template**, **Workflow** picker, description + char counter, **Attach Image**, footer Cancel / **Auto Mode** / Submit |
+| `create-spec.png` | `+` New Spec | Title, **Workflow** picker, description + char counter, **Attach Image**, footer Cancel / **Auto Mode** / Submit |
 
 These four also feed the AI assets: `viewer` + `comments` + `activity` are the
 three hero inputs (`hero/PROMPT.md`), and the resulting `hero.jpg` seeds the demo

--- a/package.json
+++ b/package.json
@@ -375,7 +375,7 @@
         "command": "speckit.companion.installSpecKitExtension",
         "title": "Install spec-kit Extension",
         "category": "SpecKit",
-        "icon": "$(cloud-download)"
+        "icon": "$(desktop-download)"
       },
       {
         "command": "speckit.companion.openReadme",
@@ -469,32 +469,32 @@
         {
           "command": "speckit.create",
           "when": "view == speckit.views.explorer",
-          "group": "navigation@4"
+          "group": "navigation@1"
         },
         {
           "command": "speckit.specs.filter",
           "when": "view == speckit.views.explorer",
-          "group": "navigation@1"
+          "group": "navigation@2"
         },
         {
           "command": "speckit.specs.filter.clear",
           "when": "view == speckit.views.explorer && speckit.specs.filterActive",
-          "group": "navigation@1"
+          "group": "navigation@2"
         },
         {
           "command": "speckit.specs.sort",
           "when": "view == speckit.views.explorer",
-          "group": "navigation@1"
+          "group": "navigation@2"
         },
         {
           "command": "speckit.specs.collapseAll",
           "when": "view == speckit.views.explorer && !speckit.specs.allCollapsed",
-          "group": "navigation@3"
+          "group": "navigation@2"
         },
         {
           "command": "speckit.specs.expandAll",
           "when": "view == speckit.views.explorer && speckit.specs.allCollapsed",
-          "group": "navigation@3"
+          "group": "navigation@2"
         },
         {
           "command": "speckit.steering.create",
@@ -509,12 +509,12 @@
         {
           "command": "speckit.upgrade",
           "when": "view == speckit.views.explorer && (speckit.detected || speckit.cliInstalled)",
-          "group": "navigation@2"
+          "group": "navigation@3"
         },
         {
           "command": "speckit.companion.installSpecKitExtension",
           "when": "view == speckit.views.explorer && (speckit.detected || speckit.cliInstalled) && !speckit.companion.installed",
-          "group": "navigation@2"
+          "group": "navigation@3"
         }
       ],
       "view/item/context": [

--- a/specs/152-ui-cleanup-sidebar-createspec/.spec-context.json
+++ b/specs/152-ui-cleanup-sidebar-createspec/.spec-context.json
@@ -1,0 +1,255 @@
+{
+  "workflow": "speckit",
+  "specName": "ui cleanup sidebar createspec",
+  "branch": "152-ui-cleanup-sidebar-createspec",
+  "currentStep": "implement",
+  "status": "implemented",
+  "history": [
+    {
+      "step": "specify",
+      "substep": null,
+      "kind": "start",
+      "by": "extension",
+      "at": "2026-06-11T14:26:42.735Z"
+    },
+    {
+      "step": "specify",
+      "substep": null,
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-06-11T14:27:29.689Z"
+    },
+    {
+      "step": "plan",
+      "substep": null,
+      "kind": "start",
+      "by": "ai",
+      "at": "2026-06-11T14:27:39.386Z"
+    },
+    {
+      "step": "plan",
+      "substep": null,
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-11T14:28:31.310Z"
+    },
+    {
+      "step": "tasks",
+      "substep": null,
+      "kind": "start",
+      "by": "ai",
+      "at": "2026-06-11T14:28:35.371Z"
+    },
+    {
+      "step": "tasks",
+      "substep": "generate",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-11T14:28:58.099Z"
+    },
+    {
+      "step": "tasks",
+      "substep": null,
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-11T14:28:58.164Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "kind": "start",
+      "by": "ai",
+      "at": "2026-06-11T14:29:02.346Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T001",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-11T14:29:33.573Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T002",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-11T14:29:44.994Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T003",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-11T14:30:31.841Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T004",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-11T14:34:14.090Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T005",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-11T14:34:14.158Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T006",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-11T14:34:14.231Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T007",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-11T14:35:05.936Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T008",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-11T14:35:06.004Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T009",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-11T14:35:06.078Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T010",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-11T14:35:06.149Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T011",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-11T14:35:06.225Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T012",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-11T14:35:06.300Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-06-11T14:35:17.932Z"
+    }
+  ],
+  "currentTask": "T012",
+  "task_summaries": {
+    "T001": {
+      "status": "DONE",
+      "did": "Gave install action a distinct glyph (desktop-download vs upgrade's cloud-download)",
+      "files": [
+        "package.json"
+      ]
+    },
+    "T002": {
+      "status": "DONE",
+      "did": "Regrouped view/title actions: create=nav@1, list-controls=nav@2, install/upgrade=nav@3 so dividers render",
+      "files": [
+        "package.json"
+      ]
+    },
+    "T003": {
+      "status": "DONE",
+      "did": "Removed Load Template switch cases, handleRequestTemplateDialog/handleLoadTemplate methods, and button markup from provider",
+      "files": [
+        "src/features/spec-editor/specEditorProvider.ts"
+      ]
+    },
+    "T004": {
+      "status": "DONE",
+      "did": "Removed loadTemplate/requestTemplateDialog/templateLoaded message-type union members from extension types",
+      "files": [
+        "src/features/spec-editor/types.ts"
+      ]
+    },
+    "T005": {
+      "status": "DONE",
+      "did": "Removed loadTemplateBtn lookup, click listener, and templateLoaded case from webview entry",
+      "files": [
+        "webview/src/spec-editor/index.ts"
+      ]
+    },
+    "T006": {
+      "status": "DONE",
+      "did": "Removed the three Load Template message-type members from webview types",
+      "files": [
+        "webview/src/spec-editor/types.ts"
+      ]
+    },
+    "T007": {
+      "status": "DONE",
+      "did": "Removed template-loader/load-template-btn CSS and split shared codicon rule",
+      "files": [
+        "webview/styles/spec-editor.css"
+      ]
+    },
+    "T008": {
+      "status": "DONE",
+      "did": "Removed Load Template mock button and restructured the Storybook mock row",
+      "files": [
+        "webview/src/spec-editor/CreateSpecMock.tsx"
+      ]
+    },
+    "T009": {
+      "status": "DONE",
+      "did": "Grepped all six Load Template tokens; zero in shipping source; cleaned a stale docs reference too",
+      "files": [
+        "docs/screenshots/CAPTURE.md"
+      ]
+    },
+    "T010": {
+      "status": "DONE",
+      "did": "Shortened turbo displayName to Turbo; full label moved into description tooltip; value speckit-turbo unchanged",
+      "files": [
+        "src/features/spec-editor/specEditorProvider.ts"
+      ]
+    },
+    "T011": {
+      "status": "DONE",
+      "did": "Added flex-wrap/gap/min-width/ellipsis to workflow-row and image-attachment-header; extended max-width:500px media block to stack them",
+      "files": [
+        "webview/styles/spec-editor.css"
+      ]
+    },
+    "T012": {
+      "status": "DONE",
+      "did": "Ran compile (tsc+webpack) and jest: 972/972 pass",
+      "files": [
+        "(verification)"
+      ]
+    }
+  }
+}

--- a/specs/152-ui-cleanup-sidebar-createspec/checklists/requirements.md
+++ b/specs/152-ui-cleanup-sidebar-createspec/checklists/requirements.md
@@ -1,0 +1,33 @@
+# Specification Quality Checklist: UI cleanup — sidebar install icon + Create-Spec touchups
+
+**Purpose**: Validate turbo specification completeness before planning
+**Created**: 2026-06-11
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user/business value and the change's intent
+- [x] Overview states what is delivered and why in 1–3 sentences
+- [x] All four sections present (Overview, Functional Requirements, Success Criteria, Assumptions)
+
+## Requirement Completeness
+
+- [x] Any [NEEDS CLARIFICATION] markers are genuine ambiguities (≤3) deferred to clarify — not unresolved guesses
+- [x] Each Functional Requirement is a single, testable MUST/SHOULD statement
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] Edge cases are folded into Functional Requirements or Assumptions
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] Every Functional Requirement maps to at least one Success Criterion
+- [x] Overview intent is reflected by the FR list (no orphan goals)
+- [x] No implementation details leak into the specification
+
+## Notes
+
+- FR-001/FR-002 → SC-001/SC-002 (sidebar). FR-003/FR-004 → SC-003 (Load Template removal). FR-005/FR-006 → SC-004 (Turbo label). FR-007 → SC-006 (responsive). All → SC-005 (build/test gate).
+- Note: spec mentions concrete codicon ids and CSS property names as success-criteria anchors; these are observable artifacts of the change, not prescribed implementation, and are kept minimal.

--- a/specs/152-ui-cleanup-sidebar-createspec/plan.md
+++ b/specs/152-ui-cleanup-sidebar-createspec/plan.md
@@ -1,0 +1,44 @@
+# Implementation Plan: UI cleanup — sidebar install icon + Create-Spec touchups
+
+## Summary
+
+Three independent, low-risk touchups. (1) In `package.json` `contributes`, give `speckit.companion.installSpecKitExtension` a distinct codicon and regroup the `view/title` actions for `speckit.views.explorer` into create / list-controls / install-upgrade buckets so dividers render. (2) Fully excise the Load Template feature across extension provider, webview, types, CSS, and the Storybook mock. (3) Shorten the turbo workflow option's visible label to `Turbo` (keeping the full text in its description, which already drives the `<option title>`) and add a narrow-width responsive pass to the Create-Spec stylesheet.
+
+## Technical Context
+
+- **Language**: TypeScript (extension `src/`, webview `webview/src/`), CSS, JSON manifest.
+- **Build/test**: `npm run compile` (tsc + esbuild bundles), `npm test` (node test runner + vitest webview). Python `test_context.py` has 6 known pre-existing failures — out of scope.
+- **Constraints**: VS Code `view/title` icons are monochrome-themed (distinctness by glyph only). Must not change the turbo value `speckit-turbo`. No new dead code after Load Template removal.
+- **No new dependencies, no schema/type-union widening beyond removing message-type members.**
+
+## Approach & Structure
+
+Order of attack (grouped by surface):
+
+1. **Sidebar — `package.json`**
+   - `contributes.commands`: change the `icon` of `speckit.companion.installSpecKitExtension` from `$(cloud-download)` to `$(desktop-download)` (distinct from `speckit.upgrade`'s `$(cloud-download)`).
+   - `contributes.menus."view/title"`: regroup the `speckit.views.explorer` entries into `navigation@1` = create; `navigation@2` = filter, filter.clear, sort, collapseAll, expandAll; `navigation@3` = upgrade, install. Leave the `speckit.views.steering` entries untouched (separate view).
+
+2. **Load Template removal** (remove every artifact)
+   - `src/features/spec-editor/specEditorProvider.ts`: delete the `requestTemplateDialog` and `loadTemplate` switch cases, the `handleRequestTemplateDialog` and `handleLoadTemplate` methods, and the `.template-loader` / `load-template-btn` button markup in the HTML template.
+   - `src/features/spec-editor/types.ts`: delete the `loadTemplate`, `requestTemplateDialog`, `templateLoaded` message-type union members.
+   - `webview/src/spec-editor/index.ts`: delete the `loadTemplateBtn` element lookup, its click listener, and the `templateLoaded` message case.
+   - `webview/src/spec-editor/types.ts`: delete the three message-type members.
+   - `webview/styles/spec-editor.css`: delete the `.template-loader`, `.load-template-btn`, `.load-template-btn:hover`, and the `.load-template-btn .codicon` selector (split from the shared rule); drop `.workflow-row .template-loader`.
+   - `webview/src/spec-editor/CreateSpecMock.tsx`: remove the Load Template mock button; left-align or restructure the remaining row.
+
+3. **Turbo label — `src/features/spec-editor/specEditorProvider.ts`**
+   - `buildTurboWorkflowEntry`: set `displayName` to `Turbo` (drop the `(beta)` suffix from the visible label); move the full former label text into the `description` so the `<option title>` hover still shows it. Keep `name: TURBO_WORKFLOW_NAME` (`speckit-turbo`) and `beta` flag unchanged.
+
+4. **Responsive — `webview/styles/spec-editor.css`**
+   - `.workflow-row`: add `flex-wrap: wrap` + `gap`. `.image-attachment-header`: add `flex-wrap: wrap` + `gap`. Add `min-width: 0` / ellipsis where a child label can overflow.
+   - Extend the `@media (max-width: 500px)` block to also stack/wrap `.workflow-row` and `.image-attachment-header`.
+
+5. **Verify**: grep the six Load Template tokens return zero in shipping source; `npm run compile && npm test` green (minus the known Python failures).
+
+## Out of Scope
+
+- Any change to the turbo command bodies, capture scripts, or `.spec-context.json` schema.
+- The `speckit.views.steering` title-bar actions.
+- The Python `test_context.py` suite (pre-existing failures).
+- Reworking the install/upgrade *commands* themselves — only their icons/menu grouping.

--- a/specs/152-ui-cleanup-sidebar-createspec/spec.md
+++ b/specs/152-ui-cleanup-sidebar-createspec/spec.md
@@ -1,0 +1,31 @@
+# UI cleanup: distinct sidebar install icon + ordered title-bar icons; Create-Spec touchups
+
+## Overview
+
+Tighten two surfaces found while testing. In the SpecKit sidebar title bar, give the install action a glyph distinct from the upgrade action and reorder the title-bar actions into sensible groups with dividers. In the Create-Spec webview, remove the unused Load Template control entirely, shorten the turbo workflow option label to a single word while preserving its full description on hover, and make the panel wrap gracefully at narrow widths instead of overflowing horizontally.
+
+## Functional Requirements
+
+- **FR-001**: The sidebar install action MUST use a codicon visually distinct from the upgrade action's codicon, so the two are distinguishable when the install state toggles. (Title-bar icons are monochrome-themed; distinctness is by glyph, not color.)
+- **FR-002**: The `view/title` actions for the specs explorer view MUST be ordered into distinct menu groups so VS Code renders dividers between them: create, list-view controls (filter, clear-filter, sort, collapse/expand), and install/upgrade.
+- **FR-003**: The Load Template button MUST be removed from the Create-Spec panel along with every supporting artifact: the button markup, the `requestTemplateDialog` / `loadTemplate` / `templateLoaded` message types, the extension-side handler methods, the webview click wiring and message handling, the CSS for the button/loader, and the Storybook/mock representation.
+- **FR-004**: Removing Load Template MUST NOT leave dead code, unreferenced message types, orphaned commands, unused CSS classes, or stale mocks.
+- **FR-005**: The turbo workflow picker option's visible label MUST read `Turbo` (with the `(beta)` suffix omitted from the visible label), while the full descriptive text MUST remain available as the option's hover tooltip/description.
+- **FR-006**: The turbo workflow option value MUST remain `speckit-turbo` (unchanged).
+- **FR-007**: The `.workflow-row` and `.image-attachment-header` layouts MUST wrap (rather than overflow) at narrow viewport widths, using `flex-wrap` and `min-width:0`/ellipsis where a child can overflow; the responsive breakpoint MUST cover these rows, not only the footer actions.
+
+## Success Criteria
+
+- **SC-001**: The install and upgrade title-bar actions render with different glyphs (verifiable by inspecting the two `icon` codicon ids in `package.json`).
+- **SC-002**: The specs explorer `view/title` entries resolve to at least three distinct `navigation@N` group numbers, producing dividers between create, list controls, and install/upgrade.
+- **SC-003**: A repository-wide search for `loadTemplate`, `requestTemplateDialog`, `templateLoaded`, `LoadTemplate`, `load-template`, and `Load Template` returns zero matches in shipping source, styles, mocks, and `package.json`.
+- **SC-004**: The turbo option's visible text is exactly `Turbo`; its tooltip/description contains the full descriptive sentence.
+- **SC-005**: `npm run compile` and `npm test` pass (excluding the 6 known pre-existing Python `test_context.py` failures unrelated to this change).
+- **SC-006**: At a narrow panel width the Create-Spec workflow row and image-attachment header wrap onto multiple lines with no horizontal overflow.
+
+## Assumptions
+
+- The chosen distinct install glyph is `$(desktop-download)` (a download-to-disk glyph that reads differently from the upgrade `$(cloud-download)`).
+- "Full description on hover" is satisfied by the existing `<option title="...">` rendering path; only the option's `description` text needs to carry the full label, since the visible `displayName` becomes `Turbo`.
+- No automated test currently asserts on the Load Template message types or the turbo `displayName`, so their removal/change requires no test rewrite (verified by grep before editing).
+- The Storybook representation of Load Template lives only in the `CreateSpecMock` component and is not asserted by any test.

--- a/specs/152-ui-cleanup-sidebar-createspec/tasks.md
+++ b/specs/152-ui-cleanup-sidebar-createspec/tasks.md
@@ -1,0 +1,30 @@
+# Tasks: UI cleanup — sidebar install icon + Create-Spec touchups
+
+Dependency-ordered. `[P]` = parallelizable with siblings (different files, no shared edit region).
+
+## Sidebar (package.json)
+
+- [x] **T001** Change `speckit.companion.installSpecKitExtension` command `icon` from `$(cloud-download)` to a distinct glyph `$(desktop-download)` + package.json
+- [x] **T002** Regroup `contributes.menus."view/title"` explorer entries into `navigation@1` (create), `navigation@2` (filter, filter.clear, sort, collapseAll, expandAll), `navigation@3` (upgrade, install) so dividers render + package.json
+
+## Load Template removal (full excision)
+
+- [x] **T003** Remove `requestTemplateDialog`/`loadTemplate` switch cases + `handleRequestTemplateDialog`/`handleLoadTemplate` methods + Load Template button markup in HTML template + src/features/spec-editor/specEditorProvider.ts
+- [x] **T004** [P] Remove `loadTemplate`/`requestTemplateDialog`/`templateLoaded` message-type union members + src/features/spec-editor/types.ts
+- [x] **T005** [P] Remove `loadTemplateBtn` element lookup + click listener + `templateLoaded` message case + webview/src/spec-editor/index.ts
+- [x] **T006** [P] Remove the three message-type union members + webview/src/spec-editor/types.ts
+- [x] **T007** [P] Remove `.template-loader`, `.load-template-btn`, `.load-template-btn:hover`, `.load-template-btn .codicon`, `.workflow-row .template-loader` CSS + webview/styles/spec-editor.css
+- [x] **T008** [P] Remove the Load Template mock button and restructure the mock row + webview/src/spec-editor/CreateSpecMock.tsx
+- [x] **T009** Grep `loadTemplate|requestTemplateDialog|templateLoaded|LoadTemplate|load-template|Load Template` across src/webview/package.json/mocks/tests — confirm zero residual references + (verification)
+
+## Turbo label
+
+- [x] **T010** In `buildTurboWorkflowEntry`, set `displayName` to `Turbo`, move full label text into `description` (hover tooltip), keep `name`=`speckit-turbo` and `beta` unchanged + src/features/spec-editor/specEditorProvider.ts
+
+## Responsive
+
+- [x] **T011** Add `flex-wrap`+`gap`+`min-width:0`/ellipsis to `.workflow-row` and `.image-attachment-header`; extend `@media (max-width:500px)` to wrap/stack these rows + webview/styles/spec-editor.css
+
+## Verify
+
+- [x] **T012** Run `npm run compile && npm test`; confirm green excluding the 6 known pre-existing Python `test_context.py` failures + (verification)

--- a/src/features/spec-editor/specEditorProvider.ts
+++ b/src/features/spec-editor/specEditorProvider.ts
@@ -172,10 +172,11 @@ export class SpecEditorProvider {
             return undefined;
         }
         const isBeta = mode === 'beta';
+        const fullLabel = `SpecKit Companion (Turbo)${isBeta ? ' (beta)' : ''}`;
         return {
             name: TURBO_WORKFLOW_NAME,
-            displayName: `SpecKit Companion (Turbo)${isBeta ? ' (beta)' : ''}`,
-            description: 'Pin turbo on this spec — leaner /speckit.companion.* pipeline, regardless of the project default.',
+            displayName: 'Turbo',
+            description: `${fullLabel} — pin turbo on this spec — leaner /speckit.companion.* pipeline, regardless of the project default.`,
             stepSpecify: `/${formatCommandForProvider(TURBO_SPECIFY_COMMAND)}`,
             beta: isBeta,
         };
@@ -259,14 +260,6 @@ export class SpecEditorProvider {
 
             case 'removeImage':
                 await this.handleRemoveImage(message.imageId);
-                break;
-
-            case 'requestTemplateDialog':
-                await this.handleRequestTemplateDialog();
-                break;
-
-            case 'loadTemplate':
-                await this.handleLoadTemplate(message.specPath);
                 break;
 
             case 'cancel':
@@ -521,45 +514,6 @@ export class SpecEditorProvider {
     }
 
     /**
-     * Handle request to show template dialog
-     */
-    private async handleRequestTemplateDialog(): Promise<void> {
-        const result = await vscode.window.showOpenDialog({
-            canSelectFiles: true,
-            canSelectFolders: false,
-            canSelectMany: false,
-            filters: {
-                'Markdown files': ['md'],
-                'All files': ['*']
-            },
-            title: 'Load Template'
-        });
-
-        if (result && result.length > 0) {
-            await this.handleLoadTemplate(result[0].fsPath);
-        }
-    }
-
-    /**
-     * Handle template loading
-     */
-    private async handleLoadTemplate(specPath: string): Promise<void> {
-        try {
-            const content = await vscode.workspace.fs.readFile(vscode.Uri.file(specPath));
-            const text = Buffer.from(content).toString('utf-8');
-
-            this.outputChannel.appendLine(`[SpecEditor] Template loaded: ${specPath}`);
-            this.postMessage({ type: 'templateLoaded', content: text });
-        } catch (error) {
-            this.outputChannel.appendLine(`[SpecEditor] Template load error: ${error}`);
-            this.postMessage({
-                type: 'error',
-                message: `Failed to load template: ${error instanceof Error ? error.message : String(error)}`
-            });
-        }
-    }
-
-    /**
      * Handle cancel/close
      */
     private handleCancel(): void {
@@ -630,12 +584,6 @@ export class SpecEditorProvider {
             <div id="error-container"></div>
 
             <div class="workflow-row">
-                <div class="template-loader">
-                    <button class="load-template-btn" id="loadTemplateBtn">
-                        <span class="codicon codicon-file" aria-hidden="true"></span>
-                        Load Template
-                    </button>
-                </div>
                 <div class="workflow-selector" id="workflowSelector" style="display: none;">
                     <label for="workflowSelect">Workflow</label>
                     <select id="workflowSelect">

--- a/src/features/spec-editor/types.ts
+++ b/src/features/spec-editor/types.ts
@@ -189,8 +189,6 @@ export type SpecEditorToExtensionMessage =
     | { type: 'preview' }
     | { type: 'attachImage'; name: string; size: number; dataUri: string }
     | { type: 'removeImage'; imageId: string }
-    | { type: 'loadTemplate'; specPath: string }
-    | { type: 'requestTemplateDialog' }
     | { type: 'ready' }
     | { type: 'cancel' }
     | { type: 'installSpecKitExtension' }
@@ -204,7 +202,6 @@ export type ExtensionToSpecEditorMessage =
     | { type: 'init'; workflows: WorkflowDefinition[]; defaultWorkflow?: string }
     | { type: 'imageSaved'; imageId: string; thumbnailUri: string; originalName: string }
     | { type: 'imageRemoved'; imageId: string }
-    | { type: 'templateLoaded'; content: string }
     | { type: 'previewContent'; markdown: string }
     | { type: 'submissionStarted' }
     | { type: 'submissionComplete' }

--- a/webview/src/spec-editor/CreateSpecMock.tsx
+++ b/webview/src/spec-editor/CreateSpecMock.tsx
@@ -51,25 +51,7 @@ export function CreateSpecMock({ initialContent = '', submitting = false }: Crea
                 </p>
             </header>
 
-            <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 24px;">
-                <button
-                    type="button"
-                    style="
-                        background: var(--vscode-button-secondaryBackground, #1f1828);
-                        color: var(--vscode-button-secondaryForeground, #ddd);
-                        border: 1px solid var(--vscode-widget-border, #303030);
-                        padding: 8px 14px;
-                        border-radius: 4px;
-                        font-size: 13px;
-                        cursor: pointer;
-                        display: inline-flex;
-                        align-items: center;
-                        gap: 8px;
-                    "
-                >
-                    <span style="opacity: 0.7;">📄</span>
-                    Load Template
-                </button>
+            <div style="display: flex; flex-wrap: wrap; justify-content: flex-end; align-items: center; gap: 8px; margin-bottom: 24px;">
                 <div style="display: flex; align-items: center; gap: 12px; font-size: 13px;">
                     <span style="opacity: 0.7;">Workflow</span>
                     <button

--- a/webview/src/spec-editor/index.ts
+++ b/webview/src/spec-editor/index.ts
@@ -35,7 +35,6 @@ function getElements() {
         submitBtn: document.getElementById('submitBtn') as HTMLButtonElement,
         cancelBtn: document.getElementById('cancelBtn') as HTMLButtonElement,
         attachImageBtn: document.getElementById('attachImageBtn') as HTMLButtonElement,
-        loadTemplateBtn: document.getElementById('loadTemplateBtn') as HTMLButtonElement,
         workflowSelector: document.getElementById('workflowSelector') as HTMLElement,
         workflowSelect: document.getElementById('workflowSelect') as HTMLSelectElement,
         commandButtonsContainer: document.getElementById('commandButtons') as HTMLElement,
@@ -249,11 +248,6 @@ function setupEventListeners(): void {
         vscode.postMessage({ type: 'cancel' });
     });
 
-    // Load template button
-    elements.loadTemplateBtn.addEventListener('click', () => {
-        vscode.postMessage({ type: 'requestTemplateDialog' });
-    });
-
     // Install banner actions (server-rendered, present only when the spec-kit
     // extension is missing). data-action → the matching webview→extension message.
     const installBanner = document.getElementById('install-banner');
@@ -445,13 +439,6 @@ function handleMessage(event: MessageEvent): void {
         case 'imageRemoved':
             attachedImages = attachedImages.filter(img => img.id !== message.imageId);
             updateThumbnails();
-            saveDraft();
-            break;
-
-        case 'templateLoaded':
-            const { textarea } = getElements();
-            textarea.value = message.content;
-            updateCharCount();
             saveDraft();
             break;
 

--- a/webview/src/spec-editor/types.ts
+++ b/webview/src/spec-editor/types.ts
@@ -22,8 +22,6 @@ export type SpecEditorToExtensionMessage =
     | { type: 'preview' }
     | { type: 'attachImage'; name: string; size: number; dataUri: string }
     | { type: 'removeImage'; imageId: string }
-    | { type: 'loadTemplate'; specPath: string }
-    | { type: 'requestTemplateDialog' }
     | { type: 'ready' }
     | { type: 'cancel' }
     | { type: 'installSpecKitExtension' }
@@ -46,7 +44,6 @@ export type ExtensionToSpecEditorMessage =
     | { type: 'init'; workflows: WorkflowDefinition[]; defaultWorkflow?: string }
     | { type: 'imageSaved'; imageId: string; thumbnailUri: string; originalName: string }
     | { type: 'imageRemoved'; imageId: string }
-    | { type: 'templateLoaded'; content: string }
     | { type: 'previewContent'; markdown: string }
     | { type: 'submissionStarted' }
     | { type: 'submissionComplete' }

--- a/webview/styles/spec-editor.css
+++ b/webview/styles/spec-editor.css
@@ -139,6 +139,7 @@
     margin: 0;
     min-width: 0;
     overflow: hidden;
+    white-space: nowrap;
     text-overflow: ellipsis;
     color: var(--text-primary);
 }
@@ -286,6 +287,8 @@
     cursor: pointer;
     min-width: 0;
     max-width: 100%;
+    overflow: hidden;
+    white-space: nowrap;
     text-overflow: ellipsis;
 }
 

--- a/webview/styles/spec-editor.css
+++ b/webview/styles/spec-editor.css
@@ -126,8 +126,10 @@
 
 .image-attachment-header {
     display: flex;
+    flex-wrap: wrap;
     align-items: center;
     justify-content: space-between;
+    gap: 8px;
     margin-bottom: 12px;
 }
 
@@ -135,6 +137,9 @@
     font-size: 0.9em;
     font-weight: 500;
     margin: 0;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
     color: var(--text-primary);
 }
 
@@ -158,8 +163,7 @@
 }
 
 /* Codicon baseline inside spec-editor chrome */
-.attach-image-btn .codicon,
-.load-template-btn .codicon {
+.attach-image-btn .codicon {
     font-size: 14px;
     line-height: 1;
     display: inline-flex;
@@ -248,50 +252,23 @@
 }
 
 /* ============================================
-   Template Loader
-   ============================================ */
-
-.template-loader {
-    margin-bottom: 12px;
-}
-
-.load-template-btn {
-    display: inline-flex;
-    align-items: center;
-    gap: 6px;
-    padding: 6px 14px;
-    border: 1px solid var(--vscode-button-secondaryBorder, var(--border));
-    border-radius: var(--radius-sm);
-    background: var(--vscode-button-secondaryBackground, transparent);
-    color: var(--vscode-button-secondaryForeground, var(--text-primary));
-    font-size: 0.85em;
-    cursor: pointer;
-    transition: background-color 0.15s ease;
-}
-
-.load-template-btn:hover {
-    background-color: var(--vscode-button-secondaryHoverBackground, var(--bg-hover));
-}
-
-/* ============================================
    Workflow Row
    ============================================ */
 
 .workflow-row {
     display: flex;
+    flex-wrap: wrap;
     justify-content: space-between;
     align-items: center;
+    gap: 8px;
     margin-bottom: 12px;
-}
-
-.workflow-row .template-loader {
-    margin-bottom: 0;
 }
 
 .workflow-selector {
     display: flex;
     align-items: center;
     gap: 8px;
+    min-width: 0;
 }
 
 .workflow-selector label {
@@ -307,6 +284,9 @@
     color: var(--vscode-input-foreground);
     font-size: 0.85em;
     cursor: pointer;
+    min-width: 0;
+    max-width: 100%;
+    text-overflow: ellipsis;
 }
 
 .workflow-selector select:focus {
@@ -509,5 +489,21 @@
 
     .action-spacer {
         display: none;
+    }
+
+    /* Stack the workflow row and image-attachment header so neither overflows
+       horizontally at narrow widths. */
+    .workflow-row,
+    .image-attachment-header {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .workflow-selector {
+        justify-content: space-between;
+    }
+
+    .workflow-selector select {
+        flex: 1;
     }
 }


### PR DESCRIPTION
Closes #258

## Summary
Sidebar + Create-Spec touchups found while testing.

**Sidebar**
- Install action now uses `$(desktop-download)` (was `$(cloud-download)`, identical to upgrade) so install vs upgrade are visually distinct.
- Title-bar actions regrouped into `navigation@1` (create) | `@2` (filter / clear / sort / collapse / expand) | `@3` (install / upgrade) so VS Code renders dividers between the groups. No `when`-clause changed — install/upgrade visibility per installed-state is preserved.

**Create-Spec**
- Removed the unused **Load Template** feature in full: the button, the `requestTemplateDialog`/`loadTemplate`/`templateLoaded` message types (both type files), the provider switch cases + handler methods, the webview element lookup/listener/message case, the CSS, the Storybook mock, and a stale `docs/screenshots/CAPTURE.md` reference. Zero dangling references remain (`tsc` clean).
- Shortened the turbo workflow option to **`Turbo`** in the dropdown; the full "SpecKit Companion (Turbo)…" text moved to the option's `description`/tooltip. Value `speckit-turbo` unchanged (per-spec pin resolution unaffected).
- Responsive pass: `flex-wrap` + `min-width:0`/ellipsis on `.workflow-row` and `.image-attachment-header`, extended breakpoint — the panel no longer overflows horizontally at narrow widths.

`npm test` 972 pass; the codicon CSS split was verified so the attach-image button keeps its icon style.

## How to verify (manual)
- Sidebar title bar: install vs upgrade icons look different; actions render in three divider-separated groups.
- Create-Spec: no Load Template button; the turbo option reads `Turbo` with the full text on hover.
- Narrow the Create-Spec panel: the workflow row + image-attachment header wrap/stack instead of overflowing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)