### PR TITLE
fix(viewer): align task checkboxes with their labels (#297)

### DIFF
--- a/specs/175-checkbox-alignment/.spec-context.json
+++ b/specs/175-checkbox-alignment/.spec-context.json
@@ -1,0 +1,125 @@
+{
+  "workflow": "speckit",
+  "specName": "checkbox alignment",
+  "branch": "main",
+  "currentStep": "implement",
+  "status": "implemented",
+  "history": [
+    {
+      "step": "specify",
+      "substep": null,
+      "kind": "start",
+      "by": "extension",
+      "at": "2026-06-15T03:52:04.994Z"
+    },
+    {
+      "step": "specify",
+      "substep": null,
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-06-15T03:52:40.309Z"
+    },
+    {
+      "step": "plan",
+      "substep": "fast-path",
+      "kind": "start",
+      "by": "ai",
+      "at": "2026-06-15T03:52:40.379Z"
+    },
+    {
+      "step": "plan",
+      "substep": "fast-path",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-15T03:52:40.446Z"
+    },
+    {
+      "step": "tasks",
+      "substep": "fast-path",
+      "kind": "start",
+      "by": "ai",
+      "at": "2026-06-15T03:52:40.528Z"
+    },
+    {
+      "step": "tasks",
+      "substep": "fast-path",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-15T03:52:40.602Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "kind": "start",
+      "by": "extension",
+      "at": "2026-06-15T03:52:50.663Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T001",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-15T03:53:01.004Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T002",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-15T03:53:40.212Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T003",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-15T03:53:58.122Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T004",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-15T03:54:24.426Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-15T03:54:24.427Z"
+    }
+  ],
+  "currentTask": "T004",
+  "task_summaries": {
+    "T001": {
+      "status": "DONE",
+      "did": "Center task checkbox on first label line via line-height-relative top margin",
+      "files": [
+        "webview/styles/spec-viewer/_tasks.css"
+      ]
+    },
+    "T002": {
+      "status": "DONE",
+      "did": "Mirror line-height-relative checkbox margin in story baseline via shared checkboxStyle/taskTextStyle",
+      "files": [
+        "webview/src/spec-viewer/components/TaskLine.stories.tsx"
+      ]
+    },
+    "T003": {
+      "status": "DONE",
+      "did": "Reviewed InlineComment stories — bare checkbox has no hardcoded margin to correct (row-height-parity stories); no change needed",
+      "files": [
+        "webview/src/spec-viewer/components/InlineComment.stories.tsx"
+      ]
+    },
+    "T004": {
+      "status": "DONE",
+      "did": "Verified npm run compile and npm test pass (86 suites, 1026 tests)"
+    }
+  }
+}

--- a/specs/175-checkbox-alignment/checklists/requirements.md
+++ b/specs/175-checkbox-alignment/checklists/requirements.md
@@ -1,0 +1,32 @@
+# Specification Quality Checklist: Tasks checkbox alignment
+
+**Purpose**: Validate Companion specification completeness before planning
+**Created**: 2026-06-14
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user/business value and the change's intent
+- [x] Overview states what is delivered and why in 1–3 sentences
+- [x] All four sections present (Overview, Functional Requirements, Success Criteria, Assumptions)
+
+## Requirement Completeness
+
+- [x] Any [NEEDS CLARIFICATION] markers are genuine ambiguities (≤3) deferred to clarify — not unresolved guesses
+- [x] Each Functional Requirement is a single, testable MUST/SHOULD statement
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] Edge cases are folded into Functional Requirements or Assumptions
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] Every Functional Requirement maps to at least one Success Criterion
+- [x] Overview intent is reflected by the FR list (no orphan goals)
+- [x] No implementation details leak into the specification
+
+## Notes
+
+- Items marked incomplete require spec updates before clarify or plan

