### PR TITLE
feat(spec-editor): slim, dismissible install banner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- **The "Install spec-kit extension" prompt is smaller and you can dismiss it for good** (#353): the prompt that suggests installing the companion spec-kit extension used to be a tall card — a rocket icon, a heading, two lines of text, and a button — sitting at the top of Create Spec and the Activity panel on every visit, with no way to make it go away. It's now a single compact line with an Install action, a Learn more link, and an "×" to dismiss it. Dismissing hides it right away and remembers your choice everywhere, so it won't come back in any project or after a reload. It still only appears when the extension isn't installed.
 - **Leaner instructions sent alongside SpecKit Companion commands** (#352): when the editor runs a SpecKit Companion step, the bookkeeping instructions it prepends are now trimmed to just the parts that change each run — the dispatch time, the spec folder, and the "don't get ahead of yourself" note — because the Companion command already carries the full recording protocol. This removes a duplicated block of text that wasted space and could occasionally cause a step to be logged twice. Plain SpecKit steps are unchanged in scope but now use a single, more reliable instruction to mark a step done and move the status forward, instead of a two-step manual edit. You won't see a difference in the spec timeline; runs are just a bit tighter and less error-prone.
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ There are **two** installs, and they're independent:
 1. **The VS Code extension** (this product) — the Visual Spec Viewer, inline review comments, the sidebar, and command dispatch. Install it from the VS Code Marketplace (or a `.vsix`). This works on its own.
 2. **The companion spec-kit *CLI* extension** — adds the lean `/speckit.companion.*` pipeline and the lifecycle **capture** hooks that drive the Activity timeline. This is a [spec-kit](https://github.com/github/spec-kit) *CLI* extension, **not** a VS Code Marketplace extension, so it installs through the `specify` CLI.
 
-**One-click from inside the editor.** When the spec-kit extension is missing, an **Install spec-kit extension** banner appears in the Create-Spec and Activity panels, and an install icon appears in the Specs sidebar. Click it and the extension runs the install in an integrated terminal — no copy-paste. (Already have it installed? You'll never see the banner.)
+**One-click from inside the editor.** When the spec-kit extension is missing, a slim single-line **Install spec-kit extension** banner appears in the Create-Spec and Activity panels, and an install icon appears in the Specs sidebar. Click **Install** and the extension runs the install in an integrated terminal — no copy-paste. The banner has an **×** to dismiss it for good — once dismissed it stays hidden in every project and after a reload. (Already have it installed? You'll never see the banner.)
 
 **Manual install.** You need a **github-source** spec-kit CLI first — the stock PyPI `specify-cli` does **not** ship the `extension` subcommand:
 

--- a/specs/353-install-banner-slim/.spec-context.json
+++ b/specs/353-install-banner-slim/.spec-context.json
@@ -1,0 +1,302 @@
+{
+  "workflow": "speckit",
+  "specName": "install banner slim",
+  "branch": "353-install-banner-slim",
+  "currentStep": "implement",
+  "status": "implemented",
+  "history": [
+    {
+      "step": "specify",
+      "substep": null,
+      "kind": "start",
+      "by": "extension",
+      "at": "2026-06-18T16:40:49.920Z"
+    },
+    {
+      "step": "specify",
+      "substep": null,
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-06-18T16:41:41.094Z"
+    },
+    {
+      "step": "plan",
+      "substep": "research",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-18T16:43:01.114Z"
+    },
+    {
+      "step": "plan",
+      "substep": "design",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-18T16:43:01.193Z"
+    },
+    {
+      "step": "plan",
+      "substep": null,
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-18T16:43:01.272Z"
+    },
+    {
+      "step": "tasks",
+      "substep": "generate",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-18T16:43:35.125Z"
+    },
+    {
+      "step": "tasks",
+      "substep": null,
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-18T16:43:35.200Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "kind": "start",
+      "by": "extension",
+      "at": "2026-06-18T16:44:04.008Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T001",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-18T16:44:37.599Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T002",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-18T16:44:37.657Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T003",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-18T16:44:37.712Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T004",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-18T16:44:37.764Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T005",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-18T16:45:51.286Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T006",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-18T16:45:51.339Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T007",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-18T16:45:51.394Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T008",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-18T16:46:22.098Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T009",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-18T16:46:22.156Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T010",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-18T16:47:08.388Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T011",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-18T16:47:08.443Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T012",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-18T16:47:08.499Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T013",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-18T16:48:18.957Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T014",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-18T16:48:19.011Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T015",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-18T16:49:23.279Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-06-18T16:49:23.357Z"
+    }
+  ],
+  "size": "normal",
+  "currentTask": "T015",
+  "task_summaries": {
+    "T001": {
+      "status": "DONE",
+      "did": "Add installBannerDismissed globalState key",
+      "files": [
+        "src/core/constants.ts"
+      ]
+    },
+    "T002": {
+      "status": "DONE",
+      "did": "Add dismissInstallBanner to spec-editor extension message union",
+      "files": [
+        "src/features/spec-editor/types.ts"
+      ]
+    },
+    "T003": {
+      "status": "DONE",
+      "did": "Add dismissInstallBanner to webview spec-editor message union",
+      "files": [
+        "webview/src/spec-editor/types.ts"
+      ]
+    },
+    "T004": {
+      "status": "DONE",
+      "did": "Add dismissInstallBanner to spec-viewer message union",
+      "files": [
+        "src/features/spec-viewer/types.ts"
+      ]
+    },
+    "T005": {
+      "status": "DONE",
+      "did": "Gate Create-Spec banner on dismissed flag and handle dismissInstallBanner message",
+      "files": [
+        "src/features/spec-editor/specEditorProvider.ts"
+      ]
+    },
+    "T006": {
+      "status": "DONE",
+      "did": "Gate computeShowInstallPrompt on installBannerDismissed globalState flag",
+      "files": [
+        "src/features/spec-viewer/specViewerProvider.ts"
+      ]
+    },
+    "T007": {
+      "status": "DONE",
+      "did": "Add dismissInstallBanner handler: set flag + refresh panel",
+      "files": [
+        "src/features/spec-viewer/messageHandlers.ts"
+      ]
+    },
+    "T008": {
+      "status": "DONE",
+      "did": "Create-Spec banner click: remove node + post dismissInstallBanner",
+      "files": [
+        "webview/src/spec-editor/index.ts"
+      ]
+    },
+    "T009": {
+      "status": "DONE",
+      "did": "Spec-viewer banner click: post dismissInstallBanner",
+      "files": [
+        "src/features/spec-viewer/html/generator.ts"
+      ]
+    },
+    "T010": {
+      "status": "DONE",
+      "did": "Slim server-rendered banner to single row + dismiss button",
+      "files": [
+        "src/features/spec-editor/installBanner.ts"
+      ]
+    },
+    "T011": {
+      "status": "DONE",
+      "did": "Slim Preact InstallBanner to single row + dismiss button",
+      "files": [
+        "webview/src/spec-viewer/components/ActivityPanel.tsx"
+      ]
+    },
+    "T012": {
+      "status": "DONE",
+      "did": "Restyle .install-banner to compact row + .install-banner__dismiss",
+      "files": [
+        "webview/styles/spec-viewer/_install-banner.css"
+      ]
+    },
+    "T013": {
+      "status": "DONE",
+      "did": "Add slim + dismissed install-banner stories",
+      "files": [
+        "webview/src/spec-viewer/components/ActivityPanel.stories.tsx"
+      ]
+    },
+    "T014": {
+      "status": "DONE",
+      "did": "Add user-facing CHANGELOG entry; update README banner copy",
+      "files": [
+        "CHANGELOG.md",
+        "README.md"
+      ]
+    },
+    "T015": {
+      "status": "DONE",
+      "did": "Validation: compile + 1033 tests green + webview bundle builds; add dismiss-button banner test",
+      "files": [
+        "src/features/spec-editor/installBanner.test.ts"
+      ]
+    }
+  }
+}

--- a/specs/353-install-banner-slim/checklists/requirements.md
+++ b/specs/353-install-banner-slim/checklists/requirements.md
@@ -1,0 +1,35 @@
+# Specification Quality Checklist: Slim, dismissible install banner
+
+**Purpose**: Validate Companion specification completeness before planning
+**Created**: 2026-06-18
+**Feature**: [Link to spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed (User Scenarios, Requirements, Success Criteria)
+
+## Requirement Completeness
+
+- [x] Any [NEEDS CLARIFICATION] markers are genuine ambiguities (≤3) deferred to clarify — not unresolved guesses
+- [x] Each Functional Requirement is a single, testable MUST/SHOULD statement
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into the specification
+
+## Notes
+
+- Items marked incomplete require spec updates before clarify or plan
+- No open clarifications; informed defaults recorded under Assumptions.

--- a/specs/353-install-banner-slim/contracts/ui-contract.md
+++ b/specs/353-install-banner-slim/contracts/ui-contract.md
@@ -1,0 +1,32 @@
+# UI Contract: Slim, dismissible install banner
+
+## DOM / markup contract (both surfaces)
+
+The banner keeps its existing identifiers so the shared CSS and click delegation continue to resolve:
+
+- Root: `<div class="install-banner" id="install-banner" role="region" aria-label="Install spec-kit extension">`
+- Glyph: `codicon codicon-rocket`, `aria-hidden="true"`
+- Install action: `button` with `data-action="installSpecKitExtension"`
+- Learn more action: `button`/link with `data-action="openReadme"`
+- **New** dismiss action: `button` with `data-action="dismissInstallBanner"` and `aria-label="Dismiss install prompt"`
+
+All three actions are reached through the existing delegated handler on `#install-banner [data-action]`.
+
+## Message contract (webview → extension)
+
+New message added to **both** unions (`src/features/spec-editor/types.ts`, `src/features/spec-viewer/types.ts`, and the webview-side `webview/src/spec-editor/types.ts`):
+
+```
+{ type: 'dismissInstallBanner' }
+```
+
+Handled by:
+- `specEditorProvider.handleMessage` — `case 'dismissInstallBanner'`
+- spec-viewer `messageHandlers` — `dismissInstallBanner` entry
+
+Handler effect: set `globalState[speckit.installBannerDismissed] = true`, then re-render the surface without the banner.
+
+## State contract
+
+- Global-state key: `speckit.installBannerDismissed` (boolean). Absent/`false` ⇒ may show; `true` ⇒ never show.
+- Visibility, per surface: `shouldShowInstallPrompt(enabled, installed) && !dismissed`.

--- a/specs/353-install-banner-slim/plan.md
+++ b/specs/353-install-banner-slim/plan.md
@@ -1,0 +1,52 @@
+# Implementation Plan: Slim, dismissible install banner
+
+**Feature**: `353-install-banner-slim` · **Issue**: #353
+
+## Summary
+
+Slim the install-prompt banner to a single compact row and make it permanently dismissible. The banner renders on two surfaces through two code paths: the Create-Spec view builds it server-side as an HTML string (`renderInstallBannerHtml` in `src/features/spec-editor/installBanner.ts`), and the spec-viewer Activity panel builds it as a Preact component (`InstallBanner` in `webview/src/spec-viewer/components/ActivityPanel.tsx`). Both share the same `install-banner` CSS and the same `data-action` click contract, so the markup change is mirrored across both. The dismiss decision is stored in the extension's `globalState` under a new key; each provider already computes the banner's visibility, so each gains an extra `&& !dismissed` term reading that flag, plus a new `dismissInstallBanner` webview→extension message that sets the flag and re-renders.
+
+## Project Structure
+
+```
+src/
+├── core/constants.ts                                    # add globalState.installBannerDismissed key
+├── features/spec-editor/
+│   ├── installBanner.ts                                 # slim markup + dismiss button (Create-Spec)
+│   ├── types.ts                                         # add dismissInstallBanner message type
+│   └── specEditorProvider.ts                            # gate on dismissed flag; handle dismiss msg
+├── features/spec-viewer/
+│   ├── types.ts                                         # add dismissInstallBanner message type
+│   ├── messageHandlers.ts                               # handle dismiss msg → set flag → refresh
+│   └── specViewerProvider.ts                            # gate computeShowInstallPrompt on dismissed
+webview/
+├── src/spec-editor/
+│   ├── index.ts                                         # post dismiss msg on × click
+│   └── types.ts                                         # add dismissInstallBanner message type
+├── src/spec-viewer/
+│   ├── components/ActivityPanel.tsx                     # slim Preact banner + dismiss button
+│   ├── components/ActivityPanel.stories.tsx             # cover slim + dismissed states
+│   └── html/generator.ts                                # delegate × click → post dismiss msg
+└── styles/spec-viewer/_install-banner.css               # restyle to single compact row + × button
+CHANGELOG.md                                             # user-facing entry
+```
+
+**Structure Decision**: No new files. The change threads a single `dismissed` boolean from `globalState` (read in each provider) through the existing visibility gate, and adds one new message type across the existing spec-editor and spec-viewer message unions. Banner markup is edited in the two existing renderers; CSS is restyled in place.
+
+## Constitution Check
+
+No `.specify/memory/constitution.md` is present in this project, so there is no formal constitution gate. The change is held to the repo conventions in `CLAUDE.md` and `.claude/review-checklist.md` instead:
+
+| Principle | Assessment |
+|-----------|------------|
+| Webview invariants (aria-label, `e.target instanceof Element` guard, design tokens) | PASS — dismiss button gets `aria-label`; both click delegations guard `e.target`; colors via VS Code theme tokens |
+| Extension isolation (no `.claude/**` / `.specify/**` edits) | PASS — all behavior lives in `src/` and `webview/` |
+| globalState (not workspaceState) for cross-workspace persistence | PASS — flag stored in `context.globalState` |
+| Stories stay in sync | PASS — `ActivityPanel.stories.tsx` updated for slim + dismissed |
+| No version bump in feature PR | PASS — `package.json` untouched |
+
+## Key Decisions
+
+- **Decision**: Store one global boolean `speckit.installBannerDismissed`. **Rationale**: Issue requires "stays dismissed everywhere," which is exactly `globalState` (machine-wide) vs `workspaceState` (per-folder). A single boolean is the smallest sufficient state; no per-surface or per-version dismissal is in scope. **Alternatives**: per-workspace dismissal (rejected — issue explicitly wants global); a settings.json entry (rejected — this is a transient UI choice, not user configuration, and globalState is the established pattern for `initSuggestionDismissed`).
+- **Decision**: Add the dismissed term to each provider's existing visibility computation rather than to the shared pure `shouldShowInstallPrompt`. **Rationale**: `shouldShowInstallPrompt(enabled, installed)` is unit-tested and stays a pure two-input predicate; the dismissed flag is I/O (a `globalState` read) that belongs in the provider, consistent with how `installed` is already read there. **Alternatives**: widen `shouldShowInstallPrompt` to three args (rejected — pushes I/O into the pure helper and rewrites its tests for no gain).
+- **Decision**: Reuse the existing `data-action` click-delegation contract; add `data-action="dismissInstallBanner"` to the × button. **Rationale**: Both surfaces already delegate clicks on `#install-banner [data-action]`; the dismiss button slots into that exact path. Both delegation handlers already guard `e.target instanceof Element` (spec-editor `index.ts`) / use `.closest()` after a guard — verify and keep the guard. **Alternatives**: a dedicated `id`-based listener (rejected — duplicates the working delegation).

--- a/specs/353-install-banner-slim/research.md
+++ b/specs/353-install-banner-slim/research.md
@@ -1,0 +1,31 @@
+# Research: Slim, dismissible install banner (#353)
+
+## Decision 1 — persistence: `globalState`, key `speckit.installBannerDismissed`
+
+- **Decision**: Store a single boolean in `context.globalState` under a new key added to `ConfigKeys.globalState` in `src/core/constants.ts` (e.g. `installBannerDismissed: 'speckit.installBannerDismissed'`).
+- **Rationale**: The issue requires the dismissal to "stay dismissed everywhere." `globalState` is machine-wide; `workspaceState` is per-folder. The repo already uses `globalState` for an equivalent one-time-dismiss affordance (`initSuggestionDismissed`, read in `extension.ts`), so this matches the established pattern.
+- **Alternatives**: `workspaceState` (rejected — per-workspace, the opposite of the requirement); a `settings.json` config entry (rejected — a transient UI dismissal is not user configuration).
+
+## Decision 2 — visibility gate lives in the providers, not the pure helper
+
+- **Decision**: Keep `shouldShowInstallPrompt(enabled, installed)` a pure two-arg predicate. Add the `&& !dismissed` term where each provider already computes visibility: `specEditorProvider` (the `renderInstallBannerHtml(...)` call site) and `specViewerProvider.computeShowInstallPrompt()`.
+- **Rationale**: `installed` is already read from disk in the provider, and `dismissed` is the same kind of I/O (a `globalState` read). Both providers hold `this.context`, so the read is local. Leaving the pure helper untouched preserves its unit tests.
+- **Alternatives**: Widen `shouldShowInstallPrompt` to a third `dismissed` arg (rejected — moves I/O concerns into the pure helper and forces a test rewrite for no benefit).
+
+## Decision 3 — dismiss wiring reuses the existing `data-action` delegation
+
+- **Decision**: Render the × button with `data-action="dismissInstallBanner"` and `aria-label="Dismiss install prompt"`. Both surfaces already delegate clicks on `#install-banner [data-action]` and both already guard `e.target instanceof Element` before `.closest()` (verified: `webview/src/spec-editor/index.ts` and the inline script in `src/features/spec-viewer/html/generator.ts`). Add a `dismissInstallBanner` branch to each that posts `{ type: 'dismissInstallBanner' }`.
+- **Rationale**: The dismiss action is one more `data-action`; it slots into the working delegation without a new listener. The instanceof guard is already in place, satisfying the webview invariant.
+- **Alternatives**: A dedicated id-bound listener (rejected — duplicates the existing delegation and risks the not-yet-mounted-banner pitfall the viewer comment already documents).
+
+## Decision 4 — extension-side handlers set the flag, then re-render
+
+- **Decision**: Add a `dismissInstallBanner` case to `specEditorProvider.handleMessage` and to the spec-viewer `messageHandlers` map. Each sets `context.globalState.update(ConfigKeys.globalState.installBannerDismissed, true)` then re-renders its surface (Create-Spec re-runs `handleReady`/refresh; the viewer refreshes the active panel so `computeShowInstallPrompt()` now returns false and the Preact banner unmounts).
+- **Rationale**: Re-rendering after the write is what makes the banner vanish without a manual reload, satisfying FR-002 and FR-008. The viewer already has a refresh path that recomputes `showInstallPrompt` and posts a fresh `navState`.
+- **Alternatives**: Optimistic client-side hide only (rejected — would not persist and would re-appear on the next render).
+
+## Decision 5 — CSS: single compact row + dismiss button
+
+- **Decision**: Restyle `.install-banner` to a single-row flex layout (glyph + one line of text + Install + Learn more + ×) and add a `.install-banner__dismiss` button styled with theme tokens (`--vscode-foreground`, transparent background, hover state). Drop the `flex-wrap`/multi-line text block; collapse the heading+paragraph into one short line.
+- **Rationale**: "Smaller footprint" → one row. The existing tokens already drive the banner; the dismiss button reuses them for theme-correctness.
+- **Alternatives**: A collapse-to-one-liner-after-first-view (mentioned as optional in the issue; rejected for scope — permanent dismissal already removes the friction).

--- a/specs/353-install-banner-slim/spec.md
+++ b/specs/353-install-banner-slim/spec.md
@@ -1,0 +1,94 @@
+# Feature Specification: Slim, dismissible install banner
+
+**Feature**: `353-install-banner-slim`
+**Issue**: #353 — make the "install spec-kit extension" banner less invasive
+
+## Summary
+
+The prompt that nudges a user to install the companion spec-kit extension currently shows up as a large bordered card — a rocket icon, a heading, two lines of body text, and two buttons stacked together. It sits at the top of both the Create-Spec view and the spec-viewer Activity panel, on every visit, with no way to make it go away. Once a user has decided (installed the extension, or chosen to skip it), that big card is pure friction. This feature slims the banner down to a single compact line and gives it a dismiss control that remembers the choice everywhere.
+
+## User Scenarios & Testing
+
+### User Story 1 - Dismiss the banner for good (Priority: P1)
+
+A developer who has seen the install prompt and doesn't want it anymore clicks a small "×" on the banner. The banner disappears immediately, and it stays gone — on this project and every other project they open — even after reloading the window or reopening the editor.
+
+**Why this priority**: This is the core of the issue. The banner being permanently dismissible is what removes the recurring friction; without it the change has no value.
+
+**Independent Test**: Open Create Spec (or the Activity panel) in a project where the spec-kit extension is not installed. Confirm the banner shows. Click the "×". Confirm it disappears, reload the window, and confirm it does not come back. Open a *different* project and confirm it is also absent there.
+
+**Acceptance Scenarios**:
+1. **Given** the spec-kit extension is absent and the banner has never been dismissed, **When** the user opens Create Spec, **Then** the slim banner is shown.
+2. **Given** the slim banner is shown, **When** the user clicks the dismiss control, **Then** the banner is hidden without a reload.
+3. **Given** the user dismissed the banner, **When** they reload the window or open any other workspace, **Then** the banner does not reappear.
+4. **Given** the user dismissed the banner, **When** they open the spec-viewer Activity panel, **Then** the banner is also absent there (one dismissal covers both surfaces).
+
+### User Story 2 - A lighter, single-row banner (Priority: P1)
+
+A developer opening Create Spec or the Activity panel sees a compact one-line hint instead of a tall bordered card: a small glyph, one short sentence, an Install action, and a "Learn more" link, all on one row. It takes far less vertical space above the thing they actually came to do.
+
+**Why this priority**: "Smaller footprint" is the other half of the requirement. Even before dismissal, the banner should stop dominating the panel.
+
+**Independent Test**: Open Create Spec with the extension absent and the banner not dismissed; confirm the banner is a single compact row (glyph + one line + Install + Learn more + dismiss), not the old icon/heading/paragraph/two-button stack.
+
+**Acceptance Scenarios**:
+1. **Given** the banner is shown, **Then** it presents as a single compact row with a glyph, one short line of text, an Install action, a Learn more link, and a dismiss control.
+2. **Given** the banner is shown, **When** the user clicks Install, **Then** the existing install flow runs (unchanged).
+3. **Given** the banner is shown, **When** the user clicks Learn more, **Then** the README opens (unchanged).
+
+### User Story 3 - Same behavior on both surfaces (Priority: P2)
+
+The Create-Spec view and the Activity panel show the same slim banner and honor the same dismissal. A change to the look or the gating applies to both surfaces without divergence.
+
+**Why this priority**: The two surfaces render the banner through different code paths (server-rendered HTML vs. a Preact component). Keeping them consistent is required, but it is a correctness property of stories 1 and 2 rather than a separate user-facing feature.
+
+**Independent Test**: Eyeball both surfaces back to back; confirm identical slim look and that dismissal on one hides it on the other.
+
+**Acceptance Scenarios**:
+1. **Given** the extension is absent, **Then** both the Create-Spec banner and the Activity-panel banner render in the same slim form.
+2. **Given** the banner is dismissed on either surface, **Then** both surfaces hide it.
+
+## Edge Cases
+
+- The extension is already installed → the banner never shows, regardless of the dismiss flag (the existing absence gate still wins first).
+- The dismiss flag has never been set → treated as not-dismissed (banner shows when the extension is absent).
+- The user dismisses, then later installs and uninstalls the extension → the banner stays dismissed (a permanent user choice; re-surfacing on a new reason is explicitly out of scope for this change).
+- A click lands on the row but not on the dismiss control → only the matching action runs; a click on empty banner area does nothing.
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: The install banner MUST render as a single compact row containing a glyph, one short line of text, an Install action, a Learn more link, and a dismiss control — not the prior icon/heading/paragraph/two-button stack.
+- **FR-002**: The banner MUST include a dismiss control that hides the banner immediately when activated.
+- **FR-003**: Dismissing the banner MUST persist the choice in the extension's global state (not workspace state), so it stays dismissed across all workspaces and across reloads.
+- **FR-004**: The banner MUST be shown only when the spec-kit extension is absent AND the banner has not been dismissed. The existing absence gate continues to take precedence.
+- **FR-005**: Both the Create-Spec view and the spec-viewer Activity panel MUST honor the same slim look and the same dismissal state.
+- **FR-006**: The Install and Learn more actions MUST continue to behave exactly as before (run the install flow / open the README).
+- **FR-007**: The dismiss control MUST carry an accessible label so assistive technology announces its purpose.
+- **FR-008**: The webview MUST send a dismiss message to the extension when the dismiss control is activated; the extension MUST set the global-state flag and re-render the affected surface without the banner.
+
+### Key Entities
+
+- **Install-banner dismissed flag** — a single boolean stored in the extension's global state. Absent/false means "show when the extension is missing"; true means "never show again."
+
+## Success Criteria
+
+### Measurable Outcomes
+
+- **SC-001**: When the extension is absent and the banner is not dismissed, the banner occupies a single row rather than the multi-line card (vertical footprint visibly reduced).
+- **SC-002**: After a user dismisses the banner once, it does not reappear in 100% of subsequent opens — across reloads and across different workspaces.
+- **SC-003**: When the extension is installed, the banner shows 0% of the time, unchanged from today.
+- **SC-004**: The Install and Learn more actions succeed at the same rate as before the change (no regression in the install / README flows).
+
+## Assumptions
+
+- A dismissal is permanent. Re-surfacing the banner when "a new reason appears" (mentioned as optional in the issue) is out of scope for this change.
+- The dismiss flag is a single global boolean; no per-surface or per-version dismissal is needed.
+- The banner remains static markup with no user-supplied data, so the existing escaping approach is sufficient.
+
+## Verbatim Constraints
+
+- Global-state key suffix: `installBannerDismissed` (added alongside the existing `speckit.globalState.*` keys).
+- The dismiss control is rendered with an `aria-label`.
+- The banner must NOT be modified under `speckit-extension/`; the `package.json` version must NOT be bumped.

--- a/specs/353-install-banner-slim/tasks.md
+++ b/specs/353-install-banner-slim/tasks.md
@@ -1,0 +1,74 @@
+# Tasks: Slim, dismissible install banner
+
+**Feature**: `353-install-banner-slim` · **Issue**: #353
+
+Line format: `- [ ] **T###** [P?] [US#] Description · file`. `[P]` = independent within its wave.
+
+## Phase 1: Setup
+
+_No setup tasks — this change extends existing modules; no new tooling or structure._
+
+## Phase 2: Foundational (blocks all stories)
+
+Shared state key and message types every surface depends on.
+
+**Wave 1 — independent (different files):**
+
+- [x] **T001** [P] [US1] Add `installBannerDismissed: 'speckit.installBannerDismissed'` to `ConfigKeys.globalState` · src/core/constants.ts
+- [x] **T002** [P] [US1] Add `{ type: 'dismissInstallBanner' }` to the spec-editor webview→extension message union · src/features/spec-editor/types.ts
+- [x] **T003** [P] [US1] Add `{ type: 'dismissInstallBanner' }` to the webview-side spec-editor message union · webview/src/spec-editor/types.ts
+- [x] **T004** [P] [US1] Add `{ type: 'dismissInstallBanner' }` to the spec-viewer message union · src/features/spec-viewer/types.ts
+
+**⟶ Wait for Wave 1, then proceed to the story phases.**
+
+## Phase 3: User Story 1 — Dismiss the banner for good (P1)
+
+**Goal**: Clicking × hides the banner and persists the choice in globalState; the banner stays gone across reloads and workspaces.
+
+**Independent Test**: Banner shows (extension absent); click ×; it disappears; reload + open another workspace; still absent.
+
+### Implementation
+
+**Wave 1 — extension-side gate + handlers (different files):**
+
+- [x] **T005** [P] [US1] In `renderInstallBannerHtml`, gate the Create-Spec banner on `!dismissed` (read `globalState[installBannerDismissed]` at the call site) and add a `case 'dismissInstallBanner'` to `handleMessage` that sets the flag and re-renders · src/features/spec-editor/specEditorProvider.ts
+- [x] **T006** [P] [US1] Gate `computeShowInstallPrompt()` on `!dismissed` (read the globalState flag via `this.context`) · src/features/spec-viewer/specViewerProvider.ts
+- [x] **T007** [P] [US1] Add a `dismissInstallBanner` entry to the spec-viewer `messageHandlers` map that sets the globalState flag and refreshes the panel · src/features/spec-viewer/messageHandlers.ts
+
+**⟶ Wait for Wave 1, then wire the webview click delegation:**
+
+**Wave 2 — webview click → dismiss message (different files):**
+
+- [x] **T008** [P] [US1] Add a `dismissInstallBanner` branch to the Create-Spec banner click delegation (already guards `e.target instanceof Element`) · webview/src/spec-editor/index.ts
+- [x] **T009** [P] [US1] Add a `dismissInstallBanner` branch to the spec-viewer document-delegated banner click handler · src/features/spec-viewer/html/generator.ts
+
+**Checkpoint**: Dismissing on either surface persists to globalState and removes the banner everywhere after re-render. US1 is independently functional.
+
+## Phase 4: User Story 2 — A lighter, single-row banner (P1)
+
+**Goal**: The banner renders as one compact row (glyph + line + Install + Learn more + ×) on both surfaces.
+
+**Independent Test**: Open Create Spec / Activity panel with the extension absent and not dismissed; confirm the slim single-row layout with a × control.
+
+### Implementation
+
+**Wave 1 — markup + styles (different files):**
+
+- [x] **T010** [P] [US2] Slim the server-rendered banner markup to a single row and add the × button (`data-action="dismissInstallBanner"`, `aria-label="Dismiss install prompt"`) · src/features/spec-editor/installBanner.ts
+- [x] **T011** [P] [US2] Slim the Preact `InstallBanner` markup to match (single row + × button with the same `data-action`/`aria-label`) · webview/src/spec-viewer/components/ActivityPanel.tsx
+- [x] **T012** [P] [US2] Restyle `.install-banner` to a single compact row and add `.install-banner__dismiss` using VS Code theme tokens · webview/styles/spec-viewer/_install-banner.css
+
+**Checkpoint**: Both surfaces present the slim one-row banner with a working ×. US2 is independently testable.
+
+## Phase 5: Polish
+
+- [x] **T013** [US2] Update `ActivityPanel.stories.tsx` to cover the slim banner state and the dismissed (hidden) state · webview/src/spec-viewer/components/ActivityPanel.stories.tsx
+- [x] **T014** [US1] Add a user-facing CHANGELOG entry for the slim, dismissible banner · CHANGELOG.md
+- [x] **T015** [US1] `npm run compile && npm test` — fix any failures; webview bundle builds clean · (validation)
+
+## Dependencies & Execution Order
+
+- **Phase 2 (Foundational)** blocks everything: the globalState key (T001) and the three message-type additions (T002–T004) are read/handled by the story phases. Its Wave 1 is fully parallel (four different files).
+- **Phase 3 (US1)** depends on Phase 2. Wave 1 (extension gate + handlers, T005–T007) precedes Wave 2 (webview click wiring, T008–T009), since the click messages need the handlers to exist.
+- **Phase 4 (US2)** markup/CSS (T010–T012) is parallel and depends only on the × `data-action` contract from Phase 3; can follow Phase 3.
+- **Phase 5 (Polish)** runs last: stories (T013) after the markup settles, CHANGELOG (T014) any time, validation (T015) last.

--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -79,6 +79,7 @@ export const ConfigKeys = {
         skipVersion: 'speckit.skipVersion',
         lastUpdateCheck: 'speckit.lastUpdateCheck',
         initSuggestionDismissed: 'speckit.initSuggestionDismissed',
+        installBannerDismissed: 'speckit.installBannerDismissed',
     },
     workspaceState: {
         specsFilterQuery: 'speckit.specs.filter.query',

--- a/src/features/spec-editor/installBanner.test.ts
+++ b/src/features/spec-editor/installBanner.test.ts
@@ -9,6 +9,12 @@ describe('renderInstallBannerHtml — gated banner visibility', () => {
         expect(html).toContain('data-action="openReadme"');
     });
 
+    it('renders a dismiss control with an accessible label when visible', () => {
+        const html = renderInstallBannerHtml(true);
+        expect(html).toContain('data-action="dismissInstallBanner"');
+        expect(html).toContain('aria-label="Dismiss install prompt"');
+    });
+
     it('renders nothing when not visible — no banner for installed projects', () => {
         expect(renderInstallBannerHtml(false)).toBe('');
     });

--- a/src/features/spec-editor/installBanner.ts
+++ b/src/features/spec-editor/installBanner.ts
@@ -13,9 +13,9 @@
 const BANNER_BODY = `
     <span class="install-banner__icon codicon codicon-rocket" aria-hidden="true"></span>
     <span class="install-banner__text">Install the spec-kit extension for the leaner <code>/speckit.companion.*</code> pipeline and capture.</span>
-    <button class="install-banner__btn install-banner__btn--primary" data-action="installSpecKitExtension">Install</button>
-    <button class="install-banner__btn install-banner__btn--link" data-action="openReadme">Learn more</button>
-    <button class="install-banner__dismiss codicon codicon-close" data-action="dismissInstallBanner" aria-label="Dismiss install prompt"></button>`;
+    <button type="button" class="install-banner__btn install-banner__btn--primary" data-action="installSpecKitExtension">Install</button>
+    <button type="button" class="install-banner__btn install-banner__btn--link" data-action="openReadme">Learn more</button>
+    <button type="button" class="install-banner__dismiss codicon codicon-close" data-action="dismissInstallBanner" aria-label="Dismiss install prompt"></button>`;
 
 /**
  * Render the install banner, or an empty string when it must not appear. Pass the

--- a/src/features/spec-editor/installBanner.ts
+++ b/src/features/spec-editor/installBanner.ts
@@ -5,20 +5,17 @@
  * HTML string injected into the body — the smallest, most testable surface (the
  * visibility decision is the unit-tested `shouldShowInstallPrompt`; this is just the
  * markup). The buttons carry `data-action` attributes; each webview's script posts the
- * matching message to the extension, which runs the install / opens the README.
+ * matching message to the extension, which runs the install, opens the README, or
+ * dismisses the banner for good (a global-state flag re-checked before rendering).
  */
 
-/** Banner copy + the two action buttons (install inline, README fallback link). */
+/** Slim single-row banner: glyph + one line + Install + Learn more + dismiss. */
 const BANNER_BODY = `
-    <div class="install-banner__icon"><span class="codicon codicon-rocket" aria-hidden="true"></span></div>
-    <div class="install-banner__text">
-        <strong title="Install the spec-kit extension to unlock Turbo &amp; Capture">Install the spec-kit extension to unlock Turbo &amp; Capture</strong>
-        <span>The companion spec-kit extension adds the leaner <code>/speckit.companion.*</code> pipeline and lifecycle capture. It's a one-click install — no need to leave the editor.</span>
-    </div>
-    <div class="install-banner__actions">
-        <button class="install-banner__btn install-banner__btn--primary" data-action="installSpecKitExtension">Install spec-kit extension</button>
-        <button class="install-banner__btn install-banner__btn--link" data-action="openReadme">Learn more</button>
-    </div>`;
+    <span class="install-banner__icon codicon codicon-rocket" aria-hidden="true"></span>
+    <span class="install-banner__text">Install the spec-kit extension for the leaner <code>/speckit.companion.*</code> pipeline and capture.</span>
+    <button class="install-banner__btn install-banner__btn--primary" data-action="installSpecKitExtension">Install</button>
+    <button class="install-banner__btn install-banner__btn--link" data-action="openReadme">Learn more</button>
+    <button class="install-banner__dismiss codicon codicon-close" data-action="dismissInstallBanner" aria-label="Dismiss install prompt"></button>`;
 
 /**
  * Render the install banner, or an empty string when it must not appear. Pass the

--- a/src/features/spec-editor/specEditorProvider.ts
+++ b/src/features/spec-editor/specEditorProvider.ts
@@ -261,6 +261,10 @@ export class SpecEditorProvider {
             case 'openReadme':
                 void vscode.commands.executeCommand('speckit.companion.openReadme');
                 break;
+
+            case 'dismissInstallBanner':
+                void this.context.globalState.update(ConfigKeys.globalState.installBannerDismissed, true);
+                break;
         }
     }
 
@@ -538,7 +542,12 @@ export class SpecEditorProvider {
         // extension is missing — installed projects see nothing (zero-regression).
         // Visibility is the unit-tested gate; the markup is shared with the Activity panel.
         const workspaceRoot = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+        const bannerDismissed = this.context.globalState.get<boolean>(
+            ConfigKeys.globalState.installBannerDismissed,
+            false
+        );
         const installBanner = renderInstallBannerHtml(
+            !bannerDismissed &&
             shouldShowInstallPrompt(
                 readInstallPromptEnabled(),
                 workspaceRoot ? isCompanionInstalled(workspaceRoot) : false

--- a/src/features/spec-editor/specEditorProvider.ts
+++ b/src/features/spec-editor/specEditorProvider.ts
@@ -263,7 +263,7 @@ export class SpecEditorProvider {
                 break;
 
             case 'dismissInstallBanner':
-                void this.context.globalState.update(ConfigKeys.globalState.installBannerDismissed, true);
+                await this.context.globalState.update(ConfigKeys.globalState.installBannerDismissed, true);
                 break;
         }
     }

--- a/src/features/spec-editor/types.ts
+++ b/src/features/spec-editor/types.ts
@@ -184,7 +184,8 @@ export type SpecEditorToExtensionMessage =
     | { type: 'ready' }
     | { type: 'cancel' }
     | { type: 'installSpecKitExtension' }
-    | { type: 'openReadme' };
+    | { type: 'openReadme' }
+    | { type: 'dismissInstallBanner' };
 
 // ============================================
 // Message Types: Extension → Webview

--- a/src/features/spec-viewer/html/generator.ts
+++ b/src/features/spec-viewer/html/generator.ts
@@ -165,6 +165,8 @@ export function generateHtml(
                     vscode.postMessage({ type: 'installSpecKitExtension' });
                 } else if (action === 'openReadme') {
                     vscode.postMessage({ type: 'openReadme' });
+                } else if (action === 'dismissInstallBanner') {
+                    vscode.postMessage({ type: 'dismissInstallBanner' });
                 }
             });
         })();

--- a/src/features/spec-viewer/messageHandlers.ts
+++ b/src/features/spec-viewer/messageHandlers.ts
@@ -149,6 +149,10 @@ function buildHandlerMap(): DispatcherMap<ViewerToExtensionMessage, [string, Mes
     openReadme: async (_msg, _dir, _deps) => {
       await vscode.commands.executeCommand('speckit.companion.openReadme');
     },
+    dismissInstallBanner: async (_msg, dir, deps) => {
+      await deps.context.globalState.update(ConfigKeys.globalState.installBannerDismissed, true);
+      await handleRefresh(dir, deps);
+    },
   };
 }
 

--- a/src/features/spec-viewer/specViewerProvider.ts
+++ b/src/features/spec-viewer/specViewerProvider.ts
@@ -174,6 +174,9 @@ export class SpecViewerProvider {
    * projects return `false` — no banner, no regression.
    */
   private computeShowInstallPrompt(): boolean {
+    if (this.context.globalState.get<boolean>(ConfigKeys.globalState.installBannerDismissed, false)) {
+      return false;
+    }
     const root = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
     return shouldShowInstallPrompt(
       readInstallPromptEnabled(),

--- a/src/features/spec-viewer/types.ts
+++ b/src/features/spec-viewer/types.ts
@@ -414,6 +414,9 @@ export type ViewerToExtensionMessage =
       }
     | {
           type: 'openReadme';
+      }
+    | {
+          type: 'dismissInstallBanner';
       };
 
 // ============================================

--- a/webview/src/spec-editor/index.ts
+++ b/webview/src/spec-editor/index.ts
@@ -340,6 +340,9 @@ function setupEventListeners(): void {
                 vscode.postMessage({ type: 'installSpecKitExtension' });
             } else if (action === 'openReadme') {
                 vscode.postMessage({ type: 'openReadme' });
+            } else if (action === 'dismissInstallBanner') {
+                installBanner.remove();
+                vscode.postMessage({ type: 'dismissInstallBanner' });
             }
         });
     }

--- a/webview/src/spec-editor/types.ts
+++ b/webview/src/spec-editor/types.ts
@@ -26,7 +26,8 @@ export type SpecEditorToExtensionMessage =
     | { type: 'ready' }
     | { type: 'cancel' }
     | { type: 'installSpecKitExtension' }
-    | { type: 'openReadme' };
+    | { type: 'openReadme' }
+    | { type: 'dismissInstallBanner' };
 
 // ============================================
 // Message Types: Extension → Webview

--- a/webview/src/spec-viewer/components/ActivityPanel.stories.tsx
+++ b/webview/src/spec-viewer/components/ActivityPanel.stories.tsx
@@ -12,8 +12,8 @@
 import type { Meta, StoryObj } from '@storybook/preact';
 import { ActivityPanel } from './ActivityPanel';
 import { ActivityErrorBoundary } from './ActivityErrorBoundary';
-import { viewerState } from '../signals';
-import type { ViewerState, TaskSummary, Transition } from '../types';
+import { viewerState, navState } from '../signals';
+import type { ViewerState, TaskSummary, Transition, NavState } from '../types';
 import legacyFixture from '../../../../specs/095-fix-tasks-card-concerns/fixtures/legacy-string-concerns.spec-context.json';
 
 const meta: Meta<typeof ActivityPanel> = {
@@ -44,6 +44,16 @@ const baseState = (overrides: Partial<ViewerState>): ViewerState => ({
     footer: [],
     transitions: [],
     stepHistory: {},
+    ...overrides,
+});
+
+const baseNav = (overrides: Partial<NavState>): NavState => ({
+    coreDocs: [],
+    relatedDocs: [],
+    currentDoc: 'spec',
+    workflowPhase: 'implement',
+    taskCompletionPercent: 0,
+    isViewingRelatedDoc: false,
     ...overrides,
 });
 
@@ -186,4 +196,31 @@ export const ErrorBoundaryFallback: Story = {
             <ThrowingBomb />
         </ActivityErrorBoundary>
     ),
+};
+
+// ── 6. Install banner — slim, shown ────────────────────────────
+// The extension is absent and the banner hasn't been dismissed, so
+// the slim single-row banner (glyph + one line + Install + Learn
+// more + dismiss ×) renders above the activity cards.
+
+export const InstallBannerSlim: Story = {
+    name: 'Install banner — slim, shown',
+    render: () => {
+        navState.value = baseNav({ showInstallPrompt: true });
+        viewerState.value = baseState({ status: 'draft', activeStep: 'specify' });
+        return <ActivityPanel />;
+    },
+};
+
+// ── 7. Install banner — dismissed (hidden) ─────────────────────
+// The user dismissed the banner, so `showInstallPrompt` is false and
+// the banner is absent — only the empty activity state shows.
+
+export const InstallBannerDismissed: Story = {
+    name: 'Install banner — dismissed (hidden)',
+    render: () => {
+        navState.value = baseNav({ showInstallPrompt: false });
+        viewerState.value = baseState({ status: 'draft', activeStep: 'specify' });
+        return <ActivityPanel />;
+    },
 };

--- a/webview/src/spec-viewer/components/ActivityPanel.tsx
+++ b/webview/src/spec-viewer/components/ActivityPanel.tsx
@@ -22,9 +22,9 @@ function InstallBanner() {
         <div class="install-banner" id="install-banner" role="region" aria-label="Install spec-kit extension">
             <span class="install-banner__icon codicon codicon-rocket" aria-hidden="true" />
             <span class="install-banner__text">Install the spec-kit extension for the leaner <code>/speckit.companion.*</code> pipeline and capture.</span>
-            <button class="install-banner__btn install-banner__btn--primary" data-action="installSpecKitExtension">Install</button>
-            <button class="install-banner__btn install-banner__btn--link" data-action="openReadme">Learn more</button>
-            <button class="install-banner__dismiss codicon codicon-close" data-action="dismissInstallBanner" aria-label="Dismiss install prompt" />
+            <button type="button" class="install-banner__btn install-banner__btn--primary" data-action="installSpecKitExtension">Install</button>
+            <button type="button" class="install-banner__btn install-banner__btn--link" data-action="openReadme">Learn more</button>
+            <button type="button" class="install-banner__dismiss codicon codicon-close" data-action="dismissInstallBanner" aria-label="Dismiss install prompt" />
         </div>
     );
 }

--- a/webview/src/spec-viewer/components/ActivityPanel.tsx
+++ b/webview/src/spec-viewer/components/ActivityPanel.tsx
@@ -20,15 +20,11 @@ function InstallBanner() {
     if (!navState.value?.showInstallPrompt) return null;
     return (
         <div class="install-banner" id="install-banner" role="region" aria-label="Install spec-kit extension">
-            <div class="install-banner__icon"><span class="codicon codicon-rocket" aria-hidden="true" /></div>
-            <div class="install-banner__text">
-                <strong>Install the spec-kit extension to unlock Turbo & Capture</strong>
-                <span>The companion spec-kit extension adds the leaner <code>/speckit.companion.*</code> pipeline and lifecycle capture. It's a one-click install — no need to leave the editor.</span>
-            </div>
-            <div class="install-banner__actions">
-                <button class="install-banner__btn install-banner__btn--primary" data-action="installSpecKitExtension">Install spec-kit extension</button>
-                <button class="install-banner__btn install-banner__btn--link" data-action="openReadme">Learn more</button>
-            </div>
+            <span class="install-banner__icon codicon codicon-rocket" aria-hidden="true" />
+            <span class="install-banner__text">Install the spec-kit extension for the leaner <code>/speckit.companion.*</code> pipeline and capture.</span>
+            <button class="install-banner__btn install-banner__btn--primary" data-action="installSpecKitExtension">Install</button>
+            <button class="install-banner__btn install-banner__btn--link" data-action="openReadme">Learn more</button>
+            <button class="install-banner__dismiss codicon codicon-close" data-action="dismissInstallBanner" aria-label="Dismiss install prompt" />
         </div>
     );
 }

--- a/webview/styles/spec-viewer/_install-banner.css
+++ b/webview/styles/spec-viewer/_install-banner.css
@@ -5,44 +5,29 @@
  */
 
 .install-banner {
-    container-type: inline-size;
     display: flex;
-    align-items: flex-start;
-    flex-wrap: wrap;
-    gap: 12px;
-    padding: 12px 14px;
-    margin: 0 0 12px 0;
+    align-items: center;
+    gap: 8px;
+    padding: 6px 10px;
+    margin: 0 0 10px 0;
     border: 1px solid var(--vscode-inputValidation-infoBorder, #3794ff);
     border-radius: 6px;
     background: var(--vscode-inputValidation-infoBackground, rgba(55, 148, 255, 0.1));
     color: var(--vscode-foreground);
+    font-size: 12px;
 }
 
 .install-banner__icon {
-    font-size: 18px;
-    line-height: 1.4;
+    font-size: 14px;
     flex: 0 0 auto;
 }
 
 .install-banner__text {
-    display: flex;
-    flex-direction: column;
-    gap: 4px;
     flex: 1 1 auto;
     min-width: 0;
-}
-
-.install-banner__text strong {
-    font-size: 13px;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
-    min-width: 0;
-}
-
-.install-banner__text span {
-    font-size: 12px;
-    opacity: 0.9;
 }
 
 .install-banner__text code {
@@ -50,19 +35,12 @@
     font-size: 11px;
 }
 
-.install-banner__actions {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    flex: 0 0 auto;
-    flex-wrap: wrap;
-}
-
 .install-banner__btn {
+    flex: 0 0 auto;
     font-size: 12px;
     border: none;
     border-radius: 4px;
-    padding: 6px 12px;
+    padding: 3px 10px;
     cursor: pointer;
 }
 
@@ -78,15 +56,30 @@
 .install-banner__btn--link {
     background: transparent;
     color: var(--vscode-textLink-foreground);
-    padding: 6px 4px;
+    padding: 3px 4px;
 }
 
 .install-banner__btn--link:hover {
     text-decoration: underline;
 }
 
-@container (max-width: 420px) {
-    .install-banner__actions {
-        flex: 1 0 100%;
-    }
+.install-banner__dismiss {
+    flex: 0 0 auto;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 22px;
+    height: 22px;
+    padding: 0;
+    border: none;
+    border-radius: 4px;
+    background: transparent;
+    color: var(--vscode-foreground);
+    opacity: 0.7;
+    cursor: pointer;
+}
+
+.install-banner__dismiss:hover {
+    opacity: 1;
+    background: var(--vscode-toolbar-hoverBackground, rgba(128, 128, 128, 0.2));
 }


### PR DESCRIPTION
## What this does

The prompt that nudges you to install the companion spec-kit extension used to be a big card that sat there on every visit to Create Spec and the Activity panel, with no way to make it go away. It's now a single slim row — a glyph, one short line, **Install**, **Learn more**, and a **×** to dismiss it. Dismissing it remembers your choice for good (machine-wide), so it never nags again. It still only appears when the extension is actually missing.

## How to verify (manual — UI)

In a project **without** the companion spec-kit extension (Companion Workflow beta on):
- **Create Spec** and the **Activity panel** both show the banner as one slim row.
- Click **×** → it disappears immediately; **reload the window** → still gone; **open another workspace** → also gone.
- Dismissing on one surface hides it on both.

Already exercised: `npm test` (1033 pass, incl. the banner markup test), `npm run compile` + web bundle. Storybook has new `ActivityPanel` stories for the slim + dismissed states.

## Under the hood

Closes #353.

- `renderInstallBannerHtml` (shared by Create-Spec + the Activity panel) slimmed to one row + a `×` dismiss control (icon-only `<button>` with `aria-label`).
- Dismissal persists in **`globalState`** (`speckit.installBannerDismissed`), gated into both providers' visibility checks; a `dismissInstallBanner` webview→extension message sets it. Both click paths guard `e.target instanceof Element` before `.closest()` (webview invariant).
- Stories, root `CHANGELOG.md`, and the README Create-Spec prose updated. VS Code extension change — root docs only, no version bump.

## 🖐️ Needs a human

The README Create-Spec **screenshot** (`docs/screenshots/install-banner.jpg`) still shows the OLD full card — it needs re-shooting against the new slim banner. **Overwrite the file in place** (don't rename/delete it — the Marketplace pins that URL).

🤖 Generated with [Claude Code](https://claude.com/claude-code)