### PR TITLE
feat(speckit-ext): provider-aware parallelization across the Companion pipeline

### DIFF
--- a/speckit-extension/CHANGELOG.md
+++ b/speckit-extension/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to the **spec-kit extension** (`id: companion`) are document
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/); this extension follows [Semantic Versioning](https://semver.org/).
 
+## [0.10.0] - 2026-06-15
+
+### Added
+- **The pipeline runs as fast as your assistant allows.** When your AI assistant can work on several things at once, the Companion steps now spread the work out: it reads different parts of the codebase side by side while investigating, flags which tasks are independent enough to run together, and builds those independent tasks at the same time during implementation. Assistants that can't do that simply run each step the usual one-at-a-time way and produce the exact same result — nothing to turn on, nothing breaks.
+- **Point specific kinds of work at specialist helpers.** Implementation now leaves a clean place for a project to say "send test tasks to the testing specialist," so teams can route task types to dedicated helpers without changing the built-in steps.
+
 ## [0.9.0] - 2026-06-16
 
 ### Added

--- a/speckit-extension/CHANGELOG.md
+++ b/speckit-extension/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to the **spec-kit extension** (`id: companion`) are document
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/); this extension follows [Semantic Versioning](https://semver.org/).
 
-## [0.10.0] - 2026-06-15
+## [0.10.0] - 2026-06-16
 
 ### Added
 - **The pipeline runs as fast as your assistant allows.** When your AI assistant can work on several things at once, the Companion steps now spread the work out: it reads different parts of the codebase side by side while investigating, flags which tasks are independent enough to run together, and builds those independent tasks at the same time during implementation. Assistants that can't do that simply run each step the usual one-at-a-time way and produce the exact same result — nothing to turn on, nothing breaks.

--- a/speckit-extension/README.md
+++ b/speckit-extension/README.md
@@ -10,7 +10,7 @@
 
 <p align="center">
   <img src="https://img.shields.io/badge/extension-companion-0b6dd9" alt="extension: companion">
-  <img src="https://img.shields.io/badge/version-0.8.0-0b6dd9" alt="version 0.8.0">
+  <img src="https://img.shields.io/badge/version-0.10.0-0b6dd9" alt="version 0.10.0">
   <img src="https://img.shields.io/badge/spec--kit-%E2%89%A50.9.5-008080" alt="requires spec-kit >= 0.9.5">
   <img src="https://img.shields.io/badge/license-MIT-gold" alt="license MIT">
 </p>
@@ -100,6 +100,12 @@ Full reference: [docs/commands.md](./docs/commands.md).
 Because it runs unattended, auto sets an **`unattended`** signal that project checkpoint hooks read. A checkpoint hook ("Continue / Fix / Stop") that would normally stop and ask a person to proceed checks this signal and instead records the checkpoint and keeps going. Background work, reviews, and PR steps still run as usual — only the wait-for-a-human pause is skipped. Authors of checkpoint hooks should branch on the `unattended` flag: if it is set, record and continue; otherwise ask.
 
 Auto needs an AI agent that keeps working after each step finishes. On a plain one-shot terminal it gracefully falls back to the normal flow: it runs the first step and stops, and the rest is triggered the usual way.
+
+### As fast as your assistant allows
+
+When your AI assistant can work on several things at once, the Companion steps spread the work out automatically — there's nothing to switch on. While investigating, it reads different parts of the codebase side by side instead of one file at a time. When it generates tasks, it flags which ones are independent enough to run together. During implementation, it builds those independent tasks at the same time, while anything that touches the same file or depends on earlier work still runs in order. Assistants that can't run work concurrently simply do each step the usual one-at-a-time way and produce the exact same result — no error, identical output.
+
+A project can also point specific kinds of work at a specialist helper — for example, sending test tasks to a testing specialist — without changing the built-in implementation step.
 
 ## SpecKit Companion workflow — the lean pipeline shape
 

--- a/speckit-extension/commands/speckit.companion.implement.md
+++ b/speckit-extension/commands/speckit.companion.implement.md
@@ -10,6 +10,18 @@ $ARGUMENTS
 
 ## Outline
 
+<!-- speckit-companion:part parallel -->
+## Parallel work — use subagents where your provider supports them
+
+If you can spawn subagents or run work concurrently, use that capability across this step:
+
+- **Investigation.** Fan out independent reads across subagents (one per area) and return distilled findings, instead of reading every file serially into the main context.
+- **Tasks.** Mark independent (different-file, no open dependency) tasks `[P]` so they can run together.
+- **Implement.** Run `[P]` batches concurrently via subagents; same-file or dependent tasks stay ordered.
+
+If you cannot spawn subagents, do all of it sequentially — no error, identical output. This is a capability suggestion, not a requirement: a chat-only host simply runs the step the slow way and produces the same artifacts.
+<!-- /speckit-companion:part parallel -->
+
 1. Read `.specify/feature.json` for the feature directory; load `<feature_directory>/tasks.md`, `plan.md`, and `spec.md`. Then record the **implement START** so the step's duration begins now (the script stamps the real clock; the end-of-step hook records each task and closes the step — do not hand-write implement timing):
    ```bash
    python3 .specify/extensions/companion/scripts/write-context.py --feature-dir <feature_directory> --step implement --status implementing --kind start --by extension
@@ -17,7 +29,7 @@ $ARGUMENTS
 
 2. Execute tasks in dependency order:
    - Complete each layer before the next: Setup → Foundational → Core → Integration → Polish.
-   - Tasks marked `[P]` (different files, no incomplete dependency) may run together; tasks touching the same file run sequentially.
+   - If you support subagents, run each `[P]` batch (different files, no incomplete dependency) concurrently — one subagent per task — and journal each as it finishes (timing rules unchanged). Same-file or dependent tasks stay ordered. No subagent support → run `[P]` tasks sequentially. A project may route task types to specialist subagents via a hook (the agent-routing seam).
    - Halt on a failed non-parallel task and report the cause; for `[P]` tasks, continue the others and report the failure.
 
 3. After completing a task, mark it `- [x]` in `tasks.md`.

--- a/speckit-extension/commands/speckit.companion.implement.md
+++ b/speckit-extension/commands/speckit.companion.implement.md
@@ -29,7 +29,7 @@ If you cannot spawn subagents, do all of it sequentially — no error, identical
 
 2. Execute tasks in dependency order:
    - Complete each layer before the next: Setup → Foundational → Core → Integration → Polish.
-   - If you support subagents, run each `[P]` batch (different files, no incomplete dependency) concurrently — one subagent per task — and journal each as it finishes (timing rules unchanged). Same-file or dependent tasks stay ordered. No subagent support → run `[P]` tasks sequentially. A project may route task types to specialist subagents via a hook (the agent-routing seam).
+   - If you support subagents, run each `[P]` batch (different files, no incomplete dependency) concurrently — one subagent per task. As each finishes, the main agent (never the subagents) records it one at a time, so writes to `.spec-context.json` stay foreground and never race (timing rules unchanged). Same-file or dependent tasks stay ordered. No subagent support → run `[P]` tasks sequentially. A project may route task types to specialist subagents via a hook (the agent-routing seam).
    - Halt on a failed non-parallel task and report the cause; for `[P]` tasks, continue the others and report the failure.
 
 3. After completing a task, mark it `- [x]` in `tasks.md`.

--- a/speckit-extension/commands/speckit.companion.plan.md
+++ b/speckit-extension/commands/speckit.companion.plan.md
@@ -25,8 +25,7 @@ If you cannot spawn subagents, do all of it sequentially — no error, identical
 <!-- /speckit-companion:part parallel -->
 
 1. Read `.specify/feature.json` for the feature directory; load `<feature_directory>/spec.md` and `.specify/memory/constitution.md` if present.
-
-2. If you support subagents, fan these reads out in parallel (one per area) and collect findings; otherwise read sequentially.
+   - If you support subagents, fan these reads out in parallel (one per area) and collect findings; otherwise read sequentially.
 
 2. Create `<feature_directory>/plan.md` with these sections, in order:
    - **Summary** — the primary requirement plus the technical approach in 2–4 sentences.

--- a/speckit-extension/commands/speckit.companion.plan.md
+++ b/speckit-extension/commands/speckit.companion.plan.md
@@ -12,7 +12,21 @@ $ARGUMENTS
 
 Produce a **lean** plan — just enough to drive tasks. No multi-phase research scaffolding, no dual-option structure trees.
 
+<!-- speckit-companion:part parallel -->
+## Parallel work — use subagents where your provider supports them
+
+If you can spawn subagents or run work concurrently, use that capability across this step:
+
+- **Investigation.** Fan out independent reads across subagents (one per area) and return distilled findings, instead of reading every file serially into the main context.
+- **Tasks.** Mark independent (different-file, no open dependency) tasks `[P]` so they can run together.
+- **Implement.** Run `[P]` batches concurrently via subagents; same-file or dependent tasks stay ordered.
+
+If you cannot spawn subagents, do all of it sequentially — no error, identical output. This is a capability suggestion, not a requirement: a chat-only host simply runs the step the slow way and produces the same artifacts.
+<!-- /speckit-companion:part parallel -->
+
 1. Read `.specify/feature.json` for the feature directory; load `<feature_directory>/spec.md` and `.specify/memory/constitution.md` if present.
+
+2. If you support subagents, fan these reads out in parallel (one per area) and collect findings; otherwise read sequentially.
 
 2. Create `<feature_directory>/plan.md` with these sections, in order:
    - **Summary** — the primary requirement plus the technical approach in 2–4 sentences.

--- a/speckit-extension/commands/speckit.companion.specify.md
+++ b/speckit-extension/commands/speckit.companion.specify.md
@@ -12,6 +12,18 @@ $ARGUMENTS
 
 Produce a Companion specification — **no user-story / user-scenario section**. Capture intent as testable requirements, not narrative journeys.
 
+<!-- speckit-companion:part parallel -->
+## Parallel work — use subagents where your provider supports them
+
+If you can spawn subagents or run work concurrently, use that capability across this step:
+
+- **Investigation.** Fan out independent reads across subagents (one per area) and return distilled findings, instead of reading every file serially into the main context.
+- **Tasks.** Mark independent (different-file, no open dependency) tasks `[P]` so they can run together.
+- **Implement.** Run `[P]` batches concurrently via subagents; same-file or dependent tasks stay ordered.
+
+If you cannot spawn subagents, do all of it sequentially — no error, identical output. This is a capability suggestion, not a requirement: a chat-only host simply runs the step the slow way and produces the same artifacts.
+<!-- /speckit-companion:part parallel -->
+
 1. **Resolve the feature directory — mint a fresh dir for new work.** `.specify/feature.json` is an **output** of this step, not an input to reuse: it points at the *previous* spec (frequently already completed), so reusing it would clobber finished work. Pick the target:
    - If the request explicitly names a target path (or `SPECIFY_FEATURE_DIRECTORY` is set), use it.
    - Otherwise create the next numbered dir: scan `specs/` for the highest `NNN-…` prefix, derive a 2–4 word short-name from the description, and use `specs/<NNN+1>-<short-name>/`. **Never write into a directory that already contains a `spec.md`** — that's a stale pointer to a prior spec, not this feature.

--- a/speckit-extension/commands/speckit.companion.tasks.md
+++ b/speckit-extension/commands/speckit.companion.tasks.md
@@ -12,6 +12,18 @@ $ARGUMENTS
 
 Produce tasks organized by **files and dependencies**, not grouped under user stories.
 
+<!-- speckit-companion:part parallel -->
+## Parallel work — use subagents where your provider supports them
+
+If you can spawn subagents or run work concurrently, use that capability across this step:
+
+- **Investigation.** Fan out independent reads across subagents (one per area) and return distilled findings, instead of reading every file serially into the main context.
+- **Tasks.** Mark independent (different-file, no open dependency) tasks `[P]` so they can run together.
+- **Implement.** Run `[P]` batches concurrently via subagents; same-file or dependent tasks stay ordered.
+
+If you cannot spawn subagents, do all of it sequentially — no error, identical output. This is a capability suggestion, not a requirement: a chat-only host simply runs the step the slow way and produces the same artifacts.
+<!-- /speckit-companion:part parallel -->
+
 1. Read `.specify/feature.json` for the feature directory; load `plan.md` and `spec.md` (and `data-model.md` / `contracts/` if present).
 
 2. Create `<feature_directory>/tasks.md` as a dependency-ordered checklist. Group by execution layer, not by story:
@@ -25,7 +37,7 @@ Produce tasks organized by **files and dependencies**, not grouped under user st
    ```text
    - [ ] [TaskID] [P?] Description with exact file path
    ```
-   - `[P]` marks tasks touching different files with no incomplete dependency (parallelizable).
+   - `[P]` marks tasks touching different files with no incomplete dependency (parallelizable). When the dispatcher supports subagents, be deliberate about `[P]`: split independent, different-file work so implement can run it concurrently. When it doesn't, `[P]` is informational only.
    - Each task names the concrete file it creates or edits.
    - No user-story labels, no per-story test sections, no MVP framing — traceability is to files and requirements (`FR-…`).
 

--- a/speckit-extension/extension.yml
+++ b/speckit-extension/extension.yml
@@ -3,7 +3,7 @@ schema_version: "1.0"
 extension:
   id: companion
   name: "SpecKit Companion"
-  version: "0.9.0"
+  version: "0.10.0"
   description: "Live spec-driven progress for SpecKit Companion — lifecycle capture, status, and resume."
   author: alfredoperez
   repository: https://github.com/alfredoperez/speckit-companion

--- a/speckit-extension/nodes/implement/implement-exec.md
+++ b/speckit-extension/nodes/implement/implement-exec.md
@@ -12,7 +12,7 @@ reads: []
 
 2. Execute tasks in dependency order:
    - Complete each layer before the next: Setup → Foundational → Core → Integration → Polish.
-   - If you support subagents, run each `[P]` batch (different files, no incomplete dependency) concurrently — one subagent per task — and journal each as it finishes (timing rules unchanged). Same-file or dependent tasks stay ordered. No subagent support → run `[P]` tasks sequentially. A project may route task types to specialist subagents via a hook (the agent-routing seam).
+   - If you support subagents, run each `[P]` batch (different files, no incomplete dependency) concurrently — one subagent per task. As each finishes, the main agent (never the subagents) records it one at a time, so writes to `.spec-context.json` stay foreground and never race (timing rules unchanged). Same-file or dependent tasks stay ordered. No subagent support → run `[P]` tasks sequentially. A project may route task types to specialist subagents via a hook (the agent-routing seam).
    - Halt on a failed non-parallel task and report the cause; for `[P]` tasks, continue the others and report the failure.
 
 3. After completing a task, mark it `- [x]` in `tasks.md`.

--- a/speckit-extension/nodes/implement/implement-exec.md
+++ b/speckit-extension/nodes/implement/implement-exec.md
@@ -12,7 +12,7 @@ reads: []
 
 2. Execute tasks in dependency order:
    - Complete each layer before the next: Setup → Foundational → Core → Integration → Polish.
-   - Tasks marked `[P]` (different files, no incomplete dependency) may run together; tasks touching the same file run sequentially.
+   - If you support subagents, run each `[P]` batch (different files, no incomplete dependency) concurrently — one subagent per task — and journal each as it finishes (timing rules unchanged). Same-file or dependent tasks stay ordered. No subagent support → run `[P]` tasks sequentially. A project may route task types to specialist subagents via a hook (the agent-routing seam).
    - Halt on a failed non-parallel task and report the cause; for `[P]` tasks, continue the others and report the failure.
 
 3. After completing a task, mark it `- [x]` in `tasks.md`.

--- a/speckit-extension/nodes/plan/_frame.md
+++ b/speckit-extension/nodes/plan/_frame.md
@@ -12,3 +12,15 @@ $ARGUMENTS
 
 Produce a **lean** plan — just enough to drive tasks. No multi-phase research scaffolding, no dual-option structure trees.
 
+<!-- speckit-companion:part parallel -->
+## Parallel work — use subagents where your provider supports them
+
+If you can spawn subagents or run work concurrently, use that capability across this step:
+
+- **Investigation.** Fan out independent reads across subagents (one per area) and return distilled findings, instead of reading every file serially into the main context.
+- **Tasks.** Mark independent (different-file, no open dependency) tasks `[P]` so they can run together.
+- **Implement.** Run `[P]` batches concurrently via subagents; same-file or dependent tasks stay ordered.
+
+If you cannot spawn subagents, do all of it sequentially — no error, identical output. This is a capability suggestion, not a requirement: a chat-only host simply runs the step the slow way and produces the same artifacts.
+<!-- /speckit-companion:part parallel -->
+

--- a/speckit-extension/nodes/plan/gather-context.md
+++ b/speckit-extension/nodes/plan/gather-context.md
@@ -5,6 +5,5 @@ command: plan
 reads: []
 ---
 1. Read `.specify/feature.json` for the feature directory; load `<feature_directory>/spec.md` and `.specify/memory/constitution.md` if present.
-
-2. If you support subagents, fan these reads out in parallel (one per area) and collect findings; otherwise read sequentially.
+   - If you support subagents, fan these reads out in parallel (one per area) and collect findings; otherwise read sequentially.
 

--- a/speckit-extension/nodes/plan/gather-context.md
+++ b/speckit-extension/nodes/plan/gather-context.md
@@ -6,3 +6,5 @@ reads: []
 ---
 1. Read `.specify/feature.json` for the feature directory; load `<feature_directory>/spec.md` and `.specify/memory/constitution.md` if present.
 
+2. If you support subagents, fan these reads out in parallel (one per area) and collect findings; otherwise read sequentially.
+

--- a/speckit-extension/nodes/specify/_frame.md
+++ b/speckit-extension/nodes/specify/_frame.md
@@ -12,3 +12,15 @@ $ARGUMENTS
 
 Produce a Companion specification — **no user-story / user-scenario section**. Capture intent as testable requirements, not narrative journeys.
 
+<!-- speckit-companion:part parallel -->
+## Parallel work — use subagents where your provider supports them
+
+If you can spawn subagents or run work concurrently, use that capability across this step:
+
+- **Investigation.** Fan out independent reads across subagents (one per area) and return distilled findings, instead of reading every file serially into the main context.
+- **Tasks.** Mark independent (different-file, no open dependency) tasks `[P]` so they can run together.
+- **Implement.** Run `[P]` batches concurrently via subagents; same-file or dependent tasks stay ordered.
+
+If you cannot spawn subagents, do all of it sequentially — no error, identical output. This is a capability suggestion, not a requirement: a chat-only host simply runs the step the slow way and produces the same artifacts.
+<!-- /speckit-companion:part parallel -->
+

--- a/speckit-extension/nodes/tasks/_frame.md
+++ b/speckit-extension/nodes/tasks/_frame.md
@@ -12,3 +12,15 @@ $ARGUMENTS
 
 Produce tasks organized by **files and dependencies**, not grouped under user stories.
 
+<!-- speckit-companion:part parallel -->
+## Parallel work — use subagents where your provider supports them
+
+If you can spawn subagents or run work concurrently, use that capability across this step:
+
+- **Investigation.** Fan out independent reads across subagents (one per area) and return distilled findings, instead of reading every file serially into the main context.
+- **Tasks.** Mark independent (different-file, no open dependency) tasks `[P]` so they can run together.
+- **Implement.** Run `[P]` batches concurrently via subagents; same-file or dependent tasks stay ordered.
+
+If you cannot spawn subagents, do all of it sequentially — no error, identical output. This is a capability suggestion, not a requirement: a chat-only host simply runs the step the slow way and produces the same artifacts.
+<!-- /speckit-companion:part parallel -->
+

--- a/speckit-extension/nodes/tasks/tasks-doc.md
+++ b/speckit-extension/nodes/tasks/tasks-doc.md
@@ -18,7 +18,7 @@ reads: []
    ```text
    - [ ] [TaskID] [P?] Description with exact file path
    ```
-   - `[P]` marks tasks touching different files with no incomplete dependency (parallelizable).
+   - `[P]` marks tasks touching different files with no incomplete dependency (parallelizable). When the dispatcher supports subagents, be deliberate about `[P]`: split independent, different-file work so implement can run it concurrently. When it doesn't, `[P]` is informational only.
    - Each task names the concrete file it creates or edits.
    - No user-story labels, no per-story test sections, no MVP framing — traceability is to files and requirements (`FR-…`).
 

--- a/speckit-extension/presets/_parts/parallel.md
+++ b/speckit-extension/presets/_parts/parallel.md
@@ -1,16 +1,3 @@
----
-description: "Companion implement — execute tasks.md in dependency order"
----
-
-## User Input
-
-```text
-$ARGUMENTS
-```
-
-## Outline
-
-<!-- speckit-companion:part parallel -->
 ## Parallel work — use subagents where your provider supports them
 
 If you can spawn subagents or run work concurrently, use that capability across this step:
@@ -20,5 +7,3 @@ If you can spawn subagents or run work concurrently, use that capability across 
 - **Implement.** Run `[P]` batches concurrently via subagents; same-file or dependent tasks stay ordered.
 
 If you cannot spawn subagents, do all of it sequentially — no error, identical output. This is a capability suggestion, not a requirement: a chat-only host simply runs the step the slow way and produces the same artifacts.
-<!-- /speckit-companion:part parallel -->
-

--- a/speckit-extension/tests/golden/commands/commands__speckit.companion.implement.md
+++ b/speckit-extension/tests/golden/commands/commands__speckit.companion.implement.md
@@ -10,6 +10,18 @@ $ARGUMENTS
 
 ## Outline
 
+<!-- speckit-companion:part parallel -->
+## Parallel work — use subagents where your provider supports them
+
+If you can spawn subagents or run work concurrently, use that capability across this step:
+
+- **Investigation.** Fan out independent reads across subagents (one per area) and return distilled findings, instead of reading every file serially into the main context.
+- **Tasks.** Mark independent (different-file, no open dependency) tasks `[P]` so they can run together.
+- **Implement.** Run `[P]` batches concurrently via subagents; same-file or dependent tasks stay ordered.
+
+If you cannot spawn subagents, do all of it sequentially — no error, identical output. This is a capability suggestion, not a requirement: a chat-only host simply runs the step the slow way and produces the same artifacts.
+<!-- /speckit-companion:part parallel -->
+
 1. Read `.specify/feature.json` for the feature directory; load `<feature_directory>/tasks.md`, `plan.md`, and `spec.md`. Then record the **implement START** so the step's duration begins now (the script stamps the real clock; the end-of-step hook records each task and closes the step — do not hand-write implement timing):
    ```bash
    python3 .specify/extensions/companion/scripts/write-context.py --feature-dir <feature_directory> --step implement --status implementing --kind start --by extension
@@ -17,7 +29,7 @@ $ARGUMENTS
 
 2. Execute tasks in dependency order:
    - Complete each layer before the next: Setup → Foundational → Core → Integration → Polish.
-   - Tasks marked `[P]` (different files, no incomplete dependency) may run together; tasks touching the same file run sequentially.
+   - If you support subagents, run each `[P]` batch (different files, no incomplete dependency) concurrently — one subagent per task — and journal each as it finishes (timing rules unchanged). Same-file or dependent tasks stay ordered. No subagent support → run `[P]` tasks sequentially. A project may route task types to specialist subagents via a hook (the agent-routing seam).
    - Halt on a failed non-parallel task and report the cause; for `[P]` tasks, continue the others and report the failure.
 
 3. After completing a task, mark it `- [x]` in `tasks.md`.

--- a/speckit-extension/tests/golden/commands/commands__speckit.companion.implement.md
+++ b/speckit-extension/tests/golden/commands/commands__speckit.companion.implement.md
@@ -29,7 +29,7 @@ If you cannot spawn subagents, do all of it sequentially — no error, identical
 
 2. Execute tasks in dependency order:
    - Complete each layer before the next: Setup → Foundational → Core → Integration → Polish.
-   - If you support subagents, run each `[P]` batch (different files, no incomplete dependency) concurrently — one subagent per task — and journal each as it finishes (timing rules unchanged). Same-file or dependent tasks stay ordered. No subagent support → run `[P]` tasks sequentially. A project may route task types to specialist subagents via a hook (the agent-routing seam).
+   - If you support subagents, run each `[P]` batch (different files, no incomplete dependency) concurrently — one subagent per task. As each finishes, the main agent (never the subagents) records it one at a time, so writes to `.spec-context.json` stay foreground and never race (timing rules unchanged). Same-file or dependent tasks stay ordered. No subagent support → run `[P]` tasks sequentially. A project may route task types to specialist subagents via a hook (the agent-routing seam).
    - Halt on a failed non-parallel task and report the cause; for `[P]` tasks, continue the others and report the failure.
 
 3. After completing a task, mark it `- [x]` in `tasks.md`.

--- a/speckit-extension/tests/golden/commands/commands__speckit.companion.plan.md
+++ b/speckit-extension/tests/golden/commands/commands__speckit.companion.plan.md
@@ -25,8 +25,7 @@ If you cannot spawn subagents, do all of it sequentially — no error, identical
 <!-- /speckit-companion:part parallel -->
 
 1. Read `.specify/feature.json` for the feature directory; load `<feature_directory>/spec.md` and `.specify/memory/constitution.md` if present.
-
-2. If you support subagents, fan these reads out in parallel (one per area) and collect findings; otherwise read sequentially.
+   - If you support subagents, fan these reads out in parallel (one per area) and collect findings; otherwise read sequentially.
 
 2. Create `<feature_directory>/plan.md` with these sections, in order:
    - **Summary** — the primary requirement plus the technical approach in 2–4 sentences.

--- a/speckit-extension/tests/golden/commands/commands__speckit.companion.plan.md
+++ b/speckit-extension/tests/golden/commands/commands__speckit.companion.plan.md
@@ -12,7 +12,21 @@ $ARGUMENTS
 
 Produce a **lean** plan — just enough to drive tasks. No multi-phase research scaffolding, no dual-option structure trees.
 
+<!-- speckit-companion:part parallel -->
+## Parallel work — use subagents where your provider supports them
+
+If you can spawn subagents or run work concurrently, use that capability across this step:
+
+- **Investigation.** Fan out independent reads across subagents (one per area) and return distilled findings, instead of reading every file serially into the main context.
+- **Tasks.** Mark independent (different-file, no open dependency) tasks `[P]` so they can run together.
+- **Implement.** Run `[P]` batches concurrently via subagents; same-file or dependent tasks stay ordered.
+
+If you cannot spawn subagents, do all of it sequentially — no error, identical output. This is a capability suggestion, not a requirement: a chat-only host simply runs the step the slow way and produces the same artifacts.
+<!-- /speckit-companion:part parallel -->
+
 1. Read `.specify/feature.json` for the feature directory; load `<feature_directory>/spec.md` and `.specify/memory/constitution.md` if present.
+
+2. If you support subagents, fan these reads out in parallel (one per area) and collect findings; otherwise read sequentially.
 
 2. Create `<feature_directory>/plan.md` with these sections, in order:
    - **Summary** — the primary requirement plus the technical approach in 2–4 sentences.

--- a/speckit-extension/tests/golden/commands/commands__speckit.companion.specify.md
+++ b/speckit-extension/tests/golden/commands/commands__speckit.companion.specify.md
@@ -12,6 +12,18 @@ $ARGUMENTS
 
 Produce a Companion specification — **no user-story / user-scenario section**. Capture intent as testable requirements, not narrative journeys.
 
+<!-- speckit-companion:part parallel -->
+## Parallel work — use subagents where your provider supports them
+
+If you can spawn subagents or run work concurrently, use that capability across this step:
+
+- **Investigation.** Fan out independent reads across subagents (one per area) and return distilled findings, instead of reading every file serially into the main context.
+- **Tasks.** Mark independent (different-file, no open dependency) tasks `[P]` so they can run together.
+- **Implement.** Run `[P]` batches concurrently via subagents; same-file or dependent tasks stay ordered.
+
+If you cannot spawn subagents, do all of it sequentially — no error, identical output. This is a capability suggestion, not a requirement: a chat-only host simply runs the step the slow way and produces the same artifacts.
+<!-- /speckit-companion:part parallel -->
+
 1. **Resolve the feature directory — mint a fresh dir for new work.** `.specify/feature.json` is an **output** of this step, not an input to reuse: it points at the *previous* spec (frequently already completed), so reusing it would clobber finished work. Pick the target:
    - If the request explicitly names a target path (or `SPECIFY_FEATURE_DIRECTORY` is set), use it.
    - Otherwise create the next numbered dir: scan `specs/` for the highest `NNN-…` prefix, derive a 2–4 word short-name from the description, and use `specs/<NNN+1>-<short-name>/`. **Never write into a directory that already contains a `spec.md`** — that's a stale pointer to a prior spec, not this feature.

--- a/speckit-extension/tests/golden/commands/commands__speckit.companion.tasks.md
+++ b/speckit-extension/tests/golden/commands/commands__speckit.companion.tasks.md
@@ -12,6 +12,18 @@ $ARGUMENTS
 
 Produce tasks organized by **files and dependencies**, not grouped under user stories.
 
+<!-- speckit-companion:part parallel -->
+## Parallel work — use subagents where your provider supports them
+
+If you can spawn subagents or run work concurrently, use that capability across this step:
+
+- **Investigation.** Fan out independent reads across subagents (one per area) and return distilled findings, instead of reading every file serially into the main context.
+- **Tasks.** Mark independent (different-file, no open dependency) tasks `[P]` so they can run together.
+- **Implement.** Run `[P]` batches concurrently via subagents; same-file or dependent tasks stay ordered.
+
+If you cannot spawn subagents, do all of it sequentially — no error, identical output. This is a capability suggestion, not a requirement: a chat-only host simply runs the step the slow way and produces the same artifacts.
+<!-- /speckit-companion:part parallel -->
+
 1. Read `.specify/feature.json` for the feature directory; load `plan.md` and `spec.md` (and `data-model.md` / `contracts/` if present).
 
 2. Create `<feature_directory>/tasks.md` as a dependency-ordered checklist. Group by execution layer, not by story:
@@ -25,7 +37,7 @@ Produce tasks organized by **files and dependencies**, not grouped under user st
    ```text
    - [ ] [TaskID] [P?] Description with exact file path
    ```
-   - `[P]` marks tasks touching different files with no incomplete dependency (parallelizable).
+   - `[P]` marks tasks touching different files with no incomplete dependency (parallelizable). When the dispatcher supports subagents, be deliberate about `[P]`: split independent, different-file work so implement can run it concurrently. When it doesn't, `[P]` is informational only.
    - Each task names the concrete file it creates or edits.
    - No user-story labels, no per-story test sections, no MVP framing — traceability is to files and requirements (`FR-…`).
 

--- a/specs/319-parallelization/.spec-context.json
+++ b/specs/319-parallelization/.spec-context.json
@@ -1,0 +1,82 @@
+{
+  "workflow": "companion",
+  "specName": "319-parallelization",
+  "branch": "319-parallelization",
+  "selectedAt": "2026-06-15T18:00:00.000Z",
+  "currentStep": "implement",
+  "status": "implemented",
+  "history": [
+    {
+      "step": "specify",
+      "substep": null,
+      "kind": "start",
+      "from": {
+        "step": null,
+        "substep": null
+      },
+      "by": "extension",
+      "at": "2026-06-15T18:00:00.000Z"
+    },
+    {
+      "step": "specify",
+      "substep": null,
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-15T18:03:00.000Z"
+    },
+    {
+      "step": "plan",
+      "substep": null,
+      "kind": "start",
+      "from": {
+        "step": "specify",
+        "substep": null
+      },
+      "by": "extension",
+      "at": "2026-06-15T18:03:00.000Z"
+    },
+    {
+      "step": "plan",
+      "substep": null,
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-15T18:06:00.000Z"
+    },
+    {
+      "step": "tasks",
+      "substep": null,
+      "kind": "start",
+      "from": {
+        "step": "plan",
+        "substep": null
+      },
+      "by": "extension",
+      "at": "2026-06-15T18:06:00.000Z"
+    },
+    {
+      "step": "tasks",
+      "substep": null,
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-15T18:08:00.000Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "kind": "start",
+      "from": {
+        "step": "tasks",
+        "substep": null
+      },
+      "by": "extension",
+      "at": "2026-06-15T18:08:00.000Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-15T18:20:00.000Z"
+    }
+  ]
+}

--- a/specs/319-parallelization/.spec-context.json
+++ b/specs/319-parallelization/.spec-context.json
@@ -4,7 +4,7 @@
   "branch": "319-parallelization",
   "selectedAt": "2026-06-15T18:00:00.000Z",
   "currentStep": "implement",
-  "status": "implemented",
+  "status": "completed",
   "history": [
     {
       "step": "specify",

--- a/specs/319-parallelization/plan.md
+++ b/specs/319-parallelization/plan.md
@@ -1,0 +1,28 @@
+# Plan — provider-aware parallelization across the Companion pipeline
+
+## Approach
+
+Parallelization is a **prose / node-only** layer over the existing Companion command bodies — no engine, no VS Code extension change. The AI is the runtime; we instruct it to fan work out when its provider supports subagents and to run sequentially with identical output when it does not. One new shared part carries the capability primer; three nodes gain a few provider-aware lines; the primer is prepended early to the four pipeline commands via the existing part-fence mechanism. Then golden is re-blessed because the four assembled bodies change.
+
+## Files / dependencies
+
+All under `speckit-extension/`:
+
+- `presets/_parts/parallel.md` — new shared part: the capability primer / gate (investigate / mark / execute, plus graceful sequential fallback). Authored in the house tone of `timing.md`. Must exist before any `parallel` fence (an unknown part name is a hard error).
+- `nodes/specify/_frame.md`, `nodes/plan/_frame.md`, `nodes/tasks/_frame.md`, `nodes/implement/_frame.md` — prepend a `<!-- speckit-companion:part parallel -->` fence right after the `## Outline` lead-in so the primer applies before the work.
+- `nodes/plan/gather-context.md` — add the parallel fan-out step (R3).
+- `nodes/tasks/tasks-doc.md` — make `[P]` marking provider-aware (R4).
+- `nodes/implement/implement-exec.md` — upgrade step 2 to fan out `[P]` batches concurrently + name the agent-routing seam (R5, R6).
+- `tests/golden/commands/*` — re-blessed via `capture-golden.py` after the bodies assemble (R9).
+- `README.md` + `CHANGELOG.md` + `extension.yml` `version` — document the capability (user-facing voice) and bump the minor (0.9.0 → 0.10.0).
+
+## Risk / ordering notes
+
+- **Build order is load-bearing.** Create `parallel.md` BEFORE adding any `parallel` fence (an unknown part is a hard error). Then edit nodes/parts → `assemble-nodes.py` (write bodies) → `capture-golden.py` (bless) → `assemble-nodes.py --check` + `check-shape-parity.py` both green.
+- **Golden canonicalization.** The `parallel` part, like `timing`, has its fence marker stripped in golden canonicalization, but its CONTENT survives and is real. Follow the timing-part pattern exactly; don't fight the tooling.
+- **Timing stays foreground.** Do NOT background `.spec-context.json` writes — two background read-modify-writes can lose an update. `background: true` is only for heavy side-effects (tests, builds, notifications). Per-task journaling stays foreground.
+- **Graceful degradation is the contract.** Every line must read identically-correct on a non-capable provider: sequential, no error, identical artifacts.
+
+## Summary
+
+The problem: the Companion pipeline reads files and runs tasks one at a time, even on a provider (like Claude Code) that could fan that work out across subagents and finish faster — and implement is the longest step in both modes, so parallelizing it is a general win. The solution: a short capability primer prepended to the four pipeline commands that says "if you can run work concurrently, fan out investigation, mark independent tasks parallel, and run those batches concurrently; if you can't, do it sequentially with identical output," plus a few provider-aware lines in the gather-context, tasks, and implement nodes, and an agent-routing seam so a project can point specific task types at specialist subagents. Capable providers just run faster; everything else runs exactly as before.

--- a/specs/319-parallelization/spec.md
+++ b/specs/319-parallelization/spec.md
@@ -1,0 +1,43 @@
+# Spec — provider-aware parallelization across the Companion pipeline
+
+## Intent
+
+Weave parallel work through the Companion pipeline wherever it helps — investigate, mark, execute — gated on what the AI provider can do. The AI is the runtime, so "parallelize" means instructing the AI to fan work out when it can spawn subagents, and to run sequentially with identical output when it cannot. The groundwork already exists (`tasks-doc` emits `[P]`; `implement-exec` already says `[P]` "may run together"); this adds a light, provider-gated layer: one new shared part plus a few lines in three nodes. No engine changes.
+
+## Requirements
+
+- **R1 — Capability primer part.** A new shared part `_parts/parallel.md` ships the capability primer: if the provider can spawn subagents, fan out investigation reads, mark independent tasks `[P]`, and run `[P]` batches concurrently; if it cannot, do all of it sequentially with no error and identical output. It uses the same part-fence mechanism the timing part uses.
+
+- **R2 — Primer prepended early.** The primer is prepended to the four pipeline commands (specify, plan, tasks, implement) via a `parallel` part fence, placed early (after each command's `## Outline` lead-in in `_frame.md`) so it applies before the work. It is a primer, not a new node.
+
+- **R3 — Investigate (gather-context).** `plan/gather-context.md` gains a step: if the provider supports subagents, fan the context reads out in parallel (one per area) and collect findings; otherwise read sequentially.
+
+- **R4 — Mark provider-aware (tasks-doc).** The existing `[P]` marking in `tasks/tasks-doc.md` becomes provider-aware: when the dispatcher supports subagents, deliberately split independent different-file work so implement can run it concurrently; when it doesn't, `[P]` is informational only.
+
+- **R5 — Execute (implement-exec).** `implement/implement-exec.md` step 2 is upgraded from "may run together" to actually fan out: run each `[P]` batch concurrently (one subagent per task), journal each as it finishes (timing rules unchanged); same-file / dependent tasks stay ordered; no subagent support means sequential.
+
+- **R6 — Agent-routing seam.** Implement names the seam: a project may route task types to specialist subagents via a hook (test tasks → test-expert, etc.) without forking the node.
+
+- **R7 — Graceful degradation.** Every touch point degrades gracefully — a non-capable provider runs sequentially with identical output and no error.
+
+- **R8 — Timing stays foreground.** No `.spec-context.json` write is backgrounded. Per-task journaling stays foreground inline `write-context.py` calls; `background: true` is reserved for heavy side-effects. Parallel `[P]` batches attribute time to whichever finishes last (accepted).
+
+- **R9 — Golden parity.** Changing the four command bodies changes assembled output, so golden is re-blessed via `capture-golden.py`; `assemble-nodes.py --check` and `check-shape-parity.py` both stay green.
+
+## Out of scope
+
+- The auto orchestrator (the #309 half — already shipped).
+- Custom document formats (swapping what a node emits).
+- A committed cross-project recipe doc.
+- True engine-managed gating (the spec-kit `workflow.yml` review-gate path stays as-is).
+
+## Acceptance
+
+- `_parts/parallel.md` ships and is prepended to specify, plan, tasks, implement.
+- `gather-context` fans out reads when the provider supports subagents; sequential otherwise.
+- `tasks-doc` marks `[P]` provider-aware (deliberate split when subagents available; informational otherwise).
+- Implement runs `[P]` batches concurrently where supported; sequential / dependent stay ordered.
+- The agent-routing seam exists (a project can route task types to specialist subagents via a hook).
+- Graceful degradation on providers without subagents (sequential, no error, identical output).
+- Capture / timing fidelity unchanged (per-task finish journaling still honest; timing stays foreground).
+- `npm run compile && npm test`, `assemble-nodes.py --check`, and `check-shape-parity.py` all pass.

--- a/specs/319-parallelization/tasks.md
+++ b/specs/319-parallelization/tasks.md
@@ -1,0 +1,42 @@
+# Tasks — provider-aware parallelization across the Companion pipeline
+
+Dependency-ordered. `[P]` marks tasks touching different files with no incomplete dependency (safe to fan out across subagents on a capable provider; informational otherwise).
+
+## Foundational
+
+- [x] T001 Create `speckit-extension/presets/_parts/parallel.md` — the capability primer (investigate / mark / execute, plus graceful sequential fallback), in the house tone of `timing.md`. Blocks every `parallel` fence (an unknown part name is a hard error).
+
+## Core work
+
+- [x] T002 [P] Prepend a `parallel` part fence after the `## Outline` lead-in in `speckit-extension/nodes/specify/_frame.md`.
+- [x] T003 [P] Prepend a `parallel` part fence after the `## Outline` lead-in in `speckit-extension/nodes/plan/_frame.md`.
+- [x] T004 [P] Prepend a `parallel` part fence after the `## Outline` lead-in in `speckit-extension/nodes/tasks/_frame.md`.
+- [x] T005 [P] Prepend a `parallel` part fence after the `## Outline` lead-in in `speckit-extension/nodes/implement/_frame.md`.
+- [x] T006 [P] Add the parallel fan-out step to `speckit-extension/nodes/plan/gather-context.md`.
+- [x] T007 [P] Make `[P]` marking provider-aware in `speckit-extension/nodes/tasks/tasks-doc.md`.
+- [x] T008 [P] Upgrade step 2 in `speckit-extension/nodes/implement/implement-exec.md` to fan out `[P]` batches concurrently + name the agent-routing seam.
+
+## Integration
+
+- [x] T009 Run `assemble-nodes.py` to write the four command bodies from the edited nodes/parts (depends on T001–T008).
+- [x] T010 Re-bless golden via `capture-golden.py`, then confirm `assemble-nodes.py --check` + `check-shape-parity.py` both pass (depends on T009).
+
+## Polish
+
+- [x] T011 [P] Bump `speckit-extension/extension.yml` `version` 0.9.0 → 0.10.0.
+- [x] T012 [P] Document the capability in `speckit-extension/README.md` (user-facing voice).
+- [x] T013 [P] Add a `speckit-extension/CHANGELOG.md` entry (user-facing voice, no internal symbol names).
+- [x] T014 Final verification: `npm run compile && npm test`, `assemble-nodes.py --check`, `check-shape-parity.py`, and the spec-kit-ext python unittests all green (depends on all).
+
+## Dependencies
+
+- T001 blocks T002–T008 (the fence references the part).
+- T002–T008 block T009 (assemble reads the edited nodes).
+- T009 blocks T010 (bless after the bodies assemble).
+- All block T014.
+
+## Parallel
+
+- T002–T008 are independent different-file edits — on a capable provider, fan them out (one subagent per file); journal each as it finishes.
+- T011–T013 are independent docs/version edits — also parallelizable.
+- T001, T009, T010, T014 are serial gates.


### PR DESCRIPTION
## What it does

Lets the SpecKit Companion pipeline go as fast as your AI assistant allows — without changing a thing about what it produces. When the assistant can run work in parallel (spawn subagents), the pipeline now investigates, plans, and builds concurrently; when it can't, everything runs one step at a time exactly as before, with identical output. Nothing for you to toggle — it adapts to the assistant you're using.

Concretely, three moments in the pipeline get faster on a capable assistant: research reads fan out instead of going one file at a time, the task list deliberately separates independent work so it's safe to run together, and the build step runs those independent task batches at the same time. A project can also point specific kinds of tasks at specialist helpers.

## How to test

On a subagent-capable assistant (e.g. Claude Code), run a Companion spec through specify → plan → tasks → implement and watch it fan out investigation reads and run independent (`[P]`) tasks concurrently. On a chat-only host, run the same and confirm it proceeds sequentially with the same result and no errors.

Closes #319.

## Under the hood

- New shared part `presets/_parts/parallel.md` (the capability primer), prepended via a `<!-- speckit-companion:part parallel -->` fence to the four pipeline command `_frame.md` files — same mechanism as the timing part.
- Provider-aware prose added to `nodes/plan/gather-context.md` (fan-out reads), `nodes/tasks/tasks-doc.md` (deliberate `[P]` splitting when subagents available; informational-only otherwise), `nodes/implement/implement-exec.md` (concurrent `[P]` batches, one subagent per task, journaled as each finishes; same-file/dependent stay ordered; plus the agent-routing seam).
- Every touch point degrades gracefully to sequential with identical artifacts. Timing/journaling stays foreground (no backgrounded `.spec-context.json` writes). No engine changes — prose/node/part only.
- Golden re-blessed (`tests/golden/commands/`); `extension.yml` 0.9.0 → 0.10.0; README version badge corrected to match.

## Verification

`npm run compile` ✅ · `npm test` 1018/1018 ✅ · `assemble-nodes.py --check` ✅ · `check-shape-parity.py` ✅ (14 bodies) · python suites 90/90 ✅
