### PR TITLE
fix(speckit-ext): serve a stable companion.zip install/update URL

### DIFF
--- a/.claude/commands/publish-speckit-ext.md
+++ b/.claude/commands/publish-speckit-ext.md
@@ -36,21 +36,35 @@ Release the **spec-kit extension** (`speckit-extension/`, `id: companion`) so pe
    ( cd speckit-extension && tar cf - --exclude=tests --exclude=assets . ) | ( cd /tmp/cb/companion-$V && tar xf - )
    ( cd /tmp/cb && zip -rq companion-$V.zip companion-$V )
    ```
-6. **Cut the release** (prefixed tag, attach the zip):
+6. **Cut the release** (prefixed tag, attach the version-named zip for archival):
    ```bash
    gh release create speckit-ext-v$V /tmp/cb/companion-$V.zip \
      --title "SpecKit Companion spec-kit extension v$V" \
      --notes-file <[X.Y.Z] section of speckit-extension/CHANGELOG.md> --target main
    ```
-7. **Verify the deployed install** (simulate a user) in a scratch dir:
+7. **Refresh the stable `companion-latest` asset** — this is what the README/install docs point users at, so the install/update URL never changes between releases. Force-replace the **stable-named** `companion.zip` on a reusable `companion-latest` **prerelease** with the *same* build:
+   ```bash
+   cp /tmp/cb/companion-$V.zip /tmp/cb/companion.zip
+   if gh release view companion-latest >/dev/null 2>&1; then
+     gh release upload companion-latest /tmp/cb/companion.zip --clobber
+   else
+     gh release create companion-latest /tmp/cb/companion.zip \
+       --title "SpecKit Companion (latest)" \
+       --notes "Rolling stable download for the spec-kit extension. Always serves the newest \`companion\` build. Install/update: \`specify extension add companion --from https://github.com/alfredoperez/speckit-companion/releases/download/companion-latest/companion.zip --force\`" \
+       --prerelease --target main
+   fi
+   ```
+   - **`--prerelease` is mandatory.** It keeps `companion-latest` out of the repo's `/releases/latest` (which resolves across BOTH products — a `v*` VS Code release would otherwise hijack it). The stable URL `…/releases/download/companion-latest/companion.zip` resolves by **tag**, so it's immune to the `v*`/`speckit-ext-v*` interleaving. Never document `…/releases/latest/download/…` for this repo.
+   - The `companion-latest` tag is non-`v*`, so it does **not** trigger `release.yml` (the VS Code Marketplace publish).
+8. **Verify the deployed install** (simulate a user) in a scratch dir — install from the **stable** URL, the same one users run:
    ```bash
    mkdir -p /tmp/sk-verify/.specify/extensions && cd /tmp/sk-verify
-   yes | specify extension add companion --from https://github.com/alfredoperez/speckit-companion/releases/download/speckit-ext-v$V/companion-$V.zip --force
+   yes | specify extension add companion --from https://github.com/alfredoperez/speckit-companion/releases/download/companion-latest/companion.zip --force
    specify extension list   # → SpecKit Companion (vX.Y.Z), all commands listed
    ```
    - If a prior local install left **inconsistent emission dirs** (`.{claude,cursor,agents}/skills/speckit-companion-*`, `.{gemini,qwen}/commands/speckit.companion.*`, etc.), the install can throw `FileNotFoundError`. Nuke all companion emission artifacts first, then retry.
    - **Expected non-error output** (don't flag these as failures): a raw-URL install shows a one-time `⚠ Untrusted Source` prompt; a pre-existing install aborts with `already installed … retry with --force` (remove first or use `--force`); a stale `✗ companion (v0.1.0) ⚠️ Corrupted extension` must be removed before installing; and a clean install ends with an **informational** `⚠ Configuration may be required / Check: .specify/extensions/companion/` — no manual config is actually needed.
-8. **Confirm** the prefixed tag did **not** trigger `release.yml`: `gh run list --workflow=release.yml --limit 2` (no new run).
-9. **Report** the release URL + the install command. Remind that the by-name catalog install (`specify extension add companion`) needs the **Extension Submission issue** on github/spec-kit (see `publishing.md`) — that step is the user's call.
+9. **Confirm** neither the prefixed tag nor `companion-latest` triggered `release.yml`: `gh run list --workflow=release.yml --limit 2` (no new run — both tags are non-`v*`).
+10. **Report** the release URL + the **stable** install command (`…/releases/download/companion-latest/companion.zip`, re-runnable with `--force` to update). Remind that the by-name catalog install (`specify extension add companion`) needs the **Extension Submission issue** on github/spec-kit (see `publishing.md`) — that step is the user's call.
 
-Update version references (README badge, `publishing.md`) to the new version. Never commit a VS Code `package.json` version bump as part of this.
+Update version references (README badge, `publishing.md`) to the new version; keep the documented install/update URL pointed at the stable `companion-latest/companion.zip`. Never commit a VS Code `package.json` version bump as part of this.

--- a/.claude/commands/publish-speckit-ext.md
+++ b/.claude/commands/publish-speckit-ext.md
@@ -53,8 +53,9 @@ Release the **spec-kit extension** (`speckit-extension/`, `id: companion`) so pe
        --notes "Rolling stable download for the spec-kit extension. Always serves the newest \`companion\` build. Install/update: \`specify extension add companion --from https://github.com/alfredoperez/speckit-companion/releases/download/companion-latest/companion.zip --force\`" \
        --prerelease --target main
    fi
+   gh release edit companion-latest --prerelease   # idempotent — re-asserts prerelease every run so a mis-marked prior release can't become /releases/latest
    ```
