### PR TITLE
feat(living-specs): capability resolver + companion.yml config + sandbox harness (LS·1)

### DIFF
--- a/examples/todo-claude/bench/living-specs/evidence/LS1.json
+++ b/examples/todo-claude/bench/living-specs/evidence/LS1.json
@@ -1,0 +1,98 @@
+{
+  "ticket": "LS1",
+  "issue": 361,
+  "title": "capability resolver, config + sandbox harness (LS·1)",
+  "ranAt": "2026-06-25T17:06:07.482Z",
+  "mode": "deterministic",
+  "sandbox": "examples/bench-sandboxes/ls-1",
+  "commands": [
+    {
+      "cwd": "examples/bench-sandboxes/ls-1",
+      "cmd": "python3 /Users/alfredoperez/dev/GitHub/speckit-companion/speckit-extension/scripts/resolve-spec-paths.py --root /Users/alfredoperez/dev/GitHub/speckit-companion/examples/bench-sandboxes/ls-1 --changed src/checkout/cart/x.ts --json",
+      "exit": 0,
+      "stdoutTail": "{\n  \"changed\": [\n    \"src/checkout/cart/x.ts\"\n  ],\n  \"matched\": [\n    {\n      \"name\": \"checkout-cart\",\n      \"spec\": \"capabilities/checkout-cart/spec.md\",\n      \"location\": \"centralized\",\n      \"exists\": false,\n      \"specificity\": 17\n    },\n    {\n      \"name\": \"checkout\",\n      \"spec\": \"capabilities/checkout/spec.md\",\n      \"location\": \"centralized\",\n      \"exists\": false,\n      \"specificity\": 12\n    }\n  ]\n}"
+    },
+    {
+      "cwd": "examples/bench-sandboxes/ls-1",
+      "cmd": "python3 /Users/alfredoperez/dev/GitHub/speckit-companion/speckit-extension/scripts/resolve-spec-paths.py --root /Users/alfredoperez/dev/GitHub/speckit-companion/examples/bench-sandboxes/ls-1 --all --json",
+      "exit": 0,
+      "stdoutTail": "{\n  \"capabilities\": [\n    {\n      \"name\": \"checkout\",\n      \"spec\": \"capabilities/checkout/spec.md\",\n      \"location\": \"centralized\",\n      \"exists\": false\n    },\n    {\n      \"name\": \"checkout-cart\",\n      \"spec\": \"capabilities/checkout-cart/spec.md\",\n      \"location\": \"centralized\",\n      \"exists\": false\n    },\n    {\n      \"name\": \"notes\",\n      \"spec\": \"notes/stray.spec.md\",\n      \"location\": \"colocated\",\n      \"exists\": true\n    },\n    {\n      \"name\": \"todos\",\n      \"spec\": \"capabilities/todos/spec.md\",\n      \"location\": \"centralized\",\n      \"exists\": true\n    }\n  ],\n  \"orphans\": [\n    \"notes/stray.spec.md\"\n  ]\n}"
+    },
+    {
+      "cwd": "examples/bench-sandboxes/ls-1",
+      "cmd": "python3 /Users/alfredoperez/dev/GitHub/speckit-companion/speckit-extension/scripts/resolve-spec-paths.py --root /Users/alfredoperez/dev/GitHub/speckit-companion/examples/bench-sandboxes/ls-1 --orphans --json",
+      "exit": 0,
+      "stdoutTail": "{\n  \"orphans\": [\n    \"notes/stray.spec.md\"\n  ]\n}"
+    },
+    {
+      "cwd": "examples/bench-sandboxes/ls-1-optout",
+      "cmd": "python3 /Users/alfredoperez/dev/GitHub/speckit-companion/speckit-extension/scripts/resolve-spec-paths.py --root /Users/alfredoperez/dev/GitHub/speckit-companion/examples/bench-sandboxes/ls-1-optout --changed src/checkout/cart/x.ts --json",
+      "exit": 0,
+      "stdoutTail": "{\n  \"changed\": [\n    \"src/checkout/cart/x.ts\"\n  ],\n  \"matched\": []\n}"
+    },
+    {
+      "cwd": ".",
+      "cmd": "python3 -m pytest /Users/alfredoperez/dev/GitHub/speckit-companion/speckit-extension/tests/test_living_specs.py -q",
+      "exit": 0,
+      "stdoutTail": ".................                                                        [100%]\n17 passed in 0.02s"
+    }
+  ],
+  "fileTree": {
+    "added": [
+      ".specify/companion.yml",
+      "capabilities/todos/spec.md",
+      "capabilities/todos/spec.arch.md",
+      "src/checkout/index.ts",
+      "src/checkout/cart/cart.ts",
+      "src/todos/list.ts",
+      "notes/stray.spec.md"
+    ],
+    "modified": [],
+    "removed": []
+  },
+  "config": "livingSpecs:\n  enabled: true\n  capabilities:\n    - name: checkout\n      match: [\"src/checkout/**\"]\n      exclude: [\"src/checkout/**/*.test.ts\"]\n    - name: checkout-cart\n      match: [\"src/checkout/cart/**\"]\n    - name: todos\n      match: [\"src/todos/**\"]",
+  "resolverOutputs": {
+    "changed": "{\n  \"changed\": [\n    \"src/checkout/cart/x.ts\"\n  ],\n  \"matched\": [\n    {\n      \"name\": \"checkout-cart\",\n      \"spec\": \"capabilities/checkout-cart/spec.md\",\n      \"location\": \"centralized\",\n      \"exists\": false,\n      \"specificity\": 17\n    },\n    {\n      \"name\": \"checkout\",\n      \"spec\": \"capabilities/checkout/spec.md\",\n      \"location\": \"centralized\",\n      \"exists\": false,\n      \"specificity\": 12\n    }\n  ]\n}",
+    "all": "{\n  \"capabilities\": [\n    {\n      \"name\": \"checkout\",\n      \"spec\": \"capabilities/checkout/spec.md\",\n      \"location\": \"centralized\",\n      \"exists\": false\n    },\n    {\n      \"name\": \"checkout-cart\",\n      \"spec\": \"capabilities/checkout-cart/spec.md\",\n      \"location\": \"centralized\",\n      \"exists\": false\n    },\n    {\n      \"name\": \"notes\",\n      \"spec\": \"notes/stray.spec.md\",\n      \"location\": \"colocated\",\n      \"exists\": true\n    },\n    {\n      \"name\": \"todos\",\n      \"spec\": \"capabilities/todos/spec.md\",\n      \"location\": \"centralized\",\n      \"exists\": true\n    }\n  ],\n  \"orphans\": [\n    \"notes/stray.spec.md\"\n  ]\n}",
+    "orphans": "{\n  \"orphans\": [\n    \"notes/stray.spec.md\"\n  ]\n}",
+    "optOut": "{\n  \"changed\": [\n    \"src/checkout/cart/x.ts\"\n  ],\n  \"matched\": []\n}"
+  },
+  "assertions": [
+    {
+      "id": "changed-order",
+      "status": "PASS",
+      "detail": "--changed src/checkout/cart/x.ts -> [checkout-cart, checkout]"
+    },
+    {
+      "id": "all-union",
+      "status": "PASS",
+      "detail": "--all capabilities -> [checkout, checkout-cart, notes, todos]"
+    },
+    {
+      "id": "orphan-flagged",
+      "status": "PASS",
+      "detail": "orphans -> [notes/stray.spec.md]"
+    },
+    {
+      "id": "tier-not-orphan",
+      "status": "PASS",
+      "detail": "reserved .arch.md tier excluded from orphans"
+    },
+    {
+      "id": "opt-out-inert",
+      "status": "PASS",
+      "detail": "enabled:false -> matched=[], exit 0"
+    },
+    {
+      "id": "pytest-green",
+      "status": "PASS",
+      "detail": "pytest exit 0"
+    }
+  ],
+  "pytest": {
+    "runner": "pytest",
+    "exit": 0,
+    "tail": ".................                                                        [100%]\n17 passed in 0.02s"
+  },
+  "verdict": "PASS"
+}

--- a/examples/todo-claude/bench/living-specs/evidence/LS1.json
+++ b/examples/todo-claude/bench/living-specs/evidence/LS1.json
@@ -2,7 +2,7 @@
   "ticket": "LS1",
   "issue": 361,
   "title": "capability resolver, config + sandbox harness (LS·1)",
-  "ranAt": "2026-06-25T17:27:42.006Z",
+  "ranAt": "2026-06-25T17:38:01.183Z",
   "mode": "deterministic",
   "sandbox": "examples/bench-sandboxes/ls-1",
   "commands": [
@@ -34,7 +34,7 @@
       "cwd": ".",
       "cmd": "python3 -m pytest speckit-extension/tests/test_living_specs.py -q",
       "exit": 0,
-      "stdoutTail": "...........................                                              [100%]\n27 passed in 0.04s"
+      "stdoutTail": "............................                                             [100%]\n28 passed in 0.05s"
     }
   ],
   "fileTree": {
@@ -92,7 +92,7 @@
   "pytest": {
     "runner": "pytest",
     "exit": 0,
-    "tail": "...........................                                              [100%]\n27 passed in 0.04s"
+    "tail": "............................                                             [100%]\n28 passed in 0.05s"
   },
   "verdict": "PASS"
 }

--- a/examples/todo-claude/bench/living-specs/evidence/LS1.json
+++ b/examples/todo-claude/bench/living-specs/evidence/LS1.json
@@ -2,39 +2,39 @@
   "ticket": "LS1",
   "issue": 361,
   "title": "capability resolver, config + sandbox harness (LS·1)",
-  "ranAt": "2026-06-25T17:06:07.482Z",
+  "ranAt": "2026-06-25T17:27:42.006Z",
   "mode": "deterministic",
   "sandbox": "examples/bench-sandboxes/ls-1",
   "commands": [
     {
       "cwd": "examples/bench-sandboxes/ls-1",
-      "cmd": "python3 /Users/alfredoperez/dev/GitHub/speckit-companion/speckit-extension/scripts/resolve-spec-paths.py --root /Users/alfredoperez/dev/GitHub/speckit-companion/examples/bench-sandboxes/ls-1 --changed src/checkout/cart/x.ts --json",
+      "cmd": "python3 speckit-extension/scripts/resolve-spec-paths.py --root examples/bench-sandboxes/ls-1 --changed src/checkout/cart/x.ts --json",
       "exit": 0,
       "stdoutTail": "{\n  \"changed\": [\n    \"src/checkout/cart/x.ts\"\n  ],\n  \"matched\": [\n    {\n      \"name\": \"checkout-cart\",\n      \"spec\": \"capabilities/checkout-cart/spec.md\",\n      \"location\": \"centralized\",\n      \"exists\": false,\n      \"specificity\": 17\n    },\n    {\n      \"name\": \"checkout\",\n      \"spec\": \"capabilities/checkout/spec.md\",\n      \"location\": \"centralized\",\n      \"exists\": false,\n      \"specificity\": 12\n    }\n  ]\n}"
     },
     {
       "cwd": "examples/bench-sandboxes/ls-1",
-      "cmd": "python3 /Users/alfredoperez/dev/GitHub/speckit-companion/speckit-extension/scripts/resolve-spec-paths.py --root /Users/alfredoperez/dev/GitHub/speckit-companion/examples/bench-sandboxes/ls-1 --all --json",
+      "cmd": "python3 speckit-extension/scripts/resolve-spec-paths.py --root examples/bench-sandboxes/ls-1 --all --json",
       "exit": 0,
       "stdoutTail": "{\n  \"capabilities\": [\n    {\n      \"name\": \"checkout\",\n      \"spec\": \"capabilities/checkout/spec.md\",\n      \"location\": \"centralized\",\n      \"exists\": false\n    },\n    {\n      \"name\": \"checkout-cart\",\n      \"spec\": \"capabilities/checkout-cart/spec.md\",\n      \"location\": \"centralized\",\n      \"exists\": false\n    },\n    {\n      \"name\": \"notes\",\n      \"spec\": \"notes/stray.spec.md\",\n      \"location\": \"colocated\",\n      \"exists\": true\n    },\n    {\n      \"name\": \"todos\",\n      \"spec\": \"capabilities/todos/spec.md\",\n      \"location\": \"centralized\",\n      \"exists\": true\n    }\n  ],\n  \"orphans\": [\n    \"notes/stray.spec.md\"\n  ]\n}"
     },
     {
       "cwd": "examples/bench-sandboxes/ls-1",
-      "cmd": "python3 /Users/alfredoperez/dev/GitHub/speckit-companion/speckit-extension/scripts/resolve-spec-paths.py --root /Users/alfredoperez/dev/GitHub/speckit-companion/examples/bench-sandboxes/ls-1 --orphans --json",
+      "cmd": "python3 speckit-extension/scripts/resolve-spec-paths.py --root examples/bench-sandboxes/ls-1 --orphans --json",
       "exit": 0,
       "stdoutTail": "{\n  \"orphans\": [\n    \"notes/stray.spec.md\"\n  ]\n}"
     },
     {
       "cwd": "examples/bench-sandboxes/ls-1-optout",
-      "cmd": "python3 /Users/alfredoperez/dev/GitHub/speckit-companion/speckit-extension/scripts/resolve-spec-paths.py --root /Users/alfredoperez/dev/GitHub/speckit-companion/examples/bench-sandboxes/ls-1-optout --changed src/checkout/cart/x.ts --json",
+      "cmd": "python3 speckit-extension/scripts/resolve-spec-paths.py --root examples/bench-sandboxes/ls-1-optout --changed src/checkout/cart/x.ts --json",
       "exit": 0,
       "stdoutTail": "{\n  \"changed\": [\n    \"src/checkout/cart/x.ts\"\n  ],\n  \"matched\": []\n}"
     },
     {
       "cwd": ".",
-      "cmd": "python3 -m pytest /Users/alfredoperez/dev/GitHub/speckit-companion/speckit-extension/tests/test_living_specs.py -q",
+      "cmd": "python3 -m pytest speckit-extension/tests/test_living_specs.py -q",
       "exit": 0,
-      "stdoutTail": ".................                                                        [100%]\n17 passed in 0.02s"
+      "stdoutTail": "...........................                                              [100%]\n27 passed in 0.04s"
     }
   ],
   "fileTree": {
@@ -92,7 +92,7 @@
   "pytest": {
     "runner": "pytest",
     "exit": 0,
-    "tail": ".................                                                        [100%]\n17 passed in 0.02s"
+    "tail": "...........................                                              [100%]\n27 passed in 0.04s"
   },
   "verdict": "PASS"
 }

