### PR TITLE
fix(workflow): lower speckit floor to >=0.9.5.dev0 so dev builds install

### DIFF
--- a/speckit-extension/CHANGELOG.md
+++ b/speckit-extension/CHANGELOG.md
@@ -8,6 +8,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/); this ext
 
 ## [Unreleased]
 
+## [0.5.1] - 2026-06-14
+
+### Fixed
+- **Installs again on git/`uv` dev builds of spec-kit.** The 0.5.0 minimum was written as `>=0.9.5`, which — under Python's version rules — actually *excludes* the `0.9.5.devN` pre-release builds that `uv tool install --from git+…` produces (the exact install path the README recommends). The result was a `Compatibility Error: requires spec-kit >=0.9.5, but 0.9.5.dev0 is installed` on a correctly-set-up machine. The floor is now `>=0.9.5.dev0`, which accepts those dev builds and every 0.9.5+ release.
+
 ## [0.5.0] - 2026-06-13
 
 ### Added

--- a/speckit-extension/extension.yml
+++ b/speckit-extension/extension.yml
@@ -3,7 +3,7 @@ schema_version: "1.0"
 extension:
   id: companion
   name: "SpecKit Companion"
-  version: "0.5.0"
+  version: "0.5.1"
   description: "Live spec-driven progress for SpecKit Companion — lifecycle capture, status, and resume."
   author: alfredoperez
   repository: https://github.com/alfredoperez/speckit-companion
@@ -13,8 +13,12 @@ extension:
 requires:
   # Floor is the workflow-engine surface the Companion workflow rides:
   # `specify workflow run`/`resume` plus the `command`/`gate`/`switch` step
-  # registry, all present from the 0.9.x engine (validation target 0.9.5.dev0).
-  speckit_version: ">=0.9.5"
+  # registry, all present from the 0.9.5 engine (validation target 0.9.5.dev0).
+  # The `.dev0` suffix is required: under PEP 440 a bare `>=0.9.5` EXCLUDES the
+  # `0.9.5.devN` pre-release builds that `uv tool install --from git+…` produces
+  # (the install path the README documents), so it would block every dev-build
+  # user. `>=0.9.5.dev0` admits those builds and every 0.9.5+ final.
+  speckit_version: ">=0.9.5.dev0"
   tools:
     - name: python3
       required: false

--- a/speckit-extension/workflows/speckit-companion.workflow.yml
+++ b/speckit-extension/workflows/speckit-companion.workflow.yml
@@ -9,7 +9,9 @@ workflow:
 requires:
   # Floor is the engine surface this workflow rides: `specify workflow run`/`resume`
   # plus the `command`/`gate`/`switch` step registry. Validation target: 0.9.5.dev0.
-  speckit_version: ">=0.9.5"
+  # `.dev0` suffix is deliberate — a bare `>=0.9.5` excludes the `0.9.5.devN`
+  # git/`uv` pre-release builds under PEP 440.
+  speckit_version: ">=0.9.5.dev0"
   integrations:
     # Advisory, non-exhaustive compatibility hint (the documented `any: [...]` shape).
     # The workflow runs against any integration that provides the Companion commands.


### PR DESCRIPTION
Follow-up to #298.

## The bug

#298 set the spec-kit extension's minimum to `requires.speckit_version: ">=0.9.5"`. Under PEP 440 a bare `>=0.9.5` **excludes** `0.9.5.devN` pre-release builds — and those are exactly what `uv tool install specify-cli --from git+https://github.com/github/spec-kit.git` produces, which is the install path the README recommends. So a correctly-configured machine hit:

```
Compatibility Error: Extension requires spec-kit >=0.9.5, but 0.9.5.dev0 is installed.
```

i.e. the 0.5.0 extension could not install on the very build it was developed and validated against.

## The fix

- Floor → `>=0.9.5.dev0` in both `extension.yml` and the workflow definition. This admits `0.9.5.devN` dev builds **and** every `0.9.5`+ final.
- Spec-kit extension bumped `0.5.0 → 0.5.1` + CHANGELOG entry.

## Verify

`specify extension add ./speckit-extension --dev --force` now succeeds on `specify 0.9.5.dev0` and lists all 12 commands (including the new `speckit.companion.classify` / `mark-complete`). No code/behavior change — version-constraint + docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)