### PR TITLE
test(bench): fix two faithful-bench setup gaps found when running it (#325)

### DIFF
--- a/examples/todo-claude/bench/cap.mjs
+++ b/examples/todo-claude/bench/cap.mjs
@@ -21,7 +21,16 @@ if (!existsSync(W)) {
 }
 let fd
 try { fd = JSON.parse(readFileSync(join(root, '.specify', 'feature.json'), 'utf8')).feature_directory } catch { /* */ }
-if (!fd) { console.error('[cap] no .specify/feature.json feature_directory — run specify first'); process.exit(1) }
+// Fallback when feature.json is absent (create-new-feature.sh doesn't write it):
+// derive the feature dir from the git branch — `specs/<branch>` — mirroring
+// write-context.py's resolver, so the driver doesn't have to seed feature.json.
+if (!fd) {
+  try {
+    const branch = execFileSync('git', ['-C', root, 'rev-parse', '--abbrev-ref', 'HEAD'], { encoding: 'utf8' }).trim()
+    if (branch && existsSync(join(root, 'specs', branch))) fd = join('specs', branch)
+  } catch { /* */ }
+}
+if (!fd) { console.error('[cap] no feature dir — set .specify/feature.json or run specify on a specs/<branch> first'); process.exit(1) }
 
 const [step, action, name] = process.argv.slice(2)
 const STATUS = { specify: 'specified', plan: 'planned', tasks: 'ready-to-implement', implement: 'implemented' }

--- a/examples/todo-claude/bench/lib.mjs
+++ b/examples/todo-claude/bench/lib.mjs
@@ -200,6 +200,17 @@ export function gitInitCell(cellDir) {
   try { run('git', ['init', '-q', '-b', 'main', cellDir]) } catch { /* git absent — capture falls back to feature.json */ }
 }
 
+// Commit a baseline so `create-new-feature.sh` can branch off it during a run.
+// Without an initial commit the cell sits on an unborn `main` and the script's
+// `git checkout -b` fails. Inline user identity so it works with no global git
+// config. Call AFTER the cell is fully baked (app + spec-kit + companion).
+export function gitCommitCellBaseline(cellDir) {
+  try {
+    run('git', ['-C', cellDir, 'add', '-A'])
+    run('git', ['-C', cellDir, '-c', 'user.email=bench@local', '-c', 'user.name=bench', 'commit', '-q', '-m', 'bench baseline'])
+  } catch { /* git absent or nothing to commit — capture falls back to feature.json */ }
+}
+
 // Reset a run folder to pristine for the next round: restore the mutable working
 // surface (src/, index.html) from the canonical app and clear the generated spec.
 // Leaves .specify/ (the armed companion state), node_modules, and .git intact.

--- a/examples/todo-claude/bench/sync-templates.mjs
+++ b/examples/todo-claude/bench/sync-templates.mjs
@@ -22,6 +22,7 @@ import {
   parseArgs,
   cloneDir,
   gitInitCell,
+  gitCommitCellBaseline,
   folderDir,
   writeVscodeSettings,
   seedConstitution,
@@ -94,11 +95,13 @@ if (process.argv[1] && process.argv[1].endsWith('sync-templates.mjs')) {
     writeVscodeSettings(dir, variant)
 
     if (variant === 'speckit') {
+      gitCommitCellBaseline(dir) // so create-new-feature.sh can branch during a run
       console.log(initOk ? 'stock spec-kit ✓ (plain upstream)' : 'init ✗')
       continue
     }
     process.stdout.write('extension add… ')
     const { extOk, presetOk, presetId } = installCompanion(dir, variant)
+    gitCommitCellBaseline(dir) // so create-new-feature.sh can branch during a run
     console.log(`${initOk ? 'init✓' : 'init✗'} ${extOk ? 'companion✓' : 'companion✗'} ${presetId ? (presetOk ? `${presetId}✓` : 'preset✗') : 'no-preset'} profile=${PROFILE_BY_MODE[variant]}`)
   }
 


### PR DESCRIPTION
## What it does

Follow-up to #325. Running the faithful bench for real surfaced two setup gaps that forced the driver to hand-patch each cell. This fixes both so a bench round runs clean.

1. **Cells had no initial commit.** Each baked cell sat on an unborn `main`, so spec-kit's `create-new-feature.sh` couldn't create the feature branch. `sync-templates` now makes a `bench baseline` commit per cell after baking.
2. **`feature.json` wasn't written by `create-new-feature.sh`**, but the capture wrapper needed it. `cap.mjs` now falls back to deriving the feature dir from the git branch (`specs/<branch>`), mirroring `write-context.py`'s resolver — so the driver no longer hand-seeds it.

## How to verify

`node examples/todo-claude/bench/sync-templates.mjs` → each cell's `git log` shows a `bench baseline` commit and a clean tree. A companion `specify` run then drives `cap.mjs` with no `.specify/feature.json` present.

## Validated by a real run

With these in place I ran a full faithful pipeline (specify→plan→tasks→implement) for both modes on the easy change end-to-end with no manual patching — both built green, acceptance 1/1, and the companion capture eval passed 18/0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)