### PR TITLE
fix(companion): repoint stale alfredo-dev publisher handle to alfredoperez

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,10 +76,10 @@ jobs:
             **From Extension Marketplace:**
             ```bash
             # VSCode (from VSCode Marketplace)
-            code --install-extension alfredo-dev.speckit-companion
+            code --install-extension alfredoperez.speckit-companion
 
             # Cursor (from OpenVSX)
-            cursor --install-extension alfredo-dev.speckit-companion
+            cursor --install-extension alfredoperez.speckit-companion
             ```
 
             **From VSIX file:**
@@ -93,8 +93,8 @@ jobs:
             ```
 
             ### Links
-            - [VSCode Marketplace](https://marketplace.visualstudio.com/items?itemName=alfredo-dev.speckit-companion)
-            - [OpenVSX Registry](https://open-vsx.org/extension/alfredo-dev/speckit-companion)
+            - [VSCode Marketplace](https://marketplace.visualstudio.com/items?itemName=alfredoperez.speckit-companion)
+            - [OpenVSX Registry](https://open-vsx.org/extension/alfredoperez/speckit-companion)
             - [Documentation](https://github.com/alfredoperez/speckit-companion#readme)
 
             ---

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,7 +7,7 @@
             "request": "launch",
             "args": [
                 "--extensionDevelopmentPath=${workspaceFolder}",
-                "--enable-proposed-api=alfredo-dev.speckit-companion"
+                "--enable-proposed-api=alfredoperez.speckit-companion"
             ],
             "outFiles": [
                 "${workspaceFolder}/dist/**/*.js"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- **In-app update notifications fire again, and install links resolve** (#274): the extension referenced a retired publisher handle, which silently disabled the "a new version is available" notification and pointed every Marketplace/OpenVSX install and listing link at a dead (404) page. The update check now reads your installed version reliably and the links resolve to the live listing. The check also compares only against the VS Code releases, so a spec-kit-side release no longer masquerades as a newer GUI version.
 - **Switching modes no longer deletes your commands** (#134): selecting the trimmed shape used to swap command bundles in a way that could leave a project with no usable pipeline commands — creating a spec then failed with "Unknown command: /speckit-specify". The mode is now a non-destructive routing choice: both command sets are always present, and a project left without its stock commands by an earlier version recovers automatically on the next reload.
 
 ## [0.22.0] - 2026-06-07

--- a/speckit-extension/README.md
+++ b/speckit-extension/README.md
@@ -25,10 +25,10 @@ specify extension add companion --from https://github.com/alfredoperez/speckit-c
 
 ## Made for the SpecKit Companion VS Code extension
 
-This is the **spec-kit-side half** of [**SpecKit Companion**](https://marketplace.visualstudio.com/items?itemName=alfredo-dev.speckit-companion) (`id: companion`). It runs inside spec-kit and **writes** the canonical `.spec-context.json` that the **VS Code GUI reads** — it never reads or depends on the GUI at runtime. The two are installed independently:
+This is the **spec-kit-side half** of [**SpecKit Companion**](https://marketplace.visualstudio.com/items?itemName=alfredoperez.speckit-companion) (`id: companion`). It runs inside spec-kit and **writes** the canonical `.spec-context.json` that the **VS Code GUI reads** — it never reads or depends on the GUI at runtime. The two are installed independently:
 
 ```bash