--- a/specs/175-checkbox-alignment/plan.md
+++ b/specs/175-checkbox-alignment/plan.md
@@ -1,0 +1,3 @@
+# Plan: Tasks checkbox alignment
+
+> Fast-path (simple) change. See the approach in [`./spec.md#approach`](./spec.md#approach); the task checklist is in [`./tasks.md`](./tasks.md).

--- a/specs/175-checkbox-alignment/spec.md
+++ b/specs/175-checkbox-alignment/spec.md
@@ -1,0 +1,33 @@
+# Spec: Tasks checkbox alignment in the rendered Tasks list
+
+## Overview
+
+In the spec viewer's rendered tasks, each task's round checkbox sits visibly higher than the optical center of its label, so checkboxes do not line up with their text. This change centers the checkbox on the first line of its label so the box and text read as one row across every task, including labels that wrap to multiple lines.
+
+## Functional Requirements
+
+- **FR-001** The task checkbox MUST appear vertically centered on the first line of its label text across all task rows.
+- **FR-002** The alignment MUST hold across editor font sizes (the checkbox offset MUST track the label's line box, not a fixed pixel value).
+- **FR-003** For a label that wraps onto multiple lines, the checkbox MUST stay anchored to the first line (top-aligned to the first line box), not the vertical center of the whole block.
+- **FR-004** The existing inline-comment hover affordance (the per-line "+" button and comment slot) MUST continue to work unchanged, and the wrapped comment slot MUST stay aligned under the label.
+- **FR-005** Completed (checked) and in-progress task rows MUST keep the same checkbox-to-label alignment as idle rows.
+
+## Success Criteria
+
+- **SC-001** In all task rows, the checkbox's vertical center is within ~1px of the first text line's optical center at the default editor font size (pass/fail by visual inspection / story baseline).
+- **SC-002** Increasing the editor font size keeps the checkbox centered on the first line — no fixed-pixel drift.
+- **SC-003** A wrapping multi-line task keeps its checkbox on the first line, and its comment slot aligned under the label.
+- **SC-004** No regression to the inline-comment hover UX (the "+" button and comment card still appear and function).
+
+## Assumptions
+
+- The fix lives in the task-item CSS for the rendered markdown (`webview/styles/spec-viewer/_tasks.css`); the rendered HTML structure (flex row: checkbox + `.task-text`) stays the same.
+- The label line-height used for centering is the `.task-text` line-height (`1.4`), so the centering offset is derived from `1.4em` and the 16px checkbox.
+- Sibling Storybook files that mirror this markup are updated to reflect the corrected alignment.
+
+## Approach
+
+- Edit `webview/styles/spec-viewer/_tasks.css`, rule `#markdown-content li.task-item input[type="checkbox"]`: replace the fixed `margin: 2px 0 0 0` with a line-height-relative top offset `margin: calc((1.4em - 16px) / 2) 0 0 0` so the 16px checkbox centers on the first `1.4em` text line regardless of font size. Keep `align-items: flex-start` on the row so wrapping labels stay first-line-anchored (FR-003).
+- Update `webview/src/spec-viewer/components/TaskLine.stories.tsx` — the inline checkbox style mirroring the CSS — to use the same line-height-relative margin so the story baseline matches the shipped alignment.
+- Check `webview/src/spec-viewer/components/InlineComment.stories.tsx`; update its task-row checkbox style only if it carries a hardcoded margin that would now mis-mirror the CSS.
+- Verify `npm run compile && npm test` pass.

--- a/specs/175-checkbox-alignment/tasks.md
+++ b/specs/175-checkbox-alignment/tasks.md
@@ -1,0 +1,6 @@
+# Tasks: Tasks checkbox alignment
+
+- [x] **T001** Center the task checkbox on the first label line by replacing the fixed `margin: 2px 0 0 0` with `margin: calc((1.4em - 16px) / 2) 0 0 0` in the `#markdown-content li.task-item input[type="checkbox"]` rule + webview/styles/spec-viewer/_tasks.css
+- [x] **T002** Mirror the corrected checkbox margin in the story baseline so it matches the shipped CSS + webview/src/spec-viewer/components/TaskLine.stories.tsx
+- [x] **T003** Update the task-row checkbox style only if it hardcodes a now-mismatched margin + webview/src/spec-viewer/components/InlineComment.stories.tsx
+- [x] **T004** Verify the build and tests pass (`npm run compile && npm test`)

--- a/webview/src/spec-viewer/components/TaskLine.stories.tsx
+++ b/webview/src/spec-viewer/components/TaskLine.stories.tsx
@@ -112,9 +112,11 @@ const taskItemBaseStyle: React.CSSProperties = {
   lineHeight: "1.5",
 };
 
-// Custom checkbox styles (mirror li.task-item input[type="checkbox"] CSS).
-// margin-top tracks the label line-height so the box centers on the first
-// text line at any font size — matches _tasks.css, not a fixed pixel.
+// Layout-relevant checkbox styles from li.task-item input[type="checkbox"]
+// (size + margin + flex-shrink — the bits that drive alignment). Cosmetic props
+// like cursor/transition are intentionally omitted; this is a story baseline,
+// not a 1:1 CSS clone. margin-top tracks the label line-height so the box
+// centers on the first text line at any font size — matches _tasks.css.
 const checkboxStyle: React.CSSProperties = {
   appearance: "none",
   WebkitAppearance: "none",

--- a/webview/src/spec-viewer/components/TaskLine.stories.tsx
+++ b/webview/src/spec-viewer/components/TaskLine.stories.tsx
@@ -112,6 +112,29 @@ const taskItemBaseStyle: React.CSSProperties = {
   lineHeight: "1.5",
 };
 
+// Custom checkbox styles (mirror li.task-item input[type="checkbox"] CSS).
+// margin-top tracks the label line-height so the box centers on the first
+// text line at any font size — matches _tasks.css, not a fixed pixel.
+const checkboxStyle: React.CSSProperties = {
+  appearance: "none",
+  WebkitAppearance: "none",
+  width: "16px",
+  height: "16px",
+  minWidth: "16px",
+  margin: "calc((1.4em - 16px) / 2) 0 0 0",
+  border: "2px solid var(--border-checkbox)",
+  borderRadius: "50%",
+  background: "var(--bg-checkbox)",
+  flexShrink: 0,
+};
+
+// Mirrors li.task-item .task-text — tighter line-height than the row.
+const taskTextStyle: React.CSSProperties = {
+  flex: "1 1 auto",
+  minWidth: 0,
+  lineHeight: "1.4",
+};
+
 // ============================================================
 // US1 / SC-001: Zero layout shift on hover
 // ============================================================
@@ -132,8 +155,8 @@ export const TaskLineSingleLineIdle: Story = {
         >
           <CommentIconSVG />
         </button>
-        <input type="checkbox" />
-        <span class="task-text line-content">
+        <input type="checkbox" style={checkboxStyle} />
+        <span class="task-text line-content" style={taskTextStyle}>
           Implement login form with email and password fields
         </span>
         <div class="line-comment-slot"></div>
@@ -146,8 +169,8 @@ export const TaskLineSingleLineIdle: Story = {
         >
           <CommentIconSVG />
         </button>
-        <input type="checkbox" />
-        <span class="task-text line-content">
+        <input type="checkbox" style={checkboxStyle} />
+        <span class="task-text line-content" style={taskTextStyle}>
           Write unit tests for form validation
         </span>
         <div class="line-comment-slot"></div>
@@ -189,8 +212,8 @@ export const TaskLineSingleLineHover: Story = {
         >
           <CommentIconSVG />
         </button>
-        <input type="checkbox" />
-        <span class="task-text line-content">
+        <input type="checkbox" style={checkboxStyle} />
+        <span class="task-text line-content" style={taskTextStyle}>
           Implement login form with email and password fields
         </span>
         <div class="line-comment-slot"></div>
@@ -203,8 +226,8 @@ export const TaskLineSingleLineHover: Story = {
         >
           <CommentIconSVG />
         </button>
-        <input type="checkbox" />
-        <span class="task-text line-content">
+        <input type="checkbox" style={checkboxStyle} />
+        <span class="task-text line-content" style={taskTextStyle}>
           Write unit tests for form validation
         </span>
         <div class="line-comment-slot"></div>
@@ -238,8 +261,8 @@ export const TaskLineWrappingIdle: Story = {
         >
           <CommentIconSVG />
         </button>
-        <input type="checkbox" />
-        <span class="task-text line-content">{WRAPPING_TEXT}</span>
+        <input type="checkbox" style={checkboxStyle} />
+        <span class="task-text line-content" style={taskTextStyle}>{WRAPPING_TEXT}</span>
         <div class="line-comment-slot"></div>
       </li>
       <li class="task-item line" style={taskItemBaseStyle}>
@@ -250,8 +273,8 @@ export const TaskLineWrappingIdle: Story = {
         >
           <CommentIconSVG />
         </button>
-        <input type="checkbox" />
-        <span class="task-text line-content">Short single-line task below</span>
+        <input type="checkbox" style={checkboxStyle} />
+        <span class="task-text line-content" style={taskTextStyle}>Short single-line task below</span>
         <div class="line-comment-slot"></div>
       </li>
     </ul>
@@ -291,8 +314,8 @@ export const TaskLineWrappingHover: Story = {
         >
           <CommentIconSVG />
         </button>
-        <input type="checkbox" />
-        <span class="task-text line-content">{WRAPPING_TEXT}</span>
+        <input type="checkbox" style={checkboxStyle} />
+        <span class="task-text line-content" style={taskTextStyle}>{WRAPPING_TEXT}</span>
         <div class="line-comment-slot"></div>
       </li>
       <li class="task-item line" style={taskItemBaseStyle}>
@@ -303,8 +326,8 @@ export const TaskLineWrappingHover: Story = {
         >
           <CommentIconSVG />
         </button>
-        <input type="checkbox" />
-        <span class="task-text line-content">Short single-line task below</span>
+        <input type="checkbox" style={checkboxStyle} />
+        <span class="task-text line-content" style={taskTextStyle}>Short single-line task below</span>
         <div class="line-comment-slot"></div>
       </li>
     </ul>

--- a/webview/styles/spec-viewer/_tasks.css
+++ b/webview/styles/spec-viewer/_tasks.css
@@ -122,7 +122,7 @@
   width: 16px;
   height: 16px;
   min-width: 16px;
-  margin: 2px 0 0 0;
+  margin: calc((1.4em - 16px) / 2) 0 0 0;
   border: 2px solid var(--border-checkbox);
   border-radius: 50%;
   background: var(--bg-checkbox);


### PR DESCRIPTION
## Summary

In the spec viewer's rendered task list, the round checkbox sat slightly above its label text — and the gap got worse as you increased the editor font size. Now the checkbox centers on the first line of its label at any font size.

## How to verify

- Open a spec's `tasks.md` in the viewer; the checkboxes line up with their labels across all rows, including multi-line labels (the box stays anchored to the first line).
- Bump the editor font size up and down — alignment holds (it was font-size-dependent before).

## Under the hood

The checkbox used a fixed `margin: 2px 0 0 0`, which can't track the label's line box. Replaced it with a line-height-relative offset `margin: calc((1.4em - 16px) / 2) 0 0 0` (the box is 16px, the label runs at `line-height: 1.4`), so it stays optically centered on the first text line regardless of font size. `flex-start` is kept so wrapped labels still anchor the checkbox to the first line. `TaskLine.stories.tsx` mirrors the same checkbox/label styles so the Storybook baseline matches. Compile clean, 1026 tests pass.

Closes #297

🤖 Generated with [Claude Code](https://claude.com/claude-code)