### PR TITLE
fix(viewer): task label sits beside the checkbox + checkbox tracks font size (#331)

### DIFF
--- a/webview/styles/spec-viewer/_tasks.css
+++ b/webview/styles/spec-viewer/_tasks.css
@@ -89,7 +89,10 @@
    Tighter line-height than the surrounding prose so a wrapping task doesn't
    visually bloat into a pseudo-paragraph (spec 112). */
 #markdown-content li.task-item .task-text {
-  flex: 1 1 auto;
+  /* flex-basis 0 (not auto): auto resolves to the text's max-content width, which
+     with the row's flex-wrap pushes the whole label onto its own line below the
+     checkbox. basis 0 lets it sit beside the checkbox and wrap internally (#331). */
+  flex: 1 1 0;
   min-width: 0;
   line-height: 1.4;
 }

--- a/webview/styles/spec-viewer/_tasks.css
+++ b/webview/styles/spec-viewer/_tasks.css
@@ -119,6 +119,9 @@
 #markdown-content li.task-item input[type="checkbox"] {
   appearance: none;
   -webkit-appearance: none;
+  /* Inherit the text font so `1.4em` below tracks the real line-height at every
+     font size — form controls default to ~13.3px, freezing the offset (#331). */
+  font: inherit;
   width: 16px;
   height: 16px;
   min-width: 16px;


### PR DESCRIPTION
## What it does

Fixes the rendered task list so a multi-line task reads as

```
[✓] T001 Simplify deriveRunningStepInfo to return only...
    artifactReady / startedAt / label and the await...
```

instead of stranding the checkbox alone on its own line with the whole label dropped below it.

Closes #331.

## Root cause (two layers)

1. **Label kicked to its own row (the real bug).** `.task-text` used `flex: 1 1 auto`; `flex-basis: auto` resolves to the label's **max-content** width, and with `flex-wrap: wrap` on the row the browser moved that wide item onto its own line below the checkbox. `min-width: 0` doesn't help — the wrap decision is made on flex-basis *before* shrinking. Fixed with `flex-basis: 0` (`flex: 1 1 0`), so the label sits beside the checkbox and wraps internally with a hanging indent.
2. **Checkbox offset frozen across font sizes.** The checkbox centered via `margin-top: calc((1.4em - 16px) / 2)`, but a form control defaults to ~13.3px font, so `1.4em` froze at ~18.7px regardless of the editor font — at larger sizes the box drifted off the (taller) line. `font: inherit` makes `1.4em` track the real line-height at every size.

## How to verify

Open the spec viewer on a spec with a long, multi-line **checked** task: the checkbox sits on the first line, wrapped lines hang-indent under the label, and the alignment holds when you bump the editor font up/down. Verified live (installed locally, eyeballed across font sizes).

## Refs

- `webview/styles/spec-viewer/_tasks.css` (`.task-text` flex-basis; `input[type="checkbox"]` font)
- Prior attempt: #297 / PR #321

🤖 Generated with [Claude Code](https://claude.com/claude-code)