-   - **`--prerelease` is mandatory.** It keeps `companion-latest` out of the repo's `/releases/latest` (which resolves across BOTH products — a `v*` VS Code release would otherwise hijack it). The stable URL `…/releases/download/companion-latest/companion.zip` resolves by **tag**, so it's immune to the `v*`/`speckit-ext-v*` interleaving. Never document `…/releases/latest/download/…` for this repo.
+   - **`--prerelease` is mandatory.** It keeps `companion-latest` out of the repo's `/releases/latest` (which resolves across BOTH products — a `v*` VS Code release would otherwise hijack it). The stable URL `…/releases/download/companion-latest/companion.zip` resolves by **tag**, so it's immune to the `v*`/`speckit-ext-v*` interleaving. The trailing `gh release edit … --prerelease` re-asserts the flag on every run (the create path sets it, but an existing release that lost the flag would otherwise stay a normal release). Never document `…/releases/latest/download/…` for this repo.
    - The `companion-latest` tag is non-`v*`, so it does **not** trigger `release.yml` (the VS Code Marketplace publish).
 8. **Verify the deployed install** (simulate a user) in a scratch dir — install from the **stable** URL, the same one users run:
    ```bash

--- a/.claude/commands/publish-speckit-ext.md
+++ b/.claude/commands/publish-speckit-ext.md
@@ -50,7 +50,7 @@ Release the **spec-kit extension** (`speckit-extension/`, `id: companion`) so pe
    else
      gh release create companion-latest /tmp/cb/companion.zip \
        --title "SpecKit Companion (latest)" \
-       --notes "Rolling stable download for the spec-kit extension. Always serves the newest \`companion\` build. Install/update: \`specify extension add companion --from https://github.com/alfredoperez/speckit-companion/releases/download/companion-latest/companion.zip --force\`" \
+       --notes 'Rolling stable download for the spec-kit extension. Always serves the newest `companion` build. Install/update: `specify extension add companion --from https://github.com/alfredoperez/speckit-companion/releases/download/companion-latest/companion.zip --force`' \
        --prerelease --target main
    fi
    gh release edit companion-latest --prerelease   # idempotent — re-asserts prerelease every run so a mis-marked prior release can't become /releases/latest

--- a/README.md
+++ b/README.md
@@ -156,10 +156,10 @@ There are **two** installs, and they're independent:
 uv tool install specify-cli --from git+https://github.com/github/spec-kit.git --force
 
 # 2. the companion spec-kit extension (installs/updates; --force is idempotent)
-specify extension add companion --from https://github.com/alfredoperez/speckit-companion/releases/download/speckit-ext-v0.3.0/companion-0.3.0.zip --force
+specify extension add companion --from https://github.com/alfredoperez/speckit-companion/releases/download/companion-latest/companion.zip --force
 ```
 
-> Once the extension is listed in the spec-kit catalog, the second command shortens to `specify extension add companion --force`. Until then, install from the release URL above.
+> The `companion-latest/companion.zip` URL is a stable rolling asset — it always serves the newest build, so the same command installs **and** updates (re-run with `--force`). Once the extension is listed in the spec-kit catalog, it shortens to `specify extension add companion --force`.
 
 **Update it later** from the Specs view **Upgrade…** menu → *Update spec-kit Extension* (runs the same install with `--force`).
 

--- a/speckit-extension/CHANGELOG.md
+++ b/speckit-extension/CHANGELOG.md
@@ -8,6 +8,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/); this ext
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-06-12
+
+### Changed
+- **One stable install command that also updates you.** The install command now points at a permanent download URL that always serves the newest release, so you're no longer frozen on whatever version you happened to copy. Install with `specify extension add companion --from https://github.com/alfredoperez/speckit-companion/releases/download/companion-latest/companion.zip --force`, and **to update later, re-run the exact same line** — `--force` refreshes your installed copy in place. No version number to bump, no new URL to hunt down.
+
 ## [0.3.0] - 2026-06-10
 
 The spec-kit extension's first catalog release — full lifecycle capture, Status + Resume, selectable template profiles, and accurate timing. See [ROADMAP.md](./ROADMAP.md).

--- a/speckit-extension/README.md
+++ b/speckit-extension/README.md
@@ -10,14 +10,17 @@
 
 <p align="center">
   <img src="https://img.shields.io/badge/extension-companion-0b6dd9" alt="extension: companion">