-code --install-extension alfredo-dev.speckit-companion   # the GUI (VS Code Marketplace / OpenVSX)
+code --install-extension alfredoperez.speckit-companion   # the GUI (VS Code Marketplace / OpenVSX)
 specify extension add --from <release-url>                # this extension (spec-kit side)
 ```
 
@@ -141,7 +141,7 @@ Each lifecycle hook appends one entry to the canonical append-only `history[]` a
 
 ## Docs & links
 
-- [**SpecKit Companion (VS Code)**](https://marketplace.visualstudio.com/items?itemName=alfredo-dev.speckit-companion) — the GUI this feeds.
+- [**SpecKit Companion (VS Code)**](https://marketplace.visualstudio.com/items?itemName=alfredoperez.speckit-companion) — the GUI this feeds.
 - [docs/install.md](./docs/install.md) — install (release / dev / fallback) + verification.
 - [docs/commands.md](./docs/commands.md) — the commands and the hooks they run.
 - [docs/how-it-works.md](./docs/how-it-works.md) — the hook → script → `.spec-context.json` chain and canonical schema.

--- a/specs/155-fix-publisher-handle/.spec-context.json
+++ b/specs/155-fix-publisher-handle/.spec-context.json
@@ -1,0 +1,173 @@
+{
+  "workflow": "speckit",
+  "specName": "fix publisher handle",
+  "branch": "main",
+  "currentStep": "implement",
+  "status": "implemented",
+  "history": [
+    {
+      "step": "specify",
+      "substep": null,
+      "kind": "start",
+      "by": "extension",
+      "at": "2026-06-12T23:21:52.629Z"
+    },
+    {
+      "step": "specify",
+      "substep": null,
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-06-12T23:22:36.130Z"
+    },
+    {
+      "step": "plan",
+      "substep": "fast-path",
+      "kind": "start",
+      "by": "ai",
+      "at": "2026-06-12T23:22:43.069Z"
+    },
+    {
+      "step": "plan",
+      "substep": "fast-path",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-12T23:22:43.148Z"
+    },
+    {
+      "step": "tasks",
+      "substep": "fast-path",
+      "kind": "start",
+      "by": "ai",
+      "at": "2026-06-12T23:22:43.227Z"
+    },
+    {
+      "step": "tasks",
+      "substep": "fast-path",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-12T23:22:43.308Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "kind": "start",
+      "by": "extension",
+      "at": "2026-06-12T23:22:54.789Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T001",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-12T23:23:14.252Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T002",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-12T23:23:21.004Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T003",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-12T23:23:41.554Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T004",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-12T23:23:41.635Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T005",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-12T23:23:41.719Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T006",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-12T23:23:59.988Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T007",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-12T23:25:16.896Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-06-12T23:25:30.262Z"
+    }
+  ],
+  "currentTask": "T007",
+  "task_summaries": {
+    "T001": {
+      "status": "DONE",
+      "did": "Read installed version from context.extension.packageJSON.version instead of hardcoded alfredo-dev handle",
+      "files": [
+        "src/speckit/updateChecker.ts"
+      ]
+    },
+    "T002": {
+      "status": "DONE",
+      "did": "Fetch /releases and select newest v<x.y.z> tag, excluding speckit-ext-v* releases",
+      "files": [
+        "src/speckit/updateChecker.ts"
+      ]
+    },
+    "T003": {
+      "status": "DONE",
+      "did": "Replaced alfredo-dev with alfredoperez in install commands, Marketplace itemName, and OpenVSX namespace URL",
+      "files": [
+        ".github/workflows/release.yml"
+      ]
+    },
+    "T004": {
+      "status": "DONE",
+      "did": "Replaced alfredo-dev with alfredoperez in enable-proposed-api arg",
+      "files": [
+        ".vscode/launch.json"
+      ]
+    },
+    "T005": {
+      "status": "DONE",
+      "did": "Replaced alfredo-dev with alfredoperez in Marketplace links and install command",
+      "files": [
+        "speckit-extension/README.md"
+      ]
+    },
+    "T006": {
+      "status": "DONE",
+      "did": "Added user-facing Fixed entry: update notifications fire again and install links resolve",
+      "files": [
+        "CHANGELOG.md"
+      ]
+    },
+    "T007": {
+      "status": "DONE",
+      "did": "Verified zero residual alfredo-dev in tracked non-dist files; added updateChecker unit tests; full suite green",
+      "files": [
+        "src/speckit/updateChecker.test.ts"
+      ]
+    }
+  }
+}

--- a/specs/155-fix-publisher-handle/checklists/requirements.md
+++ b/specs/155-fix-publisher-handle/checklists/requirements.md
@@ -1,0 +1,33 @@
+# Specification Quality Checklist: Fix stale publisher handle "alfredo-dev"
+
+**Purpose**: Validate turbo specification completeness before planning
+**Created**: 2026-06-12
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user/business value and the change's intent
+- [x] Overview states what is delivered and why in 1–3 sentences
+- [x] All four sections present (Overview, Functional Requirements, Success Criteria, Assumptions)
+
+## Requirement Completeness
+
+- [x] Any [NEEDS CLARIFICATION] markers are genuine ambiguities (≤3) deferred to clarify — not unresolved guesses
+- [x] Each Functional Requirement is a single, testable MUST/SHOULD statement
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] Edge cases are folded into Functional Requirements or Assumptions
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] Every Functional Requirement maps to at least one Success Criterion
+- [x] Overview intent is reflected by the FR list (no orphan goals)
+- [x] No implementation details leak into the specification
+
+## Notes
+
+- Fast-path (simple) verdict: 4–5 files, ~7 small tasks, scope signal "fix/rename" (smaller), fastPathEnabled=true. Eligible for simple mode.
+- The spec Overview/Approach references the file paths since this is a code-location-specific bug fix; the FR/SC sections remain implementation-agnostic.

--- a/specs/155-fix-publisher-handle/plan.md
+++ b/specs/155-fix-publisher-handle/plan.md
@@ -1,0 +1,3 @@
+# Plan
+
+> Fast-path spec. The implementation approach lives inline in [`./spec.md#approach`](./spec.md#approach); the task checklist is in [`./tasks.md`](./tasks.md).

