### PR TITLE
fix(install-banner): show the install banner regardless of the Companion beta setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- **The "Install spec-kit extension" banner no longer hides behind the beta setting** (#369): the prompt that offers to install the companion spec-kit extension used to appear only after you'd turned on the SpecKit Companion Workflow beta — which meant the people most likely to want the extension never saw the nudge to get it. The banner now shows on its own merits: whenever the extension is missing and you haven't dismissed it or turned its setting off, no matter how the workflow toggle is set. Installing the extension, dismissing the banner, and turning off its `speckit.companion.installPrompt` setting all still hide it exactly as before.
+
 ## [0.25.0] - 2026-06-23
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -292,10 +292,10 @@ The opt-in beta toggles appear under **Beta Features** in VS Code Settings in ad
 | Order | Setting | Requires the spec-kit extension? |
 |-------|---------|----------------------------------|
 | 1 | `speckit.companion.speckitCompanionWorkflow` — turns on the whole **SpecKit Companion Workflow** (Create-Spec picker + Continue/Resume button) | Yes |
-| 2 | `speckit.companion.installPrompt` — install banner when the extension is missing; **only applies while the Companion workflow is on** | No (it surfaces the missing extension) |
+| 2 | `speckit.companion.installPrompt` — install banner when the extension is missing; shows independently of the Companion workflow toggle | No (it surfaces the missing extension) |
 | 3 | `speckit.viewer.activityPanel` — per-spec Activity timeline in the viewer | Yes |
 
-The Companion workflow is the master switch: with it off, the workflow picker, the Continue/Resume button, and the install banner all stay hidden — there's nothing to install when the workflow isn't in use. Each setting only functions once the [companion spec-kit extension](#install-the-spec-kit-extension) is installed; their descriptions carry that install link, so a toggle that looks inert is usually waiting on the extension. Each setting is detailed in the subsections below.
+The Companion workflow is the master switch for the workflow picker and the Continue/Resume button: with it off, both stay hidden. The install banner is the exception — it is decoupled from this toggle so that people who have not yet opted into beta still see the nudge to install the extension that powers the workflow. The banner shows whenever the extension is missing and you have not turned its own prompt off (or dismissed it), regardless of the workflow setting. Each setting is detailed in the subsections below.
 
 ### Workflow Choice
 
@@ -332,7 +332,7 @@ Companion specs run roughly 60 to 68% leaner, write zero throwaway side files at
 
 ### SpecKit Companion Workflow (picker + resume)
 
-A single **opt-in beta** that **defaults to `false`** and turns on the whole SpecKit Companion experience. In VS Code Settings it reads as **SpecKit Companion Workflow**. With it on, Create Spec offers the SpecKit / SpecKit Companion picker (when the companion extension is installed), the sidebar shows a resume (▶) button on active specs (active / tasks-done), and the install banner can appear when the extension is missing. With it off, all three disappear and you're on stock SpecKit only. Toggling it updates visibility immediately, with no window reload.
+A single **opt-in beta** that **defaults to `false`** and turns on the whole SpecKit Companion experience. In VS Code Settings it reads as **SpecKit Companion Workflow**. With it on, Create Spec offers the SpecKit / SpecKit Companion picker (when the companion extension is installed) and the sidebar shows a resume (▶) button on active specs (active / tasks-done). With it off, both disappear and you're on stock SpecKit only. Toggling it updates visibility immediately, with no window reload. The install banner is **not** gated by this toggle — it follows its own `speckit.companion.installPrompt` setting so the nudge to install the extension reaches users before they opt into beta.
 
 ```json
 {
@@ -342,8 +342,8 @@ A single **opt-in beta** that **defaults to `false`** and turns on the whole Spe
 
 | Value | Behavior |
 |-------|----------|
-| `false` (default) | No workflow picker; the resume (▶) button and the install banner are hidden on all specs. |
-| `true` | The picker appears (when the companion extension is installed), the resume (▶) button appears on eligible specs (active / tasks-done), and the install banner appears when the extension is missing. |
+| `false` (default) | No workflow picker; the resume (▶) button is hidden on all specs. The install banner still appears when the extension is missing (it follows its own setting, not this toggle). |
+| `true` | The picker appears (when the companion extension is installed) and the resume (▶) button appears on eligible specs (active / tasks-done). |
 
 This one setting replaces the former separate resume toggle, and was previously keyed `speckit.companion.workflowBeta` (labeled "Workflow Beta"). A prior `speckit.companion.resumeBeta` or `speckit.companion.workflowBeta` opt-in carries over to it automatically on upgrade.
 

--- a/package.json
+++ b/package.json
@@ -1050,7 +1050,7 @@
             "default": true,
             "scope": "window",
             "order": 6,
-            "markdownDescription": "Offer a one-click banner to install the companion spec-kit extension when it's missing. Only applies while the **SpecKit Companion Workflow** is on."
+            "markdownDescription": "Offer a one-click banner to install the companion spec-kit extension when it's missing. Independent of the **SpecKit Companion Workflow** toggle — the banner shows whenever the extension is missing and you haven't turned this off or dismissed it."
           },
           "speckit.viewer.activityPanel": {
             "type": "boolean",

--- a/specs/354-install-banner-beta-decouple/.spec-context.json
+++ b/specs/354-install-banner-beta-decouple/.spec-context.json
@@ -1,0 +1,143 @@
+{
+  "workflow": "speckit",
+  "specName": "install banner beta decouple",
+  "branch": "354-install-banner-beta-decouple",
+  "currentStep": "implement",
+  "status": "completed",
+  "history": [
+    {
+      "step": "specify",
+      "substep": null,
+      "kind": "start",
+      "by": "extension",
+      "at": "2026-06-25T15:50:31.989Z"
+    },
+    {
+      "step": "specify",
+      "substep": null,
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-06-25T15:51:25.792Z"
+    },
+    {
+      "step": "plan",
+      "substep": "fast-path",
+      "kind": "start",
+      "by": "ai",
+      "at": "2026-06-25T15:51:25.865Z"
+    },
+    {
+      "step": "plan",
+      "substep": "fast-path",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-25T15:51:25.945Z"
+    },
+    {
+      "step": "tasks",
+      "substep": "fast-path",
+      "kind": "start",
+      "by": "ai",
+      "at": "2026-06-25T15:51:26.024Z"
+    },
+    {
+      "step": "tasks",
+      "substep": "fast-path",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-25T15:51:26.101Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "kind": "start",
+      "by": "extension",
+      "at": "2026-06-25T15:51:38.545Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T001",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-25T15:53:40.684Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T002",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-25T15:53:40.739Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T003",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-25T15:53:40.790Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T004",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-25T15:53:40.844Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T005",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-25T15:54:40.681Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-06-25T15:54:40.762Z"
+    }
+  ],
+  "size": "simple",
+  "currentTask": "T005",
+  "task_summaries": {
+    "T001": {
+      "status": "DONE",
+      "did": "Removed isCompanionWorkflowEnabled short-circuit from readInstallPromptEnabled; updated JSDoc to describe beta-independent gating",
+      "files": [
+        "src/speckit/specKitExtensionInstall.ts"
+      ]
+    },
+    "T002": {
+      "status": "DONE",
+      "did": "Dropped now-unused isCompanionWorkflowEnabled import",
+      "files": [
+        "src/speckit/specKitExtensionInstall.ts"
+      ]
+    },
+    "T003": {
+      "status": "DONE",
+      "did": "Re-derived stale installPromptGate.spec.ts to the decoupled contract (beta off + prompt on -> true; prompt off -> false regardless of beta)",
+      "files": [
+        "tests/unit/core/installPromptGate.spec.ts"
+      ]
+    },
+    "T004": {
+      "status": "DONE",
+      "did": "Confirmed both render sites gate via shared helper (no change); corrected README, package.json description, and CHANGELOG for decoupled gating",
+      "files": [
+        "README.md",
+        "package.json",
+        "CHANGELOG.md"
+      ]
+    },
+    "T005": {
+      "status": "DONE",
+      "did": "npm run compile && npm test both green (1064 tests pass)"
+    }
+  }
+}

--- a/specs/354-install-banner-beta-decouple/checklists/requirements.md
+++ b/specs/354-install-banner-beta-decouple/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Decouple the install banner from the beta setting
+
+**Purpose**: Validate Companion specification completeness before planning
+**Created**: 2026-06-25
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed (User Scenarios, Requirements, Success Criteria)
+
+## Requirement Completeness
+
+- [x] Any [NEEDS CLARIFICATION] markers are genuine ambiguities (≤3) deferred to clarify — not unresolved guesses
+- [x] Each Functional Requirement is a single, testable MUST/SHOULD statement
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into the specification
+
+## Notes
+
+- Verbatim Constraints intentionally name identifiers (`readInstallPromptEnabled`, `speckit.companion.installPrompt`) because the user pinned them; that is the one allowed place for exact identifiers.

--- a/specs/354-install-banner-beta-decouple/plan.md
+++ b/specs/354-install-banner-beta-decouple/plan.md
@@ -1,0 +1,3 @@
+# Implementation Plan: Decouple the install banner from the beta setting
+
+> Fast-tracked (simple change). The implementation approach lives inline in the spec — see [`./spec.md#approach`](./spec.md#approach). The task checklist is in [`./tasks.md`](./tasks.md).

--- a/specs/354-install-banner-beta-decouple/spec.md
+++ b/specs/354-install-banner-beta-decouple/spec.md
@@ -1,0 +1,87 @@
+# Feature Specification: Decouple the install banner from the beta setting
+
+**Feature Branch**: `354-install-banner-beta-decouple`
+**Created**: 2026-06-25
+**Status**: Specified
+**Issue**: #369
+
+## Overview
+
+The banner that offers to install the SpecKit Companion spec-kit extension is currently hidden whenever the Companion workflow beta is turned off. That means the people most likely to benefit from discovering the extension — those who have not yet opted into beta — never see the nudge to install it. This change makes the banner show on its own merits: it appears when the extension is missing and the user has not turned the prompt off, no matter what the beta setting says.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - See the install prompt without opting into beta (Priority: P1)
+
+A developer who has the SpecKit Companion VS Code extension but has not turned on the Companion workflow beta opens a spec. Because the spec-kit extension is not installed, the install banner appears, inviting them to install it. They can act on the prompt regardless of the beta toggle.
+
+**Why this priority**: This is the entire point of the fix — the audience that most needs the discovery nudge is exactly the one currently denied it.
+
+**Independent Test**: With the beta setting off and the spec-kit extension not installed, open a spec in the editor or viewer and confirm the install banner renders.
+
+**Acceptance Scenarios**:
+
+1. **Given** the Companion workflow beta is off **and** the spec-kit extension is not installed **and** the install prompt has not been dismissed, **When** a spec is opened in the editor or viewer, **Then** the install banner is shown.
+2. **Given** the Companion workflow beta is on **and** the spec-kit extension is not installed, **When** a spec is opened, **Then** the install banner is shown (unchanged from before).
+
+### User Story 2 - Keep every existing way to suppress the banner (Priority: P1)
+
+A developer who has already installed the extension, dismissed the banner, or explicitly turned the install prompt off must not be bothered by the banner. Decoupling from beta must not weaken any of those existing guards.
+
+**Why this priority**: A discovery nudge that ignores the user's explicit "no" is worse than no nudge. These guards are the zero-regression contract.
+
+**Independent Test**: Toggle each suppressing condition (installed, dismissed, prompt off) and confirm the banner stays hidden in each, independent of the beta setting.
+
+**Acceptance Scenarios**:
+
+1. **Given** the spec-kit extension is installed, **When** a spec is opened, **Then** the banner is hidden (regardless of beta or prompt setting).
+2. **Given** the install prompt preference is explicitly `false`, **When** a spec is opened, **Then** the banner is hidden.
+3. **Given** the user dismissed the banner this session, **When** a spec is opened, **Then** the banner stays hidden.
+
+## Edge Cases
+
+- Beta off, extension installed → no banner (install guard wins over beta-decoupling).
+- Beta off, extension missing, prompt explicitly `false` → no banner (opt-out wins).
+- Legacy tri-state string still stored for the install-prompt preference → coerced to a boolean as before; decoupling does not change that coercion.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The install banner's visibility MUST NOT depend on whether the Companion workflow beta is enabled.
+- **FR-002**: The install banner MUST be shown when the extension is missing AND the install prompt preference is enabled (default `true`) AND the user has not dismissed it.
+- **FR-003**: The install banner MUST remain hidden when the extension is installed.
+- **FR-004**: The install banner MUST remain hidden when the install prompt preference is explicitly `false`.
+- **FR-005**: The install banner MUST remain hidden when the user has dismissed it for the session.
+- **FR-006**: Both render sites (the spec editor and the spec viewer) MUST reflect the decoupled behavior identically, since both resolve visibility through the same shared helper.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: With beta off and the extension missing and the prompt not dismissed, the banner renders in 100% of editor and viewer opens.
+- **SC-002**: All three suppression conditions (installed, dismissed, prompt `false`) keep the banner hidden in 100% of cases, independent of the beta setting.
+- **SC-003**: The test suite covers the "beta off + extension missing → banner shows" case and passes.
+
+## Assumptions
+
+- The render sites already resolve banner visibility through `readInstallPromptEnabled()` + `shouldShowInstallPrompt()`, so removing the beta short-circuit inside `readInstallPromptEnabled()` is sufficient and no call-site change is required.
+- The dismissal guard lives at the render sites and is unaffected by this change.
+
+## Verbatim Constraints
+
+- `speckit.companion.installPrompt` — the preference the banner is gated on (default `true`).
+- `readInstallPromptEnabled()` — the helper whose beta short-circuit is removed.
+- `shouldShowInstallPrompt(enabled, installed)` — the pure gate, unchanged.
+- `installBannerDismissed` — the session dismissal flag, unchanged.
+
+## Approach
+
+A small, surgical change. The fix lives in one helper; the render sites already consume it correctly.
+
+- `src/speckit/specKitExtensionInstall.ts` — in `readInstallPromptEnabled()`, remove the `if (!isCompanionWorkflowEnabled(config)) return false;` short-circuit so the result depends only on the `speckit.companion.installPrompt` preference. Drop the now-unused `isCompanionWorkflowEnabled` import. Update the JSDoc to describe the decoupled gating.
+- `src/features/spec-editor/installBanner.test.ts` — add a case asserting that `shouldShowInstallPrompt(true, false)` (prompt enabled, extension missing) renders the banner, framed as the beta-off-but-visible scenario, plus a note that visibility no longer reads the beta setting.
+- Verify (no change expected) the two render sites `src/features/spec-editor/specEditorProvider.ts` and `src/features/spec-viewer/specViewerProvider.ts` already gate on `shouldShowInstallPrompt(readInstallPromptEnabled(), …)`.
+- `README.md` — if the install-banner section documents the beta gating, correct it to the decoupled rule.
+
+Dependencies: none beyond the existing helpers. No webview/CSS change.

--- a/specs/354-install-banner-beta-decouple/tasks.md
+++ b/specs/354-install-banner-beta-decouple/tasks.md
@@ -1,0 +1,7 @@
+# Tasks: Decouple the install banner from the beta setting
+
+- [x] **T001** Remove the `isCompanionWorkflowEnabled` short-circuit from `readInstallPromptEnabled()` and update its JSDoc to describe beta-independent gating + src/speckit/specKitExtensionInstall.ts
+- [x] **T002** Drop the now-unused `isCompanionWorkflowEnabled` import (keep `coerceLegacyBoolean`) + src/speckit/specKitExtensionInstall.ts
+- [x] **T003** Add a test covering "beta off + extension missing → banner shows" and note visibility no longer reads the beta setting + src/features/spec-editor/installBanner.test.ts
+- [x] **T004** Confirm both render sites already gate on `shouldShowInstallPrompt(readInstallPromptEnabled(), …)`; correct README if it documents beta gating + src/features/spec-editor/specEditorProvider.ts, src/features/spec-viewer/specViewerProvider.ts, README.md
+- [x] **T005** Run `npm run compile && npm test` and confirm green + (verification)

--- a/src/features/spec-editor/installBanner.test.ts
+++ b/src/features/spec-editor/installBanner.test.ts
@@ -27,13 +27,4 @@ describe('renderInstallBannerHtml — gated banner visibility', () => {
         // Missing extension but explicitly disabled: no banner.
         expect(renderInstallBannerHtml(shouldShowInstallPrompt(false, false))).toBe('');
     });
-
-    it('shows when the extension is missing even with the Companion beta off — visibility never reads the beta setting', () => {
-        // The banner is gated only on its own prompt preference + the extension being
-        // missing. `shouldShowInstallPrompt` takes no beta input at all, so a beta-off
-        // user with a missing extension and the prompt enabled still gets the banner.
-        const enabled = true; // readInstallPromptEnabled() default, independent of beta
-        const installed = false; // extension missing
-        expect(renderInstallBannerHtml(shouldShowInstallPrompt(enabled, installed))).toContain('install-banner');
-    });
 });

