### PR TITLE
test(capture): green-baseline the 6 stale test_context.py tests + gate in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,3 +28,21 @@ jobs:
 
       - name: Run tests
         run: npm test
+
+  capture-suite:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Run capture tests (stdlib unittest, no deps)
+        run: python3 -m unittest discover -s speckit-extension/tests -p "test_*.py"
+
+      - name: Check capture shape parity
+        run: python3 speckit-extension/scripts/check-shape-parity.py

--- a/speckit-extension/tests/test_context.py
+++ b/speckit-extension/tests/test_context.py
@@ -48,9 +48,11 @@ class LifecycleCaptureTests(unittest.TestCase):
         wc.update_context(self.fd, "plan", "planned", "extension")
         h2 = _ctx(self.fd)["history"]
         self.assertGreater(len(h2), n1)
+        # Append-only: the prior specify entry survives untouched and the new
+        # plan start lands at the tail (current shape has no `from` key — #138).
+        self.assertEqual([e["step"] for e in h2], ["specify", "plan"])
         self.assertEqual(h2[-1]["step"], "plan")
         self.assertEqual(h2[-1]["kind"], "start")
-        self.assertEqual(h2[-1]["from"], {"step": "specify", "substep": None})
 
     def test_duplicate_same_step_start_is_deduped(self) -> None:
         # GUI startStep + the after_specify hook both firing must not append two
@@ -65,8 +67,12 @@ class LifecycleCaptureTests(unittest.TestCase):
         wc.update_context(self.fd, "specify", "specified", "extension")  # deduped
         wc.update_context(self.fd, "plan", "planned", "extension")
         h = _ctx(self.fd)["history"]
+        # The dedup collapsed the duplicate specify start, but the next step's
+        # start still appends — exactly one specify start, then the plan start.
+        specify_starts = [e for e in h if e["step"] == "specify" and e["kind"] == "start"]
+        self.assertEqual(len(specify_starts), 1)
         self.assertEqual(h[-1]["step"], "plan")
-        self.assertEqual(h[-1]["from"], {"step": "specify", "substep": None})
+        self.assertEqual(h[-1]["kind"], "start")
 
     def test_writes_canonical_history_not_legacy_keys(self) -> None:
         wc.update_context(self.fd, "specify", "specified", "extension")
@@ -281,9 +287,13 @@ class LifecycleCaptureTests(unittest.TestCase):
         wc.sync_tasks(self.fd, tasks_md, "implemented", "extension")
         self.assertEqual(_ctx(self.fd)["status"], "implemented")
         # The hook owns the implement self-close: a single step-level complete lands.
+        # A step-level complete is substep None AND task None — per-task finishes now
+        # also carry substep None (the id lives in `task`), so they must be excluded
+        # or they'd be miscounted as step completions (#138).
         step_completes = [
             t for t in _ctx(self.fd)["history"]
-            if t["step"] == "implement" and t["substep"] is None and t["kind"] == "complete"
+            if t["step"] == "implement" and t["substep"] is None
+            and t.get("task") is None and t["kind"] == "complete"
         ]
         self.assertEqual(len(step_completes), 1)
 
@@ -291,23 +301,31 @@ class LifecycleCaptureTests(unittest.TestCase):
         tasks_md = self.fd / "tasks.md"
         tasks_md.write_text(_tasks("- [x] **T001** a", "- [ ] **T002** b"))
         wc.sync_tasks(self.fd, tasks_md, "implemented", "extension")
+        # Step-level complete = substep None AND task None; T001's per-task finish
+        # (substep None, task set) must NOT be miscounted as the step's self-close.
         step_completes = [
             t for t in _ctx(self.fd)["history"]
-            if t["step"] == "implement" and t["substep"] is None and t["kind"] == "complete"
+            if t["step"] == "implement" and t["substep"] is None
+            and t.get("task") is None and t["kind"] == "complete"
         ]
         self.assertEqual(step_completes, [], "implement must not self-close while tasks remain")
 
     def test_per_task_entries_are_substeps_not_step_completions(self) -> None:
