### PR TITLE
fix(settings): collapse beta tri-state to boolean + drop beta badges

### DIFF
--- a/package.json
+++ b/package.json
@@ -1024,34 +1024,14 @@
         "title": "Beta Features",
         "properties": {
           "speckit.viewer.activityPanel": {
-            "type": "string",
-            "default": "beta",
-            "enum": [
-              "off",
-              "beta",
-              "on"
-            ],
-            "enumDescriptions": [
-              "Hide the toggle.",
-              "Show the toggle with a \"beta\" badge (default).",
-              "Show the toggle with no badge (treat as stable)."
-            ],
+            "type": "boolean",
+            "default": true,
             "scope": "window",
             "description": "Show a per-spec Activity timeline in the viewer — step transitions, decisions, and files touched. Opt-in beta."
           },
           "speckit.companion.turboWorkflowPicker": {
-            "type": "string",
-            "default": "beta",
-            "enum": [
-              "off",
-              "beta",
-              "on"
-            ],
-            "enumDescriptions": [
-              "Hide the turbo choice from the Create New Spec workflow dropdown.",
-              "Offer a \"SpecKit Companion (Turbo)\" choice with a \"beta\" badge when the Companion extension is installed in the project (default).",
-              "Offer the \"SpecKit Companion (Turbo)\" choice with no badge (treat as stable) when the Companion extension is installed."
-            ],
+            "type": "boolean",
+            "default": true,
             "scope": "window",
             "description": "Add a \"SpecKit Companion (Turbo)\" choice to the Create-Spec workflow dropdown, pinning turbo on just that spec. Appears only when the spec-kit extension is installed. Opt-in beta."
           },
@@ -1084,20 +1064,10 @@
             "description": "Show a Resume (▶) button on sidebar specs that dispatches the next pipeline step. Opt-in beta, off by default."
           },
           "speckit.companion.installPrompt": {
-            "type": "string",
-            "default": "on",
-            "enum": [
-              "off",
-              "beta",
-              "on"
-            ],
-            "enumDescriptions": [
-              "Never show the spec-kit extension install banner, even when it's missing.",
-              "Show the install banner when the spec-kit extension is missing (same as 'on'; reserved for parity with other flags).",
-              "Show a one-click install banner in the Create-Spec and Activity panels when the spec-kit extension is missing (default)."
-            ],
+            "type": "boolean",
+            "default": true,
             "scope": "window",
-            "description": "Prompt to install the companion spec-kit extension (Create-Spec + Activity panels) when it's missing. Hidden once installed. Defaults to on."
+            "description": "Prompt to install the companion spec-kit extension (Create-Spec + Activity panels) when it's missing — a one-click install banner in the Create-Spec and Activity panels. Hidden once installed. Opt-in beta; defaults to on."
           }
         }
       }

--- a/specs/153-boolean-beta-settings/.spec-context.json
+++ b/specs/153-boolean-beta-settings/.spec-context.json
@@ -1,0 +1,291 @@
+{
+  "workflow": "speckit",
+  "specName": "boolean beta settings",
+  "branch": "153-boolean-beta-settings",
+  "currentStep": "implement",
+  "status": "implemented",
+  "history": [
+    {
+      "step": "specify",
+      "substep": null,
+      "kind": "start",
+      "by": "extension",
+      "at": "2026-06-11T14:55:21.495Z"
+    },
+    {
+      "step": "specify",
+      "substep": null,
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-06-11T14:56:15.691Z"
+    },
+    {
+      "step": "plan",
+      "substep": null,
+      "kind": "start",
+      "by": "ai",
+      "at": "2026-06-11T14:56:25.500Z"
+    },
+    {
+      "step": "plan",
+      "substep": null,
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-11T14:56:59.146Z"
+    },
+    {
+      "step": "tasks",
+      "substep": null,
+      "kind": "start",
+      "by": "ai",
+      "at": "2026-06-11T14:57:09.272Z"
+    },
+    {
+      "step": "tasks",
+      "substep": "generate",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-11T14:57:37.486Z"
+    },
+    {
+      "step": "tasks",
+      "substep": null,
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-11T14:57:37.564Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "kind": "start",
+      "by": "extension",
+      "at": "2026-06-11T14:57:41.875Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T001",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-11T14:58:34.303Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T002",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-11T14:59:04.309Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T003",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-11T14:59:26.461Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T004",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-11T15:01:04.600Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T005",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-11T15:01:04.675Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T006",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-11T15:03:32.373Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T007",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-11T15:03:32.454Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T008",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-11T15:03:32.538Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T009",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-11T15:03:32.621Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T010",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-11T15:03:32.710Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T011",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-11T15:03:32.794Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T012",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-11T15:03:32.878Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T013",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-11T15:03:32.962Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T014",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-11T15:04:45.006Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-06-11T15:04:57.487Z"
+    }
+  ],
+  "currentTask": "T014",
+  "task_summaries": {
+    "T001": {
+      "status": "DONE",
+      "did": "Add settingsMigration.ts: coerceLegacyBoolean + migrateBetaTriStateSettings (per-scope rewrite)",
+      "files": [
+        "src/core/settingsMigration.ts"
+      ]
+    },
+    "T002": {
+      "status": "DONE",
+      "did": "Add settingsMigration.test.ts: coercion + per-scope migration + idempotency (9 cases, passing)",
+      "files": [
+        "src/core/settingsMigration.test.ts",
+        "tests/__mocks__/vscode.ts"
+      ]
+    },
+    "T003": {
+      "status": "DONE",
+      "did": "Convert 3 settings to boolean type/default:true in package.json; removed enum/enumDescriptions; kept opt-in beta wording",
+      "files": [
+        "package.json"
+      ]
+    },
+    "T004": {
+      "status": "DONE",
+      "did": "installPrompt reader→boolean (readInstallPromptEnabled via coerceLegacyBoolean); shouldShowInstallPrompt(enabled,installed); updated its 2 tests",
+      "files": [
+        "src/speckit/specKitExtensionInstall.ts",
+        "src/speckit/specKitExtensionInstall.test.ts",
+        "src/features/spec-editor/installBanner.test.ts"
+      ]
+    },
+    "T005": {
+      "status": "DONE",
+      "did": "Updated both shouldShowInstallPrompt/readInstallPromptEnabled call sites in spec-editor + spec-viewer providers",
+      "files": [
+        "src/features/spec-editor/specEditorProvider.ts",
+        "src/features/spec-viewer/specViewerProvider.ts"
+      ]
+    },
+    "T006": {
+      "status": "DONE",
+      "did": "buildTurboWorkflowEntry reads boolean; dropped (beta) label suffix and beta field",
+      "files": [
+        "src/features/spec-editor/specEditorProvider.ts"
+      ]
+    },
+    "T007": {
+      "status": "DONE",
+      "did": "readActivityPanelMode→readActivityPanelEnabled(boolean); updated 2 call sites; payload now activityPanelEnabled",
+      "files": [
+        "src/features/spec-viewer/specViewerProvider.ts"
+      ]
+    },
+    "T008": {
+      "status": "DONE",
+      "did": "NavState activityPanelMode→activityPanelEnabled?:boolean in both type files",
+      "files": [
+        "src/features/spec-viewer/types.ts",
+        "webview/src/spec-viewer/types.ts"
+      ]
+    },
+    "T009": {
+      "status": "DONE",
+      "did": "generator.ts param activityPanelMode→activityPanelEnabled:boolean default true",
+      "files": [
+        "src/features/spec-viewer/html/generator.ts"
+      ]
+    },
+    "T010": {
+      "status": "DONE",
+      "did": "Dropped unused beta field from WorkflowDefinition in both type files",
+      "files": [
+        "src/features/spec-editor/types.ts",
+        "webview/src/spec-editor/types.ts"
+      ]
+    },
+    "T011": {
+      "status": "DONE",
+      "did": "NavigationBar reads activityPanelEnabled; removed activity-toggle__beta span",
+      "files": [
+        "webview/src/spec-viewer/components/NavigationBar.tsx"
+      ]
+    },
+    "T012": {
+      "status": "DONE",
+      "did": "Removed .activity-toggle__beta CSS rule",
+      "files": [
+        "webview/styles/spec-viewer/_activity.css"
+      ]
+    },
+    "T013": {
+      "status": "DONE",
+      "did": "Call migrateBetaTriStateSettings() early in activate()",
+      "files": [
+        "src/extension.ts"
+      ]
+    },
+    "T014": {
+      "status": "DONE",
+      "did": "npm run compile + compile-web + jest all green (80 suites, 981 tests); audited residual symbols; fixed stale comment",
+      "files": [
+        "src/features/spec-editor/specEditorProvider.ts"
+      ]
+    }
+  }
+}