-  <img src="https://img.shields.io/badge/version-0.3.0-0b6dd9" alt="version 0.3.0">
+  <img src="https://img.shields.io/badge/version-0.4.0-0b6dd9" alt="version 0.4.0">
   <img src="https://img.shields.io/badge/spec--kit-%E2%89%A50.8.5-008080" alt="requires spec-kit >= 0.8.5">
   <img src="https://img.shields.io/badge/license-MIT-gold" alt="license MIT">
 </p>
 
 ```bash
-specify extension add companion --from https://github.com/alfredoperez/speckit-companion/releases/download/speckit-ext-v0.3.0/companion-0.3.0.zip
+# Install — and update, by re-running with --force (always pulls the newest build)
+specify extension add companion --from https://github.com/alfredoperez/speckit-companion/releases/download/companion-latest/companion.zip --force
 ```
+
+> The URL above is **stable** — it always serves the newest release, so the same command installs and updates. To update later, just re-run it (the `--force` flag refreshes an existing install in place).
 
 > Tags: `#spec-driven-development` `#tracking` `#companion` · Independently maintained.
 
@@ -113,14 +116,14 @@ uv tool install specify-cli --from git+https://github.com/github/spec-kit.git --
 Then install the extension:
 
 ```bash
-# From the release archive (recommended)
-specify extension add companion --from https://github.com/alfredoperez/speckit-companion/releases/download/speckit-ext-v0.3.0/companion-0.3.0.zip
+# From the release archive (recommended) — this URL is stable, so the SAME line updates you later
+specify extension add companion --from https://github.com/alfredoperez/speckit-companion/releases/download/companion-latest/companion.zip --force
 
 # Or from a local checkout while developing
 specify extension add ./speckit-extension --dev
 ```
 
-Once it lands in the spec-kit community catalog this shortens to `specify extension add companion`. `python3` is used by the capture scripts but is **optional** — capture skips gracefully if it's missing and never fails the host command. Full prerequisites + a CLI-less fallback: [docs/install.md](./docs/install.md).
+**To update:** re-run the exact same command — the `companion-latest/companion.zip` URL always serves the newest release, and `--force` refreshes the installed copy in place. No version string to bump, no new URL to find. Once it lands in the spec-kit community catalog this shortens to `specify extension add companion`. `python3` is used by the capture scripts but is **optional** — capture skips gracefully if it's missing and never fails the host command. Full prerequisites + a CLI-less fallback: [docs/install.md](./docs/install.md).
 
 Verify:
 

--- a/speckit-extension/docs/install.md
+++ b/speckit-extension/docs/install.md
@@ -13,6 +13,19 @@ specify extension --help     # confirm `add` / `list` are present
 
 > **Version floor:** the extension declares `requires.speckit_version: ">=0.8.5"` (the floor for the workflow `integration: auto` path later phases ride). Confirm/raise once the exact spec-kit release that wired `after_specify`/`after_plan` is verified.
 