-        # A substep==null transition whose from.step==step reads as a step
-        # COMPLETION in the viewer — per-task entries must never look like that,
-        # or the implement step renders done while still in flight.
+        # #138 moved the per-task id off `substep` and into its own `task` field;
+        # a per-task entry now carries `task` (the id) with `substep` None. It must
+        # still be distinguishable from a step-level complete (which has BOTH
+        # substep and task None) so the viewer never renders implement done while
+        # tasks remain — that distinction is the carried `task` id.
         tasks_md = self.fd / "tasks.md"
         tasks_md.write_text(_tasks("- [x] **T001** a", "- [x] **T002** b", "- [ ] **T003** c"))
         wc.sync_tasks(self.fd, tasks_md, "implemented", "extension")
-        for t in _ctx(self.fd)["history"]:
-            if t.get("task"):
-                self.assertEqual(t["substep"], t["task"])
-                self.assertIsNotNone(t["substep"])
+        per_task = [t for t in _ctx(self.fd)["history"] if t.get("task")]
+        self.assertEqual([t["task"] for t in per_task], ["T001", "T002"])
+        for t in per_task:
+            self.assertIsNotNone(t["task"])
+            self.assertIsNone(t["substep"])
+            # A per-task entry must never read as a step-level boundary.
+            self.assertFalse(wc._is_step_level(t))
 
     def test_duplicate_marker_id_yields_one_task(self) -> None:
         tasks_md = self.fd / "tasks.md"
@@ -409,10 +427,11 @@ class DeriveRoundTripTests(unittest.TestCase):
         self.assertEqual(ctx["status"], "implemented")
         distinct = list(dict.fromkeys(t["task"] for t in ctx["history"] if t.get("task")))
         self.assertEqual(distinct, ["T001", "T002"])
-        # Each task derives a paired start+complete (matches sync_tasks shape).
+        # Finish-only: each task derives a SINGLE `complete` event (no 0s start+
+        # complete pair), matching write-context.py sync_tasks (#138).
         for tid in ("T001", "T002"):
-            kinds = sorted(t["kind"] for t in ctx["history"] if t.get("task") == tid)
-            self.assertEqual(kinds, ["complete", "start"])
+            kinds = [t["kind"] for t in ctx["history"] if t.get("task") == tid]
+            self.assertEqual(kinds, ["complete"])
         self.assertTrue(any(t.get("by") == "derive" for t in ctx["history"]))
 
     def test_derive_distinct_id_coverage_matches_sync(self) -> None:

--- a/speckit-extension/tests/test_context.py
+++ b/speckit-extension/tests/test_context.py
@@ -44,12 +44,16 @@ class LifecycleCaptureTests(unittest.TestCase):
 
     def test_history_is_append_only(self) -> None:
         wc.update_context(self.fd, "specify", "specified", "extension")
-        n1 = len(_ctx(self.fd)["history"])
+        h1 = _ctx(self.fd)["history"]
+        n1 = len(h1)
+        specify_entry = dict(h1[0])  # snapshot the prior entry before the next write
         wc.update_context(self.fd, "plan", "planned", "extension")
         h2 = _ctx(self.fd)["history"]
         self.assertGreater(len(h2), n1)
-        # Append-only: the prior specify entry survives untouched and the new
-        # plan start lands at the tail (current shape has no `from` key — #138).
+        # Append-only: the prior specify entry survives BYTE-FOR-BYTE untouched
+        # (not just its step) and the new plan start lands at the tail (current
+        # shape has no `from` key — #138).
+        self.assertEqual(h2[0], specify_entry)
         self.assertEqual([e["step"] for e in h2], ["specify", "plan"])
         self.assertEqual(h2[-1]["step"], "plan")
         self.assertEqual(h2[-1]["kind"], "start")

