### PR TITLE
chore(specs): mark merged specs as completed

### DIFF
--- a/specs/144-opencode-image-staging/.spec-context.json
+++ b/specs/144-opencode-image-staging/.spec-context.json
@@ -3,7 +3,7 @@
   "specName": "opencode-image-staging",
   "branch": "144-opencode-image-staging",
   "currentStep": "implement",
-  "status": "implemented",
+  "status": "completed",
   "history": [
     {
       "step": "specify",

--- a/specs/145-launch-extension-discovery/.spec-context.json
+++ b/specs/145-launch-extension-discovery/.spec-context.json
@@ -3,7 +3,7 @@
   "specName": "launch extension discovery",
   "branch": "145-launch-extension-discovery",
   "currentStep": "implement",
-  "status": "implemented",
+  "status": "completed",
   "history": [
     {
       "step": "specify",

--- a/specs/146-close-implement-on-tasks-complete/.spec-context.json
+++ b/specs/146-close-implement-on-tasks-complete/.spec-context.json
@@ -3,7 +3,7 @@
   "specName": "close implement on tasks complete",
   "branch": "146-close-implement-on-tasks-complete",
   "currentStep": "implement",
-  "status": "implemented",
+  "status": "completed",
   "history": [
     {
       "step": "specify",

--- a/specs/147-step-tab-sync-glyph/.spec-context.json
+++ b/specs/147-step-tab-sync-glyph/.spec-context.json
@@ -3,7 +3,7 @@
   "specName": "step tab sync glyph",
   "branch": "147-step-tab-sync-glyph",
   "currentStep": "implement",
-  "status": "implemented",
+  "status": "completed",
   "history": [
     {
       "step": "specify",

--- a/specs/148-contrast-secondary-muted-tokens/.spec-context.json
+++ b/specs/148-contrast-secondary-muted-tokens/.spec-context.json
@@ -3,7 +3,7 @@
   "specName": "contrast secondary muted tokens",
   "branch": "148-contrast-secondary-muted-tokens",
   "currentStep": "implement",
-  "status": "implemented",
+  "status": "completed",
   "history": [
     {
       "step": "specify",

--- a/specs/149-spec-viewer-inflight-status-banner-dot/.spec-context.json
+++ b/specs/149-spec-viewer-inflight-status-banner-dot/.spec-context.json
@@ -3,7 +3,7 @@
   "specName": "spec viewer inflight status banner dot",
   "branch": "149-spec-viewer-inflight-status-banner-dot",
   "currentStep": "implement",
-  "status": "implemented",
+  "status": "completed",
   "history": [
     {
       "step": "specify",

--- a/specs/150-script-task-summaries/.spec-context.json
+++ b/specs/150-script-task-summaries/.spec-context.json
@@ -3,7 +3,7 @@
   "specName": "Script-written task_summaries + live implement percentage label",
   "branch": "150-script-task-summaries",
   "currentStep": "implement",
-  "status": "implemented",
+  "status": "completed",
   "history": [
     {
       "step": "specify",

--- a/specs/151-implemented-terminal-status/.spec-context.json
+++ b/specs/151-implemented-terminal-status/.spec-context.json
@@ -3,7 +3,7 @@
   "specName": "Hide Resume on Terminal Specs (Make `implemented` a First-Class Status)",
   "branch": "151-implemented-terminal-status",
   "currentStep": "implement",
-  "status": "implemented",
+  "status": "completed",
   "history": [
     {
       "step": "specify",

--- a/specs/152-ui-cleanup-sidebar-createspec/.spec-context.json
+++ b/specs/152-ui-cleanup-sidebar-createspec/.spec-context.json
@@ -3,7 +3,7 @@
   "specName": "ui cleanup sidebar createspec",
   "branch": "152-ui-cleanup-sidebar-createspec",
   "currentStep": "implement",
-  "status": "implemented",
+  "status": "completed",
   "history": [
     {
       "step": "specify",

--- a/specs/154-stale-capture-tests/.spec-context.json
+++ b/specs/154-stale-capture-tests/.spec-context.json
@@ -3,7 +3,7 @@
   "specName": "Green-Baseline Stale Capture Tests + CI Gate",
   "branch": "154-stale-capture-tests",
   "currentStep": "implement",
-  "status": "implemented",
+  "status": "completed",
   "history": [
     {
       "step": "specify",

--- a/specs/155-fix-publisher-handle/.spec-context.json
+++ b/specs/155-fix-publisher-handle/.spec-context.json
@@ -3,7 +3,7 @@
   "specName": "fix publisher handle",
   "branch": "main",
   "currentStep": "implement",
-  "status": "implemented",
+  "status": "completed",
   "history": [
     {
       "step": "specify",

--- a/specs/156-stable-companion-zip/.spec-context.json
+++ b/specs/156-stable-companion-zip/.spec-context.json
@@ -3,7 +3,7 @@
   "specName": "stable companion zip",
   "branch": "156-stable-companion-zip",
   "currentStep": "implement",
-  "status": "implemented",
+  "status": "completed",
   "history": [
     {
       "step": "specify",

--- a/specs/157-implement-lifecycle/.spec-context.json
+++ b/specs/157-implement-lifecycle/.spec-context.json
@@ -3,7 +3,7 @@
   "specName": "Implement Lifecycle Reliability",
   "branch": "157-implement-lifecycle",
   "currentStep": "implement",
-  "status": "implemented",
+  "status": "completed",
   "profile": "turbo",
   "history": [
     {

--- a/specs/162-provider-adoption-telemetry/.spec-context.json
+++ b/specs/162-provider-adoption-telemetry/.spec-context.json
@@ -3,7 +3,7 @@
   "specName": "provider adoption telemetry",
   "branch": "main",
   "currentStep": "implement",
-  "status": "implemented",
+  "status": "completed",
   "history": [
     {
       "step": "specify",

--- a/specs/170-single-beta-gate/.spec-context.json
+++ b/specs/170-single-beta-gate/.spec-context.json
@@ -4,7 +4,7 @@
   "branch": "170-single-beta-gate",
   "selectedAt": "2026-06-14T13:53:29.626Z",
   "currentStep": "implement",
-  "status": "implementing",
+  "status": "completed",
   "history": [
     {
       "step": "specify",

--- a/specs/172-composable-command-nodes/.spec-context.json
+++ b/specs/172-composable-command-nodes/.spec-context.json
@@ -4,7 +4,7 @@
   "branch": "172-composable-command-nodes",
   "selectedAt": "2026-06-14T19:45:33.354Z",
   "currentStep": "implement",
-  "status": "implementing",
+  "status": "completed",
   "history": [
     {
       "step": "specify",
@@ -628,7 +628,7 @@
         "speckit-extension/workflows/speckit-companion.workflow.yml"
       ],
       "concerns": [
-        "SC-005/SC-006 (live agentic-CLI self-advance vs one-shot, and stock SpecKit stopping at 'implemented') were verified by code/wiring inspection, not by an end-to-end run in each environment \u2014 those require live CLIs."
+        "SC-005/SC-006 (live agentic-CLI self-advance vs one-shot, and stock SpecKit stopping at 'implemented') were verified by code/wiring inspection, not by an end-to-end run in each environment — those require live CLIs."
       ]
     },
     "T033": {

--- a/specs/174-beta-settings-cleanup/.spec-context.json
+++ b/specs/174-beta-settings-cleanup/.spec-context.json
@@ -3,7 +3,7 @@
   "specName": "beta settings cleanup",
   "branch": "main",
   "currentStep": "implement",
-  "status": "implemented",
+  "status": "completed",
   "history": [
     {
       "step": "specify",

--- a/specs/175-checkbox-alignment/.spec-context.json
+++ b/specs/175-checkbox-alignment/.spec-context.json
@@ -3,7 +3,7 @@
   "specName": "checkbox alignment",
   "branch": "main",
   "currentStep": "implement",
-  "status": "implemented",
+  "status": "completed",
   "history": [
     {
       "step": "specify",

--- a/specs/176-assemble-stock-carrier/.spec-context.json
+++ b/specs/176-assemble-stock-carrier/.spec-context.json
@@ -3,7 +3,7 @@
   "specName": "assemble stock carrier",
   "branch": "176-assemble-stock-carrier",
   "currentStep": "implement",
-  "status": "implemented",
+  "status": "completed",
   "history": [
     {
       "step": "specify",

--- a/specs/177-remove-markstepcomplete-orphan/.spec-context.json
+++ b/specs/177-remove-markstepcomplete-orphan/.spec-context.json
@@ -3,7 +3,7 @@
   "specName": "remove markstepcomplete orphan",
   "branch": "177-remove-markstepcomplete-orphan",
   "currentStep": "implement",
-  "status": "implemented",
+  "status": "completed",
   "history": [
     {
       "step": "specify",


### PR DESCRIPTION
Flips the 20 specs that were left at `implemented`/`implementing` (the 144–177 range that never got the final status flip) to `completed`, so the sidebar's **Completed** group reflects reality instead of showing finished work as still active.

- Touches only `.spec-context.json` `status` — no other fields, no code.
- **Leaves the `_NN_demo-*` fixtures untouched** (they deliberately pin viewer states: specified / planned / ready-to-implement).
- **Leaves the 4 archived specs as-is** — archived is already a terminal state; flipping it back to completed would be wrong.

Already-completed specs (151) are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)