### PR TITLE
chore(review): add scrub-includes-spec-artifacts check (learning from #311)

### DIFF
--- a/.claude/review-checklist.md
+++ b/.claude/review-checklist.md
@@ -48,6 +48,7 @@ The review subagent in `/ship-ticket` and `/fix-tickets` reads this **before** r
 - **Trace a deleted component's FULL message/handler/state chain.** Follow `postMessage` → handler → state fields → disk probes and remove/​re-home the whole chain, not just the `.tsx`. (#277)
 - **A menu `when` that newly matches a contextValue needs a handler that ACTS on it.** Broadening a row's contextValue can surface a menu whose command no-ops → a dead, misleading click. Re-check every `view/item/context` `when` it now matches. (#257)
 - **When you gate/change a UI list, gate EVERY assembler that feeds it — the source you edited may not be the one that renders.** The Create-Spec workflow picker is built independently in `workflowManager.getWorkflows()` AND `specEditorProvider.getWorkflows()`; gating only the former left the picker always showing Companion. Grep for the displayed entry/option across all builders; reuse one predicate (`isCompanionSelectable()`) rather than gating one copy. (#302)
+- **Scrubbing a term project-wide must include the current spec's own generated artifacts.** `specs/<NNN>/spec.md` and `checklists/requirements.md` are copies of the command template made *before* you edited it, so a global rename leaves them stale — run the scrub grep over `specs/<current>/` too, not just `src/`/`speckit-extension/`/`docs/`. (#311)
 
 ## Shell & release scripts
 


### PR DESCRIPTION
## What it does

Adds one line to the review checklist capturing a lesson from #311: when you scrub a term across the whole repo, the current spec's own generated artifacts (`spec.md`, `checklists/requirements.md`) are copies of the command template made *before* the edit, so they keep the old wording. Copilot caught a leftover "turbo" in the checklist that the project-wide scrub missed.

## Under the hood

- `.claude/review-checklist.md` — one new bullet under "Deleting / broadening a component."

Follow-up to #311 / #312.

🤖 Generated with [Claude Code](https://claude.com/claude-code)