### PR TITLE
fix(spec-editor): fade the Create Spec placeholder so it reads as guidance (#330)

### DIFF
--- a/webview/styles/spec-editor.css
+++ b/webview/styles/spec-editor.css
@@ -132,8 +132,11 @@
 }
 
 .spec-editor-textarea::placeholder {
-    color: var(--text-body);
-    opacity: 0.85;
+    /* Muted, not body color, so the empty field reads as guidance — but the
+       placeholder carries real teaching, so don't stack a low token with low
+       opacity (#330). One muted token at full opacity stays legible. */
+    color: var(--text-secondary);
+    opacity: 1;
 }
 
 /* Composer-style row beneath the textarea: attach control left, counter right. */


### PR DESCRIPTION
## What it does

The Create Spec description field's placeholder used the full body text color, so an empty field looked like it already had real text typed in. It's now visibly faded — clearly guidance, not content — while staying legible (the placeholder carries the field's writing guidance).

Closes #330.

## Change

`webview/styles/spec-editor.css` — `.spec-editor-textarea::placeholder`: `color: var(--text-body); opacity: 0.85` → `color: var(--text-secondary); opacity: 1` (a muted token at full opacity, rather than stacking a low token with low opacity).

## How to verify

Open Create Spec with an empty field: the placeholder is now lighter/grayer than typed content but still readable, on both light and dark themes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)