--- a/src/features/spec-editor/installBanner.test.ts
+++ b/src/features/spec-editor/installBanner.test.ts
@@ -27,4 +27,13 @@ describe('renderInstallBannerHtml — gated banner visibility', () => {
         // Missing extension but explicitly disabled: no banner.
         expect(renderInstallBannerHtml(shouldShowInstallPrompt(false, false))).toBe('');
     });
+
+    it('shows when the extension is missing even with the Companion beta off — visibility never reads the beta setting', () => {
+        // The banner is gated only on its own prompt preference + the extension being
+        // missing. `shouldShowInstallPrompt` takes no beta input at all, so a beta-off
+        // user with a missing extension and the prompt enabled still gets the banner.
+        const enabled = true; // readInstallPromptEnabled() default, independent of beta
+        const installed = false; // extension missing
+        expect(renderInstallBannerHtml(shouldShowInstallPrompt(enabled, installed))).toContain('install-banner');
+    });
 });

--- a/src/speckit/specKitExtensionInstall.ts
+++ b/src/speckit/specKitExtensionInstall.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import { isCompanionInstalled } from '../features/settings/companionPresetReconciler';
-import { coerceLegacyBoolean, isCompanionWorkflowEnabled } from '../core/settingsMigration';
+import { coerceLegacyBoolean } from '../core/settingsMigration';
 
 /**
  * One-click install / update of the Companion **spec-kit CLI extension**.
@@ -77,17 +77,15 @@ export function shouldShowInstallPrompt(
 }
 
 /**
- * Resolve whether the install prompt is enabled. The prompt offers to install the
- * companion spec-kit extension, which only matters once the SpecKit Companion
- * Workflow is on — so it is gated on that workflow being enabled AND the prompt's
- * own setting. With the workflow off, no install prompt regardless of the prompt
- * setting. Both reads tolerate a legacy tri-state string until migration rewrites it.
+ * Resolve whether the install prompt is enabled — gated only on its own
+ * `speckit.companion.installPrompt` preference (default `true`), independent of the
+ * Companion workflow beta. The extension is what powers the workflow, so the prompt to
+ * install it must reach users who have not opted into beta — that audience needs the
+ * discovery nudge most. The read tolerates a legacy tri-state string until migration
+ * rewrites it. Whether the banner actually shows is `shouldShowInstallPrompt(this, installed)`.
  */
 export function readInstallPromptEnabled(): boolean {
     const config = vscode.workspace.getConfiguration('speckit');
-    if (!isCompanionWorkflowEnabled(config)) {
-        return false;
-    }
     return coerceLegacyBoolean(config.get<unknown>('companion.installPrompt', true), true);
 }
 