--- a/specs/155-fix-publisher-handle/spec.md
+++ b/specs/155-fix-publisher-handle/spec.md
@@ -1,0 +1,40 @@
+# Fix stale publisher handle "alfredo-dev"
+
+## Overview
+
+The extension is published under the `alfredoperez` publisher (`alfredoperez.speckit-companion`), but the repository still references the retired `alfredo-dev` handle in several places. The dead handle silently disables the in-app update check and points install/listing links at a non-existent (404) Marketplace/OpenVSX listing. This change replaces every stale reference with the correct handle and hardens the update checker so it identifies itself by its real extension id and only compares against VS Code releases.
+
+## Functional Requirements
+
+- **FR-001** The system MUST resolve the current extension version using the extension's own id rather than the hardcoded stale handle, so the in-app update check can read the installed version.
+- **FR-002** The update checker MUST select the newest release whose tag matches a VS Code version tag (`v<major>.<minor>.<patch>`) and MUST ignore spec-kit extension releases (`speckit-ext-v*`) when determining whether a newer version is available.
+- **FR-003** Every occurrence of the publisher handle `alfredo-dev.speckit-companion` in source, CI workflows, editor config, and documentation MUST be replaced with `alfredoperez.speckit-companion`.
+- **FR-004** The OpenVSX listing reference using the `alfredo-dev` namespace MUST be replaced with the `alfredoperez` namespace.
+- **FR-005** After the change, no reference to the `alfredo-dev` handle MUST remain anywhere in the tracked repository (excluding build artifacts under `dist/`).
+- **FR-006** All install commands and Marketplace/OpenVSX listing links MUST resolve to the live `alfredoperez` listing.
+
+## Success Criteria
+
+- **SC-001** With an outdated version installed, the in-app update notification fires and the output log records the current installed version (no "Could not get current extension version" bail).
+- **SC-002** The update checker compares the installed version only against VS Code (`v*`) releases and never against `speckit-ext-v*` releases.
+- **SC-003** A repository-wide search for `alfredo-dev` (excluding `node_modules`, `.git`, and `dist/`) returns zero matches.
+- **SC-004** Every install command and listing link in the repo points at `alfredoperez.speckit-companion` and resolves (HTTP 200).
+
+## Assumptions
+
+- `alfredoperez` is the correct, settled publisher identity everywhere; `alfredo-dev` is purely leftover. `package.json` `publisher` has been `alfredoperez` since 2025-12-02.
+- Build artifacts under `dist/` are regenerated on compile and are not edited by hand; they are excluded from the stale-handle sweep.
+- The GitHub releases list co-mingles two products (VS Code `v*` and spec-kit `speckit-ext-v*`); the update checker is concerned only with the VS Code product.
+- The OpenVSX namespace mirrors the publisher handle (`alfredoperez`).
+
+## Approach
+
+Files to touch:
+
+- `src/speckit/updateChecker.ts` — replace `getExtension('alfredo-dev.speckit-companion')` with id derived from `this.context.extension.id`; replace the `/releases/latest` fetch with a `/releases` fetch that filters to tags matching `^v\d+\.\d+\.\d+$`, sorts, and picks the newest (ignoring `speckit-ext-v*`). Reuse the existing `isNewerVersion` comparison.
+- `.github/workflows/release.yml` — replace `alfredo-dev` in the two `--install-extension` lines, the Marketplace `itemName` URL, and the OpenVSX URL.
+- `.vscode/launch.json` — replace `alfredo-dev` in the `--enable-proposed-api` arg.
+- `speckit-extension/README.md` — replace `alfredo-dev` in the two Marketplace links and the `--install-extension` command.
+- `CHANGELOG.md` — add a user-facing entry (update notifications fire again; install links resolve).
+
+Dependencies: none. The `GitHubRelease` type already carries `tag_name`; fetching an array of releases needs no new type beyond `GitHubRelease[]`.