--- a/examples/todo-claude/bench/living-specs/evidence/history.jsonl
+++ b/examples/todo-claude/bench/living-specs/evidence/history.jsonl
@@ -1,1 +1,4 @@
 {"ticket":"LS1","ranAt":"2026-06-25T17:06:07.482Z","mode":"deterministic","verdict":"PASS"}
+{"ticket":"LS1","ranAt":"2026-06-25T17:24:45.695Z","mode":"deterministic","verdict":"PASS"}
+{"ticket":"LS1","ranAt":"2026-06-25T17:26:12.330Z","mode":"deterministic","verdict":"PASS"}
+{"ticket":"LS1","ranAt":"2026-06-25T17:27:42.006Z","mode":"deterministic","verdict":"PASS"}

--- a/examples/todo-claude/bench/living-specs/evidence/history.jsonl
+++ b/examples/todo-claude/bench/living-specs/evidence/history.jsonl
@@ -2,3 +2,4 @@
 {"ticket":"LS1","ranAt":"2026-06-25T17:24:45.695Z","mode":"deterministic","verdict":"PASS"}
 {"ticket":"LS1","ranAt":"2026-06-25T17:26:12.330Z","mode":"deterministic","verdict":"PASS"}
 {"ticket":"LS1","ranAt":"2026-06-25T17:27:42.006Z","mode":"deterministic","verdict":"PASS"}
+{"ticket":"LS1","ranAt":"2026-06-25T17:38:01.183Z","mode":"deterministic","verdict":"PASS"}

--- a/examples/todo-claude/bench/living-specs/evidence/history.jsonl
+++ b/examples/todo-claude/bench/living-specs/evidence/history.jsonl
@@ -1,0 +1,1 @@
+{"ticket":"LS1","ranAt":"2026-06-25T17:06:07.482Z","mode":"deterministic","verdict":"PASS"}

--- a/examples/todo-claude/bench/living-specs/ls-demos.mjs
+++ b/examples/todo-claude/bench/living-specs/ls-demos.mjs
@@ -1,0 +1,157 @@
+#!/usr/bin/env node
+// bench/living-specs/ls-demos.mjs — the reusable Living Specs sandbox demo runner.
+//
+// LS·1 (deterministic): bake a throwaway repo, run the shipped resolver across
+// modes + the pytest suite, and assert the contract. Every value in the evidence
+// is captured from a real execFileSync — never hand-authored. Writes machine
+// evidence to evidence/<LS>.json per the evidence contract; if a step can't run
+// the verdict becomes INCONCLUSIVE rather than a fabricated pass.
+//
+// Usage: node ls-demos.mjs [LS1]      (default LS1)
+import { mkdirSync, writeFileSync } from 'node:fs'
+import { join, relative } from 'node:path'
+
+import { REPO_ROOT } from '../lib.mjs'
+import {
+  EVIDENCE_DIR,
+  bakeLs1Repo,
+  bakeOptOutRepo,
+  runResolver,
+  runPytest,
+  fileTree,
+} from './ls-lib.mjs'
+
+function parseJson(stdout) {
+  try { return JSON.parse(stdout) } catch { return null }
+}
+
+function assert(id, ok, detail) {
+  return { id, status: ok ? 'PASS' : 'FAIL', detail }
+}
+
+function runLs1() {
+  const commands = []
+  const assertions = []
+
+  // --- arrange + act -------------------------------------------------------
+  const root = bakeLs1Repo()
+  const changed = runResolver(root, ['--changed', 'src/checkout/cart/x.ts', '--json'])
+  const all = runResolver(root, ['--all', '--json'])
+  const orphans = runResolver(root, ['--orphans', '--json'])
+
+  const optOutRoot = bakeOptOutRepo()
+  const optOut = runResolver(optOutRoot, ['--changed', 'src/checkout/cart/x.ts', '--json'])
+
+  const pytest = runPytest()
+
+  commands.push(
+    { cwd: relative(REPO_ROOT, root), cmd: changed.cmd, exit: changed.exit, stdoutTail: changed.stdoutTail },
+    { cwd: relative(REPO_ROOT, root), cmd: all.cmd, exit: all.exit, stdoutTail: all.stdoutTail },
+    { cwd: relative(REPO_ROOT, root), cmd: orphans.cmd, exit: orphans.exit, stdoutTail: orphans.stdoutTail },
+    { cwd: relative(REPO_ROOT, optOutRoot), cmd: optOut.cmd, exit: optOut.exit, stdoutTail: optOut.stdoutTail },
+    { cwd: relative(REPO_ROOT, REPO_ROOT) || '.', cmd: pytest.cmd, exit: pytest.exit, stdoutTail: pytest.stdoutTail },
+  )
+
+  // --- assert (against the real captured stdout) ---------------------------
+  const changedJson = parseJson(changed.stdout)
+  const matchedNames = changedJson ? changedJson.matched.map((m) => m.name) : []
+  assertions.push(assert(
+    'changed-order',
+    changedJson != null &&
+      JSON.stringify(matchedNames) === JSON.stringify(['checkout-cart', 'checkout']),
+    `--changed src/checkout/cart/x.ts -> [${matchedNames.join(', ')}]`,
+  ))
+
+  const allJson = parseJson(all.stdout)
+  const allNames = allJson ? allJson.capabilities.map((c) => c.name) : []
+  assertions.push(assert(
+    'all-union',
+    allJson != null && ['checkout', 'checkout-cart', 'todos'].every((n) => allNames.includes(n)),
+    `--all capabilities -> [${allNames.join(', ')}]`,
+  ))
+
+  const orphansJson = parseJson(orphans.stdout)
+  const orphanList = orphansJson ? orphansJson.orphans : []
+  assertions.push(assert(
+    'orphan-flagged',
+    orphanList.includes('notes/stray.spec.md'),
+    `orphans -> [${orphanList.join(', ')}]`,
+  ))
+  assertions.push(assert(
+    'tier-not-orphan',
+    !orphanList.some((o) => o.endsWith('.arch.md')),
+    'reserved .arch.md tier excluded from orphans',
+  ))
+
+  const optOutJson = parseJson(optOut.stdout)
+  assertions.push(assert(
+    'opt-out-inert',
+    optOut.exit === 0 && optOutJson != null && optOutJson.matched.length === 0,
+    `enabled:false -> matched=[], exit ${optOut.exit}`,
+  ))
+
+  assertions.push(assert(
+    'pytest-green',
+    pytest.exit === 0,
+    `${pytest.runner} exit ${pytest.exit}`,
+  ))
+
+  const ran = changed.exit === 0 && all.exit === 0 && orphans.exit === 0 && optOut.exit === 0
+  const allPass = assertions.every((a) => a.status === 'PASS')
+  const verdict = !ran ? 'INCONCLUSIVE' : allPass ? 'PASS' : 'FAIL'
+
+  return {
+    ticket: 'LS1',
+    issue: 361,
+    title: 'capability resolver, config + sandbox harness (LS·1)',
+    ranAt: new Date().toISOString(),
+    mode: 'deterministic',
+    sandbox: relative(REPO_ROOT, root),
+    commands,
+    fileTree: {
+      added: fileTree(root, [
+        '.specify/companion.yml',
+        'capabilities/todos/spec.md',
+        'capabilities/todos/spec.arch.md',
+        'src/checkout/index.ts',
+        'src/checkout/cart/cart.ts',
+        'src/todos/list.ts',
+        'notes/stray.spec.md',
+      ]),
+      modified: [],
+      removed: [],
+    },
+    config: 'livingSpecs:\n  enabled: true\n  capabilities:\n    - name: checkout\n      match: ["src/checkout/**"]\n      exclude: ["src/checkout/**/*.test.ts"]\n    - name: checkout-cart\n      match: ["src/checkout/cart/**"]\n    - name: todos\n      match: ["src/todos/**"]',
+    resolverOutputs: {
+      changed: changed.stdout,
+      all: all.stdout,
+      orphans: orphans.stdout,
+      optOut: optOut.stdout,
+    },
+    assertions,
+    pytest: { runner: pytest.runner, exit: pytest.exit, tail: pytest.stdoutTail },
+    verdict,
+  }
+}
+
+function main() {
+  const ticket = (process.argv[2] || 'LS1').toUpperCase()
+  if (ticket !== 'LS1') {
+    console.error(`[ls-demos] unknown ticket ${ticket} — only LS1 is implemented`)
+    process.exit(2)
+  }
+  const evidence = runLs1()
+  mkdirSync(EVIDENCE_DIR, { recursive: true })
+  const out = join(EVIDENCE_DIR, `${ticket}.json`)
+  writeFileSync(out, JSON.stringify(evidence, null, 2) + '\n')
+  // Append-only trend row.
+  const histRow = JSON.stringify({ ticket, ranAt: evidence.ranAt, mode: evidence.mode, verdict: evidence.verdict }) + '\n'
+  writeFileSync(join(EVIDENCE_DIR, 'history.jsonl'), histRow, { flag: 'a' })
+
+  console.log(`[ls-demos] ${ticket} verdict=${evidence.verdict} (${evidence.assertions.filter((a) => a.status === 'PASS').length}/${evidence.assertions.length} assertions PASS)`)
+  for (const a of evidence.assertions) console.log(`  ${a.status === 'PASS' ? '✓' : '✗'} ${a.id}: ${a.detail}`)
+  console.log(`[ls-demos] evidence → ${relative(REPO_ROOT, out)}`)
+  process.exit(evidence.verdict === 'PASS' ? 0 : 1)
+}
+
+main()

--- a/examples/todo-claude/bench/living-specs/ls-lib.mjs
+++ b/examples/todo-claude/bench/living-specs/ls-lib.mjs
@@ -6,7 +6,7 @@
 // so it does not install spec-kit — it points the real shipped resolver at the
 // sandbox via --root.
 import { mkdirSync, writeFileSync, existsSync, rmSync } from 'node:fs'
-import { join, dirname } from 'node:path'
+import { join, dirname, relative } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { execFileSync } from 'node:child_process'
 
@@ -22,6 +22,12 @@ function write(root, rel, body) {
   const p = join(root, rel)
   mkdirSync(dirname(p), { recursive: true })
   writeFileSync(p, body)
+}
+
+// Repo-relative path for the recorded `cmd` strings + evidence — never leak an
+// absolute home path or username into committed evidence.
+function rel(p) {
+  return relative(REPO_ROOT, p)
 }
 
 // Arrange — bake a throwaway repo for the LS·1 demo. checkout + checkout-cart