+## From the release archive (recommended)
+
+Install from the **stable** release URL — it always serves the newest build, so the same command installs and updates:
+
+```bash
+specify extension add companion --from https://github.com/alfredoperez/speckit-companion/releases/download/companion-latest/companion.zip --force
+specify extension list   # confirm "companion" is listed at the new version
+```
+
+**To update:** re-run the exact same command. The `companion-latest/companion.zip` URL is reused on every release (it's a dedicated rolling asset, not a version-pinned one), and `--force` refreshes an existing install in place — no version string to edit, no new URL to find. A raw-URL install shows a one-time "untrusted source" prompt until the catalog lists `companion`.
+
+> **Why not `/releases/latest/download/…`?** This repo publishes two products into one releases list (the VS Code extension on `v*` tags and this extension on `speckit-ext-v*` tags). GitHub's `/releases/latest` tracks the newest release across **both**, so a `/releases/latest/download/companion.zip` URL would 404 the moment the next VS Code release is cut. The `companion-latest` tag above resolves by name and is immune to that.
+
 ## Local / development (today)
 
 Not published to the spec-kit catalog yet, so install straight from this directory. From the repo root:

--- a/speckit-extension/docs/publishing.md
+++ b/speckit-extension/docs/publishing.md
@@ -68,7 +68,7 @@ The whole flow is automated by the `/publish-speckit-ext` skill.
 ```yaml
 id: companion
 name: SpecKit Companion
-version: 0.2.0
+version: 0.4.0
 description: "Live spec-driven progress for SpecKit Companion — lifecycle capture, status, and resume."
 author: alfredoperez
 repository: https://github.com/alfredoperez/speckit-companion

--- a/speckit-extension/docs/publishing.md
+++ b/speckit-extension/docs/publishing.md
@@ -56,7 +56,7 @@ The whole flow is automated by the `/publish-speckit-ext` skill.
 ## Pre-submit checklist (mapped to the guide)
 
 - [x] `id` lowercase-with-hyphens — `companion`
-- [x] `version` semver — `0.2.0`
+- [x] `version` semver — matches `extension.yml` `extension.version` (e.g. `X.Y.Z`)
 - [x] `description` < 100 chars — 88
 - [x] `repository` valid public GitHub URL
 - [x] `homepage` present

--- a/speckit-extension/docs/publishing.md
+++ b/speckit-extension/docs/publishing.md
@@ -24,11 +24,19 @@ v0.2.0                  ❌  matches v* → would publish the WRONG thing to the
    ( cd speckit-extension && tar cf - --exclude=tests --exclude=assets . ) | ( cd /tmp/cb/companion-$V && tar xf - )
    ( cd /tmp/cb && zip -rq companion-$V.zip companion-$V )
    ```
-6. **Create the GitHub release** with a **prefixed tag** (`speckit-ext-v0.2.0`) and attach the zip:
+6. **Create the GitHub release** with a **prefixed tag** (`speckit-ext-v0.2.0`) and attach the version-named zip (archival):
    ```bash
    gh release create speckit-ext-v$V /tmp/cb/companion-$V.zip --title "..." --notes-file <CHANGELOG [X.Y.Z]> --target main
    ```
-7. **Verify the deployed install** in a scratch dir (simulate a user): `mkdir -p /tmp/v/.specify/extensions && cd /tmp/v && yes | specify extension add companion --from <release-zip-url> --force` → `specify extension list` shows the version + all commands. Note: the **`companion` name arg is required**, the URL must be **HTTPS**, and a raw-URL install shows a one-time "untrusted source" prompt. If a prior local install left inconsistent emission dirs, nuke all `speckit-companion-*` / `speckit.companion.*` artifacts first.
+7. **Refresh the stable `companion-latest` asset** — the README/install docs point users at a *stable* URL so install/update never needs a version edit. Force-replace `companion.zip` on a reusable `companion-latest` **prerelease** with the same build:
+   ```bash
+   cp /tmp/cb/companion-$V.zip /tmp/cb/companion.zip
+   gh release view companion-latest >/dev/null 2>&1 \
+     && gh release upload companion-latest /tmp/cb/companion.zip --clobber \
+     || gh release create companion-latest /tmp/cb/companion.zip --title "SpecKit Companion (latest)" --prerelease --target main
+   ```
+   **Why a dedicated tag, not `/releases/latest`:** this is a two-product repo — `release.yml` publishes the VS Code extension on `v*` tags, and those releases interleave with `speckit-ext-v*` in one GitHub releases list. GitHub's `/releases/latest` resolves to the newest non-prerelease across **both** products, so `…/releases/latest/download/companion.zip` would 404 the moment the next VS Code `v*` release is cut. The stable URL `…/releases/download/companion-latest/companion.zip` resolves **by tag** and is immune to that interleaving. The `--prerelease` flag keeps `companion-latest` out of `/releases/latest`; the non-`v*` tag keeps it from triggering the Marketplace publish.
+8. **Verify the deployed install** in a scratch dir (simulate a user), from the **stable** URL: `mkdir -p /tmp/v/.specify/extensions && cd /tmp/v && yes | specify extension add companion --from https://github.com/alfredoperez/speckit-companion/releases/download/companion-latest/companion.zip --force` → `specify extension list` shows the version + all commands. Note: the **`companion` name arg is required**, the URL must be **HTTPS**, and a raw-URL install shows a one-time "untrusted source" prompt. If a prior local install left inconsistent emission dirs, nuke all `speckit-companion-*` / `speckit.companion.*` artifacts first.
 
    **What a real install looks like** (so the output below isn't mistaken for an error):
 
@@ -36,8 +44,8 @@ v0.2.0                  ❌  matches v* → would publish the WRONG thing to the
    - **Already-installed guard** — if a prior `companion` is present, the install aborts with `Extension 'companion' is already installed. … retry with --force`. Either `specify extension remove companion` first (config is backed up to `.specify/extensions/.backup/companion/`) or re-run with `--force`.
    - **Stale/corrupted leftover** — `specify extension list` may show an old `✗ companion (v0.1.0) … ⚠️ Corrupted extension, Commands: 0`. Remove it (`yes | specify extension remove companion`) before installing the current release; the fresh install reports `✓ Extension installed successfully! SpecKit Companion (v0.2.0)` with all 6 commands.
    - **"Configuration may be required" footer** — a successful install ends with `⚠ Configuration may be required / Check: .specify/extensions/companion/`. This is **informational, not a failure** — it points at the installed extension dir; no manual config step is needed for companion.
-8. **Submit to the catalog** — file an **issue** on github/spec-kit using the **Extension Submission** template (NOT a PR). Maintainers verify metadata + URL reachability and add the entry to `extensions/catalog.community.json`. Review is 3–7 business days. Only then does the by-name `specify extension add companion` resolve.
-9. **For later updates** — repeat, and file a new submission issue noting it's an update.
+9. **Submit to the catalog** — file an **issue** on github/spec-kit using the **Extension Submission** template (NOT a PR). Maintainers verify metadata + URL reachability and add the entry to `extensions/catalog.community.json`. Review is 3–7 business days. Only then does the by-name `specify extension add companion` resolve. Point the catalog `download_url` at the stable `companion-latest/companion.zip` so it tracks the newest release.
+10. **For later updates** — repeat; step 7 refreshes the stable asset automatically, so existing users update by re-running their install command with `--force` (no new URL). File a new submission issue only if catalog metadata changed.
 
 The whole flow is automated by the `/publish-speckit-ext` skill.
 
@@ -78,7 +86,7 @@ commands:
   - speckit.companion.capture-implement# after_implement hook (per-task journaling)
   - speckit.companion.status           # report step/status/decisions/next action
   - speckit.companion.resume           # resume the pipeline from the recorded step
-download_url: https://github.com/alfredoperez/speckit-companion/releases/download/speckit-ext-v0.2.0/companion-0.2.0.zip
+download_url: https://github.com/alfredoperez/speckit-companion/releases/download/companion-latest/companion.zip
 ```
 
 ### What this release delivers (for the submission body)

--- a/speckit-extension/docs/publishing.md
+++ b/speckit-extension/docs/publishing.md
@@ -31,10 +31,14 @@ v0.2.0                  ❌  matches v* → would publish the WRONG thing to the
 7. **Refresh the stable `companion-latest` asset** — the README/install docs point users at a *stable* URL so install/update never needs a version edit. Force-replace `companion.zip` on a reusable `companion-latest` **prerelease** with the same build:
    ```bash
    cp /tmp/cb/companion-$V.zip /tmp/cb/companion.zip
-   gh release view companion-latest >/dev/null 2>&1 \
-     && gh release upload companion-latest /tmp/cb/companion.zip --clobber \
-     || gh release create companion-latest /tmp/cb/companion.zip --title "SpecKit Companion (latest)" --prerelease --target main
+   if gh release view companion-latest >/dev/null 2>&1; then
+     gh release upload companion-latest /tmp/cb/companion.zip --clobber
+   else
+     gh release create companion-latest /tmp/cb/companion.zip --title "SpecKit Companion (latest)" --prerelease --target main
+   fi
+   gh release edit companion-latest --prerelease   # idempotent — re-asserts prerelease every run
    ```
+   > Use `if/else`, not `view && upload || create`: with the `&&…||` chain a transient `upload` failure falls through to `create` and then errors on the already-existing tag, masking the real fault.
    **Why a dedicated tag, not `/releases/latest`:** this is a two-product repo — `release.yml` publishes the VS Code extension on `v*` tags, and those releases interleave with `speckit-ext-v*` in one GitHub releases list. GitHub's `/releases/latest` resolves to the newest non-prerelease across **both** products, so `…/releases/latest/download/companion.zip` would 404 the moment the next VS Code `v*` release is cut. The stable URL `…/releases/download/companion-latest/companion.zip` resolves **by tag** and is immune to that interleaving. The `--prerelease` flag keeps `companion-latest` out of `/releases/latest`; the non-`v*` tag keeps it from triggering the Marketplace publish.
 8. **Verify the deployed install** in a scratch dir (simulate a user), from the **stable** URL: `mkdir -p /tmp/v/.specify/extensions && cd /tmp/v && yes | specify extension add companion --from https://github.com/alfredoperez/speckit-companion/releases/download/companion-latest/companion.zip --force` → `specify extension list` shows the version + all commands. Note: the **`companion` name arg is required**, the URL must be **HTTPS**, and a raw-URL install shows a one-time "untrusted source" prompt. If a prior local install left inconsistent emission dirs, nuke all `speckit-companion-*` / `speckit.companion.*` artifacts first.
 

--- a/speckit-extension/extension.yml
+++ b/speckit-extension/extension.yml
@@ -3,7 +3,7 @@ schema_version: "1.0"
 extension:
   id: companion
   name: "SpecKit Companion"
-  version: "0.3.0"
+  version: "0.4.0"
   description: "Live spec-driven progress for SpecKit Companion — lifecycle capture, status, and resume."
   author: alfredoperez
   repository: https://github.com/alfredoperez/speckit-companion

--- a/specs/156-stable-companion-zip/.spec-context.json
+++ b/specs/156-stable-companion-zip/.spec-context.json
@@ -1,0 +1,166 @@
+{
+  "workflow": "speckit",
+  "specName": "stable companion zip",
+  "branch": "156-stable-companion-zip",
+  "currentStep": "implement",
+  "status": "implemented",
+  "history": [
+    {
+      "step": "specify",
+      "substep": null,
+      "kind": "start",
+      "by": "extension",
+      "at": "2026-06-12T23:45:19.760Z"
+    },
+    {
+      "step": "specify",
+      "substep": null,
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-06-12T23:46:20.104Z"
+    },
+    {
+      "step": "plan",
+      "substep": "fast-path",
+      "kind": "start",
+      "by": "ai",
+      "at": "2026-06-12T23:46:20.183Z"
+    },
+    {
+      "step": "plan",
+      "substep": "fast-path",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-12T23:46:20.262Z"
+    },
+    {
+      "step": "tasks",
+      "substep": "fast-path",
+      "kind": "start",
+      "by": "ai",
+      "at": "2026-06-12T23:46:20.343Z"
+    },
+    {
+      "step": "tasks",
+      "substep": "fast-path",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-12T23:46:20.422Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T001",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-12T23:46:54.274Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T002",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-12T23:47:36.097Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T003",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-12T23:48:08.225Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T004",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-12T23:48:35.050Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T005",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-12T23:48:52.059Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T006",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-12T23:48:52.141Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T007",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-12T23:49:27.417Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-06-12T23:49:33.228Z"
+    }
+  ],
+  "currentTask": "T007",
+  "task_summaries": {
+    "T001": {
+      "status": "DONE",
+      "did": "Added companion-latest stable-asset step to the release flow (force-replace companion.zip on a prerelease) and updated verify/report steps",
+      "files": [
+        ".claude/commands/publish-speckit-ext.md"
+      ]
+    },
+    "T002": {
+      "status": "DONE",
+      "did": "Added companion-latest stable-asset step to the publishing Process, explained the two-product /releases/latest pitfall, and pointed the catalog download_url at the stable URL",
+      "files": [
+        "speckit-extension/docs/publishing.md"
+      ]
+    },
+    "T003": {
+      "status": "DONE",
+      "did": "Replaced both version-pinned install commands with the stable companion-latest URL, added --force update guidance, bumped version badge to 0.4.0",
+      "files": [
+        "speckit-extension/README.md"
+      ]
+    },
+    "T004": {
+      "status": "DONE",
+      "did": "Added a stable release-archive install/update section with the companion-latest URL, --force update note, and the /releases/latest pitfall explainer",
+      "files": [
+        "speckit-extension/docs/install.md"
+      ]
+    },
+    "T005": {
+      "status": "DONE",
+      "did": "Bumped extension.version 0.3.0 to 0.4.0",
+      "files": [
+        "speckit-extension/extension.yml"
+      ]
+    },
+    "T006": {
+      "status": "DONE",
+      "did": "Added a user-facing 0.4.0 CHANGELOG entry for the stable install/update URL",
+      "files": [
+        "speckit-extension/CHANGELOG.md"
+      ]
+    },
+    "T007": {
+      "status": "DONE",
+      "did": "Verified: npm compile clean, 987 tests pass, check-shape-parity OK, publish shell snippets pass bash -n",
+      "files": [
+        "(verification only)"
+      ]
+    }
+  }
+}

--- a/specs/156-stable-companion-zip/checklists/requirements.md
+++ b/specs/156-stable-companion-zip/checklists/requirements.md
@@ -1,0 +1,32 @@
+# Specification Quality Checklist: Stable companion.zip asset + re-runnable install/update command
+
+**Purpose**: Validate turbo specification completeness before planning
+**Created**: 2026-06-12
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user/business value and the change's intent
+- [x] Overview states what is delivered and why in 1–3 sentences
+- [x] All four sections present (Overview, Functional Requirements, Success Criteria, Assumptions)
+
+## Requirement Completeness
+
+- [x] Any [NEEDS CLARIFICATION] markers are genuine ambiguities (≤3) deferred to clarify — none needed
+- [x] Each Functional Requirement is a single, testable MUST/SHOULD statement
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic
+- [x] Edge cases are folded into Functional Requirements or Assumptions
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] Every Functional Requirement maps to at least one Success Criterion
+- [x] Overview intent is reflected by the FR list (no orphan goals)
+- [x] No implementation details leak into the specification
+
+## Notes
+
+- Stable-URL approach (companion-latest prerelease) deliberately deviates from the ticket's /releases/latest acceptance criterion — documented in Assumptions.

--- a/specs/156-stable-companion-zip/plan.md
+++ b/specs/156-stable-companion-zip/plan.md
@@ -1,0 +1,3 @@
+# Plan
+
+> Fast-path (turbo simple mode). The implementation approach lives inline in the spec: see [`./spec.md#approach`](./spec.md#approach). The dependency-ordered task checklist is in [`./tasks.md`](./tasks.md).

--- a/specs/156-stable-companion-zip/spec.md
+++ b/specs/156-stable-companion-zip/spec.md
@@ -1,0 +1,44 @@
+# Stable companion.zip asset + re-runnable install/update command
+
+## Overview
+
+The documented way to install and update the spec-kit extension (`id: companion`) hardcodes a version into the download URL (tag `speckit-ext-v0.3.0` and asset `companion-0.3.0.zip`), so anyone who copied the command is frozen on whatever version was pinned at the time — there is no stable URL and no update path. This delivers a genuinely stable download URL that survives every future release and a single re-runnable install/update command, so users can always pull the newest extension by re-running one line.
+
+## Functional Requirements
+
+- **FR-001** The release flow MUST publish a stable-named `companion.zip` asset reachable at a URL that does **not** change between releases, in addition to the existing archival version-named `companion-<ver>.zip`.
+- **FR-002** The stable URL MUST remain valid even after a newer VS Code (`v*`) release is cut. Because this is a two-product repo where `v*` (VS Code) and `speckit-ext-v*` (spec-kit ext) releases interleave in one GitHub releases list, `…/releases/latest/download/companion.zip` MUST NOT be used — GitHub's `/releases/latest` resolves to the newest non-prerelease across *both* products, so it 404s the moment the next `v*` release becomes "latest".
+- **FR-003** The stable URL MUST be served from a dedicated reusable release/tag (`companion-latest`) whose `companion.zip` asset is **force-replaced** on every `/publish-speckit-ext` run, yielding `…/releases/download/companion-latest/companion.zip` — a URL immune to product interleaving.
+- **FR-004** The `/publish-speckit-ext` command MUST, after cutting the normal `speckit-ext-v<X.Y.Z>` release, create-or-update the `companion-latest` release and clobber its `companion.zip` asset with the current build (so the stable URL always serves the newest version).
+- **FR-005** The `companion-latest` release MUST be marked **prerelease** so it never becomes the repo's `/releases/latest` and never triggers the VS Code Marketplace publish (`release.yml` keys off `v*` tags only; `companion-latest` is a non-`v*` tag, satisfying that constraint as well).
+- **FR-006** `speckit-extension/README.md` MUST document the install command using the stable `companion-latest/companion.zip` URL, and MUST include an explicit "to update, re-run the same command with `--force`" instruction.
+- **FR-007** `speckit-extension/docs/install.md` MUST document the same stable install/update command and the `--force` update line.
+- **FR-008** `speckit-extension/docs/publishing.md` MUST document the `companion-latest` stable-asset step as part of the release process.
+- **FR-009** `speckit-extension/extension.yml` `extension.version` MUST be bumped, and `speckit-extension/CHANGELOG.md` MUST gain a user-facing entry describing the stable install/update URL. Root `README.md`/`CHANGELOG.md`/`package.json` MUST NOT be touched.
+- **FR-010** No release may be published as part of this change — the flow is wired so the *next* `/publish-speckit-ext` produces the stable asset.
+
+## Success Criteria
+
+- **SC-001** After the next real `/publish-speckit-ext`, the stable URL returns HTTP 200 for the newest build, and continues to return 200 after a subsequent VS Code `v*` release (no product-interleaving 404).
+- **SC-002** A user can install and later update the extension by running one identical command (adding `--force` to update) — zero version strings to edit.
+- **SC-003** README and install.md show the stable install/update command plus an update instruction; publishing.md documents producing the stable asset on every release.
+- **SC-004** `python3 speckit-extension/scripts/check-shape-parity.py` passes and the project build/test suite is green.
+
+## Assumptions
+
+- The robust approach is a dedicated reusable `companion-latest` prerelease (the ticket's literal `/releases/latest/download/…` acceptance criterion is unsound for this two-product repo and is deviated from deliberately — documented as such).
+- The community-catalog submission (ticket item 4) is long-term and out of scope here; this change covers the stable-URL + docs portion.
+- The live HTTP-200 check (SC-001) can only be verified after the next real publish, since this change does not publish a release.
+
+## Approach
+
+Files to touch (docs + maintainer release tooling — no extension runtime code, no root README/CHANGELOG/package.json):
+
+- `.claude/commands/publish-speckit-ext.md` — after the existing `gh release create speckit-ext-v$V …` step, add a step that force-updates a reusable `companion-latest` **prerelease** with the same build's zip, copied to the stable asset name `companion.zip`. Implementation: `cp /tmp/cb/companion-$V.zip /tmp/cb/companion.zip`, then `gh release delete-asset companion-latest companion.zip -y` (ignore-if-absent), and either create the release if missing (`gh release create companion-latest … --prerelease --target main`) or upload the asset with `--clobber`. The `--prerelease` flag keeps it out of `/releases/latest`. Update the command's verify step and the closing "update version references" note to mention the stable URL.
+- `speckit-extension/docs/publishing.md` — add the `companion-latest` stable-asset step to the Process list; note the prerelease flag and the resulting stable URL `…/releases/download/companion-latest/companion.zip`.
+- `speckit-extension/README.md` — replace the two version-pinned install commands (top hero block + Installation section) with the stable `companion-latest/companion.zip` URL; add a "To update: re-run the same command with `--force`" line; bump the version badge.
+- `speckit-extension/docs/install.md` — add the stable release-archive install command + the `--force` update line to the install section.
+- `speckit-extension/extension.yml` — bump `extension.version` (0.3.0 → 0.4.0).
+- `speckit-extension/CHANGELOG.md` — add a dated `0.4.0` section with a user-facing entry: stable install/update URL, re-runnable with `--force`.
+
+Dependencies: docs edits are independent of each other; the publish-command edit is the load-bearing wiring. No source compilation depends on these, but `check-shape-parity.py` runs because `speckit-extension/**` changed.

--- a/specs/156-stable-companion-zip/spec.md
+++ b/specs/156-stable-companion-zip/spec.md
@@ -14,7 +14,7 @@ The documented way to install and update the spec-kit extension (`id: companion`
 - **FR-006** `speckit-extension/README.md` MUST document the install command using the stable `companion-latest/companion.zip` URL, and MUST include an explicit "to update, re-run the same command with `--force`" instruction.
 - **FR-007** `speckit-extension/docs/install.md` MUST document the same stable install/update command and the `--force` update line.
 - **FR-008** `speckit-extension/docs/publishing.md` MUST document the `companion-latest` stable-asset step as part of the release process.
-- **FR-009** `speckit-extension/extension.yml` `extension.version` MUST be bumped, and `speckit-extension/CHANGELOG.md` MUST gain a user-facing entry describing the stable install/update URL. Root `README.md`/`CHANGELOG.md`/`package.json` MUST NOT be touched.
+- **FR-009** `speckit-extension/extension.yml` `extension.version` MUST be bumped, and `speckit-extension/CHANGELOG.md` MUST gain a user-facing entry describing the stable install/update URL. The root `README.md`'s spec-kit-extension **install command** MUST be repointed to the same stable URL (a factual link-accuracy fix — otherwise root-README users stay version-pinned); root `CHANGELOG.md`/`package.json` and the root extension's own versioned docs MUST NOT be touched.
 - **FR-010** No release may be published as part of this change — the flow is wired so the *next* `/publish-speckit-ext` produces the stable asset.
 
 ## Success Criteria

--- a/specs/156-stable-companion-zip/tasks.md
+++ b/specs/156-stable-companion-zip/tasks.md
@@ -1,0 +1,9 @@
+# Tasks
+
+- [x] **T001** Wire the `companion-latest` stable-asset step into the release flow (force-update a prerelease `companion-latest` with `companion.zip`) + `.claude/commands/publish-speckit-ext.md`
+- [x] **T002** [P] Document the stable-asset step in the publishing process + `speckit-extension/docs/publishing.md`
+- [x] **T003** [P] Replace the two version-pinned install commands with the stable URL + add a `--force` update line + bump the version badge + `speckit-extension/README.md`
+- [x] **T004** [P] Add the stable install/update command + `--force` update line to the install doc + `speckit-extension/docs/install.md`
+- [x] **T005** [P] Bump `extension.version` 0.3.0 → 0.4.0 + `speckit-extension/extension.yml`
+- [x] **T006** [P] Add a user-facing `0.4.0` CHANGELOG entry for the stable install/update URL + `speckit-extension/CHANGELOG.md`
+- [x] **T007** Verify: `npm run compile && npm test` green + `python3 speckit-extension/scripts/check-shape-parity.py` passes + `bash -n` the publish-command shell snippets


### PR DESCRIPTION
## Summary
Anyone installing the spec-kit extension (`id: companion`) from the docs was frozen on whatever version was hardcoded in the download URL — there was no "latest" URL and no update path. Now the docs point at one stable URL that always serves the newest build, so the same command both installs and updates (re-run with `--force`).

## Technical
- The published install/update URL is now `…/releases/download/companion-latest/companion.zip` — a dedicated reusable **prerelease** (`companion-latest`) whose `companion.zip` asset is force-replaced (`gh release upload --clobber`) on every `/publish-speckit-ext` run, with an idempotent `gh release edit … --prerelease` re-asserting the flag each run.
- This deliberately avoids `…/releases/latest/download/…`: this repo publishes two products into one releases list (VS Code on `v*`, this extension on `speckit-ext-v*`), so GitHub's `/releases/latest` tracks the newest across **both** and a `/releases/latest/download/companion.zip` URL would 404 the moment the next VS Code release is cut. Resolving by the `companion-latest` tag is immune to that interleaving. `--prerelease` keeps `companion-latest` out of `/releases/latest`; the non-`v*` tag also never triggers `release.yml` (the Marketplace publish).
- `/publish-speckit-ext` step 7 wired to create-or-clobber `companion-latest`; `publishing.md` documents the rolling-asset step; `install.md` + both READMEs show the stable command + a "to update, re-run with `--force`" line.

## Review checklist
- ✅ **SpecKit extension** — affected
    - publish tooling: `companion-latest` rolling asset step (`.claude/commands/publish-speckit-ext.md`)
    - docs: `speckit-extension/README.md` + `install.md` + `publishing.md` stable URL + update instruction
    - version: `extension.yml` 0.3.0 → 0.4.0 (correct — the spec-kit ext's own release-versioned change)
- ✅ **Root README** — install-URL repoint only
    - the spec-kit-ext install command in the root `README.md` was version-pinned too; repointed to the stable URL (link-accuracy fix — NOT a CHANGELOG/version/package.json change; isolation otherwise intact)
- ✅ **Changelog**
    - `speckit-extension/CHANGELOG.md` — user-facing entry (install/update from one stable URL)
- ✅ **Docs**
    - `speckit-extension/docs/install.md` + `docs/publishing.md` updated
    - catalog-submission YAML + pre-submit checklist version reconciled (review + Copilot findings)
- ✅ **Verify**
    - `npm run compile` clean · `npm test` green (987) · `check-shape-parity.py` passes
    - no old version-pinned install URL remains in user docs
    - no root `package.json`/`CHANGELOG.md` change
- ⚠️ **Live 200 check deferred** — the stable URL returns 200 only after the **next** `/publish-speckit-ext` run creates `companion-latest` (no auto-publish in this PR). Verify then, and re-verify after a subsequent VS Code `v*` release.

## Gaps / how to see it
- The stable asset doesn't exist until the next real publish — this PR wires the flow + docs. Long-term, landing `companion` in the spec-kit community catalog (`specify extension add companion` by name) supersedes the raw-URL install.
- Try (after next publish): `specify extension add companion --from https://github.com/alfredoperez/speckit-companion/releases/download/companion-latest/companion.zip --force` then `specify extension list`.

Closes #273

🤖 Generated with [Claude Code](https://claude.com/claude-code)