--- a/src/speckit/specKitExtensionInstall.ts
+++ b/src/speckit/specKitExtensionInstall.ts
@@ -82,7 +82,7 @@ export function shouldShowInstallPrompt(
  * Companion workflow beta. The extension is what powers the workflow, so the prompt to
  * install it must reach users who have not opted into beta — that audience needs the
  * discovery nudge most. The read tolerates a legacy tri-state string until migration
- * rewrites it. Whether the banner actually shows is `shouldShowInstallPrompt(this, installed)`.
+ * rewrites it. Whether the banner actually shows is `shouldShowInstallPrompt(readInstallPromptEnabled(), installed)`.
  */
 export function readInstallPromptEnabled(): boolean {
     const config = vscode.workspace.getConfiguration('speckit');

--- a/tests/unit/core/installPromptGate.spec.ts
+++ b/tests/unit/core/installPromptGate.spec.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import { readInstallPromptEnabled, shouldShowInstallPrompt } from '../../../src/speckit/specKitExtensionInstall';
 
-describe('readInstallPromptEnabled — gated on the Companion workflow', () => {
+describe('readInstallPromptEnabled — gated only on its own prompt setting, not the beta', () => {
     const getConfigSpy = vscode.workspace.getConfiguration as jest.Mock;
 
     const configWith = (values: Record<string, unknown>) => ({
@@ -13,33 +13,40 @@ describe('readInstallPromptEnabled — gated on the Companion workflow', () => {
         getConfigSpy.mockReturnValue({ get: jest.fn().mockReturnValue(['specs']) });
     });
 
-    it('returns false when the Companion workflow is off, even if the prompt is on', () => {
+    it('returns true with the Companion workflow OFF and the prompt on — decoupled from beta', () => {
         getConfigSpy.mockReturnValue(
             configWith({ 'companion.speckitCompanionWorkflow': false, 'companion.installPrompt': true })
         );
-        expect(readInstallPromptEnabled()).toBe(false);
-    });
-
-    it('returns false when the workflow setting is unset (defaults off)', () => {
-        getConfigSpy.mockReturnValue(configWith({ 'companion.installPrompt': true }));
-        expect(readInstallPromptEnabled()).toBe(false);
-    });
-
-    it('returns true when the workflow is on and the prompt is on (default)', () => {
-        getConfigSpy.mockReturnValue(configWith({ 'companion.speckitCompanionWorkflow': true }));
         expect(readInstallPromptEnabled()).toBe(true);
     });
 
-    it('returns false when the workflow is on but the prompt is explicitly off', () => {
+    it('returns true when the workflow setting is unset (beta off) and the prompt defaults on', () => {
+        getConfigSpy.mockReturnValue(configWith({ 'companion.installPrompt': true }));
+        expect(readInstallPromptEnabled()).toBe(true);
+    });
+
+    it('defaults to true when neither the workflow nor the prompt is set', () => {
+        getConfigSpy.mockReturnValue(configWith({}));
+        expect(readInstallPromptEnabled()).toBe(true);
+    });
+
+    it('returns false when the prompt is explicitly off, regardless of the workflow', () => {
         getConfigSpy.mockReturnValue(
             configWith({ 'companion.speckitCompanionWorkflow': true, 'companion.installPrompt': false })
         );
         expect(readInstallPromptEnabled()).toBe(false);
     });
 
-    it('honors a legacy tri-state opt-in on the workflow key', () => {
-        getConfigSpy.mockReturnValue(configWith({ 'companion.speckitCompanionWorkflow': 'on' }));
-        expect(readInstallPromptEnabled()).toBe(true);
+    it('still false when the prompt is off even with the workflow off', () => {
+        getConfigSpy.mockReturnValue(
+            configWith({ 'companion.speckitCompanionWorkflow': false, 'companion.installPrompt': false })
+        );
+        expect(readInstallPromptEnabled()).toBe(false);
+    });
+
+    it('honors a legacy tri-state opt-out on the prompt key', () => {
+        getConfigSpy.mockReturnValue(configWith({ 'companion.installPrompt': 'off' }));
+        expect(readInstallPromptEnabled()).toBe(false);
     });
 });
 


### PR DESCRIPTION
Closes #369

## Summary

The banner that invites you to install the SpecKit Companion (spec-kit) extension used to stay hidden unless the Companion **beta** workflow was turned on. That hid the prompt from exactly the people who most need it (anyone who hasn't flipped beta yet). Now the banner follows only its own preference and whether the extension is actually missing, independent of the beta toggle.

## What changed for users

- With the Companion beta **off** and the spec-kit extension **missing**, the install banner now appears (in both the spec editor and the spec viewer).
- It still stays hidden when the extension is installed, when you've dismissed it, or when you set the install-prompt preference to off.
- This makes the webview banner consistent with the sidebar install icon, which was already always-on-when-missing.

## Under the hood

- Dropped the `isCompanionWorkflowEnabled` short-circuit from `readInstallPromptEnabled()` (`src/speckit/specKitExtensionInstall.ts`); the gate is now just the `speckit.companion.installPrompt` preference (default true) + extension-missing.
- Both render sites (`specEditorProvider.ts`, `specViewerProvider.ts`) compose the shared helper, so no call-site change was needed.
- Updated `installBanner.test.ts` + `installPromptGate.spec.ts` to assert the decoupled contract, the `installPrompt` setting description in `package.json`, three README sections, and a CHANGELOG entry.

## How to verify

1. Turn the Companion Workflow beta **off** and ensure the spec-kit extension is not installed → the install banner shows in the spec editor and viewer.
2. Dismiss it (×) → stays hidden; set `speckit.companion.installPrompt: false` → stays hidden; install the extension → stays hidden.

## Tests
`npm run compile` clean; `npm test` green (1064 tests). Code review: no findings.