--- a/specs/153-boolean-beta-settings/checklists/requirements.md
+++ b/specs/153-boolean-beta-settings/checklists/requirements.md
@@ -1,0 +1,32 @@
+# Specification Quality Checklist: Collapse Beta Tri-State Settings to Boolean On/Off
+
+**Purpose**: Validate turbo specification completeness before planning
+**Created**: 2026-06-11
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user/business value and the change's intent
+- [x] Overview states what is delivered and why in 1–3 sentences
+- [x] All four sections present (Overview, Functional Requirements, Success Criteria, Assumptions)
+
+## Requirement Completeness
+
+- [x] Any [NEEDS CLARIFICATION] markers are genuine ambiguities (≤3) deferred to clarify — none needed
+- [x] Each Functional Requirement is a single, testable MUST/SHOULD statement
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] Edge cases are folded into Functional Requirements or Assumptions (in-flight string-vs-boolean read, scope preservation)
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] Every Functional Requirement maps to at least one Success Criterion
+- [x] Overview intent is reflected by the FR list (no orphan goals)
+- [x] No implementation details leak into the specification
+
+## Notes
+
+- Items marked incomplete require spec updates before clarify or plan. All pass.

--- a/specs/153-boolean-beta-settings/plan.md
+++ b/specs/153-boolean-beta-settings/plan.md
@@ -1,0 +1,45 @@
+# Implementation Plan: Collapse Beta Tri-State Settings to Boolean On/Off
+
+## Summary
+
+Convert three tri-state (`off`/`beta`/`on`) settings to plain booleans in `package.json`, drop the two in-UI beta badges, and add a one-time activation migration plus a defensive boolean coercion shared by every reader. The crux is migration correctness: every reader must read a boolean, and a user's persisted legacy string (`beta`/`on` → `true`, `off` → `false`) must produce the same effective on/off state it had before, preserving config scope.
+
+## Technical Context
+
+- **Language/version**: TypeScript (VS Code extension, `tsc -p ./`), Preact webview, Jest tests.
+- **Primary dependencies**: `vscode` API (`workspace.getConfiguration`, `inspect`, `update`, `ConfigurationTarget`), Preact.
+- **Storage**: VS Code settings (`settings.json`) at global/workspace/folder scope.
+- **Testing**: Jest (`npm test`). The migration/coercion gets a unit test with a mocked config.
+- **Target platform**: VS Code extension host + webview.
+- **Constraints**: Zero effective on/off flip for existing users; no tri-state enum left; "opt-in beta" wording retained in descriptions.
+
+## Approach & Structure
+
+Order of attack, organized by file:
+
+1. **`src/core/settingsMigration.ts` (new)** — `coerceLegacyBoolean(value, default): boolean` (the defensive reader helper: `true`/`false` pass through; `'beta'`/`'on'` → `true`; `'off'` → `false`; anything else → default) and `migrateBetaTriStateSettings(): Promise<void>` that, for each of the three keys, `inspect()`s per scope (global/workspace/folder), and where the persisted value is a legacy string, `update()`s it to the coerced boolean at that same scope. Idempotent — skips values already boolean/undefined.
+2. **`src/extension.ts`** — call `migrateBetaTriStateSettings()` early in `activate()` (before the readers run / providers build).
+3. **`package.json`** — change the three settings to `"type": "boolean"`, `"default": true`, remove `enum`/`enumDescriptions`, keep "opt-in beta" wording in each `description`.
+4. **`src/speckit/specKitExtensionInstall.ts`** — `readInstallPromptMode()` → `readInstallPrompt(): boolean` via `coerceLegacyBoolean(get('companion.installPrompt'), true)`; `shouldShowInstallPrompt(enabled: boolean, installed: boolean)` returns `enabled && !installed`. Update both call sites in `specEditorProvider.ts` and `specViewerProvider.ts`.
+5. **`src/features/spec-editor/specEditorProvider.ts`** — `buildTurboWorkflowEntry()` reads boolean via `coerceLegacyBoolean`; gate on `!enabled` → undefined; drop the `(beta)` label suffix and the `beta` field on the synthetic `WorkflowDefinition`.
+6. **`src/features/spec-viewer/specViewerProvider.ts`** — `readActivityPanelMode()` → `readActivityPanelEnabled(): boolean` (default `true`); update its two call sites; thread a boolean `activityPanelEnabled` through `buildViewerPayload` and the initial HTML.
+7. **`src/features/spec-viewer/html/generator.ts`** + **`src/features/spec-viewer/types.ts`** + **`webview/src/spec-viewer/types.ts`** — change `activityPanelMode?: 'off'|'beta'|'on'` to `activityPanelEnabled?: boolean`.
+8. **`webview/src/spec-viewer/components/NavigationBar.tsx`** — read `ns.activityPanelEnabled ?? true`; render toggle when truthy; remove the `<span class="activity-toggle__beta">beta</span>`.
+9. **`webview/styles/spec-viewer/_activity.css`** — remove the now-unused `.activity-toggle__beta` rule.
+10. **Drop `beta` from `WorkflowDefinition`** in `src/features/spec-editor/types.ts` + `webview/src/spec-editor/types.ts` (it's set but never read for rendering).
+11. **`src/core/settingsMigration.test.ts` (new)** — unit-test `coerceLegacyBoolean` for `"beta"→true`, `"on"→true`, `"off"→false`, `true→true`, `false→false`, junk→default; and test `migrateBetaTriStateSettings` with a mocked `getConfiguration`/`inspect`/`update` asserting legacy strings get rewritten at the correct scope and booleans are left alone.
+
+**Decisions:**
+- **Defensive coercion + migration (both).** Migration runs at activation, but a reader could fire before it completes or read an un-migrated folder scope, so every reader funnels through `coerceLegacyBoolean` — robust to either type. This honors the lessons-learned "widen the type, don't cast" spirit: the reader's return type is `boolean`, no `as string`.
+- **Rename `activityPanelMode` → `activityPanelEnabled`** (and `installPromptMode` → boolean) so the type itself enforces boolean — no string-comparison reader can survive compile.
+- **Per-scope migration via `inspect()`** preserves whether the user set the value globally vs per-workspace.
+
+## Out of Scope
+
+- The other boolean beta settings (`complexityFastPath`, `resumeBeta`) — already booleans, untouched.
+- `speckit.companion.templateProfile` — stays a tri-state enum (`standard`/`turbo`/`off`); it is genuinely three-valued, not a badge toggle.
+- Any change to what the features DO when enabled.
+
+## Constitution Check
+
+No constitution gates defined for this repo. No violations.

--- a/specs/153-boolean-beta-settings/spec.md
+++ b/specs/153-boolean-beta-settings/spec.md
@@ -1,0 +1,32 @@
+# Specification: Collapse Beta Tri-State Settings to Boolean On/Off
+
+## Overview
+
+Three beta-gated settings (`speckit.viewer.activityPanel`, `speckit.companion.turboWorkflowPicker`, `speckit.companion.installPrompt`) are currently tri-state (`off`/`beta`/`on`), where `beta` and `on` produce identical behavior and differ only by whether a redundant in-UI "beta" badge renders. This change collapses the three settings to plain boolean on/off, removes the redundant in-UI beta badges, and migrates existing persisted string values so no user's effective on/off state flips.
+
+## Functional Requirements
+
+- **FR-001**: The settings `speckit.viewer.activityPanel`, `speckit.companion.turboWorkflowPicker`, and `speckit.companion.installPrompt` MUST be declared as `boolean` in `package.json`, with no tri-state `enum`/`enumDescriptions` remaining.
+- **FR-002**: Default values MUST be `true` for all three settings (preserving today's effective defaults: `activityPanel` and `turboWorkflowPicker` defaulted to `beta` = shown; `installPrompt` defaulted to `on` = shown).
+- **FR-003**: Each setting's `description` MUST retain the "opt-in beta" wording so users see the feature is experimental before enabling it.
+- **FR-004**: The in-UI "(beta)" suffix on the "SpecKit Companion (Turbo)" workflow option MUST be removed.
+- **FR-005**: The in-UI "beta" badge span on the viewer's Activity toggle MUST be removed (the markup and its dedicated CSS rule).
+- **FR-006**: Every reader of the three settings MUST read a boolean. No reader may compare against `'off'`, `'beta'`, or `'on'` string literals as the live setting type.
+- **FR-007**: A migration MUST run once at extension activation that rewrites any persisted legacy string value of the three settings: `'beta'` and `'on'` map to `true`, `'off'` maps to `false`. The migration MUST preserve the configuration scope (global/workspace/folder) at which the legacy value was set, and MUST NOT write a value where none was set.
+- **FR-008**: Readers MUST defensively tolerate BOTH a legacy string AND a boolean during the in-flight transition (before migration completes or for an un-migrated scope), coercing a legacy string with the same mapping as FR-007.
+- **FR-009**: No behavior MUST change beyond badge removal and the on/off simplification — a feature that was effectively shown stays shown, a feature that was off stays off.
+
+## Success Criteria
+
+- **SC-001**: A fresh install with no overrides shows the Activity toggle, offers the Turbo workflow option, and shows the install banner (when the extension is missing) — none with a "beta" badge.
+- **SC-002**: A user with a persisted `"speckit.viewer.activityPanel": "beta"` (or `"on"`) ends up with the feature shown; a persisted `"off"` ends up hidden — identical effective state to before the change.
+- **SC-003**: No "(beta)" suffix or "beta" badge renders for any of the three features in any setting state.
+- **SC-004**: `npm run compile` and `npm test` pass; a unit test feeds legacy `"beta"`, `"on"`, and `"off"` strings through the coercion/migration and asserts the boolean outcome (`true`, `true`, `false`).
+- **SC-005**: No tri-state `enum` for these three keys remains anywhere in `package.json` or in the TypeScript reader signatures.
+
+## Assumptions
+
+- The `beta` field on the synthetic turbo `WorkflowDefinition` is set but never read for rendering (the "(beta)" label suffix is the only badge); it can be dropped or left inert without behavior change. Removing it is preferred to avoid a dead field.
+- The migration is best-effort and idempotent: re-running it on already-boolean values is a no-op.
+- `installPrompt`'s `beta` enum value was documented as "reserved for parity" with no distinct behavior, so collapsing loses nothing.
+- Scope precedence (folder > workspace > global) is preserved by migrating each scope where a legacy value is explicitly set, using VS Code's `inspect()` per-scope values.

--- a/specs/153-boolean-beta-settings/tasks.md
+++ b/specs/153-boolean-beta-settings/tasks.md
@@ -1,0 +1,35 @@
+# Tasks: Collapse Beta Tri-State Settings to Boolean On/Off
+
+Dependency-ordered. Turbo profile — organized by file/concern, not user story.
+
+## Phase 1: Migration core (blocks readers)
+
+- [x] **T001** Create `src/core/settingsMigration.ts` with `coerceLegacyBoolean(value: unknown, fallback: boolean): boolean` (true/false pass through; `'beta'`/`'on'` → true; `'off'` → false; else fallback) and `BETA_BOOLEAN_SETTING_KEYS` listing the three relative keys + their defaults + `migrateBetaTriStateSettings(): Promise<void>` that per-scope `inspect()`s each key and `update()`s legacy-string values to the coerced boolean at the same scope (idempotent; skips boolean/undefined) + src/core/settingsMigration.ts
+- [x] **T002** [P] Add `src/core/settingsMigration.test.ts` — unit-test `coerceLegacyBoolean` (`"beta"`→true, `"on"`→true, `"off"`→false, true→true, false→false, junk→fallback) and `migrateBetaTriStateSettings` with a mocked `vscode.workspace.getConfiguration`/`inspect`/`update` asserting legacy strings rewrite at the correct scope and booleans/undefined are left untouched + src/core/settingsMigration.test.ts
+
+## Phase 2: package.json schema
+
+- [x] **T003** In `package.json`, change `speckit.viewer.activityPanel`, `speckit.companion.turboWorkflowPicker`, `speckit.companion.installPrompt` to `"type": "boolean"`, `"default": true`, remove `enum` + `enumDescriptions`, keep "opt-in beta" wording in each `description` + package.json
+
+## Phase 3: Readers → boolean
+
+- [x] **T004** In `src/speckit/specKitExtensionInstall.ts`, replace `readInstallPromptMode(): 'off'|'beta'|'on'` with a boolean reader (`coerceLegacyBoolean(get('companion.installPrompt'), true)`) and change `shouldShowInstallPrompt(enabled: boolean, installed: boolean) => enabled && !installed` + src/speckit/specKitExtensionInstall.ts
+- [x] **T005** Update both `shouldShowInstallPrompt`/`readInstallPrompt` call sites in `src/features/spec-editor/specEditorProvider.ts` and `src/features/spec-viewer/specViewerProvider.ts` to the boolean signature + src/features/spec-editor/specEditorProvider.ts, src/features/spec-viewer/specViewerProvider.ts
+- [x] **T006** In `src/features/spec-editor/specEditorProvider.ts` `buildTurboWorkflowEntry()`, read the boolean via `coerceLegacyBoolean`, return undefined when disabled, drop the `(beta)` label suffix and the `beta` field on the returned `WorkflowDefinition` + src/features/spec-editor/specEditorProvider.ts
+- [x] **T007** In `src/features/spec-viewer/specViewerProvider.ts`, rename `readActivityPanelMode()` → `readActivityPanelEnabled(): boolean` (default true, via `coerceLegacyBoolean`) and update its two call sites; thread boolean `activityPanelEnabled` into the viewer payload + src/features/spec-viewer/specViewerProvider.ts
+
+## Phase 4: Types + payload threading
+
+- [x] **T008** [P] Change `activityPanelMode?: 'off'|'beta'|'on'` → `activityPanelEnabled?: boolean` in `src/features/spec-viewer/types.ts` and `webview/src/spec-viewer/types.ts` + src/features/spec-viewer/types.ts, webview/src/spec-viewer/types.ts
+- [x] **T009** Update `src/features/spec-viewer/html/generator.ts` to accept/forward `activityPanelEnabled: boolean` (default true) in place of `activityPanelMode` + src/features/spec-viewer/html/generator.ts
+- [x] **T010** [P] Drop the now-unused `beta?: boolean` field from `WorkflowDefinition` in `src/features/spec-editor/types.ts` and `webview/src/spec-editor/types.ts` + src/features/spec-editor/types.ts, webview/src/spec-editor/types.ts
+
+## Phase 5: Badge removal (webview)
+
+- [x] **T011** In `webview/src/spec-viewer/components/NavigationBar.tsx`, read `ns.activityPanelEnabled ?? true`, render the toggle when truthy, and remove the `<span class="activity-toggle__beta">beta</span>` markup + webview/src/spec-viewer/components/NavigationBar.tsx
+- [x] **T012** [P] Remove the `.activity-toggle__beta` rule from `webview/styles/spec-viewer/_activity.css` + webview/styles/spec-viewer/_activity.css
+
+## Phase 6: Activation wiring + verify
+
+- [x] **T013** Call `migrateBetaTriStateSettings()` early in `activate()` in `src/extension.ts` (before providers build) + src/extension.ts
+- [x] **T014** Run `npm run compile` and `npm test`; fix any failures (grep for residual `'beta'`/`'on'`/`'off'` reads, `activityPanelMode`, `.activity-toggle__beta`, `(beta)` suffix) + (verification)

--- a/src/core/settingsMigration.test.ts
+++ b/src/core/settingsMigration.test.ts
@@ -115,6 +115,20 @@ describe('migrateBetaTriStateSettings', () => {
         expect(update).not.toHaveBeenCalled();
     });
 
+    it('leaves an unknown (non-legacy) string untouched rather than coercing it', async () => {
+        const { update } = setupConfig({
+            'viewer.activityPanel': { globalValue: 'maybe' },
+            'companion.turboWorkflowPicker': {},
+            'companion.installPrompt': {},
+        });
+
+        await migrateBetaTriStateSettings();
+
+        // Only the three known legacy strings ('off'/'beta'/'on') are migrated;
+        // a typo is left for VS Code to flag, not silently rewritten to a boolean.
+        expect(update).not.toHaveBeenCalled();
+    });
+
     it('covers all three former tri-state settings', () => {
         expect(BETA_BOOLEAN_SETTINGS.map(s => s.key)).toEqual([
             'viewer.activityPanel',

--- a/src/core/settingsMigration.test.ts
+++ b/src/core/settingsMigration.test.ts
@@ -1,0 +1,125 @@
+import * as vscode from 'vscode';
+import {
+    coerceLegacyBoolean,
+    migrateBetaTriStateSettings,
+    BETA_BOOLEAN_SETTINGS,
+} from './settingsMigration';
+
+describe('coerceLegacyBoolean', () => {
+    it('maps legacy "beta" and "on" strings to true', () => {
+        expect(coerceLegacyBoolean('beta', false)).toBe(true);
+        expect(coerceLegacyBoolean('on', false)).toBe(true);
+    });
+
+    it('maps legacy "off" string to false', () => {
+        expect(coerceLegacyBoolean('off', true)).toBe(false);
+    });
+
+    it('passes real booleans through unchanged', () => {
+        expect(coerceLegacyBoolean(true, false)).toBe(true);
+        expect(coerceLegacyBoolean(false, true)).toBe(false);
+    });
+
+    it('falls back for undefined / unknown values', () => {
+        expect(coerceLegacyBoolean(undefined, true)).toBe(true);
+        expect(coerceLegacyBoolean(undefined, false)).toBe(false);
+        expect(coerceLegacyBoolean('weird', true)).toBe(true);
+        expect(coerceLegacyBoolean(42, false)).toBe(false);
+    });
+});
+
+describe('migrateBetaTriStateSettings', () => {
+    type Inspection = {
+        globalValue?: unknown;
+        workspaceValue?: unknown;
+        workspaceFolderValue?: unknown;
+    };
+
+    function setupConfig(inspections: Record<string, Inspection>) {
+        const update = jest.fn().mockResolvedValue(undefined);
+        const inspect = jest.fn((key: string) => inspections[key]);
+        jest.spyOn(vscode.workspace, 'getConfiguration').mockReturnValue({
+            inspect,
+            update,
+            get: jest.fn(),
+        } as unknown as vscode.WorkspaceConfiguration);
+        return { update, inspect };
+    }
+
+    afterEach(() => jest.restoreAllMocks());
+
+    it('rewrites a legacy "beta" string to true at the global scope', async () => {
+        const { update } = setupConfig({
+            'viewer.activityPanel': { globalValue: 'beta' },
+            'companion.turboWorkflowPicker': {},
+            'companion.installPrompt': {},
+        });
+
+        await migrateBetaTriStateSettings();
+
+        expect(update).toHaveBeenCalledWith(
+            'viewer.activityPanel',
+            true,
+            vscode.ConfigurationTarget.Global
+        );
+    });
+
+    it('rewrites legacy "on" → true and "off" → false at their set scopes', async () => {
+        const { update } = setupConfig({
+            'viewer.activityPanel': {},
+            'companion.turboWorkflowPicker': { workspaceValue: 'on' },
+            'companion.installPrompt': { workspaceFolderValue: 'off' },
+        });
+
+        await migrateBetaTriStateSettings();
+
+        expect(update).toHaveBeenCalledWith(
+            'companion.turboWorkflowPicker',
+            true,
+            vscode.ConfigurationTarget.Workspace
+        );
+        expect(update).toHaveBeenCalledWith(
+            'companion.installPrompt',
+            false,
+            vscode.ConfigurationTarget.WorkspaceFolder
+        );
+    });
+
+    it('preserves scope: a global override is not relocated to workspace', async () => {
+        const { update } = setupConfig({
+            'viewer.activityPanel': { globalValue: 'off' },
+            'companion.turboWorkflowPicker': {},
+            'companion.installPrompt': {},
+        });
+
+        await migrateBetaTriStateSettings();
+
+        expect(update).toHaveBeenCalledWith(
+            'viewer.activityPanel',
+            false,
+            vscode.ConfigurationTarget.Global
+        );
+        // Only the global scope was touched.
+        expect(update).toHaveBeenCalledTimes(1);
+    });
+
+    it('is a no-op for already-boolean and unset values (idempotent)', async () => {
+        const { update } = setupConfig({
+            'viewer.activityPanel': { globalValue: true },
+            'companion.turboWorkflowPicker': { workspaceValue: false },
+            'companion.installPrompt': {},
+        });
+
+        await migrateBetaTriStateSettings();
+
+        expect(update).not.toHaveBeenCalled();
+    });
+
+    it('covers all three former tri-state settings', () => {
+        expect(BETA_BOOLEAN_SETTINGS.map(s => s.key)).toEqual([
+            'viewer.activityPanel',
+            'companion.turboWorkflowPicker',
+            'companion.installPrompt',
+        ]);
+    });
+});

--- a/src/core/settingsMigration.ts
+++ b/src/core/settingsMigration.ts
@@ -69,18 +69,19 @@ const SCOPES: ReadonlyArray<{
  */
 export async function migrateBetaTriStateSettings(): Promise<void> {
     const config = vscode.workspace.getConfiguration('speckit');
-    for (const { key } of BETA_BOOLEAN_SETTINGS) {
+    for (const { key, default: settingDefault } of BETA_BOOLEAN_SETTINGS) {
         const inspected = config.inspect(key);
         if (!inspected) {
             continue;
         }
         for (const { target, field } of SCOPES) {
             const persisted = inspected[field];
-            // Only rewrite a legacy *string* value. A boolean is already migrated;
-            // undefined means the user never set it at this scope — leave it.
-            if (typeof persisted === 'string') {
-                const coerced = coerceLegacyBoolean(persisted, true);
-                await config.update(key, coerced, target);
+            // Only rewrite a KNOWN legacy tri-state string. A boolean is already
+            // migrated; undefined means unset at this scope; and an unknown string
+            // (typo) is left untouched for VS Code to flag rather than silently
+            // coerced. Fall back to the per-setting default (not a hardcoded true).
+            if (persisted === 'off' || persisted === 'beta' || persisted === 'on') {
+                await config.update(key, coerceLegacyBoolean(persisted, settingDefault), target);
             }
         }
     }

--- a/src/core/settingsMigration.ts
+++ b/src/core/settingsMigration.ts
@@ -1,0 +1,87 @@
+import * as vscode from 'vscode';
+
+/**
+ * Migration + defensive coercion for the three former tri-state beta settings
+ * (#259). These were `'off' | 'beta' | 'on'` string enums where `beta` and `on`
+ * behaved identically (they differed only by a redundant in-UI badge). They are
+ * now plain booleans. This module:
+ *
+ *  1. Coerces a persisted value to a boolean at read time, tolerating BOTH a
+ *     legacy string AND a real boolean (`coerceLegacyBoolean`) — so a reader is
+ *     correct even before the migration has run or for an un-migrated scope.
+ *  2. Rewrites any persisted legacy string in `settings.json` to its boolean
+ *     equivalent at the same config scope, once, at activation
+ *     (`migrateBetaTriStateSettings`).
+ *
+ * Mapping: `'beta'` / `'on'` → `true`, `'off'` → `false`. This preserves every
+ * existing user's effective on/off state (no surprise flip).
+ */
+
+/** Settings whose legacy `'off' | 'beta' | 'on'` strings migrate to booleans. */
+export const BETA_BOOLEAN_SETTINGS: ReadonlyArray<{
+    /** Key relative to the `speckit` configuration section. */
+    readonly key: string;
+    /** Boolean default once migrated (matches the pre-migration effective default). */
+    readonly default: boolean;
+}> = [
+    { key: 'viewer.activityPanel', default: true },
+    { key: 'companion.turboWorkflowPicker', default: true },
+    { key: 'companion.installPrompt', default: true },
+];
+
+/**
+ * Coerce a persisted setting value to a boolean, tolerating the legacy tri-state
+ * strings. `true`/`false` pass through; `'beta'`/`'on'` → `true`; `'off'` → `false`;
+ * anything else (undefined, unknown string) → `fallback`.
+ *
+ * Every reader of the three settings funnels through this so the live read is a
+ * boolean regardless of whether the migration has rewritten settings.json yet.
+ */
+export function coerceLegacyBoolean(value: unknown, fallback: boolean): boolean {
+    if (typeof value === 'boolean') {
+        return value;
+    }
+    if (value === 'beta' || value === 'on') {
+        return true;
+    }
+    if (value === 'off') {
+        return false;
+    }
+    return fallback;
+}
+
+/** The three config scopes a value can be explicitly set at, with their inspect field. */
+const SCOPES: ReadonlyArray<{
+    readonly target: vscode.ConfigurationTarget;
+    readonly field: 'globalValue' | 'workspaceValue' | 'workspaceFolderValue';
+}> = [
+    { target: vscode.ConfigurationTarget.Global, field: 'globalValue' },
+    { target: vscode.ConfigurationTarget.Workspace, field: 'workspaceValue' },
+    { target: vscode.ConfigurationTarget.WorkspaceFolder, field: 'workspaceFolderValue' },
+];
+
+/**
+ * One-time, idempotent migration: for each former tri-state setting, rewrite any
+ * persisted *string* value to its boolean equivalent at the same scope it was set.
+ * Values already boolean (or unset) are left untouched, so re-running is a no-op.
+ * Scope is preserved via per-scope `inspect()` so a global vs. workspace override
+ * isn't relocated.
+ */
+export async function migrateBetaTriStateSettings(): Promise<void> {
+    const config = vscode.workspace.getConfiguration('speckit');
+    for (const { key } of BETA_BOOLEAN_SETTINGS) {
+        const inspected = config.inspect(key);
+        if (!inspected) {
+            continue;
+        }
+        for (const { target, field } of SCOPES) {
+            const persisted = inspected[field];
+            // Only rewrite a legacy *string* value. A boolean is already migrated;
+            // undefined means the user never set it at this scope — leave it.
+            if (typeof persisted === 'string') {
+                const coerced = coerceLegacyBoolean(persisted, true);
+                await config.update(key, coerced, target);
+            }
+        }
+    }
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -106,7 +106,8 @@ export async function activate(context: vscode.ExtensionContext) {
     try {
         await migrateBetaTriStateSettings();
     } catch (err) {
-        outputChannel.appendLine(`[Extension] Beta-settings migration skipped: ${err}`);
+        const detail = err instanceof Error ? err.message : String(err);
+        outputChannel.appendLine(`[Extension] Beta-settings migration skipped: ${detail}`);
     }
 
     // Reload ConfigManager settings on configuration changes (single listener for all consumers)

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -26,6 +26,7 @@ import { isCompanionInstalled } from './features/settings/companionPresetReconci
 import { Views, setupFileWatchers, setupTasksWatcher, setupSpecViewerWatcher } from './core';
 import { ConfigKeys } from './core/constants';
 import { ConfigManager } from './core/utils/configManager';
+import { migrateBetaTriStateSettings } from './core/settingsMigration';
 import { openSpecFile } from './core/utils/fileOpener';
 
 let aiProvider: IAIProvider;
@@ -97,6 +98,16 @@ export async function activate(context: vscode.ExtensionContext) {
     // Initialize providers and managers
     aiProvider = AIProviderFactory.getProvider(context, outputChannel);
     outputChannel.appendLine(`[Extension] Using AI provider: ${aiProvider.name}`);
+
+    // Migrate the former tri-state beta settings (#259) to booleans before any
+    // reader runs. Idempotent and scope-preserving: legacy `'beta'`/`'on'` → true,
+    // `'off'` → false. Readers still coerce defensively, so an un-migrated scope or
+    // an in-flight read is safe regardless.
+    try {
+        await migrateBetaTriStateSettings();
+    } catch (err) {
+        outputChannel.appendLine(`[Extension] Beta-settings migration skipped: ${err}`);
+    }
 
     // Reload ConfigManager settings on configuration changes (single listener for all consumers)
     const configManager = ConfigManager.getInstance();

--- a/src/features/spec-editor/installBanner.test.ts
+++ b/src/features/spec-editor/installBanner.test.ts
@@ -13,12 +13,12 @@ describe('renderInstallBannerHtml — gated banner visibility', () => {
         expect(renderInstallBannerHtml(false)).toBe('');
     });
 
-    it('is driven by shouldShowInstallPrompt: installed → empty, missing+on → banner', () => {
-        // Installed project: no banner regardless of mode (zero regression).
-        expect(renderInstallBannerHtml(shouldShowInstallPrompt('on', true))).toBe('');
-        // Missing extension + prompt on: banner shows.
-        expect(renderInstallBannerHtml(shouldShowInstallPrompt('on', false))).toContain('install-banner');
-        // Missing extension but explicitly off: no banner.
-        expect(renderInstallBannerHtml(shouldShowInstallPrompt('off', false))).toBe('');
+    it('is driven by shouldShowInstallPrompt: installed → empty, missing+enabled → banner', () => {
+        // Installed project: no banner whether enabled or not (zero regression).
+        expect(renderInstallBannerHtml(shouldShowInstallPrompt(true, true))).toBe('');
+        // Missing extension + prompt enabled: banner shows.
+        expect(renderInstallBannerHtml(shouldShowInstallPrompt(true, false))).toContain('install-banner');
+        // Missing extension but explicitly disabled: no banner.
+        expect(renderInstallBannerHtml(shouldShowInstallPrompt(false, false))).toBe('');
     });
 });

--- a/src/features/spec-editor/specEditorProvider.ts
+++ b/src/features/spec-editor/specEditorProvider.ts
@@ -15,9 +15,10 @@ import { formatCommandForProvider } from '../../ai-providers/aiProvider';
 import { buildSpecifyCreationPreamble } from '../../ai-providers/promptBuilder';
 import { resolveNewSpecProfileCommandWithFallback } from '../specs/profileDispatch';
 import { isCompanionInstalled } from '../settings/companionPresetReconciler';
-import { shouldShowInstallPrompt, readInstallPromptMode } from '../../speckit/specKitExtensionInstall';
+import { shouldShowInstallPrompt, readInstallPromptEnabled } from '../../speckit/specKitExtensionInstall';
 import { renderInstallBannerHtml } from './installBanner';
 import { AIProviders, WorkflowSteps, ConfigKeys } from '../../core/constants';
+import { coerceLegacyBoolean } from '../../core/settingsMigration';
 
 /** The turbo specify twin the picker routes to when turbo is chosen. */
 const TURBO_SPECIFY_COMMAND = 'speckit.companion.specify';
@@ -133,11 +134,9 @@ export class SpecEditorProvider {
     /**
      * Build the synthetic "SpecKit Companion (Turbo)" picker entry, or undefined
      * when it must not appear. Returns undefined when the `turboWorkflowPicker`
-     * beta toggle resolves to `off`, OR when the Companion spec-kit extension is
-     * not installed in the project (so an `on`/`beta` toggle in a non-Companion
-     * project still hides it). When `beta`, the label carries a "(beta)" suffix;
-     * when `on`, the suffix is dropped (treated as stable) — mirroring the
-     * activity-panel beta-flag precedent.
+     * toggle is off, OR when the Companion spec-kit extension is not installed in
+     * the project (so an enabled toggle in a non-Companion project still hides it).
+     * The toggle is a boolean opt-in; the label carries no badge.
      */
     /**
      * Non-blocking warning shown when a turbo specify dispatch was downgraded to
@@ -161,24 +160,21 @@ export class SpecEditorProvider {
     }
 
     private buildTurboWorkflowEntry(): WorkflowDefinition | undefined {
-        const mode = vscode.workspace
+        const raw = vscode.workspace
             .getConfiguration(ConfigKeys.namespace)
-            .get<'off' | 'beta' | 'on'>('companion.turboWorkflowPicker', 'beta');
-        if (mode === 'off') {
+            .get<unknown>('companion.turboWorkflowPicker', true);
+        if (!coerceLegacyBoolean(raw, true)) {
             return undefined;
         }
         const workspaceRoot = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
         if (!workspaceRoot || !isCompanionInstalled(workspaceRoot)) {
             return undefined;
         }
-        const isBeta = mode === 'beta';
-        const fullLabel = `SpecKit Companion (Turbo)${isBeta ? ' (beta)' : ''}`;
         return {
             name: TURBO_WORKFLOW_NAME,
             displayName: 'Turbo',
-            description: `${fullLabel} — pin turbo on this spec — leaner /speckit.companion.* pipeline, regardless of the project default.`,
+            description: `SpecKit Companion (Turbo) — pin turbo on this spec — leaner /speckit.companion.* pipeline, regardless of the project default.`,
             stepSpecify: `/${formatCommandForProvider(TURBO_SPECIFY_COMMAND)}`,
-            beta: isBeta,
         };
     }
 
@@ -545,14 +541,13 @@ export class SpecEditorProvider {
 
         const nonce = generateNonce();
 
-        // Install banner: shown only when the prompt mode isn't `off` AND the
-        // spec-kit extension is missing — installed projects see nothing (FR-007,
-        // zero-regression). Visibility is the unit-tested gate; the markup is shared
-        // with the Activity panel.
+        // Install banner: shown only when the prompt is enabled AND the spec-kit
+        // extension is missing — installed projects see nothing (zero-regression).
+        // Visibility is the unit-tested gate; the markup is shared with the Activity panel.
         const workspaceRoot = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
         const installBanner = renderInstallBannerHtml(
             shouldShowInstallPrompt(
-                readInstallPromptMode(),
+                readInstallPromptEnabled(),
                 workspaceRoot ? isCompanionInstalled(workspaceRoot) : false
             )
         );

--- a/src/features/spec-editor/types.ts
+++ b/src/features/spec-editor/types.ts
@@ -175,8 +175,6 @@ export interface WorkflowDefinition {
     stepImplement?: string;
     /** Custom commands for the specify step (shown next to Submit) */
     specifyCommands?: Array<{ name: string; title: string; command: string; tooltip?: string }>;
-    /** Marks a beta-gated synthetic entry (e.g. the turbo picker option). */
-    beta?: boolean;
 }
 
 // ============================================

--- a/src/features/spec-viewer/html/generator.ts
+++ b/src/features/spec-viewer/html/generator.ts
@@ -42,7 +42,7 @@ export function generateHtml(
     currentFilePath?: string | null,
     currentStep?: string | null,
     stepHistory?: Record<string, { startedAt?: string; completedAt?: string | null }>,
-    activityPanelMode: 'off' | 'beta' | 'on' = 'beta',
+    activityPanelEnabled: boolean = true,
     showInstallPrompt: boolean = false
 ): string {
     // Get URIs for resources
@@ -99,7 +99,7 @@ export function generateHtml(
         currentStep: currentStep ?? null,
         filePath: currentFilePath ?? null,
         docTypeLabel: getDocTypeLabel(currentStep ?? currentDocType),
-        activityPanelMode,
+        activityPanelEnabled,
         showInstallPrompt,
     };
 

--- a/src/features/spec-viewer/specViewerProvider.ts
+++ b/src/features/spec-viewer/specViewerProvider.ts
@@ -45,6 +45,7 @@ import {
 import { getDocumentTypeFromPath, getSpecDirectoryFromPath } from "./utils";
 import { optionalCommandButtonsForTab } from "./optionalCommands";
 import { ConfigKeys, SpecStatuses, WorkflowSteps } from "../../core/constants";
+import { coerceLegacyBoolean } from "../../core/settingsMigration";
 import type { CustomCommandConfig } from "../../core/types/config";
 import { deriveChangeRoot } from "../../core/specDirectoryResolver";
 import { deriveSpecName } from "../specs/specContextManager";
@@ -55,7 +56,7 @@ import { backfillMinimalContext } from "../specs/specContextBackfill";
 import { resetMalformedContext } from "../specs/specContextReset";
 import { reconcileAndPersist } from "../specs/specContextReconciler";
 import { isCompanionInstalled } from "../settings/companionPresetReconciler";
-import { shouldShowInstallPrompt, readInstallPromptMode } from "../../speckit/specKitExtensionInstall";
+import { shouldShowInstallPrompt, readInstallPromptEnabled } from "../../speckit/specKitExtensionInstall";
 import { deriveViewerState, isStepCompleted, findRunningStep } from "./stateDerivation";
 import { hasNonTrivialArtifact } from "./stepArtifact";
 import { StepCompletionNotifier, NotifierContext } from "./stepCompletionNotifier";
@@ -157,14 +158,16 @@ export class SpecViewerProvider {
   ) {}
 
   /**
-   * Read `speckit.viewer.activityPanel` from VS Code settings. Falls back
-   * to `"beta"` if the setting is missing or has an unknown value.
+   * Read `speckit.viewer.activityPanel` from VS Code settings as a boolean.
+   * Defaults to `true` (shown). Tolerates a legacy tri-state string
+   * (`'beta'`/`'on'` → `true`, `'off'` → `false`) until the settings migration
+   * rewrites it.
    */
-  private readActivityPanelMode(): 'off' | 'beta' | 'on' {
-    const v = vscode.workspace
+  private readActivityPanelEnabled(): boolean {
+    const raw = vscode.workspace
       .getConfiguration('speckit.viewer')
-      .get<string>('activityPanel', 'beta');
-    return v === 'off' || v === 'on' ? v : 'beta';
+      .get<unknown>('activityPanel', true);
+    return coerceLegacyBoolean(raw, true);
   }
 
   /**
@@ -175,7 +178,7 @@ export class SpecViewerProvider {
   private computeShowInstallPrompt(): boolean {
     const root = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
     return shouldShowInstallPrompt(
-      readInstallPromptMode(),
+      readInstallPromptEnabled(),
       root ? isCompanionInstalled(root) : false
     );
   }
@@ -614,7 +617,7 @@ export class SpecViewerProvider {
         doc?.filePath ?? null,
         featureCtx?.currentStep ?? doc?.type ?? null,
         derived.stepHistoryByTab,
-        this.readActivityPanelMode(),
+        this.readActivityPanelEnabled(),
         this.computeShowInstallPrompt(),
       );
 
@@ -974,7 +977,7 @@ export class SpecViewerProvider {
       currentStep: featureCtx?.currentStep ?? resolvedType ?? null,
       filePath: doc?.filePath ?? null,
       docTypeLabel: getDocTypeLabel(featureCtx?.currentStep ?? resolvedType),
-      activityPanelMode: this.readActivityPanelMode(),
+      activityPanelEnabled: this.readActivityPanelEnabled(),
       // Must be re-sent on every update: the webview replaces the whole navState
       // object, so omitting this would make the relocated Activity-panel banner
       // (#255) vanish on the first content/spec-context refresh after load.

--- a/src/features/spec-viewer/types.ts
+++ b/src/features/spec-viewer/types.ts
@@ -257,8 +257,8 @@ export interface NavState {
     filePath?: string | null;
     /** Display label for the current doc type (e.g., "Spec", "Plan") */
     docTypeLabel?: string | null;
-    /** Activity panel visibility mode (from `speckit.viewer.activityPanel` setting). */
-    activityPanelMode?: 'off' | 'beta' | 'on';
+    /** Whether the Activity toggle is shown (from `speckit.viewer.activityPanel` setting). */
+    activityPanelEnabled?: boolean;
     /** Whether to render the install banner inside the Activity panel (viewer only). */
     showInstallPrompt?: boolean;
 }

--- a/src/speckit/specKitExtensionInstall.test.ts
+++ b/src/speckit/specKitExtensionInstall.test.ts
@@ -28,19 +28,17 @@ describe('specKitExtensionInstall', () => {
     });
 
     describe('shouldShowInstallPrompt', () => {
-        it('shows when missing and mode is on/beta', () => {
-            expect(shouldShowInstallPrompt('on', false)).toBe(true);
-            expect(shouldShowInstallPrompt('beta', false)).toBe(true);
+        it('shows when missing and the prompt is enabled', () => {
+            expect(shouldShowInstallPrompt(true, false)).toBe(true);
         });
 
         it('never shows when installed — zero regression for existing users', () => {
-            expect(shouldShowInstallPrompt('on', true)).toBe(false);
-            expect(shouldShowInstallPrompt('beta', true)).toBe(false);
-            expect(shouldShowInstallPrompt('off', true)).toBe(false);
+            expect(shouldShowInstallPrompt(true, true)).toBe(false);
+            expect(shouldShowInstallPrompt(false, true)).toBe(false);
         });
 
-        it('never shows when mode is off — explicit opt-out', () => {
-            expect(shouldShowInstallPrompt('off', false)).toBe(false);
+        it('never shows when disabled — explicit opt-out', () => {
+            expect(shouldShowInstallPrompt(false, false)).toBe(false);
         });
     });
 

--- a/src/speckit/specKitExtensionInstall.ts
+++ b/src/speckit/specKitExtensionInstall.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import { isCompanionInstalled } from '../features/settings/companionPresetReconciler';
+import { coerceLegacyBoolean } from '../core/settingsMigration';
 
 /**
  * One-click install / update of the Companion **spec-kit CLI extension**.
@@ -58,26 +59,29 @@ export function buildInstallCommand(): string {
 
 /**
  * Pure gate for whether an install prompt (banner / affordance) should be shown:
- * the prompt mode is not `off` AND the extension is missing. Installed projects and
- * an explicit `off` always return `false` — no banner, no warning (zero-regression
- * acceptance). Mirrors the `activityPanel` `'off' | 'beta' | 'on'` precedent.
+ * the prompt is enabled AND the extension is missing. Installed projects and an
+ * explicit opt-out (`enabled === false`) always return `false` — no banner, no
+ * warning (zero-regression acceptance).
  */
 export function shouldShowInstallPrompt(
-    mode: 'off' | 'beta' | 'on',
+    enabled: boolean,
     installed: boolean
 ): boolean {
-    return mode !== 'off' && !installed;
+    return enabled && !installed;
 }
 
 /**
- * Resolve the install-prompt mode from VS Code settings. Defaults to `'on'`: this is
- * launch-critical safety guidance shown to everyone who is missing the extension, not
- * an experiment — `'off'` is the explicit opt-out.
+ * Resolve whether the install prompt is enabled from VS Code settings. Defaults to
+ * `true`: this is launch-critical guidance shown to everyone missing the extension,
+ * not an experiment — `false` is the explicit opt-out. Tolerates a legacy tri-state
+ * string (`'beta'`/`'on'` → `true`, `'off'` → `false`) until the settings migration
+ * rewrites it.
  */
-export function readInstallPromptMode(): 'off' | 'beta' | 'on' {
-    return vscode.workspace
+export function readInstallPromptEnabled(): boolean {
+    const raw = vscode.workspace
         .getConfiguration('speckit')
-        .get<'off' | 'beta' | 'on'>('companion.installPrompt', 'on');
+        .get<unknown>('companion.installPrompt', true);
+    return coerceLegacyBoolean(raw, true);
 }
 
 /**

--- a/tests/__mocks__/vscode.ts
+++ b/tests/__mocks__/vscode.ts
@@ -97,6 +97,12 @@ export class RelativePattern {
     }
 }
 
+export enum ConfigurationTarget {
+    Global = 1,
+    Workspace = 2,
+    WorkspaceFolder = 3,
+}
+
 export const workspace = {
     fs: {
         readDirectory: jest.fn().mockResolvedValue([]),

--- a/webview/src/spec-editor/types.ts
+++ b/webview/src/spec-editor/types.ts
@@ -36,8 +36,6 @@ export interface WorkflowDefinition {
     displayName: string;
     description?: string;
     specifyCommands?: Array<{ name: string; title: string; command: string; tooltip?: string }>;
-    /** Marks a beta-gated synthetic entry (e.g. the turbo picker option). */
-    beta?: boolean;
 }
 
 export type ExtensionToSpecEditorMessage =

--- a/webview/src/spec-viewer/components/NavigationBar.tsx
+++ b/webview/src/spec-viewer/components/NavigationBar.tsx
@@ -63,7 +63,7 @@ export function NavigationBar() {
     const showChildrenRow = displayRelatedDocs.length > 0 && parentStepDoc;
 
     const activityActive = activityVisible.value;
-    const activityMode = ns.activityPanelMode ?? 'beta';
+    const activityEnabled = ns.activityPanelEnabled ?? true;
     const handleActivityToggle = () => {
         activityVisible.value = !activityVisible.value;
     };
@@ -102,7 +102,7 @@ export function NavigationBar() {
                         );
                     })}
                 </div>
-                {activityMode !== 'off' && (
+                {activityEnabled && (
                     <button
                         type="button"
                         class="activity-toggle"
@@ -111,9 +111,6 @@ export function NavigationBar() {
                         onClick={handleActivityToggle}
                     >
                         Activity
-                        {activityMode === 'beta' && (
-                            <span class="activity-toggle__beta">beta</span>
-                        )}
                     </button>
                 )}
             </div>

--- a/webview/src/spec-viewer/types.ts
+++ b/webview/src/spec-viewer/types.ts
@@ -82,7 +82,8 @@ export interface NavState {
     currentStep?: string | null;
     filePath?: string | null;
     docTypeLabel?: string | null;
-    activityPanelMode?: 'off' | 'beta' | 'on';
+    /** Whether the Activity toggle is shown (from `speckit.viewer.activityPanel` setting). */
+    activityPanelEnabled?: boolean;
     /** Whether to render the install banner inside the Activity panel (viewer only). */
     showInstallPrompt?: boolean;
 }

--- a/webview/styles/spec-viewer/_activity.css
+++ b/webview/styles/spec-viewer/_activity.css
@@ -555,20 +555,6 @@
     font-weight: 700;
 }
 
-.activity-toggle__beta {
-    display: inline-block;
-    font-size: 0.62rem;
-    font-weight: 700;
-    text-transform: uppercase;
-    letter-spacing: 0.06em;
-    padding: 1px 6px;
-    border-radius: 999px;
-    background: color-mix(in srgb, var(--warning) 18%, transparent);
-    color: var(--warning);
-    border: 1px solid color-mix(in srgb, var(--warning) 50%, transparent);
-    line-height: 1.2;
-}
-
 /* ── Review comments card ─────────────────────────────────────── */
 .comments-doc-group {
     margin-bottom: 12px;


### PR DESCRIPTION
Closes #259

## Summary
The three beta-gated settings were tri-state (`off`/`beta`/`on`), but `beta` and `on` differed only by whether an in-UI badge showed — behavior was identical. Enabling a beta feature is already an explicit opt-in, so the badge was redundant.

- **Collapsed to boolean** (default `true`): `speckit.viewer.activityPanel`, `speckit.companion.turboWorkflowPicker`, `speckit.companion.installPrompt`. The old `enum`/`enumDescriptions` are removed; each `description` still says "opt-in beta".
- **Dropped the in-UI beta badges**: the `(beta)` suffix on the turbo workflow option (and the now-dead `WorkflowDefinition.beta` field) and the `beta` span + CSS on the activity toggle.
- **Migration**: a one-time, scope-preserving, idempotent `migrateBetaTriStateSettings()` runs at activation — it inspects each key per scope (global/workspace/folder) and rewrites a persisted *string* to its boolean at the **same** scope (`beta`/`on`→`true`, `off`→`false`), leaving booleans/unset untouched.
- **Belt-and-suspenders**: every reader funnels its raw value through `coerceLegacyBoolean(value, fallback)`, so a read before migration completes — or an un-migrated folder scope — still resolves correctly. This prevents the classic `Boolean("off") === true` bug: a legacy `"off"` string resolves to `false`, never truthy.

## Verification
- 981 tests pass, incl. the new `settingsMigration.test.ts` (legacy strings → correct boolean, scope preservation, idempotency, no-op for boolean/unset).
- `activityPanelMode` → `activityPanelEnabled` rename threaded through both the initial navState (`generator.ts`) and `buildViewerPayload` (so it survives refreshes — the #255 lesson).
- No `beta`/`isBeta`/`activityPanelMode` dangling references; no `as string` casts.

## How to verify (manual)
- VS Code Settings UI: the three settings render as **checkboxes** (not dropdowns), all checked by default; descriptions still read "opt-in beta".
- Activity toggle shows "Activity" with **no** beta badge; the turbo workflow option has **no** `(beta)` suffix.
- A user with a persisted legacy string (e.g. `activityPanel: "beta"` or `"off"`) keeps the identical shown/hidden state after upgrade — confirm in settings.json that it migrated to the right boolean at its original scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)