--- a/specs/154-stale-capture-tests/.spec-context.json
+++ b/specs/154-stale-capture-tests/.spec-context.json
@@ -1,0 +1,126 @@
+{
+  "workflow": "speckit",
+  "specName": "Green-Baseline Stale Capture Tests + CI Gate",
+  "branch": "154-stale-capture-tests",
+  "currentStep": "implement",
+  "status": "implemented",
+  "history": [
+    {
+      "step": "specify",
+      "substep": null,
+      "kind": "start",
+      "by": "extension",
+      "at": "2026-06-11T21:59:53.263Z"
+    },
+    {
+      "step": "plan",
+      "substep": null,
+      "kind": "start",
+      "by": "extension",
+      "at": "2026-06-11T22:00:23.166Z"
+    },
+    {
+      "step": "tasks",
+      "substep": null,
+      "kind": "start",
+      "by": "extension",
+      "at": "2026-06-11T22:00:48.990Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T001",
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-06-11T22:02:01.111Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T002",
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-06-11T22:02:01.111Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T003",
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-06-11T22:02:01.111Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T004",
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-06-11T22:02:01.111Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T005",
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-06-11T22:02:01.111Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T006",
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-06-11T22:02:01.111Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T007",
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-06-11T22:02:01.111Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T008",
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-06-11T22:02:01.111Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T009",
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-06-11T22:02:01.111Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T010",
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-06-11T22:02:01.111Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T011",
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-06-11T22:02:01.111Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-06-11T22:02:01.111Z"
+    }
+  ],
+  "currentTask": "T011"
+}

--- a/specs/154-stale-capture-tests/checklists/requirements.md
+++ b/specs/154-stale-capture-tests/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Green-Baseline Stale Capture Tests + CI Gate
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-06-11
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs) — note: test/CI commands are the deliverable here, so naming them is in-scope, not leakage
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (within the constraint that this is a test/CI feature)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified (a test revealing a real bug → leave failing, FR-009)
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification beyond the necessary command surface
+
+## Notes
+
+- This is a test-hardening + CI feature; the "no implementation details" items are interpreted against that nature (the commands under test ARE the subject).

