### PR TITLE
feat(spec-editor): improve Create Spec page UX and accessibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+
+- **The Create Spec page is easier to use and accessible** (#272): the form now sits in a centered, readable-width column instead of stretching across the whole editor, with persistent writing guidance below the field (it stays visible while you type) and a primary button that reads **Create Spec** and stays disabled until you've written something. The attachments area collapsed into a compact "Attach image" control beside the field, and the character counter stays out of the way until you near the 50,000 limit. It's now usable without a mouse or sight: errors, "creating your spec…", and image attach/remove are announced to screen readers; every button has a meaningful name; every control shows a visible focus ring when you tab to it; the limit is communicated beyond color and over-limit content can't be submitted; the keyboard hint shows Cmd on macOS; and pressing Esc with typed content asks before discarding your work.
+
 ### Added
 
 - **Mark implemented specs complete from the sidebar, and tell them apart at a glance** (#271): a spec that finishes the pipeline sits in the **Completed** group as "implemented" but still needs your confirmation. You can now right-click it and choose **Mark as Completed** — previously the only way to confirm was the spec viewer's footer. Implemented specs also get a distinct **yellow** beaker icon (vs. the green icon for confirmed-completed specs), so within the Completed group you can see at a glance which specs are done and which are still awaiting your sign-off.

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Comments live entirely in `.spec-context.json`; the old per-document `<doc>-extr
 
 ### Create Specs Visually
 
-Create new specs with a dedicated dialog. Write a detailed description, select your workflow, and attach screenshots or mockups for context.
+Create new specs with a dedicated dialog. Write a detailed description, select your workflow, and attach screenshots or mockups for context. The form is a centered, readable-width column with persistent writing guidance below the field, and the **Create Spec** button stays disabled until you've written something. It's built for keyboard and screen-reader use: errors, in-progress submission, and image attach/remove are announced, every control has a visible focus ring and a meaningful name, the character limit is conveyed beyond color (and over-limit content can't be submitted), and pressing Esc with typed content asks before discarding.
 
 ![Create Spec](https://raw.githubusercontent.com/alfredoperez/speckit-companion/main/docs/screenshots/create-spec.png)
 *Create-spec dialog. Write a detailed description, pick a workflow, attach a screenshot. The AI never sees a one-liner.*

--- a/specs/164-create-spec-ux/.spec-context.json
+++ b/specs/164-create-spec-ux/.spec-context.json
@@ -1,0 +1,208 @@
+{
+  "workflow": "speckit",
+  "specName": "create spec ux",
+  "branch": "164-create-spec-ux",
+  "currentStep": "implement",
+  "status": "implemented",
+  "history": [
+    {
+      "step": "specify",
+      "substep": null,
+      "kind": "start",
+      "by": "extension",
+      "at": "2026-06-13T03:54:37.172Z"
+    },
+    {
+      "step": "specify",
+      "substep": null,
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-06-13T03:55:22.894Z"
+    },
+    {
+      "step": "plan",
+      "substep": null,
+      "kind": "start",
+      "by": "extension",
+      "at": "2026-06-13T03:55:29.846Z"
+    },
+    {
+      "step": "plan",
+      "substep": "research",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-13T03:56:06.830Z"
+    },
+    {
+      "step": "plan",
+      "substep": "design",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-13T03:56:07.918Z"
+    },
+    {
+      "step": "plan",
+      "substep": null,
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-13T03:56:09.019Z"
+    },
+    {
+      "step": "tasks",
+      "substep": null,
+      "kind": "start",
+      "by": "extension",
+      "at": "2026-06-13T03:56:15.028Z"
+    },
+    {
+      "step": "tasks",
+      "substep": "generate",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-13T03:56:38.235Z"
+    },
+    {
+      "step": "tasks",
+      "substep": null,
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-13T03:56:39.318Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "kind": "start",
+      "by": "extension",
+      "at": "2026-06-13T03:56:42.973Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T001",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-13T03:56:56.414Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T002",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-13T03:57:22.575Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T003",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-13T03:58:49.721Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T004",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-13T04:00:13.385Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T005",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-13T04:00:55.949Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T006",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-13T04:01:16.705Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T007",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-13T04:01:55.131Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T008",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-13T04:02:40.205Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-06-13T04:02:52.344Z"
+    }
+  ],
+  "currentTask": "T008",
+  "task_summaries": {
+    "T001": {
+      "status": "DONE",
+      "did": "Added pure submitGate helpers (canSubmit, isOverLimit, shouldShowCharCount, isMacPlatform) + helper/subtitle text constants",
+      "files": [
+        "webview/src/spec-editor/submitGate.ts"
+      ]
+    },
+    "T002": {
+      "status": "DONE",
+      "did": "Reworked HTML template: main landmark, removed h3-skip, what-happens-next subtitle, persistent helper text, role=alert error region, aria-describedby textarea, hidden counter, composer-row attach button with aria-label, aria-busy loading overlay with status text, Create Spec disabled-by-default, regrouped footer, sr-only status region",
+      "files": [
+        "src/features/spec-editor/specEditorProvider.ts"
+      ]
+    },
+    "T003": {
+      "status": "DONE",
+      "did": "Wired submit gate (disabled on empty/over-limit), hidden-until-90% counter with non-color over-limit text, accessible error close+focus, aria-busy loading, sr-status announcements for attach/remove, aria-labelled remove buttons, platform-correct Cmd/Ctrl hints, Esc confirm-before-discard",
+      "files": [
+        "webview/src/spec-editor/index.ts"
+      ]
+    },
+    "T004": {
+      "status": "DONE",
+      "did": "Restyled: centered 800px column, proportional textarea+placeholder, helper-text via --text-body, visible focus-visible rings on textarea/select/all buttons/close/remove, removed dashed drag affordance + composer row, dropped divider rules, sr-only utility, hidden-counter, single-row footer hints-left, loading-text",
+      "files": [
+        "webview/styles/spec-editor.css"
+      ]
+    },
+    "T005": {
+      "status": "DONE",
+      "did": "Updated CreateSpecMock + stories to new layout (centered main, helper text, Create Spec disabled-on-empty, composer attach row, Cmd hint, footer hints-left) and added Empty-disabled + OverLimit variants",
+      "files": [
+        "webview/src/spec-editor/CreateSpecMock.tsx",
+        "webview/src/spec-editor/__stories__/CreateSpec.stories.tsx"
+      ]
+    },
+    "T006": {
+      "status": "DONE",
+      "did": "Added submitGate unit tests covering empty/whitespace/over-limit/at-limit canSubmit, isOverLimit boundary, shouldShowCharCount 90% threshold, isMacPlatform across platform/userAgent",
+      "files": [
+        "webview/src/spec-editor/__tests__/submitGate.test.ts"
+      ]
+    },
+    "T007": {
+      "status": "DONE",
+      "did": "Updated README Create-Specs-Visually section and added CHANGELOG [Unreleased] user-facing entry for the Create Spec UX+a11y overhaul",
+      "files": [
+        "README.md",
+        "CHANGELOG.md"
+      ]
+    },
+    "T008": {
+      "status": "DONE",
+      "did": "Verified: npm run compile clean, full suite 1020/1020 green, npm run package built webview with no webpack/tsc errors"
+    }
+  }
+}

--- a/specs/164-create-spec-ux/checklists/requirements.md
+++ b/specs/164-create-spec-ux/checklists/requirements.md
@@ -1,0 +1,32 @@
+# Specification Quality Checklist: Create Spec Page — UX & Accessibility Overhaul
+
+**Purpose**: Validate turbo specification completeness before planning
+**Created**: 2026-06-12
+**Feature**: [Link to spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user/business value and the change's intent
+- [x] Overview states what is delivered and why in 1–3 sentences
+- [x] All four sections present (Overview, Functional Requirements, Success Criteria, Assumptions)
+
+## Requirement Completeness
+
+- [x] Any [NEEDS CLARIFICATION] markers are genuine ambiguities (≤3) deferred to clarify — not unresolved guesses
+- [x] Each Functional Requirement is a single, testable MUST/SHOULD statement
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] Edge cases are folded into Functional Requirements or Assumptions
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] Every Functional Requirement maps to at least one Success Criterion
+- [x] Overview intent is reflected by the FR list (no orphan goals)
+- [x] No implementation details leak into the specification
+
+## Notes
+
+- No open clarifications: the issue is detailed and the informed defaults (800px column, 90% counter threshold, confirm-before-discard) are recorded in Assumptions.

--- a/specs/164-create-spec-ux/plan.md
+++ b/specs/164-create-spec-ux/plan.md
@@ -1,0 +1,68 @@
+# Implementation Plan: Create Spec Page — UX & Accessibility Overhaul
+
+## Summary
+
+Rework the spec-editor webview (a vanilla-DOM webview, not Preact) across three files — the server-rendered HTML template, the webview behavior script, and the stylesheet — to deliver a centered readable-width column, persistent accessible helper text, a gated **Create Spec** button, ARIA live announcements for errors/loading/attachments, accessible button names, a non-color over-limit gate, visible focus rings, landmark/heading fixes, a platform-correct keyboard hint, and an Esc-discard confirmation. Pure helpers (empty/over-limit submit gate, Mac detection, helper text) are extracted so they can be unit-tested without a webview harness. The Storybook mock is updated to match the new layout.
+
+## Technical Context
+
+- **Language/version**: TypeScript 5.3+ (ES2022, strict), VS Code Extension API (`@types/vscode ^1.84.0`), Preact only in Storybook mock.
+- **Primary surfaces**: vanilla-DOM webview (`webview/src/spec-editor/index.ts`), server-rendered HTML string (`src/features/spec-editor/specEditorProvider.ts`), CSS (`webview/styles/spec-editor.css`), shared tokens (`webview/styles/tokens.css` — read-only here).
+- **Storage**: N/A (UI-only change; draft persists via `vscode.setState` as today).
+- **Testing**: Jest + ts-jest. New pure helpers get unit tests; webview DOM wiring stays review-only (known config/webview coverage gap).
+- **Target platform**: VS Code webview (Chromium), all themes (dark/light/high-contrast) + reduced-motion.
+- **Constraints**: extension ships in isolation — only `src/` + `webview/` + assets. Readable text uses `--text-body`/`--text-primary`. CSP forbids inline `onclick` handlers via nonce script-src — the existing `onclick="this.parentElement.remove()"` on the error close button must move to a delegated listener.
+
+## Approach & Structure
+
+Order of attack, by file:
+
+1. **`webview/src/spec-editor/submitGate.ts` (new)** — pure helpers, no DOM:
+   - `canSubmit(content: string, max: number): boolean` — `false` when trimmed-empty or `length > max`.
+   - `isOverLimit(content: string, max: number): boolean`.
+   - `shouldShowCharCount(count: number, max: number): boolean` — true at ≥90% of max.
+   - `isMacPlatform(platform: string, userAgent: string): boolean` — Mac detection.
+   - `helperText` / `subtitleText` constants (the persistent guidance + "what happens next" subtitle).
+   These are imported by `index.ts` and exercised directly by tests.
+
+2. **`src/features/spec-editor/specEditorProvider.ts` (HTML template ~l.585-650)**:
+   - Wrap the content region in `<main>`; demote the attachments `<h3>` to `<h2>` (fix h1→h3 skip).
+   - Rewrite the subtitle to say what the AI does next.
+   - Add persistent `<p class="helper-text">` under the textarea label; drop the long mono placeholder (short or none).
+   - `#error-container` gets `role="alert" aria-live="assertive"`.
+   - Textarea gets `aria-describedby="charCount helperText"`; counter starts hidden.
+   - Collapse the attachments section into a compact composer row; remove the dashed dropzone styling target.
+   - Loading overlay gets `role="status" aria-live="polite" aria-busy` + visible+SR text "Creating your spec…".
+   - Submit button → **Create Spec**, `disabled` by default; footer regrouped (Cancel + Create right, hints left).
+   - Add an `aria-live="polite"` visually-hidden status region (`#sr-status`) for attach/remove announcements.
+
+3. **`webview/src/spec-editor/index.ts`**:
+   - Import the gate helpers; add `updateSubmitState()` called on input + after restore/init — toggles `submitBtn.disabled` via `canSubmit`.
+   - `updateCharCount()` toggles counter visibility (`shouldShowCharCount`) and over-limit text; submit click + Ctrl/Cmd+Enter both early-return when `!canSubmit`.
+   - `showError()` close button → accessible name + delegated listener (no inline `onclick`); set focus to error.
+   - `setLoading()` toggles `aria-busy`/`aria-hidden` and overlay text.
+   - `updateThumbnails()`/`removeImage()` write `#sr-status` ("Image <name> attached/removed"); remove buttons get `aria-label`.
+   - Keyboard hint text built from `isMacPlatform(...)` (Cmd vs Ctrl) — applied in initial render and `updateCommandButtons()`.
+   - Esc handler: if textarea has non-whitespace content, `confirm()` before posting `cancel`.
+
+4. **`webview/styles/spec-editor.css`**:
+   - Centered column: `max-width: 800px; margin: 0 auto` on the content wrapper (and footer/hints aligned to it).
+   - Textarea `font-family: var(--font-family)` (proportional), helper text `--text-body` ≥4.5:1.
+   - Visible `:focus-visible` outline on textarea, select, and all buttons; remove bare `outline:none` without replacement.
+   - Remove dashed border / drag affordance on the attach button; composer-row layout.
+   - Drop section-divider `border-top` rules; counter `.hidden` utility; over-limit `.error` with non-color cue handled in markup/text.
+   - Footer single row: hints left, actions right.
+   - `.sr-only` visually-hidden utility for the status region.
+
+5. **`webview/src/spec-editor/CreateSpecMock.tsx` + stories** — update mock to the new layout (centered, helper text, Create Spec, disabled-empty, composer attachments, Cmd/Ctrl, footer grouping); add an `OverLimit`/`Empty-disabled` story variant.
+
+## Out of Scope
+
+- Implementing drag-and-drop attachment (explicitly removing the misleading affordance instead).
+- Changing the submit/command message protocol or the extension-side submit handling.
+- Reworking the install banner, workflow selector data flow, or image storage.
+- Any change to `tokens.css` values (read-only here).
+
+## Constitution Check
+
+No constitution gates defined (`.specify/memory/constitution.md` absent or empty). Pass.

--- a/specs/164-create-spec-ux/plan.md
+++ b/specs/164-create-spec-ux/plan.md
@@ -22,8 +22,8 @@ Order of attack, by file:
    - `isOverLimit(content: string, max: number): boolean`.
    - `shouldShowCharCount(count: number, max: number): boolean` — true at ≥90% of max.
    - `isMacPlatform(platform: string, userAgent: string): boolean` — Mac detection.
-   - `helperText` / `subtitleText` constants (the persistent guidance + "what happens next" subtitle).
-   These are imported by `index.ts` and exercised directly by tests.
+   - `MAX_CHARS` and `CHAR_COUNT_REVEAL_RATIO` constants (the limit + counter reveal threshold).
+   The persistent guidance + "what happens next" subtitle copy lives in the HTML template (`specEditorProvider.ts`) and the mock — not in this module. These helpers are imported by `index.ts` and exercised directly by tests.
 
 2. **`src/features/spec-editor/specEditorProvider.ts` (HTML template ~l.585-650)**:
    - Wrap the content region in `<main>`; demote the attachments `<h3>` to `<h2>` (fix h1→h3 skip).

--- a/specs/164-create-spec-ux/spec.md
+++ b/specs/164-create-spec-ux/spec.md
@@ -1,0 +1,69 @@
+# Create Spec Page — UX & Accessibility Overhaul
+
+## Overview
+
+The Create Spec page (the spec-editor webview) wastes wide editors, hides its writing guidance behind a low-contrast placeholder that vanishes on the first keystroke, lets an empty description be submitted, and is silent to assistive technology about errors, in-progress submission, and image attachment changes. This feature makes the form comfortable at any width, gives writers persistent readable guidance, gates submission on real input, and brings the page to WCAG AA — so screen-reader and keyboard users get the same feedback sighted mouse users already do.
+
+## Functional Requirements
+
+### Layout & guidance
+
+- **FR-001** The form content MUST be constrained to a centered, readable-width column (~720–840px) regardless of editor width; the textarea MUST NOT span the full editor width.
+- **FR-002** The page MUST present persistent helper text (visible while typing) that guides what to write, in a proportional font with contrast ≥ 4.5:1 against the background — replacing the monospace placeholder example that vanished on first keystroke.
+- **FR-003** The specification textarea MUST use a proportional, readable font for entered text (not a monospace font).
+- **FR-004** The subtitle MUST state what happens next (the AI generates spec/plan/tasks) rather than restating the page title.
+- **FR-005** The Attachments area MUST collapse into a compact composer-style control attached to the textarea; the misleading dashed drag-and-drop affordance MUST be removed (drag-and-drop is not implemented).
+- **FR-006** Section divider rules MUST be dropped in the single-column layout.
+
+### Primary action & validation
+
+- **FR-007** The primary submit button MUST be labeled **Create Spec** (not "Submit").
+- **FR-008** The Create Spec button MUST be disabled while the description is empty (whitespace-only counts as empty) and enabled once non-empty content exists.
+- **FR-009** The character counter MUST stay hidden until the content reaches ~90% of the limit, then become visible in a warning color.
+- **FR-010** When content exceeds the character limit, submission MUST be blocked (button disabled and keyboard-submit suppressed), and the over-limit state MUST be communicated by more than color alone.
+- **FR-011** The footer MUST be one aligned row: Cancel + Create Spec grouped on the right, keyboard hints on the left.
+
+### Accessibility — announcements
+
+- **FR-012** Error messages MUST be announced to assistive technology when they appear (live region with assertive politeness).
+- **FR-013** The loading overlay MUST announce that submission is in progress and MUST set a busy state on the affected region.
+- **FR-014** Attaching or removing an image MUST produce non-visual feedback announced to assistive technology.
+
+### Accessibility — names, discoverability, focus
+
+- **FR-015** Every "×" close/remove button MUST have a meaningful accessible name (e.g. "Remove image <name>", "Dismiss error").
+- **FR-016** The character limit MUST be discoverable non-visually by associating the textarea with the counter (the textarea references the counter as its description).
+- **FR-017** Every interactive control (textarea, select, all buttons) MUST show a clearly visible focus indicator when navigated by keyboard; focus outlines MUST NOT be suppressed without a visible replacement.
+- **FR-018** The main content MUST be wrapped in a `<main>` landmark and the heading order MUST not skip levels (no h1→h3 jump).
+- **FR-019** Keyboard hints MUST show the platform-correct modifier (Cmd on macOS, Ctrl elsewhere) rather than a hardcoded "Ctrl".
+
+### Safety
+
+- **FR-020** Pressing Escape with typed content MUST NOT silently discard work — it MUST either confirm before discarding or rely on a draft that demonstrably restores the typed content.
+
+### Regression guardrails
+
+- **FR-021** Existing flows MUST remain functional: workflow selection, custom command buttons, paste-to-attach, file-picker attach, and draft restore.
+
+## Success Criteria
+
+- **SC-001** At any editor width, the form renders as a centered column no wider than ~840px (readable line length maintained).
+- **SC-002** Writing guidance is visible both before and during typing and meets ≥ 4.5:1 contrast.
+- **SC-003** The primary button reads "Create Spec" and cannot be activated (click or keyboard) when the description is empty or over the limit.
+- **SC-004** A screen reader announces: an error when it occurs, that submission is in progress, and confirmation when an image is attached or removed.
+- **SC-005** Every button exposes a non-empty accessible name to assistive technology.
+- **SC-006** The character limit is conveyed by text/state in addition to color, and over-limit content cannot be submitted.
+- **SC-007** Every interactive control shows a visible focus ring when reached by keyboard.
+- **SC-008** Heading levels are sequential and the primary content sits inside a `<main>` landmark.
+- **SC-009** On macOS the keyboard hint reads "Cmd"; elsewhere "Ctrl".
+- **SC-010** Pressing Escape with unsaved typed content does not lose the content without acknowledgement.
+- **SC-011** All listed existing flows continue to work unchanged.
+
+## Assumptions
+
+- The webview is vanilla DOM (not Preact); the `CreateSpecMock.tsx` Storybook component is a visual reference only and is updated to match the new layout.
+- Readable content uses `--text-body` / `--text-primary` tokens (never `--text-secondary` / `--text-muted`, which are intentionally low-contrast metadata tokens per the project token rules).
+- Platform detection for the Cmd/Ctrl hint uses the webview `navigator.platform`/userAgent (Mac detection) at runtime.
+- The Esc-discard safety is satisfied by a confirm-before-discard prompt when content is present (the existing draft-restore is retained as a complementary safety net).
+- The helper-text column width target lands at 800px as the informed default within the 720–840px range.
+- The character-counter reveal threshold is 90% of the 50,000 limit (45,000 characters).

--- a/specs/164-create-spec-ux/tasks.md
+++ b/specs/164-create-spec-ux/tasks.md
@@ -4,7 +4,7 @@ Dependency-ordered, grouped by execution layer. Traceability is to files and `FR
 
 ## Foundational
 
-- [x] **T001** Create pure helper module `webview/src/spec-editor/submitGate.ts` with `canSubmit`, `isOverLimit`, `shouldShowCharCount`, `isMacPlatform`, and exported `HELPER_TEXT` / `SUBTITLE_TEXT` constants (FR-002, FR-004, FR-008, FR-009, FR-010, FR-019)
+- [x] **T001** Create pure helper module `webview/src/spec-editor/submitGate.ts` exporting `MAX_CHARS`, `CHAR_COUNT_REVEAL_RATIO`, and the gate helpers `canSubmit`, `isOverLimit`, `shouldShowCharCount`, `isMacPlatform`; the helper/subtitle copy lives in the HTML template and the mock, not in this module (FR-002, FR-004, FR-008, FR-009, FR-010, FR-019)
 
 ## Core work
 

--- a/specs/164-create-spec-ux/tasks.md
+++ b/specs/164-create-spec-ux/tasks.md
@@ -1,0 +1,34 @@
+# Tasks: Create Spec Page — UX & Accessibility Overhaul
+
+Dependency-ordered, grouped by execution layer. Traceability is to files and `FR-…`.
+
+## Foundational
+
+- [x] **T001** Create pure helper module `webview/src/spec-editor/submitGate.ts` with `canSubmit`, `isOverLimit`, `shouldShowCharCount`, `isMacPlatform`, and exported `HELPER_TEXT` / `SUBTITLE_TEXT` constants (FR-002, FR-004, FR-008, FR-009, FR-010, FR-019)
+
+## Core work
+
+- [x] **T002** Rework the HTML template in `src/features/spec-editor/specEditorProvider.ts`: `<main>` landmark, h1→h2 heading fix, rewritten subtitle, persistent helper text, `role=alert`/`aria-live` on `#error-container`, `aria-describedby` textarea→counter+helper, hidden counter, composer-style attachments (no dashed dropzone), `aria-busy`+status text on loading overlay, **Create Spec** button disabled-by-default, regrouped footer, visually-hidden `#sr-status` region (FR-001, FR-004, FR-005, FR-007, FR-008, FR-011, FR-012, FR-013, FR-016, FR-018)
+- [x] **T003** Update webview behavior in `webview/src/spec-editor/index.ts`: import gate helpers; `updateSubmitState()` on input/init/restore; counter visibility + over-limit gate in `updateCharCount()`; submit click & Ctrl/Cmd+Enter early-return on `!canSubmit`; accessible error close + delegated listener + focus; `setLoading()` toggles `aria-busy`/overlay text; attach/remove writes `#sr-status` and remove buttons get `aria-label`; platform-correct keyboard hint via `isMacPlatform`; Esc confirms when content present (FR-002, FR-008, FR-010, FR-012, FR-013, FR-014, FR-015, FR-016, FR-019, FR-020, FR-021)
+- [x] **T004** Restyle `webview/styles/spec-editor.css`: centered ~800px column, proportional textarea font, helper-text `--text-body`, visible `:focus-visible` on textarea/select/all buttons, remove dashed/drag affordance + composer row, drop divider rules, `.sr-only` + counter-hidden utilities, single-row footer (FR-001, FR-002, FR-003, FR-005, FR-006, FR-009, FR-011, FR-017)
+
+## Integration
+
+- [x] **T005** [P] Update the Storybook mock `webview/src/spec-editor/CreateSpecMock.tsx` and `__stories__/CreateSpec.stories.tsx` to the new layout (centered column, helper text, Create Spec button, disabled-on-empty, composer attachments, platform hint, footer grouping) and add Empty-disabled / OverLimit story variants (FR-001, FR-002, FR-005, FR-007, FR-008, FR-011)
+
+## Polish
+
+- [x] **T006** [P] Add unit tests `webview/src/spec-editor/__tests__/submitGate.test.ts` covering empty/whitespace/over-limit `canSubmit`, `shouldShowCharCount` threshold, and `isMacPlatform` (FR-008, FR-009, FR-010, FR-019)
+- [x] **T007** [P] Docs: README Create-Spec / "Reading Specs" area + root `CHANGELOG.md` `[Unreleased]` user-facing entry; note screenshots to re-shoot (FR-001..FR-020)
+- [x] **T008** Verify: `npm run compile && npm test` green and `npm run package` builds the webview with no tsc/webpack errors (SC-001..SC-011)
+
+## Dependencies
+
+- T001 blocks T002, T003, T006 (they import/exercise the helpers).
+- T002 (markup ids/aria hooks) blocks T003 (wires to those ids) and T004 (styles those classes).
+- T005, T006, T007 depend on the behavior/markup being final (T002–T004).
+- T008 is last (full verify).
+
+## Parallel
+
+- T005, T006, T007 are `[P]` — different files, runnable together once T002–T004 land.

--- a/src/features/spec-editor/specEditorProvider.ts
+++ b/src/features/spec-editor/specEditorProvider.ts
@@ -584,69 +584,63 @@ export class SpecEditorProvider {
 </head>
 <body>
     <div class="spec-editor" id="app">
-        <header class="spec-editor-header">
-            <h1>Create New Spec</h1>
-            <p>Write a detailed specification for your feature or task</p>
-        </header>
+        <main class="spec-editor-column">
+            <header class="spec-editor-header">
+                <h1>Create New Spec</h1>
+                <p>Describe your feature — the AI will generate the spec, plan, and tasks for it.</p>
+            </header>
 
-        <div class="spec-editor-content">
-            ${installBanner}
-            <div id="error-container"></div>
+            <div class="spec-editor-content">
+                ${installBanner}
+                <div id="error-container" role="alert" aria-live="assertive"></div>
 
-            <div class="workflow-row">
-                <div class="workflow-selector" id="workflowSelector" style="display: none;">
-                    <label for="workflowSelect">Workflow</label>
-                    <select id="workflowSelect">
-                        <option value="speckit">SpecKit</option>
-                    </select>
+                <div class="workflow-row">
+                    <div class="workflow-selector" id="workflowSelector" style="display: none;">
+                        <label for="workflowSelect">Workflow</label>
+                        <select id="workflowSelect">
+                            <option value="speckit">SpecKit</option>
+                        </select>
+                    </div>
+                </div>
+
+                <div class="editor-container">
+                    <label class="editor-label" for="specContent">Specification</label>
+                    <p class="helper-text" id="helperText">Write what you want and why. Helpful to include: the problem it solves, who it is for, the key requirements, and any constraints or dependencies.</p>
+                    <textarea
+                        class="spec-editor-textarea"
+                        id="specContent"
+                        aria-describedby="helperText charCount"
+                        placeholder="Describe your feature or task in detail…"
+                    ></textarea>
+                    <div class="editor-footer-row">
+                        <button class="attach-image-btn" id="attachImageBtn" aria-label="Attach image (or paste an image to attach)">
+                            <span class="codicon codicon-file-media" aria-hidden="true"></span>
+                            Attach image
+                        </button>
+                        <div class="char-count" id="charCount" hidden>0 / 50,000</div>
+                    </div>
+                    <div class="image-thumbnails" id="thumbnails"></div>
+                    <div class="image-size-info" id="sizeInfo"></div>
                 </div>
             </div>
 
-            <div class="editor-container">
-                <label class="editor-label" for="specContent">Specification</label>
-                <textarea
-                    class="spec-editor-textarea"
-                    id="specContent"
-                    placeholder="Describe your feature or task in detail...
-
-Example:
-- What is the feature about?
-- What problem does it solve?
-- Who are the target users?
-- What are the key requirements?
-- Are there any constraints or dependencies?"
-                ></textarea>
-                <div class="char-count" id="charCount">0 / 50,000</div>
-            </div>
-
-            <div class="image-attachment-section">
-                <div class="image-attachment-header">
-                    <h3>Attachments</h3>
-                    <button class="attach-image-btn" id="attachImageBtn">
-                        <span class="codicon codicon-file-media" aria-hidden="true"></span>
-                        Attach Image
-                    </button>
+            <footer class="spec-editor-actions">
+                <div class="keyboard-hints" id="keyboardHints">
+                    <kbd>Ctrl</kbd>+<kbd>Enter</kbd> to submit • <kbd>Esc</kbd> to cancel
                 </div>
-                <p class="paste-hint">Use the button above or paste (Ctrl+V / Cmd+V) to attach images</p>
-                <div class="image-thumbnails" id="thumbnails"></div>
-                <div class="image-size-info" id="sizeInfo"></div>
-            </div>
-        </div>
+                <div class="action-spacer"></div>
+                <span id="commandButtons" style="display: none;"></span>
+                <button class="btn-cancel" id="cancelBtn">Cancel</button>
+                <button class="btn-primary" id="submitBtn" disabled>Create Spec</button>
+            </footer>
+        </main>
 
-        <footer class="spec-editor-actions">
-            <button class="btn-cancel" id="cancelBtn">Cancel</button>
-            <div class="action-spacer"></div>
-            <span id="commandButtons" style="display: none;"></span>
-            <button class="btn-primary" id="submitBtn">Submit</button>
-        </footer>
-
-        <div class="keyboard-hints">
-            <kbd>Ctrl</kbd>+<kbd>Enter</kbd> to submit • <kbd>Esc</kbd> to cancel
-        </div>
+        <div class="sr-only" id="sr-status" role="status" aria-live="polite"></div>
     </div>
 
-    <div class="loading-overlay" id="loadingOverlay" style="display: none;">
-        <div class="loading-spinner"></div>
+    <div class="loading-overlay" id="loadingOverlay" role="status" aria-live="polite" aria-hidden="true" style="display: none;">
+        <div class="loading-spinner" aria-hidden="true"></div>
+        <p class="loading-text">Creating your spec…</p>
     </div>
 
     <script nonce="${nonce}">

--- a/src/features/spec-editor/specEditorProvider.ts
+++ b/src/features/spec-editor/specEditorProvider.ts
@@ -583,7 +583,7 @@ export class SpecEditorProvider {
     <title>New Spec</title>
 </head>
 <body>
-    <div class="spec-editor" id="app">
+    <div class="spec-editor" id="app" aria-busy="false">
         <main class="spec-editor-column">
             <header class="spec-editor-header">
                 <h1>Create New Spec</h1>
@@ -617,7 +617,7 @@ export class SpecEditorProvider {
                             <span class="codicon codicon-file-media" aria-hidden="true"></span>
                             Attach image
                         </button>
-                        <div class="char-count" id="charCount" hidden>0 / 50,000</div>
+                        <div class="char-count sr-only" id="charCount">0 / 50,000</div>
                     </div>
                     <div class="image-thumbnails" id="thumbnails"></div>
                     <div class="image-size-info" id="sizeInfo"></div>

--- a/webview/src/spec-editor/CreateSpecMock.tsx
+++ b/webview/src/spec-editor/CreateSpecMock.tsx
@@ -138,7 +138,7 @@ export function CreateSpecMock({
 
                 <footer style="padding-top: 16px; display: flex; align-items: center; gap: 12px;">
                     <p style="margin: 0; font-size: 11px; color: var(--vscode-foreground, #c8c8c8);">
-                        <kbd style="background: var(--vscode-keybindingLabel-background, #2a2a2a); padding: 1px 6px; border-radius: 3px; border: 1px solid var(--vscode-widget-border, #303030);">Cmd</kbd>
+                        <kbd style="background: var(--vscode-keybindingLabel-background, #2a2a2a); padding: 1px 6px; border-radius: 3px; border: 1px solid var(--vscode-widget-border, #303030);">Ctrl/Cmd</kbd>
                         {' + '}
                         <kbd style="background: var(--vscode-keybindingLabel-background, #2a2a2a); padding: 1px 6px; border-radius: 3px; border: 1px solid var(--vscode-widget-border, #303030);">Enter</kbd>
                         {' to submit · '}

--- a/webview/src/spec-editor/CreateSpecMock.tsx
+++ b/webview/src/spec-editor/CreateSpecMock.tsx
@@ -7,27 +7,32 @@
  *   - SpecEditor/CreateSpec stories (standalone view).
  *   - Viewer/Transitions/CreateSpec (the lifecycle "phase zero" entry).
  *
- * Auto Mode lives here, next to Submit — by design it is the canonical
+ * Auto Mode lives here, next to Create Spec — by design it is the canonical
  * first-time entry point for the spec pipeline, NOT a viewer-footer button.
  */
 
 export interface CreateSpecMockProps {
     initialContent?: string;
     submitting?: boolean;
+    overLimit?: boolean;
 }
 
-export function CreateSpecMock({ initialContent = '', submitting = false }: CreateSpecMockProps) {
-    const placeholder =
-        'Describe your feature or task in detail...\n\n' +
-        'Example:\n' +
-        '- What is the feature about?\n' +
-        '- What problem does it solve?\n' +
-        '- Who are the target users?\n' +
-        '- What are the key requirements?\n' +
-        '- Are there any constraints or dependencies?';
+const MAX_CHARS = 50_000;
 
-    const charCount = initialContent.length;
-    const maxChars = 50_000;
+const HELPER_TEXT =
+    'Write what you want and why. Helpful to include: the problem it solves, who it is for, ' +
+    'the key requirements, and any constraints or dependencies.';
+
+export function CreateSpecMock({
+    initialContent = '',
+    submitting = false,
+    overLimit = false,
+}: CreateSpecMockProps) {
+    const charCount = overLimit ? MAX_CHARS + 1200 : initialContent.length;
+    const isEmpty = initialContent.trim().length === 0;
+    const canSubmit = !isEmpty && !overLimit && !submitting;
+    // Counter is hidden until ~90% of the limit, then shows in warning/over-limit color.
+    const showCount = charCount >= MAX_CHARS * 0.9;
 
     return (
         <div
@@ -38,112 +43,123 @@ export function CreateSpecMock({ initialContent = '', submitting = false }: Crea
                 padding: 32px;
                 min-height: 100vh;
                 box-sizing: border-box;
-                max-width: 760px;
-                margin: 0 auto;
             `}
         >
-            <header style="margin-bottom: 28px;">
-                <h1 style="font-size: 28px; font-weight: 700; margin: 0 0 6px; color: var(--vscode-foreground, #fff);">
-                    Create New Spec
-                </h1>
-                <p style="font-size: 13px; opacity: 0.7; margin: 0;">
-                    Write a detailed specification for your feature or task
-                </p>
-            </header>
+            <main style="max-width: 800px; margin: 0 auto;">
+                <header style="margin-bottom: 24px;">
+                    <h1 style="font-size: 28px; font-weight: 700; margin: 0 0 6px; color: var(--vscode-foreground, #fff);">
+                        Create New Spec
+                    </h1>
+                    <p style="font-size: 13px; margin: 0; color: var(--vscode-foreground, #c8c8c8);">
+                        Describe your feature — the AI will generate the spec, plan, and tasks for it.
+                    </p>
+                </header>
 
-            <div style="display: flex; flex-wrap: wrap; justify-content: flex-end; align-items: center; gap: 8px; margin-bottom: 24px;">
-                <div style="display: flex; align-items: center; gap: 12px; font-size: 13px;">
-                    <span style="opacity: 0.7;">Workflow</span>
-                    <button
-                        type="button"
-                        style="
-                            background: var(--vscode-button-secondaryBackground, #1f1828);
-                            color: var(--vscode-button-secondaryForeground, #ddd);
-                            border: 1px solid var(--vscode-widget-border, #303030);
-                            padding: 8px 14px;
-                            border-radius: 4px;
+                <div style="display: flex; justify-content: flex-end; align-items: center; gap: 8px; margin-bottom: 20px;">
+                    <div style="display: flex; align-items: center; gap: 12px; font-size: 13px;">
+                        <span>Workflow</span>
+                        <button
+                            type="button"
+                            style="
+                                background: var(--vscode-button-secondaryBackground, #1f1828);
+                                color: var(--vscode-button-secondaryForeground, #ddd);
+                                border: 1px solid var(--vscode-widget-border, #303030);
+                                padding: 6px 12px;
+                                border-radius: 4px;
+                                font-size: 13px;
+                                cursor: pointer;
+                                display: inline-flex;
+                                align-items: center;
+                                gap: 8px;
+                                min-width: 120px;
+                                justify-content: space-between;
+                            "
+                        >
+                            SpecKit
+                            <span style="opacity: 0.5;">▾</span>
+                        </button>
+                    </div>
+                </div>
+
+                <section style="margin-bottom: 20px;">
+                    <label style="display: block; font-size: 13px; font-weight: 600; margin: 0 0 6px;">
+                        Specification
+                    </label>
+                    <p style="font-size: 13px; line-height: 1.5; margin: 0 0 8px; color: var(--vscode-foreground, #c8c8c8);">
+                        {HELPER_TEXT}
+                    </p>
+                    <div
+                        style={`
+                            background: var(--vscode-input-background, #0c0814);
+                            border: 1px solid var(--vscode-widget-border, #2a2a2a);
+                            border-radius: 6px;
+                            padding: 16px;
+                            font-family: var(--vscode-font-family, system-ui, sans-serif);
                             font-size: 13px;
-                            cursor: pointer;
-                            display: inline-flex;
-                            align-items: center;
-                            gap: 8px;
-                            min-width: 120px;
-                            justify-content: space-between;
-                        "
+                            line-height: 1.6;
+                            min-height: 280px;
+                            white-space: pre-wrap;
+                            color: ${isEmpty ? 'rgba(200, 200, 200, 0.85)' : 'var(--vscode-input-foreground, #ddd)'};
+                        `}
                     >
-                        SpecKit
-                        <span style="opacity: 0.5;">▾</span>
-                    </button>
-                </div>
-            </div>
+                        {initialContent || 'Describe your feature or task in detail…'}
+                    </div>
+                    <div style="display: flex; align-items: center; justify-content: space-between; gap: 8px; margin-top: 6px;">
+                        <button
+                            type="button"
+                            aria-label="Attach image (or paste an image to attach)"
+                            style="
+                                background: transparent;
+                                color: var(--vscode-button-secondaryForeground, #ddd);
+                                border: 1px solid var(--vscode-widget-border, #303030);
+                                padding: 4px 10px;
+                                font-size: 12px;
+                                border-radius: 4px;
+                                cursor: pointer;
+                                display: inline-flex;
+                                align-items: center;
+                                gap: 6px;
+                            "
+                        >
+                            <span aria-hidden="true">🖼</span>
+                            Attach image
+                        </button>
+                        {showCount && (
+                            <span
+                                style={`font-size: 12px; color: ${overLimit ? 'var(--vscode-editorError-foreground, #f14c4c)' : 'var(--vscode-editorWarning-foreground, #cca700)'};`}
+                            >
+                                {overLimit
+                                    ? `Over limit — ${charCount.toLocaleString()} / ${MAX_CHARS.toLocaleString()} (remove ${(charCount - MAX_CHARS).toLocaleString()} characters)`
+                                    : `${charCount.toLocaleString()} / ${MAX_CHARS.toLocaleString()}`}
+                            </span>
+                        )}
+                    </div>
+                </section>
 
-            <section style="margin-bottom: 20px;">
-                <h2 style="font-size: 14px; font-weight: 600; margin: 0 0 10px;">
-                    Specification
-                </h2>
-                <div
-                    style={`
-                        background: var(--vscode-input-background, #0c0814);
-                        border: 1px solid var(--vscode-widget-border, #2a2a2a);
-                        border-radius: 6px;
-                        padding: 16px;
-                        font-family: var(--vscode-editor-font-family, monospace);
-                        font-size: 13px;
-                        line-height: 1.6;
-                        min-height: 320px;
-                        white-space: pre-wrap;
-                        color: ${initialContent ? 'var(--vscode-input-foreground, #ddd)' : 'rgba(190, 175, 230, 0.7)'};
-                    `}
-                >
-                    {initialContent || placeholder}
-                </div>
-                <div style="text-align: right; margin-top: 6px; font-size: 12px; opacity: 0.6;">
-                    {charCount.toLocaleString()} / {maxChars.toLocaleString()}
-                </div>
-            </section>
-
-            <section style="border-top: 1px solid var(--vscode-widget-border, #2a2a2a); padding-top: 16px; margin-bottom: 24px;">
-                <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 8px;">
-                    <h2 style="font-size: 14px; font-weight: 600; margin: 0;">Attachments</h2>
+                <footer style="padding-top: 16px; display: flex; align-items: center; gap: 12px;">
+                    <p style="margin: 0; font-size: 11px; color: var(--vscode-foreground, #c8c8c8);">
+                        <kbd style="background: var(--vscode-keybindingLabel-background, #2a2a2a); padding: 1px 6px; border-radius: 3px; border: 1px solid var(--vscode-widget-border, #303030);">Cmd</kbd>
+                        {' + '}
+                        <kbd style="background: var(--vscode-keybindingLabel-background, #2a2a2a); padding: 1px 6px; border-radius: 3px; border: 1px solid var(--vscode-widget-border, #303030);">Enter</kbd>
+                        {' to submit · '}
+                        <kbd style="background: var(--vscode-keybindingLabel-background, #2a2a2a); padding: 1px 6px; border-radius: 3px; border: 1px solid var(--vscode-widget-border, #303030);">Esc</kbd>
+                        {' to cancel'}
+                    </p>
+                    <div style="flex: 1;" />
                     <button
                         type="button"
                         style="
                             background: transparent;
                             color: var(--vscode-foreground, #ddd);
-                            border: none;
-                            padding: 4px 0;
+                            border: 1px solid var(--vscode-widget-border, #303030);
+                            padding: 8px 18px;
+                            border-radius: 4px;
                             font-size: 13px;
                             cursor: pointer;
-                            display: inline-flex;
-                            align-items: center;
-                            gap: 8px;
                         "
                     >
-                        <span style="opacity: 0.7;">🖼</span>
-                        Attach Image
+                        Cancel
                     </button>
-                </div>
-                <p style="font-size: 12px; opacity: 0.55; margin: 0; font-style: italic;">
-                    Use the button above or paste (Ctrl+V / Cmd+V) to attach images
-                </p>
-            </section>
-
-            <footer style="border-top: 1px solid var(--vscode-widget-border, #2a2a2a); padding-top: 16px; display: flex; justify-content: space-between; align-items: center; gap: 12px;">
-                <button
-                    type="button"
-                    style="
-                        background: transparent;
-                        color: var(--vscode-foreground, #ddd);
-                        border: 1px solid var(--vscode-widget-border, #303030);
-                        padding: 8px 18px;
-                        border-radius: 4px;
-                        font-size: 13px;
-                        cursor: pointer;
-                    "
-                >
-                    Cancel
-                </button>
-                <div style="display: flex; gap: 10px;">
                     <button
                         type="button"
                         title="Run the full spec pipeline automatically (specify → plan → tasks → implement)"
@@ -162,32 +178,23 @@ export function CreateSpecMock({ initialContent = '', submitting = false }: Crea
                     </button>
                     <button
                         type="button"
-                        disabled={submitting}
+                        disabled={!canSubmit}
                         style={`
-                            background: ${submitting ? 'var(--vscode-button-secondaryBackground, #2a2a2a)' : 'var(--vscode-button-background, #3c3c3c)'};
+                            background: ${canSubmit ? 'var(--vscode-button-background, #3c3c3c)' : 'var(--vscode-button-secondaryBackground, #2a2a2a)'};
                             color: var(--vscode-button-foreground, #fff);
                             border: 1px solid var(--vscode-widget-border, #303030);
                             padding: 8px 22px;
                             border-radius: 4px;
                             font-size: 13px;
                             font-weight: 600;
-                            cursor: ${submitting ? 'wait' : 'pointer'};
-                            opacity: ${submitting ? 0.6 : 1};
+                            cursor: ${canSubmit ? 'pointer' : 'not-allowed'};
+                            opacity: ${canSubmit ? 1 : 0.5};
                         `}
                     >
-                        {submitting ? 'Submitting…' : 'Submit'}
+                        {submitting ? 'Creating…' : 'Create Spec'}
                     </button>
-                </div>
-            </footer>
-
-            <p style="margin-top: 14px; font-size: 11px; opacity: 0.55; text-align: left;">
-                <kbd style="background: var(--vscode-keybindingLabel-background, #2a2a2a); padding: 1px 6px; border-radius: 3px; border: 1px solid var(--vscode-widget-border, #303030);">Ctrl</kbd>
-                {' + '}
-                <kbd style="background: var(--vscode-keybindingLabel-background, #2a2a2a); padding: 1px 6px; border-radius: 3px; border: 1px solid var(--vscode-widget-border, #303030);">Enter</kbd>
-                {' to submit · '}
-                <kbd style="background: var(--vscode-keybindingLabel-background, #2a2a2a); padding: 1px 6px; border-radius: 3px; border: 1px solid var(--vscode-widget-border, #303030);">Esc</kbd>
-                {' to cancel'}
-            </p>
+                </footer>
+            </main>
         </div>
     );
 }

--- a/webview/src/spec-editor/__stories__/CreateSpec.stories.tsx
+++ b/webview/src/spec-editor/__stories__/CreateSpec.stories.tsx
@@ -26,8 +26,18 @@ export default meta;
 type Story = StoryObj;
 
 export const Empty: Story = {
-    name: 'Empty',
+    name: 'Empty (Create Spec disabled)',
     render: () => <CreateSpecMock />,
+};
+
+export const OverLimit: Story = {
+    name: 'Over Limit (submission blocked)',
+    render: () => (
+        <CreateSpecMock
+            initialContent={'A very long specification that exceeds the character limit…'}
+            overLimit
+        />
+    ),
 };
 
 export const WithDraft: Story = {

--- a/webview/src/spec-editor/__tests__/submitGate.test.ts
+++ b/webview/src/spec-editor/__tests__/submitGate.test.ts
@@ -1,0 +1,65 @@
+import {
+    canSubmit,
+    isOverLimit,
+    shouldShowCharCount,
+    isMacPlatform,
+    MAX_CHARS,
+} from '../submitGate';
+
+describe('submitGate', () => {
+    describe('canSubmit', () => {
+        it('blocks an empty description', () => {
+            expect(canSubmit('')).toBe(false);
+        });
+
+        it('blocks a whitespace-only description', () => {
+            expect(canSubmit('   \n\t  ')).toBe(false);
+        });
+
+        it('allows a non-empty description within the limit', () => {
+            expect(canSubmit('Build a thing')).toBe(true);
+        });
+
+        it('blocks a description over the character limit', () => {
+            expect(canSubmit('x'.repeat(MAX_CHARS + 1))).toBe(false);
+        });
+
+        it('allows a description exactly at the limit', () => {
+            expect(canSubmit('x'.repeat(MAX_CHARS))).toBe(true);
+        });
+    });
+
+    describe('isOverLimit', () => {
+        it('is false at the limit and true one past it', () => {
+            expect(isOverLimit('x'.repeat(MAX_CHARS))).toBe(false);
+            expect(isOverLimit('x'.repeat(MAX_CHARS + 1))).toBe(true);
+        });
+    });
+
+    describe('shouldShowCharCount', () => {
+        it('hides the counter below ~90% of the limit', () => {
+            expect(shouldShowCharCount(0)).toBe(false);
+            expect(shouldShowCharCount(Math.floor(MAX_CHARS * 0.5))).toBe(false);
+        });
+
+        it('shows the counter at and above the 90% threshold', () => {
+            expect(shouldShowCharCount(Math.floor(MAX_CHARS * 0.9))).toBe(true);
+            expect(shouldShowCharCount(MAX_CHARS + 100)).toBe(true);
+        });
+    });
+
+    describe('isMacPlatform', () => {
+        it('detects Mac from navigator.platform', () => {
+            expect(isMacPlatform('MacIntel', '')).toBe(true);
+        });
+
+        it('detects Mac from userAgent when platform is empty', () => {
+            expect(isMacPlatform('', 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15)')).toBe(true);
+        });
+
+        it('returns false on Windows/Linux', () => {
+            expect(isMacPlatform('Win32', 'Mozilla/5.0 (Windows NT 10.0)')).toBe(false);
+            expect(isMacPlatform('Linux x86_64', 'Mozilla/5.0 (X11; Linux x86_64)')).toBe(false);
+        });
+    });
+});

--- a/webview/src/spec-editor/index.ts
+++ b/webview/src/spec-editor/index.ts
@@ -157,24 +157,41 @@ function updateThumbnails(): void {
         return;
     }
 
-    thumbnails.innerHTML = attachedImages.map(img => `
-        <div class="image-thumbnail" data-id="${img.id}">
-            <img src="${img.thumbnailUri}" alt="${escapeHtml(img.originalName)}">
-            <span class="image-name">${escapeHtml(img.originalName)}</span>
-            <button class="remove-btn" type="button" data-id="${img.id}" aria-label="Remove image ${escapeHtml(img.originalName)}">×</button>
-        </div>
-    `).join('');
+    // Built via DOM APIs (not innerHTML) so a filename containing quotes/markup
+    // can't break out of an attribute or inject into the webview — `escapeHtml`
+    // (textContent→innerHTML) does not escape attribute quotes.
+    thumbnails.replaceChildren();
+    for (const img of attachedImages) {
+        const wrap = document.createElement('div');
+        wrap.className = 'image-thumbnail';
+        wrap.dataset.id = img.id;
 
-    // Add remove button handlers
-    thumbnails.querySelectorAll('.remove-btn').forEach(btn => {
-        btn.addEventListener('click', (e) => {
+        const thumb = document.createElement('img');
+        thumb.src = img.thumbnailUri;
+        thumb.alt = img.originalName;
+        wrap.appendChild(thumb);
+
+        const name = document.createElement('span');
+        name.className = 'image-name';
+        name.textContent = img.originalName;
+        wrap.appendChild(name);
+
+        const remove = document.createElement('button');
+        remove.className = 'remove-btn';
+        remove.type = 'button';
+        remove.dataset.id = img.id;
+        remove.setAttribute('aria-label', `Remove image ${img.originalName}`);
+        remove.textContent = '×';
+        remove.addEventListener('click', (e) => {
             e.stopPropagation();
-            const id = (btn as HTMLElement).dataset.id;
-            if (id) {
-                removeImage(id);
+            if (remove.dataset.id) {
+                removeImage(remove.dataset.id);
             }
         });
-    });
+        wrap.appendChild(remove);
+
+        thumbnails.appendChild(wrap);
+    }
 }
 
 function removeImage(id: string): void {

--- a/webview/src/spec-editor/index.ts
+++ b/webview/src/spec-editor/index.ts
@@ -38,6 +38,7 @@ function getElements() {
         thumbnails: document.getElementById('thumbnails') as HTMLElement,
         sizeInfo: document.getElementById('sizeInfo') as HTMLElement,
         loadingOverlay: document.getElementById('loadingOverlay') as HTMLElement,
+        app: document.getElementById('app') as HTMLElement,
         submitBtn: document.getElementById('submitBtn') as HTMLButtonElement,
         cancelBtn: document.getElementById('cancelBtn') as HTMLButtonElement,
         attachImageBtn: document.getElementById('attachImageBtn') as HTMLButtonElement,
@@ -71,7 +72,7 @@ function updateCharCount(): void {
     const count = textarea.value.length;
     const over = isOverLimit(textarea.value, MAX_CHARS);
 
-    charCount.hidden = !shouldShowCharCount(count, MAX_CHARS);
+    charCount.classList.toggle('sr-only', !shouldShowCharCount(count, MAX_CHARS));
     charCount.classList.remove('warning', 'error');
 
     if (over) {
@@ -125,12 +126,14 @@ function escapeHtml(text: string): string {
 // ============================================
 
 function setLoading(loading: boolean): void {
-    const { loadingOverlay, commandButtonsContainer } = getElements();
+    const { loadingOverlay, commandButtonsContainer, app } = getElements();
     isSubmitting = loading;
 
     loadingOverlay.style.display = loading ? 'flex' : 'none';
     loadingOverlay.setAttribute('aria-hidden', loading ? 'false' : 'true');
-    loadingOverlay.setAttribute('aria-busy', loading ? 'true' : 'false');
+    if (app) {
+        app.setAttribute('aria-busy', loading ? 'true' : 'false');
+    }
     if (loading) {
         announce('Creating your spec…');
     }

--- a/webview/src/spec-editor/index.ts
+++ b/webview/src/spec-editor/index.ts
@@ -8,8 +8,7 @@ import type {
     SpecEditorToExtensionMessage,
     ExtensionToSpecEditorMessage,
     SpecEditorWebviewState,
-    AttachedImageUI,
-    SIZE_LIMITS
+    AttachedImageUI
 } from './types';
 import { canSubmit, isOverLimit, shouldShowCharCount, isMacPlatform, MAX_CHARS } from './submitGate';
 
@@ -132,6 +131,9 @@ function setLoading(loading: boolean): void {
     loadingOverlay.style.display = loading ? 'flex' : 'none';
     loadingOverlay.setAttribute('aria-hidden', loading ? 'false' : 'true');
     loadingOverlay.setAttribute('aria-busy', loading ? 'true' : 'false');
+    if (loading) {
+        announce('Creating your spec…');
+    }
     updateSubmitState();
     if (commandButtonsContainer) {
         commandButtonsContainer.querySelectorAll('button').forEach(btn => {

--- a/webview/src/spec-editor/index.ts
+++ b/webview/src/spec-editor/index.ts
@@ -11,9 +11,16 @@ import type {
     AttachedImageUI,
     SIZE_LIMITS
 } from './types';
+import { canSubmit, isOverLimit, shouldShowCharCount, isMacPlatform, MAX_CHARS } from './submitGate';
 
 // Get VS Code API
 declare const vscode: VSCodeApi;
+
+const SUBMIT_MODIFIER = isMacPlatform(navigator.platform, navigator.userAgent) ? 'Cmd' : 'Ctrl';
+
+function keyboardHintsHtml(): string {
+    return `<kbd>${SUBMIT_MODIFIER}</kbd>+<kbd>Enter</kbd> to submit • <kbd>Esc</kbd> to cancel`;
+}
 
 // State
 let attachedImages: AttachedImageUI[] = [];
@@ -38,8 +45,16 @@ function getElements() {
         workflowSelector: document.getElementById('workflowSelector') as HTMLElement,
         workflowSelect: document.getElementById('workflowSelect') as HTMLSelectElement,
         commandButtonsContainer: document.getElementById('commandButtons') as HTMLElement,
-        keyboardHints: document.querySelector('.keyboard-hints') as HTMLElement
+        keyboardHints: document.getElementById('keyboardHints') as HTMLElement,
+        srStatus: document.getElementById('sr-status') as HTMLElement
     };
+}
+
+function announce(message: string): void {
+    const { srStatus } = getElements();
+    if (srStatus) {
+        srStatus.textContent = message;
+    }
 }
 
 // Get selected workflow
@@ -55,15 +70,24 @@ function getSelectedWorkflow(): string {
 function updateCharCount(): void {
     const { textarea, charCount } = getElements();
     const count = textarea.value.length;
-    const max = 50000;
+    const over = isOverLimit(textarea.value, MAX_CHARS);
 
-    charCount.textContent = `${count.toLocaleString()} / ${max.toLocaleString()}`;
+    charCount.hidden = !shouldShowCharCount(count, MAX_CHARS);
     charCount.classList.remove('warning', 'error');
 
-    if (count > max) {
+    if (over) {
         charCount.classList.add('error');
-    } else if (count > max * 0.9) {
+        charCount.textContent = `Over limit — ${count.toLocaleString()} / ${MAX_CHARS.toLocaleString()} (remove ${(count - MAX_CHARS).toLocaleString()} characters)`;
+    } else {
         charCount.classList.add('warning');
+        charCount.textContent = `${count.toLocaleString()} / ${MAX_CHARS.toLocaleString()}`;
+    }
+}
+
+function updateSubmitState(): void {
+    const { textarea, submitBtn } = getElements();
+    if (submitBtn) {
+        submitBtn.disabled = isSubmitting || !canSubmit(textarea.value, MAX_CHARS);
     }
 }
 
@@ -75,10 +99,15 @@ function showError(message: string): void {
     const { errorContainer } = getElements();
     errorContainer.innerHTML = `
         <div class="error-message">
-            <button class="close-btn" onclick="this.parentElement.remove()">×</button>
+            <button class="close-btn" type="button" aria-label="Dismiss error">×</button>
             ${escapeHtml(message)}
         </div>
     `;
+    const closeBtn = errorContainer.querySelector('.close-btn') as HTMLButtonElement | null;
+    if (closeBtn) {
+        closeBtn.addEventListener('click', () => clearError());
+        closeBtn.focus();
+    }
 }
 
 function clearError(): void {
@@ -97,11 +126,13 @@ function escapeHtml(text: string): string {
 // ============================================
 
 function setLoading(loading: boolean): void {
-    const { loadingOverlay, submitBtn, commandButtonsContainer } = getElements();
+    const { loadingOverlay, commandButtonsContainer } = getElements();
     isSubmitting = loading;
 
     loadingOverlay.style.display = loading ? 'flex' : 'none';
-    submitBtn.disabled = loading;
+    loadingOverlay.setAttribute('aria-hidden', loading ? 'false' : 'true');
+    loadingOverlay.setAttribute('aria-busy', loading ? 'true' : 'false');
+    updateSubmitState();
     if (commandButtonsContainer) {
         commandButtonsContainer.querySelectorAll('button').forEach(btn => {
             (btn as HTMLButtonElement).disabled = loading;
@@ -125,7 +156,7 @@ function updateThumbnails(): void {
         <div class="image-thumbnail" data-id="${img.id}">
             <img src="${img.thumbnailUri}" alt="${escapeHtml(img.originalName)}">
             <span class="image-name">${escapeHtml(img.originalName)}</span>
-            <button class="remove-btn" data-id="${img.id}">×</button>
+            <button class="remove-btn" type="button" data-id="${img.id}" aria-label="Remove image ${escapeHtml(img.originalName)}">×</button>
         </div>
     `).join('');
 
@@ -218,6 +249,15 @@ function restoreDraft(): void {
     }
 }
 
+function cancelWithConfirm(): void {
+    const { textarea } = getElements();
+    const hasContent = textarea.value.trim().length > 0;
+    if (hasContent && !window.confirm('Discard this spec? Your typed content will be lost.')) {
+        return;
+    }
+    vscode.postMessage({ type: 'cancel' });
+}
+
 // ============================================
 // Event Handlers
 // ============================================
@@ -228,12 +268,13 @@ function setupEventListeners(): void {
     // Text input
     elements.textarea.addEventListener('input', () => {
         updateCharCount();
+        updateSubmitState();
         saveDraft();
     });
 
     // Submit button
     elements.submitBtn.addEventListener('click', () => {
-        if (isSubmitting) return;
+        if (isSubmitting || !canSubmit(elements.textarea.value, MAX_CHARS)) return;
         clearError();
         vscode.postMessage({
             type: 'submit',
@@ -245,7 +286,7 @@ function setupEventListeners(): void {
 
     // Cancel button
     elements.cancelBtn.addEventListener('click', () => {
-        vscode.postMessage({ type: 'cancel' });
+        cancelWithConfirm();
     });
 
     // Install banner actions (server-rendered, present only when the spec-kit
@@ -283,7 +324,7 @@ function setupEventListeners(): void {
         // Ctrl/Cmd + Enter to submit
         if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') {
             e.preventDefault();
-            if (!isSubmitting) {
+            if (!isSubmitting && canSubmit(elements.textarea.value, MAX_CHARS)) {
                 clearError();
                 vscode.postMessage({
                     type: 'submit',
@@ -297,7 +338,7 @@ function setupEventListeners(): void {
         // Escape to cancel
         if (e.key === 'Escape') {
             e.preventDefault();
-            vscode.postMessage({ type: 'cancel' });
+            cancelWithConfirm();
         }
     });
 
@@ -391,7 +432,7 @@ function updateCommandButtons(workflowName: string): void {
     if (commands.length === 0) {
         commandButtonsContainer.style.display = 'none';
         if (keyboardHints) {
-            keyboardHints.innerHTML = `<kbd>Ctrl</kbd>+<kbd>Enter</kbd> to submit \u00b7 <kbd>Esc</kbd> to cancel`;
+            keyboardHints.innerHTML = keyboardHintsHtml();
         }
         return;
     }
@@ -410,7 +451,7 @@ function updateCommandButtons(workflowName: string): void {
     }
 
     if (keyboardHints) {
-        keyboardHints.innerHTML = `<kbd>Ctrl</kbd>+<kbd>Enter</kbd> to submit \u00b7 <kbd>Esc</kbd> to cancel`;
+        keyboardHints.innerHTML = keyboardHintsHtml();
     }
 }
 
@@ -433,14 +474,18 @@ function handleMessage(event: MessageEvent): void {
                 originalName: message.originalName
             });
             updateThumbnails();
+            announce(`Image ${message.originalName} attached.`);
             saveDraft();
             break;
 
-        case 'imageRemoved':
+        case 'imageRemoved': {
+            const removed = attachedImages.find(img => img.id === message.imageId);
             attachedImages = attachedImages.filter(img => img.id !== message.imageId);
             updateThumbnails();
+            announce(removed ? `Image ${removed.originalName} removed.` : 'Image removed.');
             saveDraft();
             break;
+        }
 
         case 'submissionStarted':
             setLoading(true);
@@ -467,9 +512,14 @@ function handleMessage(event: MessageEvent): void {
 // ============================================
 
 document.addEventListener('DOMContentLoaded', () => {
+    const { keyboardHints } = getElements();
+    if (keyboardHints) {
+        keyboardHints.innerHTML = keyboardHintsHtml();
+    }
     setupEventListeners();
     restoreDraft();
     updateCharCount();
+    updateSubmitState();
 
     // Listen for messages from extension
     window.addEventListener('message', handleMessage);

--- a/webview/src/spec-editor/submitGate.ts
+++ b/webview/src/spec-editor/submitGate.ts
@@ -1,0 +1,44 @@
+/**
+ * Pure helpers for the Create Spec form — no DOM access, so they can be
+ * unit-tested without a webview harness.
+ */
+
+export const MAX_CHARS = 50_000;
+
+/** Fraction of the limit at which the character counter becomes visible. */
+export const CHAR_COUNT_REVEAL_RATIO = 0.9;
+
+export const SUBTITLE_TEXT =
+    'Describe your feature — the AI will generate the spec, plan, and tasks for it.';
+
+export const HELPER_TEXT =
+    'Write what you want and why. Helpful to include: the problem it solves, who it is for, ' +
+    'the key requirements, and any constraints or dependencies.';
+
+/** True when the description is non-empty (ignoring whitespace) and within the limit. */
+export function canSubmit(content: string, max: number = MAX_CHARS): boolean {
+    const trimmed = content.trim();
+    if (trimmed.length === 0) {
+        return false;
+    }
+    return content.length <= max;
+}
+
+export function isOverLimit(content: string, max: number = MAX_CHARS): boolean {
+    return content.length > max;
+}
+
+/** True once the content reaches the reveal threshold (~90% of the limit). */
+export function shouldShowCharCount(count: number, max: number = MAX_CHARS): boolean {
+    return count >= Math.floor(max * CHAR_COUNT_REVEAL_RATIO);
+}
+
+/** Mac detection from the webview's navigator fields (platform preferred, userAgent fallback). */
+export function isMacPlatform(platform: string, userAgent: string): boolean {
+    const p = (platform || '').toLowerCase();
+    if (p.includes('mac')) {
+        return true;
+    }
+    const ua = (userAgent || '').toLowerCase();
+    return ua.includes('macintosh') || ua.includes('mac os');
+}

--- a/webview/src/spec-editor/submitGate.ts
+++ b/webview/src/spec-editor/submitGate.ts
@@ -8,13 +8,6 @@ export const MAX_CHARS = 50_000;
 /** Fraction of the limit at which the character counter becomes visible. */
 export const CHAR_COUNT_REVEAL_RATIO = 0.9;
 
-export const SUBTITLE_TEXT =
-    'Describe your feature — the AI will generate the spec, plan, and tasks for it.';
-
-export const HELPER_TEXT =
-    'Write what you want and why. Helpful to include: the problem it solves, who it is for, ' +
-    'the key requirements, and any constraints or dependencies.';
-
 /** True when the description is non-empty (ignoring whitespace) and within the limit. */
 export function canSubmit(content: string, max: number = MAX_CHARS): boolean {
     const trimmed = content.trim();

--- a/webview/styles/spec-editor.css
+++ b/webview/styles/spec-editor.css
@@ -150,9 +150,9 @@
     text-align: right;
 }
 
-.char-count[hidden] {
-    display: none;
-}
+/* Below the reveal threshold the counter keeps the .sr-only utility so it
+   stays in the a11y tree (the textarea's aria-describedby conveys the limit)
+   while staying visually hidden. */
 
 .char-count.warning {
     color: var(--warning);
@@ -531,6 +531,10 @@
 
     .spec-editor-actions {
         flex-wrap: wrap;
+    }
+
+    .action-spacer {
+        display: none;
     }
 
     .keyboard-hints {

--- a/webview/styles/spec-editor.css
+++ b/webview/styles/spec-editor.css
@@ -26,6 +26,31 @@
     font-family: var(--font-family);
     background-color: var(--bg-primary);
     color: var(--text-primary);
+    overflow-y: auto;
+}
+
+/* Centered readable-width column — keeps line length comfortable on wide editors. */
+.spec-editor-column {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    min-height: 0;
+    width: 100%;
+    max-width: 800px;
+    margin: 0 auto;
+}
+
+/* Visually-hidden live region (announcements) — present in the a11y tree only. */
+.sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
 }
 
 .spec-editor-header {
@@ -42,7 +67,15 @@
 .spec-editor-header p {
     margin: 4px 0 0;
     font-size: 0.9em;
-    color: var(--text-secondary);
+    color: var(--text-body);
+}
+
+/* Persistent writing guidance — readable contrast, proportional font. */
+.helper-text {
+    margin: 0 0 8px;
+    font-size: 0.85em;
+    line-height: 1.5;
+    color: var(--text-body);
 }
 
 /* ============================================
@@ -84,27 +117,41 @@
     border-radius: var(--radius-sm);
     background-color: var(--vscode-input-background);
     color: var(--vscode-input-foreground);
-    font-family: var(--font-mono);
+    font-family: var(--font-family);
     font-size: var(--font-size);
     line-height: 1.5;
     resize: vertical;
     box-sizing: border-box;
 }
 
-.spec-editor-textarea:focus {
-    outline: none;
+.spec-editor-textarea:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: -1px;
     border-color: var(--accent);
 }
 
 .spec-editor-textarea::placeholder {
-    color: var(--vscode-input-placeholderForeground);
+    color: var(--text-body);
+    opacity: 0.85;
+}
+
+/* Composer-style row beneath the textarea: attach control left, counter right. */
+.editor-footer-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+    margin-top: 6px;
 }
 
 .char-count {
-    margin-top: 4px;
     font-size: 0.8em;
-    color: var(--text-secondary);
+    color: var(--warning);
     text-align: right;
+}
+
+.char-count[hidden] {
+    display: none;
 }
 
 .char-count.warning {
@@ -119,48 +166,28 @@
    Image Attachment Area
    ============================================ */
 
-.image-attachment-section {
-    border-top: 1px solid var(--border);
-    padding-top: 16px;
-}
-
-.image-attachment-header {
-    display: flex;
-    flex-wrap: wrap;
-    align-items: center;
-    justify-content: space-between;
-    gap: 8px;
-    margin-bottom: 12px;
-}
-
-.image-attachment-header h3 {
-    font-size: 0.9em;
-    font-weight: 500;
-    margin: 0;
-    min-width: 0;
-    overflow: hidden;
-    white-space: nowrap;
-    text-overflow: ellipsis;
-    color: var(--text-primary);
-}
-
+/* Compact composer-style attach control (no drag-drop affordance — DnD isn't implemented). */
 .attach-image-btn {
     display: inline-flex;
     align-items: center;
     gap: 6px;
-    padding: 6px 14px;
-    border: 1px dashed var(--vscode-button-secondaryBorder, var(--border));
+    padding: 4px 10px;
+    border: 1px solid var(--vscode-button-secondaryBorder, var(--border));
     border-radius: var(--radius-sm);
     background: transparent;
     color: var(--vscode-button-secondaryForeground, var(--text-primary));
-    font-size: 0.85em;
+    font-size: 0.8em;
     cursor: pointer;
-    transition: all 0.15s ease;
+    transition: background-color 0.15s ease;
 }
 
 .attach-image-btn:hover {
     background-color: var(--vscode-button-secondaryHoverBackground, var(--bg-hover));
-    border-style: solid;
+}
+
+.attach-image-btn:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
 }
 
 /* Codicon baseline inside spec-editor chrome */
@@ -171,19 +198,16 @@
     align-items: center;
 }
 
-/* Paste hint */
-.paste-hint {
-    margin: 0 0 12px 0;
-    color: var(--text-secondary);
-    font-size: 0.8em;
-    font-style: italic;
-}
-
 /* Thumbnail grid */
 .image-thumbnails {
     display: flex;
     flex-wrap: wrap;
     gap: 12px;
+    margin-top: 12px;
+}
+
+.image-thumbnails:empty {
+    margin-top: 0;
 }
 
 .image-thumbnail {
@@ -242,6 +266,11 @@
     opacity: 1;
 }
 
+.image-thumbnail .remove-btn:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 1px;
+}
+
 .image-thumbnail .remove-btn:hover {
     background-color: var(--vscode-inputValidation-errorBackground, var(--error));
 }
@@ -292,8 +321,9 @@
     text-overflow: ellipsis;
 }
 
-.workflow-selector select:focus {
-    outline: none;
+.workflow-selector select:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 1px;
     border-color: var(--accent);
 }
 
@@ -303,9 +333,9 @@
 
 .spec-editor-actions {
     display: flex;
+    align-items: center;
     gap: 12px;
     padding-top: 16px;
-    border-top: 1px solid var(--border);
 }
 
 .spec-editor-actions button {
@@ -321,6 +351,11 @@
 .spec-editor-actions button:disabled {
     opacity: 0.5;
     cursor: not-allowed;
+}
+
+.spec-editor-actions button:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
 }
 
 .spec-editor-actions .btn-primary {
@@ -414,9 +449,17 @@
     bottom: 0;
     background: rgba(0, 0, 0, 0.5);
     display: flex;
+    flex-direction: column;
     align-items: center;
     justify-content: center;
+    gap: 16px;
     z-index: 1000;
+}
+
+.loading-text {
+    margin: 0;
+    color: white;
+    font-size: 0.95em;
 }
 
 .loading-spinner {
@@ -454,14 +497,18 @@
     line-height: 1;
 }
 
+.error-message .close-btn:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+}
+
 /* ============================================
    Keyboard Shortcuts Hint
    ============================================ */
 
 .keyboard-hints {
     font-size: 0.75em;
-    color: var(--text-secondary);
-    margin-top: 8px;
+    color: var(--text-body);
 }
 
 .keyboard-hints kbd {
@@ -483,21 +530,21 @@
     }
 
     .spec-editor-actions {
-        flex-direction: column;
+        flex-wrap: wrap;
     }
 
-    .spec-editor-actions button {
-        width: 100%;
+    .keyboard-hints {
+        flex-basis: 100%;
+        order: 3;
     }
 
-    .action-spacer {
-        display: none;
+    .spec-editor-actions .btn-cancel,
+    .spec-editor-actions .btn-primary {
+        flex: 1;
     }
 
-    /* Stack the workflow row and image-attachment header so neither overflows
-       horizontally at narrow widths. */
-    .workflow-row,
-    .image-attachment-header {
+    /* Stack the workflow row so it doesn't overflow horizontally at narrow widths. */
+    .workflow-row {
         flex-direction: column;
         align-items: stretch;
     }


### PR DESCRIPTION
## Summary
A design + accessibility pass on the **Create Spec** page. It was usable but wasted wide editors and was largely silent to screen readers. Now it's a centered, readable column with persistent guidance, a primary button that says what it does and won't submit empty, and full screen-reader feedback for errors, progress, and attachments.

## Technical
- **Layout/UX:** centered ~800px column; the low-contrast mono placeholder replaced by persistent helper text (`--text-body`, AA contrast, proportional font); subtitle now says what happens next (the AI generates spec/plan/tasks); **Submit → Create Spec**, disabled on empty/whitespace/over-limit and gated on both click and Cmd/Ctrl+Enter (extracted to a tested `submitGate.ts`); char counter hidden until ~90% then warning color with a non-color over-limit message that blocks submit; the misleading dashed "dropzone" replaced by a compact composer-style Attach control (drag-drop isn't implemented); one-row footer (hints left, Cancel + Create right); dividers dropped.
- **Accessibility:** `role="alert"` error region + focus management; `aria-busy` loading overlay that announces "Creating your spec…" via a live region; `aria-live` status on image attach/remove; real `aria-label`s on every ×/remove button; `aria-describedby` textarea → helper/counter; visible `:focus-visible` rings on textarea/select/all buttons; `<main>` landmark; h1→h3 skip removed; Cmd-on-Mac hint via platform detection; Esc-with-typed-content confirms before discarding.

## Review checklist
- ✅ **VS Code extension / webview** — spec-editor HTML template + behavior + CSS
- ✅ **Webview component** — Storybook mock + stories updated (Empty-disabled + OverLimit variants) so the visual baseline matches the new states
- ✅ **Changelog** — root `CHANGELOG.md` `[Unreleased]` (user-facing)
- ✅ **Docs** — README Create-Spec mention updated
- ✅ **Tests** — `submitGate.ts` gate logic (empty/whitespace/over-limit, both submit paths), load-bearing
- ✅ **Verify** — compile clean · `npm test` 1020 green · `npm run package` webview builds · no version bump
- ✅ **Review** — `/code-review` high: fixed a real loading-announcement gap + 2 dead-code items
- ⚠️ **Screenshot** — `docs/screenshots/create-spec.png` should be re-shot (layout changed); overwrite in place, don't rename

## Gaps / how to see it
- The whole page is the manual surface — keyboard-tab for focus rings, screen-reader-test the error/loading/attach announcements, confirm the Create Spec button gates on empty and over-limit, and that workflow select / custom commands / paste-attach / draft restore still work.
- Skipped (out of scope): swapping `window.confirm` for a native dialog round-trip; a loading-overlay focus trap.

Closes #272

🤖 Generated with [Claude Code](https://claude.com/claude-code)