--- a/specs/155-fix-publisher-handle/tasks.md
+++ b/specs/155-fix-publisher-handle/tasks.md
@@ -1,0 +1,9 @@
+# Tasks
+
+- [x] **T001** Derive current extension id from `context.extension.id` in `getCurrentVersion()` + src/speckit/updateChecker.ts
+- [x] **T002** Replace `/releases/latest` with `/releases`, filter to `^v\d+\.\d+\.\d+$` tags (ignore `speckit-ext-v*`), pick newest + src/speckit/updateChecker.ts
+- [x] **T003** [P] Replace `alfredo-dev` → `alfredoperez` in install/listing references + .github/workflows/release.yml
+- [x] **T004** [P] Replace `alfredo-dev` → `alfredoperez` in proposed-api arg + .vscode/launch.json
+- [x] **T005** [P] Replace `alfredo-dev` → `alfredoperez` in Marketplace links + install command + speckit-extension/README.md
+- [x] **T006** Add user-facing changelog entry + CHANGELOG.md
+- [x] **T007** Sweep repo for residual `alfredo-dev` (excluding dist/node_modules/.git); compile + test

--- a/src/core/types/config.ts
+++ b/src/core/types/config.ts
@@ -45,6 +45,8 @@ export interface GitHubRelease {
     tag_name: string;
     name: string;
     html_url: string;
+    draft?: boolean;
+    prerelease?: boolean;
 }
 
 // Installed plugins (agentManager.ts, skillManager.ts)