--- a/specs/154-stale-capture-tests/plan.md
+++ b/specs/154-stale-capture-tests/plan.md
@@ -1,0 +1,42 @@
+# Implementation Plan: Green-Baseline Stale Capture Tests + CI Gate
+
+**Branch**: `154-stale-capture-tests` | **Spec**: [spec.md](./spec.md)
+
+## Technical Context
+
+- **Language/stack**: Python 3 stdlib `unittest` (no pip deps) for the capture tests; GitHub Actions YAML for CI; existing TS build untouched.
+- **Files in play**:
+  - `speckit-extension/tests/test_context.py` — the 6 stale tests.
+  - `speckit-extension/scripts/write-context.py` / `derive-from-files.py` — source of truth for the current contract (read-only here).
+  - `.github/workflows/ci.yml` — extend with the Python gate.
+- **Source of truth**: production capture scripts, NOT the old tests.
+
+## Current contract (re-derived from production code)
+
+| Old (pre-#138) expectation | Current contract |
+|---|---|
+| history entry has `from: {step, substep}` | entry is `{step, substep, kind, by, at}`; no `from` |
+| per-task entry mirrors id into `substep` (`substep == task`) | id lives in `task`; `substep` is None |
+| step-level complete = `substep is None` | step-level complete = `substep is None AND task is None` (per-task completes also have `substep None`) |
+| derive writes paired `start`+`complete` per task | derive is finish-only: one `complete` per task |
+
+## Constitution Check
+
+No constitution gates apply (test + CI hardening, no new product surface). PASS.
+
+## Approach
+
+1. Update the 6 stale tests in place, one per failing assertion, keeping each assertion's intent strong (still genuinely verifies append-only / per-task-distinct / step-complete-exclusivity / finish-only). No tautologies, no deletions.
+2. Verify the full suite is green and that each change still fails on a simulated regression (reason about it; the assertions key on the exact current shape).
+3. Add a `python-capture` step/job to `ci.yml`: set up Python, run the unittest discovery + `check-shape-parity.py`, on the same push/PR-to-main triggers. Match existing style (ubuntu-latest, single workflow, named steps).
+4. Confirm no real production bug is hiding behind any of the 6 (all 6 are stale expectations — verified against the script behavior).
+
+## Risk / no-regression
+
+- TS untouched → `npm run compile && npm test` stay green.
+- `check-shape-parity.py` untouched and run in CI.
+- Only the 6 tests + `ci.yml` change; the other 37 tests and all production scripts are read-only.
+
+## Phase artifacts
+
+Lean profile: no separate research.md / data-model.md / contracts/ — the contract table above IS the design. tasks.md follows.

--- a/specs/154-stale-capture-tests/spec.md
+++ b/specs/154-stale-capture-tests/spec.md
@@ -1,0 +1,65 @@
+# Feature Specification: Green-Baseline Stale Capture Tests + CI Gate
+
+**Feature Branch**: `154-stale-capture-tests`
+**Created**: 2026-06-11
+**Status**: Draft
+**Input**: GitHub issue #263 — Stale capture tests: 6 test_context.py failures from the #138 shape change
+
+## Overview
+
+The Python capture test suite (`speckit-extension/tests/test_context.py`) carried 6 tests that encoded the *old* `.spec-context.json` capture contract from before #138/#233/#244 hardened the shape. The production capture scripts (`write-context.py`, `derive-from-files.py`) moved on; the tests did not, so they fail on clean `main` (4 failures + 2 errors). This feature re-derives each stale assertion from the *current* correct shape so the whole suite is green, then wires the Python suite into CI so it gates future capture changes.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Green capture suite on clean main (Priority: P1)
+
+A maintainer runs the Python capture suite on `main` and gets a fully green result that genuinely encodes the current capture contract, so the suite is a trustworthy regression guard again.
+
+**Why this priority**: A red suite on `main` is noise — it trains maintainers to ignore failures and masks real regressions. This is the core deliverable.
+
+**Independent Test**: `python3 -m unittest discover -s speckit-extension/tests -p "test_*.py"` reports 0 failures, 0 errors, and each updated test still fails if the current contract regresses.
+
+### User Story 2 - Capture suite gates PRs (Priority: P1)
+
+A contributor opens a PR to `main` that changes capture behavior; CI runs the Python capture suite and the shape-parity check and blocks the merge if either fails.
+
+**Why this priority**: Without a CI gate the suite drifts stale again. Making it required is what compounds the green-baseline work.
+
+**Independent Test**: The CI workflow YAML is well-formed and contains a step that runs the unittest discovery and `check-shape-parity.py` on `pull_request` to `main`.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: Each of the 6 failing tests MUST be updated to assert the CURRENT capture contract, not the pre-#138 contract. The 6: `test_history_is_append_only`, `test_next_step_start_still_appends_after_a_deduped_start`, `test_per_task_entries_are_substeps_not_step_completions`, `test_step_complete_only_when_all_tasks_done`, `test_per_task_completes_when_all_checked`, `test_derive_all_tasks_done`.
+- **FR-002**: History entries carry no `from` key; append-only assertions MUST verify append-only against the current `{step, substep, kind, by, at}` shape (prior entries preserved, new entry at tail) without referencing `from`.
+- **FR-003**: Per-task entries carry the task id in `task` with `substep` None (the #138 move); assertions MUST verify a per-task entry is distinguishable from a step-level boundary (which has both `substep` and `task` None), not that `substep == task`.
+- **FR-004**: A step-level complete is `substep is None AND task is None`; filters counting step-level completes MUST exclude per-task completes (which now also have `substep` None), so the "implement self-closes only when all tasks done" intent holds.
+- **FR-005**: Derive writes finish-only per-task events (one `complete` per task, no start/complete pair); the derive round-trip assertion MUST expect `["complete"]` per task.
+- **FR-006**: No assertion may be weakened to a tautology (`assertTrue(True)`) or deleted. Each updated assertion MUST still fail if the corresponding contract regresses.
+- **FR-007**: The Python capture suite MUST run in CI on `pull_request` to `main` as a required gate, invoking `python3 -m unittest discover -s speckit-extension/tests -p "test_*.py"` and `python3 speckit-extension/scripts/check-shape-parity.py`.
+- **FR-008**: The CI addition MUST use stdlib unittest only (no pip dependencies) and match the existing `ci.yml` style (runner, triggers, job naming).
+- **FR-009**: If any of the 6 tests reveals a genuine production bug (the code SHOULD have the asserted behavior but does not), that test MUST be left failing and reported as its own issue, not papered over.
+
+### Non-Functional Requirements
+
+- **NFR-001**: No regression to the TypeScript build/tests (`npm run compile && npm test` stay green).
+- **NFR-002**: `check-shape-parity.py` stays green.
+
+## Success Criteria *(mandatory)*
+
+- **SC-001**: The Python capture suite reports 0 failures and 0 errors on the feature branch.
+- **SC-002**: A simulated regression in any of the 4 covered contract points (the `from` absence, per-task `task` field, step-level-complete exclusivity, finish-only derive) would make the corresponding test fail.
+- **SC-003**: CI runs the Python suite + shape-parity on PRs to `main` and the workflow YAML parses.
+- **SC-004**: `npm run compile && npm test` and `check-shape-parity.py` remain green.
+
+## Assumptions
+
+- All 6 failures are stale expectations (the production code is the source of truth) unless a test is found to describe correct-but-missing behavior — none was, per the analysis.
+- The existing `ci.yml` is the right workflow to extend (single `test` job on push/PR to `main`).
+
+## Scope
+
+**In scope**: Updating the 6 stale tests; adding the Python suite + shape-parity to CI.
+
+**Out of scope**: Changing any production capture script behavior; reordering existing `.spec-context.json` history; touching the other 37 passing tests.

--- a/specs/154-stale-capture-tests/tasks.md
+++ b/specs/154-stale-capture-tests/tasks.md
@@ -1,0 +1,38 @@
+# Tasks: Green-Baseline Stale Capture Tests + CI Gate
+
+**Feature**: `154-stale-capture-tests` | **Plan**: [plan.md](./plan.md) | **Spec**: [spec.md](./spec.md)
+
+All file paths are relative to the repo root.
+
+## Phase 1: Verify baseline
+
+- [x] T001 Reproduce the 6 failures on the branch: run `python3 -m unittest discover -s speckit-extension/tests -p "test_*.py"` and confirm 4 failures + 2 errors with the exact 6 test names.
+
+## Phase 2: User Story 1 — Green capture suite (P1)
+
+Re-derive each stale assertion from the current contract in `speckit-extension/scripts/write-context.py` / `derive-from-files.py`. Keep each assertion's intent strong.
+
+- [x] T002 [US1] Update `test_history_is_append_only` in `speckit-extension/tests/test_context.py` — drop the removed `from` assertion; verify append-only via the preserved+appended `step` sequence (`["specify","plan"]`) and the tail entry being `plan`/`start`.
+- [x] T003 [US1] Update `test_next_step_start_still_appends_after_a_deduped_start` in `speckit-extension/tests/test_context.py` — drop the `from` assertion; verify exactly one deduped specify start plus the appended `plan`/`start` tail.
+- [x] T004 [US1] Update `test_per_task_entries_are_substeps_not_step_completions` in `speckit-extension/tests/test_context.py` — per-task entries carry `task` with `substep` None; assert `task` is set, `substep` is None, and `wc._is_step_level(entry)` is False (not the old `substep == task`).
+- [x] T005 [US1] Update `test_step_complete_only_when_all_tasks_done` in `speckit-extension/tests/test_context.py` — exclude per-task completes (`task is None`) from the step-level-complete filter so a per-task finish isn't miscounted; assert no step-level complete while a task remains.
+- [x] T006 [US1] Update `test_per_task_completes_when_all_checked` in `speckit-extension/tests/test_context.py` — same filter fix (`task is None`); assert exactly one step-level complete once all tasks are checked.
+- [x] T007 [US1] Update `test_derive_all_tasks_done` in `speckit-extension/tests/test_context.py` — derive is finish-only; assert each task has `["complete"]` (not the paired `["complete","start"]`).
+- [x] T008 [US1] Run the full suite: `python3 -m unittest discover -s speckit-extension/tests -p "test_*.py"` → 0 failures, 0 errors. Run `python3 speckit-extension/scripts/check-shape-parity.py` → green.
+
+## Phase 3: User Story 2 — CI gate (P1)
+
+- [x] T009 [US2] Add a Python capture step/job to `.github/workflows/ci.yml`: set up Python 3, run `python3 -m unittest discover -s speckit-extension/tests -p "test_*.py"` and `python3 speckit-extension/scripts/check-shape-parity.py`, on the existing push + PR-to-main triggers, matching the workflow's style. Stdlib only (no pip install).
+- [x] T010 [US2] Validate the workflow YAML is well-formed (parses cleanly).
+
+## Phase 4: Polish / no-regression
+
+- [x] T011 Confirm no TS regression: `npm run compile && npm test` stay green.
+
+## Dependencies
+
+- T001 → T002–T007 (parallel-ish, same file so serialize) → T008 → T009 → T010 → T011.
+
+## MVP
+
+User Story 1 (green suite) is the MVP; User Story 2 (CI gate) makes it durable.


### PR DESCRIPTION
Closes #263

## Summary
`speckit-extension/tests/test_context.py` had **6 tests failing on clean `main`** (4 failures + 2 errors) — stale expectations encoding the pre-#138/#233/#244 capture contract (the removed `from` key; the per-task id living in `substep` instead of the dedicated `task` field; a paired start+complete from derive). Production moved on; the tests didn't.

This updates each of the 6 to the **current** contract so the suite goes green, **without weakening any assertion**, and adds a CI job so the Python suite gates future capture changes.

## The 6 tests (all stale, none a real bug)
- `test_history_is_append_only` — drop the `from`-key check; assert the preserved+appended step sequence (append-only against the current event shape).
- `test_next_step_start_still_appends_after_a_deduped_start` — assert exactly one deduped specify start + the appended plan/start tail.
- `test_per_task_entries_are_substeps_not_step_completions` — per #138 the per-task id moved from `substep` to `task`; assert `task` set, `substep is None`, and `_is_step_level()` is False.
- `test_step_complete_only_when_all_tasks_done` / `test_per_task_completes_when_all_checked` — a step-level complete is now `substep is None AND task is None`; added the `task is None` discriminator so per-task completes aren't miscounted.
- `test_derive_all_tasks_done` — `derive-from-files.py` is finish-only; assert one `complete` per task (not the old paired start+complete).

Each new assertion was verified **load-bearing** (it still fails if the contract regresses — e.g. a premature self-close, a per-task entry with `task` unset, or a duplicate history append).

## CI
Added a `capture-suite` job to `.github/workflows/ci.yml` (ubuntu-latest, pull_request→main, stdlib only): runs `python3 -m unittest discover -s speckit-extension/tests` + `check-shape-parity.py`. No `continue-on-error` — a failing capture test reds the PR.

## Verification
- Python suite **43/43 green**; `check-shape-parity.py` green.
- `npm test` 982 green (no TS change).
- Production scripts unchanged vs `main` — only the test file + CI workflow changed, so nothing was loosened to make failing code pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)