### PR TITLE
build(speckit-ext): ship only runtime files in the install package

### DIFF
--- a/.claude/commands/publish-speckit-ext.md
+++ b/.claude/commands/publish-speckit-ext.md
@@ -29,13 +29,18 @@ Release the **spec-kit extension** (`speckit-extension/`, `id: companion`) so pe
    - **Every `provides.commands[].file` exists** AND every command markdown under `speckit-extension/commands/` is listed in `provides.commands`.
    - README is current (it's the catalog listing page).
 4. **Commit + push** to `main` (`chore(speckit-ext): release v<X.Y.Z>`).
-5. **Build the archive**:
+5. **Build the archive** — **allow-list, runtime files only**. Copy just what the installed extension runs (manifest, dispatched commands, the workflow, the three runtime scripts, license). Do NOT ship docs, CHANGELOG, ROADMAP, README, `examples/`, or the build-only `nodes/`+`presets/` sources — the catalog renders README/CHANGELOG from GitHub blob URLs, not the zip. (Don't "restore" a `tar --exclude` deny-list here: an allow-list is what keeps future doc/source additions out of the package.)
    ```bash
    V=<X.Y.Z>
-   rm -rf /tmp/cb && mkdir -p /tmp/cb/companion-$V
-   ( cd speckit-extension && tar cf - --exclude=tests --exclude=assets . ) | ( cd /tmp/cb/companion-$V && tar xf - )
+   rm -rf /tmp/cb && mkdir -p /tmp/cb/companion-$V/scripts
+   cd speckit-extension
+   cp extension.yml LICENSE /tmp/cb/companion-$V/
+   cp -R commands workflows /tmp/cb/companion-$V/
+   cp scripts/write-context.py scripts/status-context.py scripts/derive-from-files.py /tmp/cb/companion-$V/scripts/
+   cd - >/dev/null
    ( cd /tmp/cb && zip -rq companion-$V.zip companion-$V )
    ```
+   Runtime-script set: commands invoke `write-context.py` and `status-context.py`; `status-context.py` imports `derive-from-files.py`, which imports `write-context.py`. If a command ever starts calling a new script, add it here.
 6. **Cut the release** (prefixed tag, attach the version-named zip for archival):
    ```bash
    gh release create speckit-ext-v$V /tmp/cb/companion-$V.zip \

--- a/speckit-extension/docs/publishing.md
+++ b/speckit-extension/docs/publishing.md
@@ -17,13 +17,19 @@ v0.2.0                  ❌  matches v* → would publish the WRONG thing to the
 2. **Update** `speckit-extension/CHANGELOG.md` — new dated section; keep prior versions.
 3. **Verify** the pre-submit checklist below.
 4. **Commit** to `main` (e.g. `chore(speckit-ext): release v0.2.0`).
-5. **Build the archive** — a **`.zip`** (the installer rejects `.tar.gz` with `BadZipFile`) with a **single top-level dir** `companion-<X.Y.Z>/` holding `extension.yml` at its root. The repo source-archive does **not** work, because the extension lives in a subdir (`extension.yml` wouldn't be at the archive root):
+5. **Build the archive** — a **`.zip`** (the installer rejects `.tar.gz` with `BadZipFile`) with a **single top-level dir** `companion-<X.Y.Z>/` holding `extension.yml` at its root. The repo source-archive does **not** work, because the extension lives in a subdir (`extension.yml` wouldn't be at the archive root). The package is an **allow-list of runtime files only** — copy just what the installed extension runs, not the whole source tree:
    ```bash
    V=0.2.0
-   rm -rf /tmp/cb && mkdir -p /tmp/cb/companion-$V
-   ( cd speckit-extension && tar cf - --exclude=tests --exclude=assets . ) | ( cd /tmp/cb/companion-$V && tar xf - )
+   rm -rf /tmp/cb && mkdir -p /tmp/cb/companion-$V/scripts
+   cd speckit-extension
+   cp extension.yml LICENSE /tmp/cb/companion-$V/
+   cp -R commands workflows /tmp/cb/companion-$V/
+   cp scripts/write-context.py scripts/status-context.py scripts/derive-from-files.py /tmp/cb/companion-$V/scripts/
+   cd - >/dev/null
    ( cd /tmp/cb && zip -rq companion-$V.zip companion-$V )
    ```
+
+   **What ships (and what doesn't).** The package carries `extension.yml`, `LICENSE`, `commands/`, `workflows/`, and exactly three scripts: `write-context.py`, `status-context.py`, `derive-from-files.py` (the only ones reached at runtime — commands call the first two; `status-context.py` imports `derive-from-files.py`, which imports `write-context.py`). It deliberately **omits** README, CHANGELOG, ROADMAP, `docs/`, `examples/`, the build-only `nodes/`+`presets/` sources, the six build/test scripts, `tests/`, and `assets/`. The catalog page renders README/CHANGELOG from the GitHub blob URLs below — they're not needed inside the zip. Keep this an allow-list; don't swap it back to a `tar --exclude` deny-list, or new docs/sources will silently bloat the package again.
 6. **Create the GitHub release** with a **prefixed tag** (`speckit-ext-v0.2.0`) and attach the version-named zip (archival):
    ```bash
    gh release create speckit-ext-v$V /tmp/cb/companion-$V.zip --title "..." --notes-file <CHANGELOG [X.Y.Z]> --target main


### PR DESCRIPTION
## Summary
Installing the spec-kit extension on a machine used to dump a pile of files the running extension never touches — the changelog, roadmap, README, a whole docs folder, examples, and the build-only source trees. This change makes the install package carry only what the extension actually runs, shrinking the download from roughly 600K to about 72K. Nothing about how the extension behaves changes; there's just far less to copy onto each user's machine.

## Technical
- The archive was built with a **deny-list** — `tar --exclude=tests --exclude=assets .` zipped the entire `speckit-extension/` tree minus those two dirs, so every non-test/asset file shipped.
- Flipped both the build step in `.claude/commands/publish-speckit-ext.md` and its mirror in `speckit-extension/docs/publishing.md` to an **allow-list**: copy `extension.yml`, `LICENSE`, `commands/`, `workflows/`, and exactly the three runtime scripts (`write-context.py`, `status-context.py`, `derive-from-files.py`) into the staging dir, then zip.
- Runtime-script set was traced, not guessed: commands invoke `write-context.py` and `status-context.py`; `status-context.py` imports `derive-from-files.py`, which imports `write-context.py`. The other six scripts are build/test-only (`build-commands.py`, `assemble-nodes.py`, `_command_parts.py`, `capture-golden.py`, `check-shape-parity.py`, `companion_config.py`).
- `nodes/` and `presets/` are build-time sources for the committed `commands/*.md`; the CLI never reads them. README/CHANGELOG are rendered on the catalog page from GitHub blob URLs (`documentation:`/`changelog:`), not from the zip — so dropping them from the package doesn't affect the listing.

## Review checklist
- ✅ **SpecKit extension — release tooling** — affected
    - publish skill: `.claude/commands/publish-speckit-ext.md` build-archive step rewritten as allow-list
    - mirror doc: `speckit-extension/docs/publishing.md` build block + new "What ships" note
- — **VS Code extension** — not touched
- ⚠️ **Changelog** — no entry yet
    - leaner install is user-observable; the dated `speckit-extension/CHANGELOG.md` note lands at the next `/publish-speckit-ext` (where the version bumps), per the release flow
- ✅ **Docs**
    - `speckit-extension/docs/publishing.md` updated in this PR (it *is* the doc for this change)
    - README / `extension.yml` version — n/a (no runtime, command, or behavior change)
- ✅ **Verify**
    - dry-ran the new build: zip contains exactly `extension.yml`, `LICENSE`, `commands/` (13), `workflows/`, `scripts/` (3) — nothing else; 72K
    - smoke-tested the 3-script subset standalone: `status-context.py --help` resolves its `derive-from-files`→`write-context` imports, no ImportError
    - no version bump
- — **Demo fixtures** — not touched

## Gaps / how to see it
- Full `specify extension add … --from <https-url>` can only run at publish time (the installer requires HTTPS, rejects a local zip path) — the publish skill's step 8 already verifies the real install against the `companion-latest` URL.
- Try: `git checkout speckit-extension-install-package`, run the allow-list build block from `publishing.md` with `V=0.11.0`, then `unzip -l /tmp/cb/companion-0.11.0.zip` — confirm only the runtime set is present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