--- a/src/core/types/config.ts
+++ b/src/core/types/config.ts
@@ -43,8 +43,8 @@ export interface HookInfo {
 // GitHub release (updateChecker.ts)
 export interface GitHubRelease {
     tag_name: string;
-    name: string;
-    html_url: string;
+    name?: string | null;
+    html_url?: string;
     draft?: boolean;
     prerelease?: boolean;
 }

--- a/src/speckit/updateChecker.test.ts
+++ b/src/speckit/updateChecker.test.ts
@@ -19,7 +19,9 @@ describe('UpdateChecker', () => {
 
     const buildOutputChannel = () => ({ appendLine: jest.fn() } as any);
 
-    const mockReleases = (releases: Array<{ tag_name: string }>) => {
+    const mockReleases = (
+        releases: Array<{ tag_name: string; draft?: boolean; prerelease?: boolean }>
+    ) => {
         global.fetch = jest.fn().mockResolvedValue({
             ok: true,
             json: async () => releases,
@@ -66,6 +68,23 @@ describe('UpdateChecker', () => {
         const context = buildContext('0.22.0');
         // A newer-by-date spec-kit release must NOT trigger a GUI update notification.
         mockReleases([{ tag_name: 'speckit-ext-v9.9.9' }, { tag_name: 'v0.22.0' }]);
+        const showSpy = jest
+            .spyOn(require('vscode').window, 'showInformationMessage')
+            .mockResolvedValue(undefined as any);
+
+        await new UpdateChecker(context, buildOutputChannel()).checkForUpdates(true);
+
+        expect(showSpy).not.toHaveBeenCalled();
+    });
+
+    it('ignores prerelease and draft v* releases', async () => {
+        const context = buildContext('0.22.0');
+        // /releases (unlike /releases/latest) surfaces unpublished builds — they must not nag.
+        mockReleases([
+            { tag_name: 'v0.24.0', prerelease: true },
+            { tag_name: 'v0.25.0', draft: true },
+            { tag_name: 'v0.22.0' },
+        ]);
         const showSpy = jest
             .spyOn(require('vscode').window, 'showInformationMessage')
             .mockResolvedValue(undefined as any);

--- a/src/speckit/updateChecker.test.ts
+++ b/src/speckit/updateChecker.test.ts
@@ -1,0 +1,98 @@
+import { UpdateChecker } from './updateChecker';
+
+describe('UpdateChecker', () => {
+    const buildContext = (currentVersion: string, skipVersion?: string) => {
+        const store = new Map<string, unknown>();
+        if (skipVersion) {
+            store.set('speckit.skipVersion', skipVersion);
+        }
+        return {
+            extension: { packageJSON: { version: currentVersion } },
+            globalState: {
+                get: (key: string, fallback?: unknown) => (store.has(key) ? store.get(key) : fallback),
+                update: async (key: string, value: unknown) => {
+                    store.set(key, value);
+                },
+            },
+        } as any;
+    };
+
+    const buildOutputChannel = () => ({ appendLine: jest.fn() } as any);
+
+    const mockReleases = (releases: Array<{ tag_name: string }>) => {
+        global.fetch = jest.fn().mockResolvedValue({
+            ok: true,
+            json: async () => releases,
+        }) as any;
+    };
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+        require('vscode').window.showInformationMessage.mockClear();
+        delete (global as any).fetch;
+    });
+
+    it('reads the current version from the extension itself, not a hardcoded id', async () => {
+        const context = buildContext('0.22.0');
+        const output = buildOutputChannel();
+        mockReleases([{ tag_name: 'v0.22.0' }]);
+        const showSpy = jest.spyOn(require('vscode').window, 'showInformationMessage');
+
+        await new UpdateChecker(context, output).checkForUpdates(true);
+
+        expect(output.appendLine).toHaveBeenCalledWith(
+            expect.stringContaining('Checking for updates... (current: 0.22.0)')
+        );
+        expect(showSpy).not.toHaveBeenCalled();
+    });
+
+    it('notifies when a newer v* release exists', async () => {
+        const context = buildContext('0.22.0');
+        mockReleases([{ tag_name: 'v0.23.0' }, { tag_name: 'v0.22.0' }]);
+        const showSpy = jest
+            .spyOn(require('vscode').window, 'showInformationMessage')
+            .mockResolvedValue(undefined as any);
+
+        await new UpdateChecker(context, buildOutputChannel()).checkForUpdates(true);
+
+        expect(showSpy).toHaveBeenCalledWith(
+            expect.stringContaining('0.23.0'),
+            'View Changelog',
+            'Skip'
+        );
+    });
+
+    it('ignores speckit-ext-v* releases when picking the latest', async () => {
+        const context = buildContext('0.22.0');
+        // A newer-by-date spec-kit release must NOT trigger a GUI update notification.
+        mockReleases([{ tag_name: 'speckit-ext-v9.9.9' }, { tag_name: 'v0.22.0' }]);
+        const showSpy = jest
+            .spyOn(require('vscode').window, 'showInformationMessage')
+            .mockResolvedValue(undefined as any);
+
+        await new UpdateChecker(context, buildOutputChannel()).checkForUpdates(true);
+
+        expect(showSpy).not.toHaveBeenCalled();
+    });
+
+    it('selects the highest v* version, not the first in the list', async () => {
+        const context = buildContext('0.22.0');
+        mockReleases([
+            { tag_name: 'v0.22.5' },
+            { tag_name: 'v0.23.1' },
+            { tag_name: 'speckit-ext-v1.0.0' },
+            { tag_name: 'v0.23.0' },
+        ]);
+        const showSpy = jest
+            .spyOn(require('vscode').window, 'showInformationMessage')
+            .mockResolvedValue(undefined as any);
+
+        await new UpdateChecker(context, buildOutputChannel()).checkForUpdates(true);
+
+        expect(showSpy).toHaveBeenCalledWith(
+            expect.stringContaining('0.23.1'),
+            'View Changelog',
+            'Skip'
+        );
+    });
+});

--- a/src/speckit/updateChecker.ts
+++ b/src/speckit/updateChecker.ts
@@ -68,7 +68,10 @@ export class UpdateChecker {
     private async fetchLatestRelease(): Promise<GitHubRelease | null> {
         try {
             this.outputChannel.appendLine('[UpdateChecker] Fetching releases from GitHub...');
-            const response = await fetch('https://api.github.com/repos/alfredoperez/speckit-companion/releases');
+            const response = await fetch(
+                'https://api.github.com/repos/alfredoperez/speckit-companion/releases?per_page=100',
+                { headers: { 'User-Agent': 'speckit-companion', Accept: 'application/vnd.github+json' } }
+            );
 
             if (!response.ok) {
                 this.outputChannel.appendLine(`[UpdateChecker] GitHub API returned ${response.status}: ${response.statusText}`);
@@ -86,19 +89,24 @@ export class UpdateChecker {
     }
 
     /**
-     * Pick the highest-version release whose tag is a VS Code `v<major>.<minor>.<patch>` tag.
-     * Excludes spec-kit releases tagged `speckit-ext-v*`, which share this releases list.
+     * Pick the highest-version published release whose tag is a VS Code `v<major>.<minor>.<patch>` tag.
+     * Excludes spec-kit releases tagged `speckit-ext-v*` (which share this list) and any draft/prerelease
+     * — the swap from `/releases/latest` to `/releases` would otherwise surface unpublished builds.
      */
     private selectLatestVsCodeRelease(releases: GitHubRelease[]): GitHubRelease | null {
         if (!Array.isArray(releases)) {
             return null;
         }
-        const vsCodeReleases = releases.filter((release) => /^v\d+\.\d+\.\d+$/.test(release.tag_name));
         let latest: GitHubRelease | null = null;
-        for (const release of vsCodeReleases) {
+        let latestVersion = '';
+        for (const release of releases) {
+            if (release.draft || release.prerelease || !/^v\d+\.\d+\.\d+$/.test(release.tag_name)) {
+                continue;
+            }
             const version = release.tag_name.replace(/^v/, '');
-            if (!latest || this.isNewerVersion(latest.tag_name.replace(/^v/, ''), version)) {
+            if (!latest || this.isNewerVersion(latestVersion, version)) {
                 latest = release;
+                latestVersion = version;
             }
         }
         return latest;

--- a/src/speckit/updateChecker.ts
+++ b/src/speckit/updateChecker.ts
@@ -59,30 +59,49 @@ export class UpdateChecker {
      * Get current extension version
      */
     private getCurrentVersion(): string | undefined {
-        const extension = vscode.extensions.getExtension('alfredo-dev.speckit-companion');
-        return extension?.packageJSON.version;
+        return this.context.extension.packageJSON.version;
     }
 
     /**
-     * Fetch latest release from GitHub API
+     * Fetch the newest VS Code (`v*`) release from GitHub, ignoring spec-kit (`speckit-ext-v*`) releases
      */
     private async fetchLatestRelease(): Promise<GitHubRelease | null> {
         try {
-            this.outputChannel.appendLine('[UpdateChecker] Fetching latest release from GitHub...');
-            const response = await fetch('https://api.github.com/repos/alfredoperez/speckit-companion/releases/latest');
+            this.outputChannel.appendLine('[UpdateChecker] Fetching releases from GitHub...');
+            const response = await fetch('https://api.github.com/repos/alfredoperez/speckit-companion/releases');
 
             if (!response.ok) {
                 this.outputChannel.appendLine(`[UpdateChecker] GitHub API returned ${response.status}: ${response.statusText}`);
                 return null;
             }
 
-            const release = await response.json() as GitHubRelease;
-            this.outputChannel.appendLine(`[UpdateChecker] Latest release: ${release?.tag_name || 'unknown'}`);
-            return release;
+            const releases = await response.json() as GitHubRelease[];
+            const latest = this.selectLatestVsCodeRelease(releases);
+            this.outputChannel.appendLine(`[UpdateChecker] Latest VS Code release: ${latest?.tag_name || 'none'}`);
+            return latest;
         } catch (error) {
-            this.outputChannel.appendLine(`[UpdateChecker] ERROR: Failed to fetch latest release: ${error}`);
+            this.outputChannel.appendLine(`[UpdateChecker] ERROR: Failed to fetch releases: ${error}`);
             return null;
         }
+    }
+
+    /**
+     * Pick the highest-version release whose tag is a VS Code `v<major>.<minor>.<patch>` tag.
+     * Excludes spec-kit releases tagged `speckit-ext-v*`, which share this releases list.
+     */
+    private selectLatestVsCodeRelease(releases: GitHubRelease[]): GitHubRelease | null {
+        if (!Array.isArray(releases)) {
+            return null;
+        }
+        const vsCodeReleases = releases.filter((release) => /^v\d+\.\d+\.\d+$/.test(release.tag_name));
+        let latest: GitHubRelease | null = null;
+        for (const release of vsCodeReleases) {
+            const version = release.tag_name.replace(/^v/, '');
+            if (!latest || this.isNewerVersion(latest.tag_name.replace(/^v/, ''), version)) {
+                latest = release;
+            }
+        }
+        return latest;
     }
     
     /**


### PR DESCRIPTION
## Summary
The extension's in-app "update available" notification was dead for every user, and its Marketplace/OpenVSX install links 404'd, because the repo still referenced a retired publisher handle (`alfredo-dev`) the project moved off long ago. This restores the update check and fixes every stale install/listing link.

## Technical
- `getCurrentVersion()` no longer hardcodes an extension id — it reads `context.extension.packageJSON.version` directly, so the version source can never drift from the real id again.
- `fetchLatestRelease()` switched from `/releases/latest` to `/releases?per_page=100` and a new `selectLatestVsCodeRelease()` that picks the highest-semver tag matching `^v\d+\.\d+\.\d+$`, excluding the spec-kit `speckit-ext-v*` releases that interleave the same list (and draft/prerelease tags).
- Swept `alfredo-dev.speckit-companion` → `alfredoperez.speckit-companion` in `.github/workflows/release.yml` (install commands + Marketplace/OpenVSX URLs), `.vscode/launch.json` (proposed-api arg), and `speckit-extension/README.md`.
- Restored protections that `/releases/latest` gave for free: draft/prerelease exclusion (added `draft`/`prerelease` to the `GitHubRelease` type), `per_page=100` pagination (41 interleaved releases would push the newest `v*` off the default 30), and a `User-Agent` header (GitHub REST 403s header-less requests).

## Review checklist
- ✅ **VS Code extension** — affected
    - update checker: id-derived version, semver `v*` selection, `speckit-ext-v*` exclusion
    - release workflow: install commands + listing URLs repointed
    - launch config: proposed-api arg repointed
- ✅ **SpecKit extension** — doc-only touch
    - `speckit-extension/README.md`: stale Marketplace links + install command fixed (no version bump — pure stale-link correction)
- ✅ **Changelog**
    - root `CHANGELOG.md` — user-facing entry (update notifications fire again)
- ✅ **Docs**
    - README has no documented in-app-update section → no doc-map doc required
- ✅ **Verify**
    - `npm run compile` clean
    - `npm test` green (987 tests, incl. new prerelease/draft-exclusion + `v*`-selection coverage)
    - `check-shape-parity.py` passes
    - no `package.json` / `extension.yml` version bump
- ✅ **No stale handle remains**
    - `grep alfredo-dev` hits only the spec docs that describe the bug + gitignored generated copies

## Gaps / how to see it
- Try: install an older version, trigger the update path (or relaunch the Extension Dev Host), and confirm the output channel logs `Checking for updates... (current: <real version>)` and the toast fires — and never offers a `speckit-ext-v*` version as the GUI update.

Closes #274

🤖 Generated with [Claude Code](https://claude.com/claude-code)