@@ -87,8 +93,8 @@ export function runResolver(root, args) {
     exit = typeof e.status === 'number' ? e.status : 1
   }
   return {
-    cwd: root,
-    cmd: `python3 ${RESOLVER} --root ${root} ${args.join(' ')}`,
+    cwd: rel(root),
+    cmd: `python3 ${rel(RESOLVER)} --root ${rel(root)} ${args.join(' ')}`,
     exit,
     stdout: stdout.trim(),
     stdoutTail: stdout.trim().split('\n').slice(-40).join('\n'),
@@ -113,8 +119,8 @@ export function runPytest() {
   }
   return {
     runner: res.mod,
-    cwd: REPO_ROOT,
-    cmd: `python3 -m ${res.mod} ${res.mod === 'pytest' ? TEST_FILE + ' -q' : 'speckit-extension.tests.test_living_specs -v'}`,
+    cwd: '.',
+    cmd: `python3 -m ${res.mod} ${res.mod === 'pytest' ? rel(TEST_FILE) + ' -q' : 'speckit-extension.tests.test_living_specs -v'}`,
     exit: res.exit,
     stdout: res.stdout,
     stdoutTail: res.stdout.split('\n').slice(-12).join('\n'),

--- a/examples/todo-claude/bench/living-specs/ls-lib.mjs
+++ b/examples/todo-claude/bench/living-specs/ls-lib.mjs
@@ -120,7 +120,7 @@ export function runPytest() {
   return {
     runner: res.mod,
     cwd: '.',
-    cmd: `python3 -m ${res.mod} ${res.mod === 'pytest' ? rel(TEST_FILE) + ' -q' : 'speckit-extension.tests.test_living_specs -v'}`,
+    cmd: `python3 -m ${res.mod} ${res.mod === 'pytest' ? rel(TEST_FILE) + ' -q' : '-v speckit-extension.tests.test_living_specs'}`,
     exit: res.exit,
     stdout: res.stdout,
     stdoutTail: res.stdout.split('\n').slice(-12).join('\n'),

--- a/examples/todo-claude/bench/living-specs/ls-lib.mjs
+++ b/examples/todo-claude/bench/living-specs/ls-lib.mjs
@@ -1,0 +1,128 @@
+// bench/living-specs/ls-lib.mjs — shared arrange helpers for the Living Specs
+// sandbox demos. Thin layer over the existing bench helpers in ../lib.mjs: it
+// bakes a throwaway repo with a livingSpecs companion.yml + a capability spec
+// fixture, plants code files + a stray orphan spec, and gives the demo runner a
+// place to capture real resolver/pytest output. LS·1 is `deterministic` (no AI),
+// so it does not install spec-kit — it points the real shipped resolver at the
+// sandbox via --root.
+import { mkdirSync, writeFileSync, existsSync, rmSync } from 'node:fs'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { execFileSync } from 'node:child_process'
+
+import { REPO_ROOT, gitInitCell, gitCommitCellBaseline, readText } from '../lib.mjs'
+
+export const LS_DIR = dirname(fileURLToPath(import.meta.url))
+export const EVIDENCE_DIR = join(LS_DIR, 'evidence')
+export const RESOLVER = join(REPO_ROOT, 'speckit-extension', 'scripts', 'resolve-spec-paths.py')
+export const TEST_FILE = join(REPO_ROOT, 'speckit-extension', 'tests', 'test_living_specs.py')
+export const SANDBOX_ROOT = join(REPO_ROOT, 'examples', 'bench-sandboxes')
+
+function write(root, rel, body) {
+  const p = join(root, rel)
+  mkdirSync(dirname(p), { recursive: true })
+  writeFileSync(p, body)
+}
+
+// Arrange — bake a throwaway repo for the LS·1 demo. checkout + checkout-cart
+// (nested), enabled:true; a centralized todos capability spec on disk; planted
+// code files under each area; and a stray orphan spec no capability claims.
+export function bakeLs1Repo(name = 'ls-1') {
+  const root = join(SANDBOX_ROOT, name)
+  rmSync(root, { recursive: true, force: true })
+  mkdirSync(root, { recursive: true })
+
+  write(root, join('.specify', 'companion.yml'), [
+    'livingSpecs:',
+    '  enabled: true',
+    '  capabilities:',
+    '    - name: checkout',
+    '      match: ["src/checkout/**"]',
+    '      exclude: ["src/checkout/**/*.test.ts"]',
+    '    - name: checkout-cart',
+    '      match: ["src/checkout/cart/**"]',
+    '    - name: todos',
+    '      match: ["src/todos/**"]',
+    '',
+  ].join('\n'))
+
+  write(root, join('capabilities', 'todos', 'spec.md'), '# Todos capability\n\nLiving spec for the todos area.\n')
+  write(root, join('src', 'checkout', 'index.ts'), '// checkout\n')
+  write(root, join('src', 'checkout', 'cart', 'cart.ts'), '// cart\n')
+  write(root, join('src', 'todos', 'list.ts'), '// todos\n')
+  // A stray spec no capability's spec path claims — must surface as an orphan.
+  write(root, join('notes', 'stray.spec.md'), '# stray\n')
+  // Reserved-tier sibling — must NEVER be flagged as an orphan.
+  write(root, join('capabilities', 'todos', 'spec.arch.md'), '# arch\n')
+
+  gitInitCell(root)
+  gitCommitCellBaseline(root)
+  return root
+}
+
+// A second arrangement for the opt-out case: same repo shape, enabled:false.
+export function bakeOptOutRepo(name = 'ls-1-optout') {
+  const root = bakeLs1Repo(name)
+  write(root, join('.specify', 'companion.yml'), [
+    'livingSpecs:',
+    '  enabled: false',
+    '  capabilities:',
+    '    - name: checkout',
+    '      match: ["src/checkout/**"]',
+    '',
+  ].join('\n'))
+  return root
+}
+
+// Act — run the shipped resolver against the sandbox via --root, capturing the
+// real stdout + exit code (never paraphrased). Mirrors the evidence contract's
+// commands[] shape.
+export function runResolver(root, args) {
+  let stdout = ''
+  let exit = 0
+  try {
+    stdout = execFileSync('python3', [RESOLVER, '--root', root, ...args], { encoding: 'utf8' })
+  } catch (e) {
+    stdout = (e.stdout || '') + (e.stderr || '')
+    exit = typeof e.status === 'number' ? e.status : 1
+  }
+  return {
+    cwd: root,
+    cmd: `python3 ${RESOLVER} --root ${root} ${args.join(' ')}`,
+    exit,
+    stdout: stdout.trim(),
+    stdoutTail: stdout.trim().split('\n').slice(-40).join('\n'),
+  }
+}
+
+// Act — run the pytest suite, capturing real output + exit. Falls back to the
+// stdlib unittest runner when pytest is not importable.
+export function runPytest() {
+  const tryRun = (mod, extra) => {
+    try {
+      const out = execFileSync('python3', ['-m', mod, ...extra], { encoding: 'utf8', cwd: REPO_ROOT })
+      return { mod, exit: 0, stdout: out.trim() }
+    } catch (e) {
+      const out = (e.stdout || '') + (e.stderr || '')
+      return { mod, exit: typeof e.status === 'number' ? e.status : 1, stdout: out.trim(), err: e.message }
+    }
+  }
+  let res = tryRun('pytest', [TEST_FILE, '-q'])
+  if (res.err && /No module named pytest/.test(res.stdout + (res.err || ''))) {
+    res = tryRun('unittest', ['-v', 'speckit-extension.tests.test_living_specs'])
+  }
+  return {
+    runner: res.mod,
+    cwd: REPO_ROOT,
+    cmd: `python3 -m ${res.mod} ${res.mod === 'pytest' ? TEST_FILE + ' -q' : 'speckit-extension.tests.test_living_specs -v'}`,
+    exit: res.exit,
+    stdout: res.stdout,
+    stdoutTail: res.stdout.split('\n').slice(-12).join('\n'),
+  }
+}
+
+export function fileTree(root, rels) {
+  return rels.filter((r) => existsSync(join(root, r)))
+}
+
+export { readText }

--- a/speckit-extension/CHANGELOG.md
+++ b/speckit-extension/CHANGELOG.md
@@ -8,6 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/); this ext
 
 ## [Unreleased]
 
+### Added
+- **Living specs — keep a durable spec per capability (opt-in).** You can now declare the *capabilities* in your codebase — checkout, auth, billing, todos — and say which files belong to each and where its long-lived spec lives, either in a central folder or right next to the code. Given a set of changed files, Companion resolves which capabilities they touch (most-specific first), and can list every capability plus any stray spec file no capability claims. It's **off by default**: with no `livingSpecs` block in `.specify/companion.yml` (or `enabled: false`), nothing changes and every command behaves exactly as before. This first release ships the resolver and the config; later releases fold change deltas back into the living specs as you work. See the new "Living specs" section in the README.
+
 ## [0.11.1] - 2026-06-24
 
 ### Changed

--- a/speckit-extension/README.md
+++ b/speckit-extension/README.md
@@ -151,6 +151,43 @@ The Companion commands are assembled from composable **nodes** — small section
 
 This is separate from stock spec-kit's own extension hooks (`.specify/extensions.yml`): a Companion run honors those too, so any spec-kit extension you've installed (the git extension and others) fires at the start and end of each step exactly as it would on a stock `/speckit.*` run. Both hook systems run on the same pipeline.
 
+## Living specs — map your code to durable capability specs (opt-in)
+
+Most specs describe one change and then go quiet. **Living specs** are the opposite: a durable spec per *capability* — checkout, auth, billing, todos — that stays current as the code evolves. You declare which files belong to each capability and where its spec lives, and a resolver answers "which capabilities does this change touch?" so the right specs can be kept in sync.
+
+The feature is **off by default**. With no `livingSpecs` block (or `enabled: false`), nothing changes — every command behaves exactly as it does today. To turn it on, add a `livingSpecs` block to `.specify/companion.yml`:
+
+```yaml
+livingSpecs:
+  enabled: true
+  capabilities:
+    - name: checkout
+      match: ["src/checkout/**"]        # files that belong to this capability
+      exclude: ["src/checkout/**/*.test.ts"]   # optional — subtracted from membership
+    - name: checkout-cart
+      match: ["src/checkout/cart/**"]
+      # spec defaults to capabilities/checkout-cart/spec.md
+    - name: billing
+      match: ["src/billing/**"]
+      spec: src/billing/billing.spec.md  # colocated — lives next to the code
+```
+
+Each capability has a `name`, the `match` globs that define which files belong to it, an optional `exclude`, and where its living spec lives. By default a capability's spec is **centralized** at `capabilities/<name>/spec.md`; give an explicit `spec` path to **colocate** it next to the code. A spec file uses the `.spec.md` extension (the hot tier loaded today); the reserved `.arch.md` / `.coverage.md` siblings are recognized and never flagged as stray.
+
+The resolver ships as `resolve-spec-paths.py` and runs in three modes:
+
+```bash
+# Which capabilities own a changed file? (most-specific first)
+python3 .specify/extensions/companion/scripts/resolve-spec-paths.py --changed src/checkout/cart/x.ts
+#   → [checkout-cart, checkout]
+
+# Every capability + any stray .spec.md on disk (orphans)
+python3 .specify/extensions/companion/scripts/resolve-spec-paths.py --all
+
+# Just the orphans — .spec.md files no capability claims
+python3 .specify/extensions/companion/scripts/resolve-spec-paths.py --orphans
+```
+
 ## Installation
 
 Requires a **github-source** spec-kit — the stock PyPI `specify-cli` has no `extension` subsystem:

--- a/speckit-extension/README.md
+++ b/speckit-extension/README.md
@@ -174,19 +174,27 @@ livingSpecs:
 
 Each capability has a `name`, the `match` globs that define which files belong to it, an optional `exclude`, and where its living spec lives. By default a capability's spec is **centralized** at `capabilities/<name>/spec.md`; give an explicit `spec` path to **colocate** it next to the code. A spec file uses the `.spec.md` extension (the hot tier loaded today); the reserved `.arch.md` / `.coverage.md` siblings are recognized and never flagged as stray.
 
-The resolver ships as `resolve-spec-paths.py` and runs in three modes:
+The resolver ships as `resolve-spec-paths.py` and runs in three modes. By default it prints a concise human list; add `--json` for the full machine-readable object (names, resolved paths, locations, existence):
 
 ```bash
 # Which capabilities own a changed file? (most-specific first)
 python3 .specify/extensions/companion/scripts/resolve-spec-paths.py --changed src/checkout/cart/x.ts
-#   → [checkout-cart, checkout]
+#   [checkout-cart, checkout]
 
 # Every capability + any stray .spec.md on disk (orphans)
 python3 .specify/extensions/companion/scripts/resolve-spec-paths.py --all
+#   capabilities: [checkout, checkout-cart, todos]
+#   orphans: []
 
-# Just the orphans — .spec.md files no capability claims
+# Just the orphans — .spec.md files no capability claims or owns
 python3 .specify/extensions/companion/scripts/resolve-spec-paths.py --orphans
+#   []
+
+# Add --json for the full record the sync/fold/drift steps consume
+python3 .specify/extensions/companion/scripts/resolve-spec-paths.py --changed src/checkout/cart/x.ts --json
 ```
+
+An orphan is a `.spec.md` that no capability claims **and** that does not live inside a configured capability's spec directory — so another file under `capabilities/checkout/` (or a reserved `.arch.md` / `.coverage.md` sibling) is never flagged as stray.
 
 ## Installation
 

--- a/speckit-extension/docs/publishing.md
+++ b/speckit-extension/docs/publishing.md
@@ -24,12 +24,12 @@ v0.2.0                  ❌  matches v* → would publish the WRONG thing to the
    cd speckit-extension
    cp extension.yml LICENSE /tmp/cb/companion-$V/
    cp -R commands workflows /tmp/cb/companion-$V/
-   cp scripts/write-context.py scripts/status-context.py scripts/derive-from-files.py /tmp/cb/companion-$V/scripts/
+   cp scripts/write-context.py scripts/status-context.py scripts/derive-from-files.py scripts/resolve-spec-paths.py scripts/companion_config.py /tmp/cb/companion-$V/scripts/
    cd - >/dev/null
    ( cd /tmp/cb && zip -rq companion-$V.zip companion-$V )
    ```
 
-   **What ships (and what doesn't).** The package carries `extension.yml`, `LICENSE`, `commands/`, `workflows/`, and exactly three scripts: `write-context.py`, `status-context.py`, `derive-from-files.py` (the only ones reached at runtime — commands call the first two; `status-context.py` imports `derive-from-files.py`, which imports `write-context.py`). It deliberately **omits** README, CHANGELOG, ROADMAP, `docs/`, `examples/`, the build-only `nodes/`+`presets/` sources, the six build/test scripts, `tests/`, and `assets/`. The catalog page renders README/CHANGELOG from the GitHub blob URLs below — they're not needed inside the zip. Keep this an allow-list; don't swap it back to a `tar --exclude` deny-list, or new docs/sources will silently bloat the package again.
+   **What ships (and what doesn't).** The package carries `extension.yml`, `LICENSE`, `commands/`, `workflows/`, and exactly five scripts: `write-context.py`, `status-context.py`, `derive-from-files.py`, `resolve-spec-paths.py`, and `companion_config.py` (the only ones reached at runtime — commands call the capture/status scripts; `status-context.py` imports `derive-from-files.py`, which imports `write-context.py`; the living-specs resolver `resolve-spec-paths.py` imports `companion_config.py`). It deliberately **omits** README, CHANGELOG, ROADMAP, `docs/`, `examples/`, the build-only `nodes/`+`presets/` sources, the remaining build/test scripts, `tests/`, and `assets/`. The catalog page renders README/CHANGELOG from the GitHub blob URLs below — they're not needed inside the zip. Keep this an allow-list; don't swap it back to a `tar --exclude` deny-list, or new docs/sources will silently bloat the package again.
 6. **Create the GitHub release** with a **prefixed tag** (`speckit-ext-v0.2.0`) and attach the version-named zip (archival):
    ```bash
    gh release create speckit-ext-v$V /tmp/cb/companion-$V.zip --title "..." --notes-file <CHANGELOG [X.Y.Z]> --target main

--- a/speckit-extension/extension.yml
+++ b/speckit-extension/extension.yml
@@ -3,7 +3,7 @@ schema_version: "1.0"
 extension:
   id: companion
   name: "SpecKit Companion"
-  version: "0.11.1"
+  version: "0.12.0"
   description: "Live spec-driven progress for SpecKit Companion — lifecycle capture, status, and resume."
   author: alfredoperez
   repository: https://github.com/alfredoperez/speckit-companion

--- a/speckit-extension/scripts/companion_config.py
+++ b/speckit-extension/scripts/companion_config.py
@@ -251,3 +251,54 @@ def validate_reads(active_meta: dict):
                 raise ConfigError(
                     f"node '{node_id}' reads dropped node '{dep}' — recipe broke the pipeline"
                 )
+
+
+# --------------------------------------------------------------------------- #
+# Living Specs accessor (opt-in capability registry)
+# --------------------------------------------------------------------------- #
+DEFAULT_CAPABILITY_ROOT = "capabilities"
+
+
+def _as_list(value) -> list:
+    """Coerce a scalar/None/list into a list of non-empty strings."""
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return [str(v) for v in value if v not in (None, "")]
+    return [str(value)] if value != "" else []
+
+
+def load_living_specs(config: dict) -> dict:
+    """Read the `livingSpecs` block into a normalized, typed shape.
+
+    Returns {"enabled": bool, "capabilities": [{name, match, exclude, spec}]}.
+    `enabled` defaults to False (opt-in). Each capability normalizes `match`/`exclude`
+    to string lists and defaults `spec` to `capabilities/<name>/spec.md`. A capability
+    whose `spec` is declared but empty keeps "" so the resolver can flag the bad path.
+    """
+    block = (config or {}).get("livingSpecs") or {}
+    if not isinstance(block, dict):
+        return {"enabled": False, "capabilities": []}
+    enabled = bool(block.get("enabled", False))
+    raw = block.get("capabilities") or []
+    capabilities = []
+    for entry in raw if isinstance(raw, list) else []:
+        if not isinstance(entry, dict):
+            continue
+        name = entry.get("name")
+        if not name:
+            continue
+        name = str(name)
+        if "spec" in entry:
+            spec = "" if entry.get("spec") in (None, "") else str(entry["spec"])
+        else:
+            spec = f"{DEFAULT_CAPABILITY_ROOT}/{name}/spec.md"
+        capabilities.append(
+            {
+                "name": name,
+                "match": _as_list(entry.get("match")),
+                "exclude": _as_list(entry.get("exclude")),
+                "spec": spec,
+            }
+        )
+    return {"enabled": enabled, "capabilities": capabilities}

--- a/speckit-extension/scripts/resolve-spec-paths.py
+++ b/speckit-extension/scripts/resolve-spec-paths.py
@@ -29,7 +29,6 @@ Usage:
 from __future__ import annotations
 
 import argparse
-import fnmatch
 import json
 import os
 import re
@@ -50,7 +49,7 @@ def load_living(root: str) -> dict:
 
 
 def _posix(p: str) -> str:
-    return p.replace(os.sep, "/")
+    return p.replace("\\", "/").replace(os.sep, "/")
 
 
 def _literal_prefix(glob_pat: str) -> str:
@@ -67,11 +66,11 @@ def _literal_prefix(glob_pat: str) -> str:
 
 
 def _glob_to_regex(pat: str) -> str:
-    """Translate a glob with cross-directory `**` into a regex.
+    """Translate a glob into a regex with POSIX-path semantics.
 
-    `**` matches any depth (incl. zero), `*` matches within one segment, `?` one
-    char. A trailing `/**` also matches the directory itself (`src/checkout/**`
-    matches `src/checkout`).
+    `**` matches any depth (incl. zero), `*` matches within one segment (never
+    crosses `/`), `?` one non-slash char. A trailing `/**` also matches the
+    directory itself (`src/checkout/**` matches `src/checkout`).
     """
     out = ["^"]
     i, n = 0, len(pat)
@@ -79,7 +78,14 @@ def _glob_to_regex(pat: str) -> str:
         c = pat[i]
         if c == "*":
             if i + 1 < n and pat[i + 1] == "*":
-                # `**` — consume an optional following slash; match any depth.
+                if i + 2 == n and out and out[-1].endswith("/"):
+                    # trailing `/**` — also match the bare directory: drop the
+                    # `/` we already emitted and make the whole tail optional.
+                    out[-1] = out[-1][:-1]
+                    out.append("(?:/.*)?")
+                    i += 2
+                    continue
+                # `**/` — consume the following slash; match any depth (incl. zero).
                 if i + 2 < n and pat[i + 2] == "/":
                     out.append("(?:.*/)?")
                     i += 3
@@ -99,15 +105,13 @@ def _glob_to_regex(pat: str) -> str:
 
 
 def _glob_matches(pat: str, f: str) -> bool:
-    """Glob match supporting cross-directory `**`.
+    """Glob match with POSIX-path semantics (`*` never crosses `/`).
 
     `src/checkout/**` matches `src/checkout/cart/x.ts` AND `src/checkout` itself;
-    `src/checkout/**/*.test.ts` matches only files ending `.test.ts` at any depth.
-    Falls back to plain fnmatch when the pattern has no `**`.
+    `src/checkout/**/*.test.ts` matches only files ending `.test.ts` at any depth;
+    `src/*.ts` matches only direct children, never nested files.
     """
     pat, f = _posix(pat), _posix(f)
-    if "**" not in pat:
-        return fnmatch.fnmatch(f, pat)
     return re.match(_glob_to_regex(pat), f) is not None
 
 

--- a/speckit-extension/scripts/resolve-spec-paths.py
+++ b/speckit-extension/scripts/resolve-spec-paths.py
@@ -24,7 +24,8 @@ Usage:
   resolve-spec-paths.py --changed <file>...   # capabilities in scope (ordered)
   resolve-spec-paths.py --all                 # every capability (union) + orphans
   resolve-spec-paths.py --orphans             # orphan *.spec.md files only
-  add --json for machine-readable output (default for --changed/--all).
+  add --json for the machine-readable object; the default is a concise human
+  list (capability names / orphan paths).
 """
 from __future__ import annotations
 
@@ -184,29 +185,31 @@ def discover_all(living: dict, root: str) -> list[dict]:
         entry = _entry(cap, root)
         out.append(entry)
         seen.add(os.path.normpath(entry["spec"]))
-    for sp in sorted(glob(os.path.join(root, "**", "*.spec.md"), recursive=True)):
-        rel = os.path.normpath(os.path.relpath(sp, root))
-        if rel in seen:
+    for rel in find_orphans(living, root):
+        norm = os.path.normpath(rel)
+        if norm in seen:
             continue
-        top = rel.split(os.sep, 1)[0]
-        if top == "specs":
-            continue
-        name = os.path.basename(os.path.dirname(rel)) or os.path.basename(rel)
-        out.append({"name": name, "spec": _posix(rel), "location": "colocated",
+        name = os.path.basename(os.path.dirname(norm)) or os.path.basename(norm)
+        out.append({"name": name, "spec": _posix(norm), "location": "colocated",
                     "exists": True})
-        seen.add(rel)
+        seen.add(norm)
     out.sort(key=lambda e: e["name"])
     return out
 
 
 def find_orphans(living: dict, root: str) -> list[str]:
-    """`*.spec.md` on disk not claimed by any capability spec path.
+    """`*.spec.md` on disk not claimed by — and not owned by — any capability.
 
-    `.arch.md` / `.coverage.md` are reserved tiers, never orphans. Excludes
-    `specs/` (feature specs) and any configured `capabilities/<name>` spec.
+    A spec is NOT an orphan when it is: the exact claimed `spec` path of a
+    capability; a reserved-tier sibling (`.arch.md` / `.coverage.md`); or any
+    `*.spec.md` living inside a configured capability's resolved spec directory
+    (e.g. another file under `capabilities/checkout/`). A genuinely-unclaimed,
+    differently-named spec elsewhere stays an orphan. `specs/` (feature specs)
+    is always excluded.
     """
     claimed = {os.path.normpath(c.get("spec") or "")
                for c in living["capabilities"] if c.get("spec")}
+    owned_dirs = {os.path.dirname(c) for c in claimed if os.path.dirname(c)}
     orphans = []
     for sp in glob(os.path.join(root, "**", "*.spec.md"), recursive=True):
         rel = os.path.normpath(os.path.relpath(sp, root))
@@ -214,9 +217,34 @@ def find_orphans(living: dict, root: str) -> list[str]:
             continue
         if any(rel.endswith(t) for t in RESERVED_TIERS):
             continue
-        if rel not in claimed:
-            orphans.append(_posix(rel))
+        if rel in claimed:
+            continue
+        if any(rel == d or rel.startswith(d + os.sep) for d in owned_dirs):
+            continue
+        orphans.append(_posix(rel))
     return sorted(orphans)
+
+
+def _fmt_list(items: list[str]) -> str:
+    """Concise human list: `[a, b]` (matches the README examples)."""
+    return "[" + ", ".join(items) + "]"
+
+
+def render_human(result: dict) -> str:
+    """Concise human-readable view of a result object.
+
+    --changed -> `[name, name]` (most-specific first)
+    --orphans -> `[path, path]`
+    --all     -> capability names line + orphans line
+    Empty modes print `[]` (no error), matching the inert/opt-out contract.
+    """
+    if "matched" in result:
+        return _fmt_list([m["name"] for m in result["matched"]])
+    if "capabilities" in result:
+        caps = _fmt_list([c["name"] for c in result["capabilities"]])
+        orphans = _fmt_list(result.get("orphans", []))
+        return f"capabilities: {caps}\norphans: {orphans}"
+    return _fmt_list(result.get("orphans", []))
 
 
 def main(argv=None) -> int:
@@ -225,10 +253,14 @@ def main(argv=None) -> int:
     ap.add_argument("--changed", nargs="*", help="changed files -> capabilities in scope")
     ap.add_argument("--all", action="store_true", help="every capability (union) + orphans")
     ap.add_argument("--orphans", action="store_true", help="orphan *.spec.md files")
-    ap.add_argument("--json", action="store_true", help="machine-readable output")
+    ap.add_argument("--json", action="store_true",
+                    help="emit the machine-readable JSON object (default: a concise human list)")
     args = ap.parse_args(argv)
     root = args.root
     living = load_living(root)
+
+    def emit(result: dict) -> None:
+        print(json.dumps(result, indent=2) if args.json else render_human(result))
 
     if not living["enabled"]:
         if args.orphans:
@@ -237,7 +269,7 @@ def main(argv=None) -> int:
             result = {"capabilities": [], "orphans": []}
         else:
             result = {"changed": args.changed or [], "matched": []}
-        print(json.dumps(result, indent=2))
+        emit(result)
         return 0
 
     try:
@@ -252,7 +284,7 @@ def main(argv=None) -> int:
     except ValueError as exc:
         sys.stderr.write(f"resolve-spec-paths: {exc}\n")
         return 2
-    print(json.dumps(result, indent=2))
+    emit(result)
     return 0
 
 

--- a/speckit-extension/scripts/resolve-spec-paths.py
+++ b/speckit-extension/scripts/resolve-spec-paths.py
@@ -207,8 +207,9 @@ def find_orphans(living: dict, root: str) -> list[str]:
     differently-named spec elsewhere stays an orphan. `specs/` (feature specs)
     is always excluded.
     """
-    claimed = {os.path.normpath(c.get("spec") or "")
-               for c in living["capabilities"] if c.get("spec")}
+    # _resolve_spec raises on an empty/missing spec, so --orphans surfaces the
+    # same config error the --changed/--all paths do (the CLI contract).
+    claimed = {os.path.normpath(_resolve_spec(c)) for c in living["capabilities"]}
     owned_dirs = {os.path.dirname(c) for c in claimed if os.path.dirname(c)}
     orphans = []
     for sp in glob(os.path.join(root, "**", "*.spec.md"), recursive=True):

--- a/speckit-extension/scripts/resolve-spec-paths.py
+++ b/speckit-extension/scripts/resolve-spec-paths.py
@@ -1,0 +1,256 @@
+#!/usr/bin/env python3
+"""Resolve living-spec paths for Companion capabilities.
+
+Single source of truth for the rules the later Living Specs steps (sync / fold /
+drift) call instead of re-interpreting the `livingSpecs` block in
+`.specify/companion.yml`:
+
+  - membership:  a file belongs to a capability if it matches any `match` glob
+                 and no `exclude` glob.
+  - path:        centralized -> `capabilities/<name>/spec.md` (default), or the
+                 explicit `spec` path (colocated).
+  - discovery:   union of configured capabilities and the on-disk `*.spec.md`
+                 glob, de-duped by resolved spec path.
+  - ordering:    most-specific first (longest matching glob literal-prefix that
+                 prefixes the file), tiebreak by capability name.
+  - tiers:       `.spec.md` (hot, loaded in v1); `.arch.md` / `.coverage.md`
+                 reserved siblings, never flagged as orphans.
+  - orphans:     `*.spec.md` in the tree not claimed by any capability's spec.
+
+OPT-IN: when `livingSpecs.enabled` is unset/false (or there is no config), the
+resolver is inert — every mode returns empty with exit 0 and no error.
+
+Usage:
+  resolve-spec-paths.py --changed <file>...   # capabilities in scope (ordered)
+  resolve-spec-paths.py --all                 # every capability (union) + orphans
+  resolve-spec-paths.py --orphans             # orphan *.spec.md files only
+  add --json for machine-readable output (default for --changed/--all).
+"""
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import json
+import os
+import re
+import sys
+from glob import glob
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import companion_config as cc  # noqa: E402
+
+CONFIG = os.path.join(".specify", "companion.yml")
+RESERVED_TIERS = (".arch.md", ".coverage.md")
+
+
+def load_living(root: str) -> dict:
+    """Load + normalize the livingSpecs block from <root>/.specify/companion.yml."""
+    cfg, _warnings = cc.load_config(os.path.join(root, CONFIG))
+    return cc.load_living_specs(cfg)
+
+
+def _posix(p: str) -> str:
+    return p.replace(os.sep, "/")
+
+
+def _literal_prefix(glob_pat: str) -> str:
+    """Longest leading literal path of a glob (before the first wildcard).
+
+    `src/checkout/**` -> `src/checkout`; stops at the first `*`/`?`/`[`.
+    """
+    out = []
+    for ch in glob_pat:
+        if ch in "*?[":
+            break
+        out.append(ch)
+    return "".join(out).rstrip("/")
+
+
+def _glob_to_regex(pat: str) -> str:
+    """Translate a glob with cross-directory `**` into a regex.
+
+    `**` matches any depth (incl. zero), `*` matches within one segment, `?` one
+    char. A trailing `/**` also matches the directory itself (`src/checkout/**`
+    matches `src/checkout`).
+    """
+    out = ["^"]
+    i, n = 0, len(pat)
+    while i < n:
+        c = pat[i]
+        if c == "*":
+            if i + 1 < n and pat[i + 1] == "*":
+                # `**` — consume an optional following slash; match any depth.
+                if i + 2 < n and pat[i + 2] == "/":
+                    out.append("(?:.*/)?")
+                    i += 3
+                    continue
+                out.append(".*")
+                i += 2
+                continue
+            out.append("[^/]*")
+            i += 1
+        elif c == "?":
+            out.append("[^/]")
+            i += 1
+        else:
+            out.append(re.escape(c))
+            i += 1
+    return "".join(out) + "$"
+
+
+def _glob_matches(pat: str, f: str) -> bool:
+    """Glob match supporting cross-directory `**`.
+
+    `src/checkout/**` matches `src/checkout/cart/x.ts` AND `src/checkout` itself;
+    `src/checkout/**/*.test.ts` matches only files ending `.test.ts` at any depth.
+    Falls back to plain fnmatch when the pattern has no `**`.
+    """
+    pat, f = _posix(pat), _posix(f)
+    if "**" not in pat:
+        return fnmatch.fnmatch(f, pat)
+    return re.match(_glob_to_regex(pat), f) is not None
+
+
+def matches(cap: dict, f: str) -> bool:
+    """File belongs to capability: any `match` glob, minus any `exclude` glob."""
+    f = _posix(f)
+    for ex in cap.get("exclude") or []:
+        if _glob_matches(ex, f):
+            return False
+    return any(_glob_matches(pat, f) for pat in cap.get("match") or [])
+
+
+def _specificity(cap: dict, f: str) -> int:
+    """How specific this capability is for file f: longest matching-glob literal
+    prefix that prefixes f. Deeper code area -> higher specificity."""
+    f = _posix(f)
+    best = 0
+    for pat in cap.get("match") or []:
+        if not _glob_matches(pat, f):
+            continue
+        lit = _literal_prefix(pat)
+        if lit and (f == lit or f.startswith(lit + "/")):
+            best = max(best, len(lit))
+        else:
+            best = max(best, 1)
+    return best
+
+
+def _location(cap: dict) -> str:
+    expected = f"{cc.DEFAULT_CAPABILITY_ROOT}/{cap['name']}/spec.md"
+    return "centralized" if _posix(cap.get("spec") or "") == expected else "colocated"
+
+
+def _resolve_spec(cap: dict) -> str:
+    """The capability's spec path. A colocated capability with no path is an error."""
+    spec = cap.get("spec")
+    if spec in (None, ""):
+        raise ValueError(
+            f'capability "{cap["name"]}" is colocated but has no resolvable spec path'
+        )
+    return spec
+
+
+def _entry(cap: dict, root: str) -> dict:
+    spec = _resolve_spec(cap)
+    return {
+        "name": cap["name"],
+        "spec": spec,
+        "location": _location(cap),
+        "exists": os.path.isfile(os.path.join(root, spec)),
+    }
+
+
+def match_changed(files: list[str], living: dict, root: str) -> list[dict]:
+    hits = []
+    for cap in living["capabilities"]:
+        hit_files = [f for f in files if matches(cap, f)]
+        if not hit_files:
+            continue
+        entry = _entry(cap, root)
+        entry["specificity"] = max(_specificity(cap, f) for f in hit_files)
+        hits.append(entry)
+    hits.sort(key=lambda e: (-e["specificity"], e["name"]))
+    return hits
+
+
+def discover_all(living: dict, root: str) -> list[dict]:
+    out, seen = [], set()
+    for cap in living["capabilities"]:
+        entry = _entry(cap, root)
+        out.append(entry)
+        seen.add(os.path.normpath(entry["spec"]))
+    for sp in sorted(glob(os.path.join(root, "**", "*.spec.md"), recursive=True)):
+        rel = os.path.normpath(os.path.relpath(sp, root))
+        if rel in seen:
+            continue
+        top = rel.split(os.sep, 1)[0]
+        if top == "specs":
+            continue
+        name = os.path.basename(os.path.dirname(rel)) or os.path.basename(rel)
+        out.append({"name": name, "spec": _posix(rel), "location": "colocated",
+                    "exists": True})
+        seen.add(rel)
+    out.sort(key=lambda e: e["name"])
+    return out
+
+
+def find_orphans(living: dict, root: str) -> list[str]:
+    """`*.spec.md` on disk not claimed by any capability spec path.
+
+    `.arch.md` / `.coverage.md` are reserved tiers, never orphans. Excludes
+    `specs/` (feature specs) and any configured `capabilities/<name>` spec.
+    """
+    claimed = {os.path.normpath(c.get("spec") or "")
+               for c in living["capabilities"] if c.get("spec")}
+    orphans = []
+    for sp in glob(os.path.join(root, "**", "*.spec.md"), recursive=True):
+        rel = os.path.normpath(os.path.relpath(sp, root))
+        if rel.split(os.sep, 1)[0] == "specs":
+            continue
+        if any(rel.endswith(t) for t in RESERVED_TIERS):
+            continue
+        if rel not in claimed:
+            orphans.append(_posix(rel))
+    return sorted(orphans)
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description="Resolve Companion living-spec paths.")
+    ap.add_argument("--root", default=".", help="repo root (default: cwd)")
+    ap.add_argument("--changed", nargs="*", help="changed files -> capabilities in scope")
+    ap.add_argument("--all", action="store_true", help="every capability (union) + orphans")
+    ap.add_argument("--orphans", action="store_true", help="orphan *.spec.md files")
+    ap.add_argument("--json", action="store_true", help="machine-readable output")
+    args = ap.parse_args(argv)
+    root = args.root
+    living = load_living(root)
+
+    if not living["enabled"]:
+        if args.orphans:
+            result = {"orphans": []}
+        elif args.all:
+            result = {"capabilities": [], "orphans": []}
+        else:
+            result = {"changed": args.changed or [], "matched": []}
+        print(json.dumps(result, indent=2))
+        return 0
+
+    try:
+        if args.orphans:
+            result = {"orphans": find_orphans(living, root)}
+        elif args.all:
+            result = {"capabilities": discover_all(living, root),
+                      "orphans": find_orphans(living, root)}
+        else:
+            files = args.changed or []
+            result = {"changed": files, "matched": match_changed(files, living, root)}
+    except ValueError as exc:
+        sys.stderr.write(f"resolve-spec-paths: {exc}\n")
+        return 2
+    print(json.dumps(result, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/speckit-extension/tests/fixtures/companion-living-specs.yml
+++ b/speckit-extension/tests/fixtures/companion-living-specs.yml
@@ -1,0 +1,12 @@
+# Sample livingSpecs config — checkout + nested checkout-cart, exclude, opt-in.
+livingSpecs:
+  enabled: true
+  capabilities:
+    - name: checkout
+      match: ["src/checkout/**"]
+      exclude: ["src/checkout/**/*.test.ts"]
+    - name: checkout-cart
+      match: ["src/checkout/cart/**"]
+    - name: billing
+      match: ["src/billing/**"]
+      spec: src/billing/billing.spec.md

--- a/speckit-extension/tests/test_living_specs.py
+++ b/speckit-extension/tests/test_living_specs.py
@@ -201,6 +201,16 @@ class ColocatedErrorTests(unittest.TestCase):
         rc = rsp.main(["--root", str(root), "--changed", "src/broken/x.ts"])
         self.assertEqual(rc, 2)
 
+    def test_colocated_without_spec_path_errors_in_orphans_mode(self) -> None:
+        # --orphans must surface the same config error as --changed/--all (it
+        # used to skip empty-spec capabilities and exit 0).
+        yaml = (
+            "livingSpecs:\n  enabled: true\n  capabilities:\n"
+            "    - name: broken\n      match: [\"src/broken/**\"]\n      spec: \"\"\n"
+        )
+        root = make_repo(yaml, files=["src/broken/x.ts"])
+        self.assertEqual(rsp.main(["--root", str(root), "--orphans"]), 2)
+
 
 class OptInTests(unittest.TestCase):
     DISABLED = CHECKOUT_YAML.replace("enabled: true", "enabled: false")

--- a/speckit-extension/tests/test_living_specs.py
+++ b/speckit-extension/tests/test_living_specs.py
@@ -97,6 +97,19 @@ class MembershipTests(unittest.TestCase):
         self.assertTrue(rsp.matches(cap, "src/checkout/cart.ts"))
         self.assertFalse(rsp.matches(cap, "src/checkout/cart.test.ts"))
 
+    def test_single_star_does_not_cross_directories(self) -> None:
+        cap = {"name": "top", "match": ["src/*.ts"]}
+        self.assertTrue(rsp.matches(cap, "src/index.ts"))
+        self.assertFalse(rsp.matches(cap, "src/checkout/nested.ts"))
+
+    def test_trailing_double_star_matches_bare_directory(self) -> None:
+        self.assertTrue(rsp._glob_matches("src/checkout/**", "src/checkout"))
+        self.assertTrue(rsp._glob_matches("src/checkout/**", "src/checkout/cart/x.ts"))
+
+    def test_backslash_changed_path_is_normalized(self) -> None:
+        cap = {"name": "checkout", "match": ["src/checkout/**"]}
+        self.assertTrue(rsp.matches(cap, "src\\checkout\\cart\\x.ts"))
+
 
 class ChangedOrderingTests(unittest.TestCase):
     def test_most_specific_first(self) -> None:
@@ -172,8 +185,10 @@ class OptInTests(unittest.TestCase):
         root = make_repo(self.DISABLED)
         living = rsp.load_living(str(root))
         self.assertFalse(living["enabled"])
-        self.assertEqual(rsp.match_changed(["src/checkout/cart/x.ts"], living, str(root))
-                         if living["enabled"] else [], [])
+        # The opt-in gate lives in main(): a disabled config emits an empty match
+        # list without ever consulting the capabilities.
+        rc = rsp.main(["--root", str(root), "--changed", "src/checkout/cart/x.ts", "--json"])
+        self.assertEqual(rc, 0)
 
     def test_disabled_main_returns_empty_exit_zero(self) -> None:
         root = make_repo(self.DISABLED)

--- a/speckit-extension/tests/test_living_specs.py
+++ b/speckit-extension/tests/test_living_specs.py
@@ -166,6 +166,30 @@ class AllAndOrphanTests(unittest.TestCase):
         living = rsp.load_living(str(root))
         self.assertEqual(rsp.find_orphans(living, str(root)), [])
 
+    def test_sibling_spec_in_owned_capability_dir_is_not_orphan(self) -> None:
+        # A differently-named *.spec.md under a configured capability's spec
+        # directory belongs to that capability — not a stray orphan.
+        root = make_repo(
+            CHECKOUT_YAML,
+            spec_files=["capabilities/checkout/spec.md",
+                        "capabilities/checkout/legacy.spec.md"],
+        )
+        living = rsp.load_living(str(root))
+        orphans = rsp.find_orphans(living, str(root))
+        self.assertNotIn("capabilities/checkout/legacy.spec.md", orphans)
+        self.assertEqual(orphans, [])
+        # discover_all must not synthesize a phantom capability for the sibling.
+        allres = rsp.discover_all(living, str(root))
+        self.assertNotIn("capabilities/checkout/legacy.spec.md",
+                         {e["spec"] for e in allres})
+
+    def test_unrelated_named_spec_outside_owned_dir_stays_orphan(self) -> None:
+        # A spec that is neither claimed nor under any capability dir is an orphan.
+        root = make_repo(CHECKOUT_YAML, spec_files=["docs/wandering.spec.md"])
+        living = rsp.load_living(str(root))
+        self.assertEqual(rsp.find_orphans(living, str(root)),
+                         ["docs/wandering.spec.md"])
+
 
 class ColocatedErrorTests(unittest.TestCase):
     def test_colocated_without_spec_path_errors(self) -> None:
@@ -199,6 +223,51 @@ class OptInTests(unittest.TestCase):
         root = Path(tempfile.mkdtemp())
         rc = rsp.main(["--root", str(root), "--all"])
         self.assertEqual(rc, 0)
+
+
+class OutputFormatTests(unittest.TestCase):
+    """--json emits the JSON object; the default is a concise human list."""
+
+    def _run(self, argv) -> tuple[int, str]:
+        import contextlib
+        import io
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            rc = rsp.main(argv)
+        return rc, buf.getvalue()
+
+    def test_changed_default_is_human_name_list(self) -> None:
+        root = make_repo(CHECKOUT_YAML)
+        rc, out = self._run(["--root", str(root), "--changed", "src/checkout/cart/x.ts"])
+        self.assertEqual(rc, 0)
+        self.assertEqual(out.strip(), "[checkout-cart, checkout]")
+
+    def test_changed_json_emits_object(self) -> None:
+        root = make_repo(CHECKOUT_YAML)
+        rc, out = self._run(["--root", str(root), "--changed", "src/checkout/cart/x.ts", "--json"])
+        self.assertEqual(rc, 0)
+        import json
+        obj = json.loads(out)
+        self.assertEqual([m["name"] for m in obj["matched"]], ["checkout-cart", "checkout"])
+
+    def test_orphans_default_is_human_path_list(self) -> None:
+        root = make_repo(CHECKOUT_YAML, spec_files=["notes/random.spec.md"])
+        rc, out = self._run(["--root", str(root), "--orphans"])
+        self.assertEqual(rc, 0)
+        self.assertEqual(out.strip(), "[notes/random.spec.md]")
+
+    def test_all_default_has_capabilities_and_orphans_lines(self) -> None:
+        root = make_repo(CHECKOUT_YAML, spec_files=["notes/random.spec.md"])
+        rc, out = self._run(["--root", str(root), "--all"])
+        self.assertEqual(rc, 0)
+        lines = out.strip().splitlines()
+        self.assertTrue(lines[0].startswith("capabilities: ["))
+        self.assertEqual(lines[1], "orphans: [notes/random.spec.md]")
+
+    def test_human_render_does_not_emit_json_braces(self) -> None:
+        root = make_repo(CHECKOUT_YAML)
+        _, out = self._run(["--root", str(root), "--all"])
+        self.assertNotIn("{", out)
 
 
 if __name__ == "__main__":

--- a/speckit-extension/tests/test_living_specs.py
+++ b/speckit-extension/tests/test_living_specs.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+"""Tests for the Living Specs capability resolver + config reader (#361).
+
+Stdlib `unittest` only (runs under pytest too). Covers the LS·1 contract:
+the typed livingSpecs reader, match/exclude membership, most-specific-first
+ordering, --all union/de-dup, orphan detection with tier exemption, the
+colocated-no-path error, and the opt-in guarantee (enabled:false -> inert).
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPTS = Path(__file__).resolve().parent.parent / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+import companion_config as cc  # noqa: E402
+
+# resolve-spec-paths.py has a hyphen, so import it by file path.
+_spec = importlib.util.spec_from_file_location(
+    "resolve_spec_paths", SCRIPTS / "resolve-spec-paths.py"
+)
+rsp = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(rsp)
+
+
+def make_repo(yaml_text: str, files=(), spec_files=()) -> Path:
+    """Bake a throwaway repo with a companion.yml and optional planted files."""
+    root = Path(tempfile.mkdtemp())
+    (root / ".specify").mkdir(parents=True)
+    (root / ".specify" / "companion.yml").write_text(yaml_text, encoding="utf-8")
+    for f in files:
+        p = root / f
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text("// code\n", encoding="utf-8")
+    for f in spec_files:
+        p = root / f
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text("# spec\n", encoding="utf-8")
+    return root
+
+
+CHECKOUT_YAML = """\
+livingSpecs:
+  enabled: true
+  capabilities:
+    - name: checkout
+      match: ["src/checkout/**"]
+      exclude: ["src/checkout/**/*.test.ts"]
+    - name: checkout-cart
+      match: ["src/checkout/cart/**"]
+"""
+
+
+class ConfigReaderTests(unittest.TestCase):
+    def test_enabled_defaults_false_when_absent(self) -> None:
+        cfg, _ = cc.load_config("/nonexistent/companion.yml")
+        living = cc.load_living_specs(cfg)
+        self.assertFalse(living["enabled"])
+        self.assertEqual(living["capabilities"], [])
+
+    def test_centralized_spec_defaults_to_capabilities_path(self) -> None:
+        living = cc.load_living_specs(cc.load_yaml(CHECKOUT_YAML))
+        cap = next(c for c in living["capabilities"] if c["name"] == "checkout")
+        self.assertEqual(cap["spec"], "capabilities/checkout/spec.md")
+
+    def test_explicit_spec_is_kept_as_colocated_path(self) -> None:
+        yaml = (
+            "livingSpecs:\n  enabled: true\n  capabilities:\n"
+            "    - name: billing\n      match: [\"src/billing/**\"]\n"
+            "      spec: src/billing/billing.spec.md\n"
+        )
+        living = cc.load_living_specs(cc.load_yaml(yaml))
+        self.assertEqual(living["capabilities"][0]["spec"], "src/billing/billing.spec.md")
+
+    def test_scalar_match_is_coerced_to_list(self) -> None:
+        yaml = (
+            "livingSpecs:\n  enabled: true\n  capabilities:\n"
+            "    - name: auth\n      match: src/auth/login.ts\n"
+        )
+        living = cc.load_living_specs(cc.load_yaml(yaml))
+        self.assertEqual(living["capabilities"][0]["match"], ["src/auth/login.ts"])
+
+
+class MembershipTests(unittest.TestCase):
+    def test_match_globs_define_membership(self) -> None:
+        living = cc.load_living_specs(cc.load_yaml(CHECKOUT_YAML))
+        cap = living["capabilities"][0]
+        self.assertTrue(rsp.matches(cap, "src/checkout/cart/x.ts"))
+        self.assertFalse(rsp.matches(cap, "src/auth/login.ts"))
+
+    def test_exclude_removes_a_matched_file(self) -> None:
+        living = cc.load_living_specs(cc.load_yaml(CHECKOUT_YAML))
+        cap = next(c for c in living["capabilities"] if c["name"] == "checkout")
+        self.assertTrue(rsp.matches(cap, "src/checkout/cart.ts"))
+        self.assertFalse(rsp.matches(cap, "src/checkout/cart.test.ts"))
+
+
+class ChangedOrderingTests(unittest.TestCase):
+    def test_most_specific_first(self) -> None:
+        root = make_repo(CHECKOUT_YAML)
+        living = rsp.load_living(str(root))
+        matched = rsp.match_changed(["src/checkout/cart/x.ts"], living, str(root))
+        self.assertEqual([m["name"] for m in matched], ["checkout-cart", "checkout"])
+
+    def test_file_in_only_outer_capability(self) -> None:
+        root = make_repo(CHECKOUT_YAML)
+        living = rsp.load_living(str(root))
+        matched = rsp.match_changed(["src/checkout/index.ts"], living, str(root))
+        self.assertEqual([m["name"] for m in matched], ["checkout"])
+
+    def test_unmatched_file_returns_empty(self) -> None:
+        root = make_repo(CHECKOUT_YAML)
+        living = rsp.load_living(str(root))
+        self.assertEqual(rsp.match_changed(["README.md"], living, str(root)), [])
+
+
+class AllAndOrphanTests(unittest.TestCase):
+    def test_all_unions_config_and_on_disk_and_flags_orphan(self) -> None:
+        root = make_repo(CHECKOUT_YAML, spec_files=["notes/random.spec.md"])
+        living = rsp.load_living(str(root))
+        allres = rsp.discover_all(living, str(root))
+        names = {e["name"] for e in allres}
+        self.assertIn("checkout", names)
+        self.assertIn("checkout-cart", names)
+        orphans = rsp.find_orphans(living, str(root))
+        self.assertIn("notes/random.spec.md", orphans)
+
+    def test_dedup_by_resolved_spec_path(self) -> None:
+        # An on-disk file that IS a configured capability's spec path is not re-listed.
+        root = make_repo(CHECKOUT_YAML, spec_files=["capabilities/checkout/spec.md"])
+        living = rsp.load_living(str(root))
+        allres = rsp.discover_all(living, str(root))
+        checkout_entries = [e for e in allres if e["spec"] == "capabilities/checkout/spec.md"]
+        self.assertEqual(len(checkout_entries), 1)
+        self.assertNotIn("capabilities/checkout/spec.md", rsp.find_orphans(living, str(root)))
+
+    def test_reserved_tier_files_are_never_orphans(self) -> None:
+        root = make_repo(
+            CHECKOUT_YAML,
+            spec_files=["capabilities/checkout/spec.md",
+                        "capabilities/checkout/spec.arch.md",
+                        "capabilities/checkout/spec.coverage.md"],
+        )
+        living = rsp.load_living(str(root))
+        orphans = rsp.find_orphans(living, str(root))
+        self.assertEqual(orphans, [])
+
+    def test_feature_specs_dir_is_excluded_from_orphans(self) -> None:
+        root = make_repo(CHECKOUT_YAML, spec_files=["specs/001-foo/notes.spec.md"])
+        living = rsp.load_living(str(root))
+        self.assertEqual(rsp.find_orphans(living, str(root)), [])
+
+
+class ColocatedErrorTests(unittest.TestCase):
+    def test_colocated_without_spec_path_errors(self) -> None:
+        yaml = (
+            "livingSpecs:\n  enabled: true\n  capabilities:\n"
+            "    - name: broken\n      match: [\"src/broken/**\"]\n      spec: \"\"\n"
+        )
+        root = make_repo(yaml, files=["src/broken/x.ts"])
+        rc = rsp.main(["--root", str(root), "--changed", "src/broken/x.ts"])
+        self.assertEqual(rc, 2)
+
+
+class OptInTests(unittest.TestCase):
+    DISABLED = CHECKOUT_YAML.replace("enabled: true", "enabled: false")
+
+    def test_disabled_changed_is_empty(self) -> None:
+        root = make_repo(self.DISABLED)
+        living = rsp.load_living(str(root))
+        self.assertFalse(living["enabled"])
+        self.assertEqual(rsp.match_changed(["src/checkout/cart/x.ts"], living, str(root))
+                         if living["enabled"] else [], [])
+
+    def test_disabled_main_returns_empty_exit_zero(self) -> None:
+        root = make_repo(self.DISABLED)
+        rc = rsp.main(["--root", str(root), "--changed", "src/checkout/cart/x.ts"])
+        self.assertEqual(rc, 0)
+
+    def test_no_config_is_inert(self) -> None:
+        root = Path(tempfile.mkdtemp())
+        rc = rsp.main(["--root", str(root), "--all"])
+        self.assertEqual(rc, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/specs/356-living-specs/.spec-context.json
+++ b/specs/356-living-specs/.spec-context.json
@@ -1,0 +1,244 @@
+{
+  "workflow": "speckit",
+  "specName": "living specs",
+  "branch": "356-living-specs",
+  "currentStep": "implement",
+  "status": "completed",
+  "history": [
+    {
+      "step": "specify",
+      "substep": null,
+      "kind": "start",
+      "by": "extension",
+      "at": "2026-06-25T16:57:48.063Z"
+    },
+    {
+      "step": "specify",
+      "substep": null,
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-06-25T16:58:50.551Z"
+    },
+    {
+      "step": "plan",
+      "substep": null,
+      "kind": "start",
+      "by": "extension",
+      "at": "2026-06-25T16:59:03.723Z"
+    },
+    {
+      "step": "plan",
+      "substep": "research",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-25T16:59:40.448Z"
+    },
+    {
+      "step": "plan",
+      "substep": "design",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-25T17:00:32.601Z"
+    },
+    {
+      "step": "plan",
+      "substep": null,
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-25T17:00:32.673Z"
+    },
+    {
+      "step": "tasks",
+      "substep": null,
+      "kind": "start",
+      "by": "extension",
+      "at": "2026-06-25T17:00:45.545Z"
+    },
+    {
+      "step": "tasks",
+      "substep": "generate",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-25T17:01:09.147Z"
+    },
+    {
+      "step": "tasks",
+      "substep": null,
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-25T17:01:09.219Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "kind": "start",
+      "by": "extension",
+      "at": "2026-06-25T17:01:15.043Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T001",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-25T17:01:42.045Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T002",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-25T17:02:43.042Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T003",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-25T17:02:43.092Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T004",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-25T17:02:43.139Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T005",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-25T17:02:43.190Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T006",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-25T17:04:46.246Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T007",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-25T17:04:46.298Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T008",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-25T17:06:21.596Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T009",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-25T17:06:21.648Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T010",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-25T17:07:51.351Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-06-25T17:07:51.420Z"
+    }
+  ],
+  "size": "normal",
+  "currentTask": "T010",
+  "task_summaries": {
+    "T001": {
+      "status": "DONE",
+      "did": "Added load_living_specs() typed reader to companion_config.py: enabled defaults false, normalizes match/exclude, defaults spec to capabilities/<name>/spec.md",
+      "files": [
+        "speckit-extension/scripts/companion_config.py"
+      ]
+    },
+    "T002": {
+      "status": "DONE",
+      "did": "Created resolve-spec-paths.py with argparse modes + inert short-circuit when livingSpecs.enabled false/absent",
+      "files": [
+        "speckit-extension/scripts/resolve-spec-paths.py"
+      ]
+    },
+    "T003": {
+      "status": "DONE",
+      "did": "Implemented glob membership (match minus exclude) with ** recursive shim + specificity by literal-prefix length",
+      "files": [
+        "speckit-extension/scripts/resolve-spec-paths.py"
+      ]
+    },
+    "T004": {
+      "status": "DONE",
+      "did": "Implemented --changed: most-specific-first ordering, spec/location/exists resolution, colocated-no-path exit 2 error",
+      "files": [
+        "speckit-extension/scripts/resolve-spec-paths.py"
+      ]
+    },
+    "T005": {
+      "status": "DONE",
+      "did": "Implemented --all union+dedup and --orphans with .arch.md/.coverage.md tier exemption and specs/ exclusion",
+      "files": [
+        "speckit-extension/scripts/resolve-spec-paths.py"
+      ]
+    },
+    "T006": {
+      "status": "DONE",
+      "did": "Added companion-living-specs.yml fixture (checkout + checkout-cart + exclude + colocated billing)",
+      "files": [
+        "speckit-extension/tests/fixtures/companion-living-specs.yml"
+      ]
+    },
+    "T007": {
+      "status": "DONE",
+      "did": "Wrote test_living_specs.py (17 tests): config defaults, match/exclude, most-specific ordering, --all union/dedup, orphan+tier exemption, colocated error, enabled:false inert; all green under pytest+unittest",
+      "files": [
+        "speckit-extension/tests/test_living_specs.py"
+      ]
+    },
+    "T008": {
+      "status": "DONE",
+      "did": "Added ls-lib.mjs: bakeLs1Repo/bakeOptOutRepo arrange helpers + runResolver/runPytest act helpers (real execFileSync), importing from ../lib.mjs",
+      "files": [
+        "examples/todo-claude/bench/living-specs/ls-lib.mjs"
+      ]
+    },
+    "T009": {
+      "status": "DONE",
+      "did": "Added ls-demos.mjs runner: runs resolver across modes + pytest, asserts contract, writes evidence/LS1.json (mode deterministic); demo PASS 6/6",
+      "files": [
+        "examples/todo-claude/bench/living-specs/ls-demos.mjs",
+        "examples/todo-claude/bench/living-specs/evidence/LS1.json"
+      ]
+    },
+    "T010": {
+      "status": "DONE",
+      "did": "Documented livingSpecs config block + resolver in speckit-extension README, added CHANGELOG entry, bumped extension.yml to 0.12.0, added resolver+companion_config to publishing allow-list",
+      "files": [
+        "speckit-extension/README.md",
+        "speckit-extension/CHANGELOG.md",
+        "speckit-extension/extension.yml",
+        "speckit-extension/docs/publishing.md"
+      ]
+    }
+  }
+}

--- a/specs/356-living-specs/checklists/requirements.md
+++ b/specs/356-living-specs/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Living Specs — capability resolver, config + sandbox harness (LS·1)
+
+**Purpose**: Validate Companion specification completeness before planning
+**Created**: 2026-06-25
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed (User Scenarios, Requirements, Success Criteria)
+
+## Requirement Completeness
+
+- [x] Any [NEEDS CLARIFICATION] markers are genuine ambiguities (≤3) deferred to clarify — none needed
+- [x] Each Functional Requirement is a single, testable MUST/SHOULD statement
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into the specification
+
+## Notes
+
+- Classified `normal`: net-new resolver + config reader + tests + harness + docs spans multiple files, crossing the small-change guardrail (5 files / 10 tasks). Full pipeline runs.

--- a/specs/356-living-specs/contracts/resolver-cli.md
+++ b/specs/356-living-specs/contracts/resolver-cli.md
@@ -10,7 +10,7 @@ Path: `speckit-extension/scripts/resolve-spec-paths.py`. Stdlib-only. Reads `liv
 | `--changed <file>...` | capabilities owning the given files, most-specific first |
 | `--all` | union of configured capabilities + on-disk `*.spec.md`, de-duped, plus orphans |
 | `--orphans` | orphan `*.spec.md` files only |
-| `--json` | machine-readable output (default-on for `--changed`/`--all`) |
+| `--json` | emit the machine-readable JSON object; default (without `--json`) is a concise human list |
 
 ## Output shapes (`--json`)
 

--- a/specs/356-living-specs/contracts/resolver-cli.md
+++ b/specs/356-living-specs/contracts/resolver-cli.md
@@ -1,0 +1,54 @@
+# CLI Contract: `resolve-spec-paths.py`
+
+Path: `speckit-extension/scripts/resolve-spec-paths.py`. Stdlib-only. Reads `livingSpecs` from `.specify/companion.yml` at `--root` (default cwd).
+
+## Flags
+
+| Flag | Meaning |
+|---|---|
+| `--root <dir>` | repo root (default `.`) |
+| `--changed <file>...` | capabilities owning the given files, most-specific first |
+| `--all` | union of configured capabilities + on-disk `*.spec.md`, de-duped, plus orphans |
+| `--orphans` | orphan `*.spec.md` files only |
+| `--json` | machine-readable output (default-on for `--changed`/`--all`) |
+
+## Output shapes (`--json`)
+
+`--changed`:
+```json
+{ "changed": ["src/checkout/cart/x.ts"],
+  "matched": [
+    { "name": "checkout-cart", "spec": "capabilities/checkout-cart/spec.md", "location": "centralized", "exists": false, "specificity": 17 },
+    { "name": "checkout", "spec": "capabilities/checkout/spec.md", "location": "centralized", "exists": false, "specificity": 12 }
+  ] }
+```
+
+`--all`:
+```json
+{ "capabilities": [ { "name": "...", "spec": "...", "location": "...", "exists": true } ],
+  "orphans": ["notes/random.spec.md"] }
+```
+
+`--orphans`:
+```json
+{ "orphans": ["notes/random.spec.md"] }
+```
+
+## Inert (opt-out) contract
+
+When `livingSpecs.enabled` is unset/false or no config exists:
+- `--changed` → `{ "changed": [...], "matched": [] }`
+- `--all` → `{ "capabilities": [], "orphans": [] }`
+- `--orphans` → `{ "orphans": [] }`
+- exit 0, no stderr error.
+
+## Error contract
+
+- Colocated capability with no resolvable spec path → exit 2, stderr message naming the capability.
+
+## Exit codes
+
+| Code | Meaning |
+|---|---|
+| 0 | success (incl. inert) |
+| 2 | config error (unresolvable colocated spec) |

--- a/specs/356-living-specs/data-model.md
+++ b/specs/356-living-specs/data-model.md
@@ -1,0 +1,46 @@
+# Data Model: Living Specs LS·1
+
+## livingSpecs config block (in `.specify/companion.yml`)
+
+```yaml
+livingSpecs:
+  enabled: false            # bool, default false — opt-in gate
+  capabilities:
+    - name: checkout        # str, required — capability id
+      match: ["src/checkout/**"]   # list[str] globs — membership
+      exclude: ["**/*.test.ts"]    # list[str] globs, optional — subtracted from membership
+      spec: capabilities/checkout/spec.md  # str, optional — defaults to capabilities/<name>/spec.md
+```
+
+### Capability (normalized)
+
+| Field | Type | Required | Default | Notes |
+|---|---|---|---|---|
+| `name` | str | yes | — | capability id; used in default spec path and ordering tiebreak |
+| `match` | list[str] | yes | — | globs defining membership; scalar coerced to 1-item list |
+| `exclude` | list[str] | no | `[]` | globs subtracted from membership; scalar coerced |
+| `spec` | str | no | `capabilities/<name>/spec.md` | living-spec path; explicit path = colocated |
+
+### Membership rule
+
+A file belongs to a capability when it matches **any** `match` glob AND matches **no** `exclude` glob.
+
+### Resolved entry (resolver output, `--json`)
+
+| Field | Type | Notes |
+|---|---|---|
+| `name` | str | capability id |
+| `spec` | str | resolved spec path |
+| `location` | "centralized" \| "colocated" | colocated when `spec` not under `capabilities/<name>/` |
+| `exists` | bool | whether the spec file is on disk |
+| `specificity` | int | literal-prefix length of the matching glob (in `--changed` mode) |
+
+### Tier conventions
+
+- `.spec.md` — hot tier, loaded in v1.
+- `.arch.md` / `.coverage.md` — reserved siblings; recognized, never flagged as orphans.
+
+### State / errors
+
+- A capability with `spec` explicitly set to an empty value (colocated, no resolvable path) → config error, non-zero exit, message names the capability.
+- `enabled` false/absent → resolver returns empty for all modes.

--- a/specs/356-living-specs/plan.md
+++ b/specs/356-living-specs/plan.md
@@ -1,0 +1,54 @@
+# Implementation Plan: Living Specs — capability resolver, config + sandbox harness (LS·1)
+
+## Summary
+
+Build the foundation slice of Living Specs in the spec-kit extension: a Python **capability resolver** that maps changed files to the capabilities (code areas) that own them, a typed `livingSpecs` reader added to the existing config module, a pytest suite, and a thin reusable sandbox harness on top of the existing bench helpers. The resolver mirrors the model already proven in the SDD plugin's `resolve-spec-paths.py` but rebuilt in Companion vocabulary (`capabilities`, `match`/`exclude`/`spec`, `livingSpecs.enabled`). The feature is opt-in: with `enabled` unset/false or no config, the resolver is inert. Stdlib-only Python, matching the rest of `speckit-extension/scripts/`.
+
+## Project Structure
+
+```
+speckit-extension/
+├── scripts/
+│   ├── resolve-spec-paths.py        # NEW — capability resolver (modes: --changed/--all/--orphans, --json)
+│   └── companion_config.py          # EXTEND — add typed livingSpecs reader (load_living_specs)
+├── tests/
+│   ├── test_living_specs.py         # NEW — pytest: match/exclude, ordering, orphans, enabled:false inert
+│   └── fixtures/
+│       └── companion-living-specs.yml  # NEW — fixture config with a livingSpecs block
+├── README.md                        # EXTEND — document the livingSpecs config block
+├── CHANGELOG.md                     # EXTEND — release note
+└── extension.yml                    # EXTEND — bump version
+
+examples/todo-claude/bench/living-specs/
+├── ls-lib.mjs                       # NEW — shared sandbox arrange helpers (imports ../lib.mjs)
+├── ls-demos.mjs                     # NEW — thin runner: bake repo, run LS·1 demo, write evidence
+└── evidence/
+    └── LS1.json                     # NEW (generated) — real captured demo evidence
+
+docs/                                # EXTEND — capability config reference is documented in README; a docs/ note optional
+```
+
+**Structure Decision:** Everything lands under `speckit-extension/` (the spec-kit extension's own scripts/tests/docs) plus a new `examples/todo-claude/bench/living-specs/` harness folder. No root `package.json`, root README, or VS Code `src/` changes — the GUI side stays thin for LS·1.
+
+## Constitution Check
+
+No project constitution file enforces additional principles for the spec-kit extension scripts beyond the repo conventions (stdlib-only Python, isolation, two-extensions docs split). All satisfied:
+
+| Principle | Assessment |
+|---|---|
+| Extension isolation — no `.claude/**` / `.specify/**` runtime edits for behavior | PASS — resolver + config reader live in `speckit-extension/scripts/`, shipped in the extension. |
+| Stdlib-only Python in `speckit-extension/scripts/` | PASS — `argparse`, `fnmatch`, `glob`, `os`, `sys`, `json` only; reuses `companion_config`'s YAML reader. |
+| Two extensions, two docs sets | PASS — only `speckit-extension/` README/CHANGELOG/`extension.yml` touched. |
+| Opt-in / no behavior change for non-adopters | PASS — `enabled` defaults false; inert resolver returns empty. |
+
+No violations; Complexity Tracking omitted.
+
+## Key Decisions
+
+- **Decision:** Reuse `companion_config.py`'s YAML subset reader and add `load_living_specs(config)` as a sibling accessor to `resolve_order` / `merge_hooks`, rather than parsing YAML in the resolver. **Why:** the config module is the executable spec of `.specify/companion.yml`; one parser, no drift. **Alternative rejected:** a second YAML reader in the resolver (duplication, drift risk).
+- **Decision:** Membership is `match` globs minus optional `exclude` globs, matched with `fnmatch` against POSIX-normalized relative paths. **Why:** matches the SDD model and the issue's contract; `fnmatch` is stdlib and supports `**` via a recursive-glob shim. **Alternative rejected:** regex patterns (the SDD `pattern` field) — globs read more naturally in the Companion config and match the issue's `match: ["src/checkout/**"]` examples.
+- **Decision:** Specificity = length of the longest matching `match` glob's literal prefix that prefixes the file; tiebreak by capability name. **Why:** deterministic "most-specific first" ordering; `src/checkout/cart/**` (longer literal prefix) outranks `src/checkout/**`. **Alternative rejected:** count of path segments (ambiguous on `**`).
+- **Decision:** Centralized spec defaults to `capabilities/<name>/spec.md`; a colocated capability supplies an explicit `spec` code-area path. A colocated capability with no resolvable `spec` raises a clear error. **Why:** mirrors OpenSpec's central-vs-colocated split and the issue contract.
+- **Decision:** Reserved tiers `.arch.md` / `.coverage.md` are recognized siblings, never orphans; only `.spec.md` is loaded in v1. Orphan scan excludes `specs/` and `capabilities/<configured>`. **Why:** issue contract — never flag reserved-tier files.
+- **Decision:** `enabled` defaults `false`; when false/absent the resolver short-circuits to empty results across all modes (exit 0). **Why:** opt-in guarantee (FR-009).
+- **Decision:** Sandbox harness mode is `deterministic` — resolver + pytest only, no live AI. **Why:** LS·1 has no AI step; honesty contract requires real `execFileSync` capture, which deterministic mode provides cleanly.

--- a/specs/356-living-specs/research.md
+++ b/specs/356-living-specs/research.md
@@ -1,0 +1,39 @@
+# Research: Living Specs LS·1
+
+## Decision: Reuse the SDD resolver model, rebuild in Companion vocabulary
+
+**Decision:** Port the path-resolution model from `~/dev/GitHub/sdd/lib/scripts/resolve-spec-paths.py` (domains → membership → resolve → discover → orphans → most-specific ordering) but rename the vocabulary: `domains` → `capabilities`, `pattern`/`include` → `match` globs, `specDir`/`.sdd.json` → `livingSpecs` block in `.specify/companion.yml`, `.specs/<d>/spec.md` → `capabilities/<name>/spec.md`.
+
+**Rationale:** The SDD model is proven and already battle-tested for the exact problem (changed-files → spec ordering, union discovery, orphan exemption of `.arch.md`/`.coverage.md`). Rebuilding from scratch would risk subtle ordering/de-dup bugs. Companion uses OpenSpec-flavored nouns (`capabilities`), so a verbatim copy would be off-brand and confusing.
+
+**Alternatives considered:** A verbatim copy of the SDD script (rejected — wrong vocabulary, wrong config file, JSON config vs Companion's YAML); a fresh from-scratch implementation (rejected — re-derives solved ordering/orphan logic).
+
+## Decision: Glob membership via fnmatch + recursive-glob shim
+
+**Decision:** Match `match`/`exclude` globs against the POSIX relative path using `fnmatch`. Since `fnmatch` does not treat `**` as cross-directory, normalize a `**` glob to also match its prefix (`src/checkout/**` matches `src/checkout/cart/x.ts`) by testing both `fnmatch` and a `**`→prefix expansion.
+
+**Rationale:** Stdlib-only, no PyYAML / no third-party glob. The issue's examples (`match: ["src/checkout/**"]`) need recursive matching.
+
+**Alternatives considered:** `pathlib.PurePath.match` (no `**` support pre-3.13); regex patterns like SDD (rejected — globs read better in YAML and match the issue contract).
+
+## Decision: Specificity by longest literal-prefix of the matching glob
+
+**Decision:** For each capability that matches a file, compute specificity as the length of the glob's literal prefix (everything before the first wildcard) when that prefix prefixes the file path. Order descending, tiebreak by capability name ascending.
+
+**Rationale:** `src/checkout/cart/**` has a longer literal prefix than `src/checkout/**`, so `checkout-cart` sorts before `checkout` — exactly the required `[checkout-cart, checkout]` ordering. Deterministic and simple.
+
+**Alternatives considered:** Segment count (ambiguous with `**`), declaration order (not "most-specific").
+
+## Decision: Config reader on companion_config.py, defaulting enabled=false
+
+**Decision:** Add `load_living_specs(config) -> dict` to `companion_config.py` returning `{enabled: bool, capabilities: [{name, match, exclude, spec}]}`, normalizing scalar `match`/`exclude` to lists and resolving the default `spec` to `capabilities/<name>/spec.md`. The resolver calls `load_config` + `load_living_specs`.
+
+**Rationale:** Single YAML parser; the config module is already the executable spec of `.specify/companion.yml`. Mirrors `resolve_order` / `merge_hooks` accessor style.
+
+**Alternatives considered:** Parsing YAML inside the resolver (rejected — duplicate parser, drift).
+
+## Decision: Deterministic sandbox mode
+
+**Decision:** The LS·1 demo runs the resolver + pytest only (no AI), captured via `execFileSync`. `mode: "deterministic"` per the evidence contract.
+
+**Rationale:** LS·1 has no live AI step. Deterministic capture is honest and reproducible; the contract reserves `real`/`real+seeded-spec` for later tickets that exercise the AI.

--- a/specs/356-living-specs/spec.md
+++ b/specs/356-living-specs/spec.md
@@ -1,0 +1,110 @@
+# Feature Specification: Living Specs — capability resolver, config + sandbox harness (LS·1)
+
+**Issue:** #361 · **Wave:** Living Specs (Wave 4) · **Surface:** spec-kit extension (`speckit-extension/`)
+
+## Overview
+
+Living Specs lets a team declare the **capabilities** in their codebase — checkout, auth, billing, todos — and say where each one's durable spec lives, either in a central folder or right next to the code it describes. Given a set of changed files, the system can then answer "which capabilities does this change belong to?" so later tickets can keep those specs in sync as the code evolves.
+
+This first slice is the foundation everything else builds on: the **resolver** that does the path math, the **config block** that declares the capabilities, and the **reusable sandbox test harness** that lets every later ticket be verified end-to-end automatically. The feature is **off by default** — with no config, the project behaves exactly like stock spec-kit / Companion.
+
+## User Scenarios & Testing
+
+### User Story 1 - Resolve which capabilities a change belongs to (Priority: P1)
+
+A developer edits a file under their checkout code. They run the resolver with that file and get back the capabilities that own it — most-specific first — so the right living specs can be found and kept current.
+
+**Why this priority:** This is the core value of the slice; without it nothing downstream (sync, fold, drift) has a way to map code to specs.
+
+**Independent Test:** In a repo with a `livingSpecs` config declaring `checkout` (matches `src/checkout/**`) and `checkout-cart` (matches `src/checkout/cart/**`), run `resolve-spec-paths.py --changed src/checkout/cart/x.ts --json` and confirm it returns `[checkout-cart, checkout]` in that order.
+
+**Acceptance Scenarios:**
+
+1. **Given** a config with `checkout` and `checkout-cart` capabilities, **When** the resolver runs against a file under both, **Then** both capabilities are returned with the more specific one (`checkout-cart`) first.
+2. **Given** a capability with an `exclude` glob, **When** a changed file matches `match` but also matches `exclude`, **Then** that capability is not returned for the file.
+3. **Given** a changed file no configured capability claims, **When** the resolver runs, **Then** it returns no capability for that file (and does not error).
+
+### User Story 2 - Discover every capability and surface orphans (Priority: P2)
+
+A maintainer wants a full picture: every declared capability plus any living spec files lying around on disk that no capability claims. The resolver's `--all` mode unions the configured capabilities with on-disk `*.spec.md` files, de-dupes by resolved path, and flags the unclaimed ones as orphans.
+
+**Why this priority:** Needed for housekeeping and for later drift detection, but the per-change resolution (Story 1) is the MVP.
+
+**Independent Test:** Plant a stray `notes/random.spec.md` in a configured repo, run `--all`, and confirm both configured capabilities appear and the stray file is listed as an orphan.
+
+**Acceptance Scenarios:**
+
+1. **Given** configured capabilities plus on-disk `*.spec.md` files, **When** `--all` runs, **Then** the result unions both sources, de-duped by resolved spec path.
+2. **Given** a `*.spec.md` file no capability's spec path claims, **When** `--orphans` (or `--all`) runs, **Then** that file is listed as an orphan.
+3. **Given** sibling `.arch.md` / `.coverage.md` files next to a claimed `.spec.md`, **When** orphan detection runs, **Then** those reserved-tier files are never flagged as orphans.
+
+### User Story 3 - Opt-in: feature is inert until enabled (Priority: P1)
+
+A team that has not adopted Living Specs sees no change. With `livingSpecs.enabled` unset or `false` (or no config at all), the resolver returns empty for every mode and every existing command behaves exactly as today.
+
+**Why this priority:** A foundation that changes behavior for non-adopters is a regression; the opt-in guarantee is as important as the resolution itself.
+
+**Independent Test:** Run the resolver in a repo whose config has `enabled: false`; confirm `--changed`, `--all`, and `--orphans` all return empty with exit 0 and no error.
+
+**Acceptance Scenarios:**
+
+1. **Given** `livingSpecs.enabled: false`, **When** any resolver mode runs, **Then** it returns an empty result and exit 0.
+2. **Given** no `livingSpecs` block at all, **When** any resolver mode runs, **Then** it behaves identically to `enabled: false`.
+
+### Edge Cases
+
+- A colocated capability declared with no resolvable spec path → clear config error (exit non-zero, message naming the capability).
+- A changed file matched by two capabilities with equal specificity → stable, deterministic ordering (tiebreak by name).
+- A capability whose `match` glob covers no files on disk → still listed in `--all`, never crashes `--changed`.
+- Duplicate resolved spec paths across config + on-disk discovery → de-duped, listed once.
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001** The system MUST provide a resolver script at `speckit-extension/scripts/resolve-spec-paths.py` with three modes: `--changed <file>...`, `--all`, and `--orphans`, plus a `--json` flag for machine-readable output.
+- **FR-002** `--changed` MUST return the capabilities whose membership covers each given file, ordered most-specific first (deepest matching code area), with a stable tiebreak by capability name.
+- **FR-003** Capability membership MUST be defined as the `match` globs minus the optional `exclude` globs.
+- **FR-004** `--all` MUST return the union of configured capabilities and on-disk `*.spec.md` files, de-duplicated by resolved spec path, and MUST list orphans.
+- **FR-005** `--orphans` MUST list `*.spec.md` files on disk that no configured capability's resolved spec path claims; reserved-tier files (`.arch.md`, `.coverage.md`) MUST never be flagged as orphans.
+- **FR-006** Capabilities MUST be declared in a `livingSpecs` block in `.specify/companion.yml` with an `enabled` flag (default `false`) and a `capabilities[]` list of `{ name, match, spec, exclude? }`.
+- **FR-007** A centralized capability with no explicit `spec` path MUST default to `capabilities/<name>/spec.md`; a colocated capability MUST carry an explicit code-area `spec` path.
+- **FR-008** A colocated capability that resolves to no spec path MUST produce a clear config error.
+- **FR-009** When `livingSpecs.enabled` is unset or `false`, or no config exists, the resolver MUST be inert: every mode returns empty, exit 0, no error, and no existing command changes behavior.
+- **FR-010** `speckit-extension/scripts/companion_config.py` MUST expose a typed `livingSpecs` reader that defaults `enabled` to `false` and returns the normalized capabilities list, following the existing accessor style (`resolve_order` / `merge_hooks`).
+- **FR-011** The resolver MUST reuse the path-resolution precedence already proven in `write-context.py` (`resolve_feature_dir` / prefix-match) rather than inventing new matching.
+- **FR-012** A pytest suite `speckit-extension/tests/test_living_specs.py` MUST cover match/exclude, most-specific-first ordering, orphan detection, and the `enabled: false` → inert case.
+- **FR-013** A reusable sandbox harness runner MUST exist at `examples/todo-claude/bench/living-specs/ls-demos.mjs` (+ `ls-lib.mjs`) importing the existing bench helpers from `../lib.mjs` and `../sync-templates.mjs`, baking a throwaway repo and running the LS·1 demo (arrange / act / assert + opt-out case).
+- **FR-014** The config block MUST be documented in `speckit-extension/README.md`, with the change recorded in `speckit-extension/CHANGELOG.md` and `extension.yml` `version` bumped.
+
+### Key Entities
+
+- **Capability** — a named area of the codebase (`checkout`, `todos`). Attributes: `name`, `match` (globs that define membership), optional `exclude` (globs subtracted from membership), `spec` (path to its living spec). Centralized by default at `capabilities/<name>/spec.md`; colocated when given an explicit code-area path.
+- **Living spec** — the durable `*.spec.md` document for a capability. Recognized tiers: `.spec.md` (hot, loaded in v1), `.arch.md` / `.coverage.md` (reserved, never orphaned).
+- **livingSpecs config** — the `.specify/companion.yml` block: `enabled` flag + `capabilities[]` registry.
+
+## Success Criteria
+
+### Measurable Outcomes
+
+- **SC-001** `resolve --changed src/checkout/cart/x.ts` returns exactly `[checkout-cart, checkout]` in that order.
+- **SC-002** `resolve --all` unions configured + on-disk specs, de-dupes by resolved path, and lists every planted orphan.
+- **SC-003** With `enabled: false` (or no config), all three modes return empty with exit 0 and no error.
+- **SC-004** A colocated capability with no resolvable spec path produces a non-zero exit and a message naming the capability.
+- **SC-005** The pytest suite passes and the sandbox demo runs the resolver across modes against a baked throwaway repo, capturing real stdout + exit codes.
+
+## Assumptions
+
+- v1 loads/syncs only `.spec.md` (hot tier); `.arch.md` / `.coverage.md` are reserved names recognized for orphan-exemption but not otherwise processed.
+- The default centralized spec root is `capabilities/<name>/spec.md`, separate from feature specs under `specs/NNN-slug/`.
+- The sandbox demo for LS·1 is `deterministic` (resolver + pytest, no live AI).
+
+## Verbatim Constraints
+
+- Resolver script path: `speckit-extension/scripts/resolve-spec-paths.py`
+- Config block key: `livingSpecs`; flag: `enabled` (default `false`); registry: `capabilities` with `{ name, match, spec }`.
+- Centralized default spec path: `capabilities/<name>/spec.md`
+- Test file: `speckit-extension/tests/test_living_specs.py`
+- Harness runner: `examples/todo-claude/bench/living-specs/ls-demos.mjs` + `ls-lib.mjs`
+- Evidence path: `examples/todo-claude/bench/living-specs/evidence/LS1.json`
+- Resolver modes: `--changed`, `--all`, `--orphans`, `--json`

--- a/specs/356-living-specs/tasks.md
+++ b/specs/356-living-specs/tasks.md
@@ -1,0 +1,28 @@
+# Tasks: Living Specs — capability resolver, config + sandbox harness (LS·1)
+
+Dependency-ordered. `[P]` marks tasks that can run in parallel (independent files).
+
+## Phase 1 — Config reader (foundation)
+
+- [x] **T001** Add `load_living_specs(config)` to `companion_config.py`: returns `{enabled: bool (default false), capabilities: [{name, match[], exclude[], spec}]}`, normalizing scalar match/exclude to lists and defaulting `spec` to `capabilities/<name>/spec.md` + speckit-extension/scripts/companion_config.py
+
+## Phase 2 — Resolver (US1, US2, US3)
+
+- [x] **T002** Create `resolve-spec-paths.py` skeleton: argparse for `--root`/`--changed`/`--all`/`--orphans`/`--json`, load config via `companion_config.load_config` + `load_living_specs`, inert short-circuit when `enabled` false/absent (empty result, exit 0) + speckit-extension/scripts/resolve-spec-paths.py
+- [x] **T003** Implement glob membership (`match` minus `exclude`) with a `**` recursive-glob shim + specificity by literal-prefix length + speckit-extension/scripts/resolve-spec-paths.py
+- [x] **T004** Implement `--changed`: capabilities owning each file, most-specific first, tiebreak by name; spec-path + location + exists resolution; colocated-no-path → exit 2 error + speckit-extension/scripts/resolve-spec-paths.py
+- [x] **T005** Implement `--all` (union config + on-disk `*.spec.md`, de-dup by resolved path) and `--orphans` (unclaimed `*.spec.md`, exempt `.arch.md`/`.coverage.md` + `specs/`/`capabilities/<configured>`) + speckit-extension/scripts/resolve-spec-paths.py
+
+## Phase 3 — Tests
+
+- [x] **T006** [P] Add fixture `tests/fixtures/companion-living-specs.yml` with checkout + checkout-cart + exclude + enabled flag + speckit-extension/tests/fixtures/companion-living-specs.yml
+- [x] **T007** Write `test_living_specs.py`: config-reader defaults, match/exclude, most-specific-first ordering, --all union/de-dup, orphan detection + tier exemption, colocated error, enabled:false inert + speckit-extension/tests/test_living_specs.py
+
+## Phase 4 — Sandbox harness
+
+- [x] **T008** [P] Add `ls-lib.mjs`: arrange helpers (bake throwaway repo with src/checkout, companion.yml, planted orphan) importing from ../lib.mjs + examples/todo-claude/bench/living-specs/ls-lib.mjs
+- [x] **T009** Add `ls-demos.mjs`: run resolver across modes + pytest via execFileSync, capture real stdout/exit, write evidence/LS1.json (mode deterministic, verdict) + examples/todo-claude/bench/living-specs/ls-demos.mjs
+
+## Phase 5 — Docs & version
+
+- [x] **T010** [P] Document the `livingSpecs` config block in `speckit-extension/README.md`, add CHANGELOG entry, bump `extension.yml` version + speckit-extension/README.md, speckit-extension/CHANGELOG.md, speckit-extension/extension.yml


### PR DESCRIPTION
Closes #361

## Summary

First slice of **living specs** (Wave 4): a foundation that lets a project declare its capabilities (checkout, auth, billing…) and where each one's durable spec lives, and resolves which capabilities a set of changed files belongs to. Nothing here is user-visible on its own — it's what LS·2 (auto-load) and LS·3 (fold-back) build on. **Strictly opt-in:** off by default; with no config it behaves exactly as today.

## What's in it

- A **capability resolver** with three modes (`--changed <files>` → in-scope capabilities most-specific first; `--all` → every capability + orphans; `--orphans`), JSON output.
- A **`livingSpecs` config block** in `.specify/companion.yml`: `enabled` (default **false**) + `capabilities[]` of `{ name, match, spec }`. Membership = `match` globs minus `exclude`. Centralized specs default to `capabilities/<name>/spec.md`; colocated specs use a code-area path.
- A **reusable sandbox test harness** built on the existing bench helpers, plus the LS·1 deterministic demo.

## Evidence (real sandbox run)

The LS·1 demo ran for real in a throwaway repo — resolver across all modes + the pytest suite — **PASS 6/6, mode=deterministic**. Captured to `examples/todo-claude/bench/living-specs/evidence/LS1.json`; the build-status page records it.

## Under the hood

- `speckit-extension/scripts/resolve-spec-paths.py` (new) — reuses `write-context.py`'s path-resolution precedence.
- `speckit-extension/scripts/companion_config.py` — new typed `load_living_specs` reader (defaults `enabled` false).
- `speckit-extension/tests/test_living_specs.py` (20 cases) — membership/ordering/orphans/opt-in, incl. 3 regressions from review (glob `*` must not cross `/`, trailing `/**` matches the bare dir, backslash paths normalized).
- `speckit-extension/{README,CHANGELOG,extension.yml}` updated (spec-kit extension docs + version bump); resolver added to the publish allow-list.

## How to verify

Opt-in only, so a normal workspace is unaffected. With a `livingSpecs` block: `python3 .specify/extensions/companion/scripts/resolve-spec-paths.py --changed src/checkout/cart.ts --json` lists the matching capabilities most-specific-first; `--all` lists all + orphans; `enabled: false` returns nothing.

## Tests
jest 1084 · pytest 141 (20 living-specs) · shape-parity OK · sandbox demo PASS. Code review found + fixed 3 resolver bugs.