### PR TITLE
feat(living-specs): surface loaded/synced living specs in the spec viewer (LS·7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Toggle **Activity** in the viewer's nav bar to swap the markdown pane for a card
 - **Approach** — one-line strategy, status pill, PR link, and commit/PR checkpoints.
 - **Phases** — a vertical timeline reporting **active time** per step and substep (idle gaps are capped, so an overnight pause doesn't inflate a step); the in-flight step pulses and the terminal phase finalizes.
 - **Tasks** — per-`T###` status, summary, file chips, and inline concerns.
+- **Living specs** — when a feature touches durable capability specs, this card lists the ones it loaded into context and marks the ones it folded its changes back into (Companion's lightweight answer to the OpenSpec Dashboard). Read-only; appears only when the spec carries living-specs context.
 - **Decisions**, **Concerns**, **Review comments** (every persisted comment grouped by document, with jump-to-line and a per-document **Run refinement** button), and **Files touched** (clickable).
 
 Each card hides itself when its data is missing, so a minimal speckit-style spec collapses to just *Phases*. Visibility is gated by `speckit.viewer.activityPanel` — `"off"`, `"beta"` (default; toggle shows a *beta* pill), or `"on"`.

--- a/docs/viewer-states.md
+++ b/docs/viewer-states.md
@@ -309,6 +309,10 @@ sub-tab have been **removed**. Review comments now persist in
 When the Activity panel is toggled off there is no cross-document list, but
 inline comments still work and still persist.
 
+### Living specs (Activity panel)
+
+When a feature touches **living specs** (durable capability specs), the spec-kit side records which capabilities were loaded into context at specify time (`livingSpecs.loaded`) and which were folded back at completion (`livingSpecs.synced`). The viewer surfaces this read-only in the Activity panel's *Living specs* card: it lists each capability and marks the synced ones as *folded back*. A capability that appears in `synced` but not `loaded` is still shown. The card hides itself when there is no `livingSpecs` data, like every other Activity card, so existing specs see no new UI. The viewer never writes `livingSpecs` — it only displays what LS·2/LS·3 wrote.
+
 ---
 
 ## Badge Text

--- a/examples/todo-claude/bench/living-specs/evidence/LS7.json
+++ b/examples/todo-claude/bench/living-specs/evidence/LS7.json
@@ -1,0 +1,80 @@
+{
+  "ticket": "LS7",
+  "issue": 367,
+  "title": "GUI surfacing in the viewer (LS·7)",
+  "ranAt": "2026-06-25T00:00:00.000Z",
+  "mode": "webview-test",
+  "note": "UI ticket. This is NOT a pipeline sandbox demo — there is no AI/CLI step to run in a throwaway repo. The 'sandbox demo' for a VS Code/webview surface is the repo's webview-test approach: jsdom render tests that drive the new component off a ViewerState carrying livingSpecs and assert the resulting DOM, plus an extension-side derivation test that asserts .spec-context.json livingSpecs maps onto ViewerState. The automated tests prove the data→DOM mapping; the VISUAL rendering (card placement, chip styling, theme) needs MANUAL verification in the running extension.",
+  "whatTheTestsAssert": {
+    "extensionDerivation": {
+      "file": "src/features/spec-viewer/__tests__/stateDerivation.test.ts",
+      "throughRealCodePath": "deriveViewerState() — the production reader, not a re-implemented predicate",
+      "cases": [
+        "loaded + synced present → ViewerState.livingSpecs = { loaded, synced }",
+        "only loaded present → synced defaults to []",
+        "no livingSpecs field → ViewerState.livingSpecs is undefined",
+        "both lists empty → undefined",
+        "malformed shape (non-string entries, synced as a bare string) → coerced to safe trimmed string[]"
+      ]
+    },
+    "webviewRender": {
+      "file": "webview/src/spec-viewer/components/cards/__tests__/LivingSpecsCard.test.tsx",
+      "env": "jsdom (preact render into a real DOM container)",
+      "cases": [
+        "loaded-only → lists loaded capability names, no 'folded back' marker",
+        "loaded+synced → synced capabilities carry a 'folded back' marker, unsynced ones do not",
+        "synced-not-loaded → a capability folded back but not loaded this run is still listed",
+        "none → card renders nothing (no .activity-card--living-specs, empty textContent)"
+      ]
+    }
+  },
+  "commands": [
+    {
+      "cwd": ".",
+      "cmd": "npx tsc -p ./",
+      "exit": 0,
+      "stdoutTail": "(no output — clean compile)"
+    },
+    {
+      "cwd": ".",
+      "cmd": "npx jest LivingSpecsCard.test stateDerivation",
+      "exit": 0,
+      "stdoutTail": "PASS webview/src/spec-viewer/components/cards/__tests__/LivingSpecsCard.test.tsx\nPASS tests/unit/spec-viewer/stateDerivation.spec.ts\nPASS src/features/spec-viewer/__tests__/stateDerivation.test.ts\nTest Suites: 3 passed, 3 total\nTests:       48 passed, 48 total"
+    },
+    {
+      "cwd": ".",
+      "cmd": "npm test",
+      "exit": 0,
+      "stdoutTail": "Test Suites: 89 passed, 89 total\nTests:       1093 passed, 1093 total"
+    }
+  ],
+  "filesChanged": [
+    "src/core/types/specContext.ts",
+    "src/features/spec-viewer/stateDerivation.ts",
+    "src/features/spec-viewer/__tests__/stateDerivation.test.ts",
+    "webview/src/spec-viewer/types.ts",
+    "webview/src/spec-viewer/components/cards/LivingSpecsCard.tsx",
+    "webview/src/spec-viewer/components/cards/LivingSpecsCard.stories.tsx",
+    "webview/src/spec-viewer/components/cards/__tests__/LivingSpecsCard.test.tsx",
+    "webview/src/spec-viewer/components/ActivityPanel.tsx",
+    "webview/styles/spec-viewer/_activity.css",
+    "README.md",
+    "docs/viewer-states.md"
+  ],
+  "manualVerification": {
+    "where": "Activity panel of the spec viewer (toggle 'Activity' in the viewer nav bar)",
+    "loadedSpec": "Open a spec whose .spec-context.json has livingSpecs.loaded — a 'Living specs' card lists those capability names.",
+    "syncedSpec": "If livingSpecs.synced is also set, those capabilities carry a 'folded back' chip.",
+    "absent": "Open any spec with no livingSpecs field — no 'Living specs' card appears (existing specs see no new UI).",
+    "stillManual": "The card's visual look (placement after Phases, chip color/contrast, theme behavior) is not asserted by the automated tests."
+  },
+  "assertions": [
+    { "name": "extension derivation maps livingSpecs onto ViewerState", "pass": true, "source": "jest" },
+    { "name": "card renders loaded names", "pass": true, "source": "jest+jsdom" },
+    { "name": "card marks synced as folded back", "pass": true, "source": "jest+jsdom" },
+    { "name": "card renders nothing with no data (opt-in)", "pass": true, "source": "jest+jsdom" },
+    { "name": "full suite green", "pass": true, "source": "npm test (1093 passed)" }
+  ],
+  "runCaptureEval": "N/A — no pipeline capture step in this UI ticket (read-only display of data LS·2/LS·3 already capture).",
+  "verdict": "PASS"
+}

--- a/specs/367-living-specs-gui-surfacing/.spec-context.json
+++ b/specs/367-living-specs-gui-surfacing/.spec-context.json
@@ -1,0 +1,70 @@
+{
+  "workflow": "speckit-companion",
+  "specName": "Living Specs — GUI surfacing in the viewer (LS·7)",
+  "branch": "367-living-specs-gui-surfacing",
+  "selectedAt": "2026-06-25T00:00:00.000Z",
+  "currentStep": "implement",
+  "status": "completed",
+  "history": [
+    {
+      "step": "specify",
+      "substep": null,
+      "kind": "start",
+      "from": { "step": null, "substep": null },
+      "by": "extension",
+      "at": "2026-06-25T00:00:00.000Z"
+    },
+    {
+      "step": "specify",
+      "substep": null,
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-25T00:05:00.000Z"
+    },
+    {
+      "step": "plan",
+      "substep": null,
+      "kind": "start",
+      "from": { "step": "specify", "substep": null },
+      "by": "extension",
+      "at": "2026-06-25T00:05:00.000Z"
+    },
+    {
+      "step": "plan",
+      "substep": null,
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-25T00:10:00.000Z"
+    },
+    {
+      "step": "tasks",
+      "substep": null,
+      "kind": "start",
+      "from": { "step": "plan", "substep": null },
+      "by": "extension",
+      "at": "2026-06-25T00:10:00.000Z"
+    },
+    {
+      "step": "tasks",
+      "substep": null,
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-25T00:15:00.000Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "kind": "start",
+      "from": { "step": "tasks", "substep": null },
+      "by": "extension",
+      "at": "2026-06-25T00:15:00.000Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-06-25T00:30:00.000Z"
+    }
+  ]
+}

--- a/specs/367-living-specs-gui-surfacing/plan.md
+++ b/specs/367-living-specs-gui-surfacing/plan.md
@@ -1,0 +1,50 @@
+# Plan — Living Specs GUI surfacing (LS·7)
+
+## Approach
+
+Mirror the existing Activity-card pattern (`DecisionsCard`, `FilesCard`). The data already lands in `.spec-context.json` under `livingSpecs.{loaded,synced}` (written by LS·2/LS·3). The work is a read-only pipe: type → derive → serialize → render → test.
+
+## Technical context
+
+- **Language**: TypeScript 5.3+ (ES2022, strict). Preact for the webview.
+- **Data source**: `.spec-context.json` `livingSpecs: { loaded: string[]; synced?: string[] }`.
+- **Render env**: jsdom render tests (per-file `@jest-environment jsdom`), as used by `StepTab.test.tsx` / `FooterActions.test.tsx`.
+
+## Data flow
+
+1. `SpecContext` (extension type) already tolerates unknown fields via its index signature, so `livingSpecs` parses today. Add a typed optional `livingSpecs?: { loaded?: string[]; synced?: string[] }`.
+2. `deriveViewerState` (`src/features/spec-viewer/stateDerivation.ts`) picks `livingSpecs` into `ViewerState.livingSpecs` as `{ loaded: string[]; synced: string[] }`, coercing each via the existing string-array helper (drops non-strings, trims, treats "None"/empty as none). Absent when both lists empty.
+3. `ViewerState` (extension `src/core/types/specContext.ts` and webview mirror `webview/src/spec-viewer/types.ts`) gains the optional `livingSpecs` field.
+4. New `LivingSpecsCard` (`webview/src/spec-viewer/components/cards/LivingSpecsCard.tsx`) renders the loaded list, marking synced entries as folded back; returns `null` when empty.
+5. `ActivityPanel` mounts `<LivingSpecsCard>`; `hasAnyData` recognizes `livingSpecs` so the panel isn't "No activity" when only living-specs data exists.
+
+## Design notes
+
+- **No user data in attributes.** Capability names go in as element text (`{name}` children), never into `title="…"`/`alt="…"` via `innerHTML`. Matches `DecisionsCard`.
+- **Coercion.** Reuse the `toStringArray`-style normalization at the derive boundary so a malformed `livingSpecs` shape can't crash the card (FR-004). The pure normalizer is the unit boundary the node test environment can exercise even without jsdom.
+- **Hide when empty.** Card returns `null` if `loaded` is empty (FR-003).
+- **Synced ⊆ display.** A capability in `synced` but not `loaded` is still shown (folded back even if it wasn't loaded this run) — union of the two lists, each annotated.
+
+## Files to change
+
+- `src/core/types/specContext.ts` — add `LivingSpecsContext` + `SpecContext.livingSpecs` + `ViewerState.livingSpecs`.
+- `src/features/spec-viewer/stateDerivation.ts` — `pickLivingSpecs(ctx)`; wire into `deriveViewerState`.
+- `webview/src/spec-viewer/types.ts` — mirror `livingSpecs` on the webview `ViewerState`.
+- `webview/src/spec-viewer/components/cards/LivingSpecsCard.tsx` — new card.
+- `webview/src/spec-viewer/components/ActivityPanel.tsx` — mount card + extend `hasAnyData`.
+- `webview/styles/spec-viewer/*` — minimal card styling (reuse `activity-card` classes; add a folded-back chip class).
+
+## Tests
+
+- `src/features/spec-viewer/__tests__/stateDerivation.test.ts` — `pickLivingSpecs` coercion: arrays pass through, non-strings dropped, malformed → safe, absent → undefined.
+- `webview/src/spec-viewer/components/cards/__tests__/LivingSpecsCard.test.tsx` — jsdom render: loaded-only shows loaded names; loaded+synced annotates folded-back; none → renders nothing.
+
+## Docs
+
+- README "Activity Panel" — add the *Living specs* card to the card list.
+- `docs/viewer-states.md` — add a *Living specs (Activity panel)* subsection next to *Review comments*.
+- New `.stories.tsx` for the card (loaded-only / loaded+synced / none states) — Storybook is the visual baseline.
+
+## Verification
+
+`npm run compile && npm test` green; jsdom render test asserts data→DOM. Visual look is manual-verify (NFR-004).

--- a/specs/367-living-specs-gui-surfacing/spec.md
+++ b/specs/367-living-specs-gui-surfacing/spec.md
@@ -1,0 +1,47 @@
+# Living Specs — GUI surfacing in the viewer (LS·7)
+
+## Summary
+
+When a feature touches one or more **living specs** (durable capability specs), the spec-kit side already records which capabilities were loaded into context at specify time and which were folded back at completion. Today that information is invisible in the VS Code viewer. This feature surfaces it: a small, read-only Activity card that shows the living specs a feature loaded and synced — Companion's lightweight answer to the OpenSpec Dashboard.
+
+This is the **GUI half** of the living-specs work (the VS Code / webview side). It only *displays* data that LS·2 and LS·3 already write into `.spec-context.json` under `livingSpecs`. It writes nothing.
+
+## User Stories
+
+### US1 — See which living specs a feature touched (P1)
+
+As a developer reviewing a feature spec in the viewer, I want to see which durable capability specs the feature loaded into context and which it folded its changes back into, so I can understand the feature's relationship to the project's living specs without leaving the viewer.
+
+**Acceptance**
+- When the spec's `.spec-context.json` carries `livingSpecs.loaded` (a non-empty list of capability names), the Activity panel shows a *Living specs* card listing the loaded capabilities.
+- When it also carries `livingSpecs.synced`, the card marks those capabilities as folded back (synced).
+- When neither list is present (or both are empty), the card renders nothing — a feature with no living-specs context shows no new UI (opt-in display).
+
+### US2 — Stay read-only and safe (P2)
+
+As a maintainer, I want the new surface to be display-only and to honor the webview safety invariants, so it cannot inject user data into the DOM or break accessibility.
+
+**Acceptance**
+- The card never writes back to `.spec-context.json`.
+- Capability names (user-authored data) are rendered as element text, never interpolated into an HTML attribute through `innerHTML`.
+- The card hides itself when empty, like every other Activity card.
+
+## Functional Requirements
+
+- **FR-001** — The extension's `ViewerState` derivation reads `livingSpecs.loaded` and `livingSpecs.synced` from `.spec-context.json` and exposes them as a normalized `livingSpecs` object on `ViewerState` (string arrays; absent when no data).
+- **FR-002** — A new webview Activity card renders the loaded capabilities, marking each that also appears in `synced` as folded back.
+- **FR-003** — The card returns `null` (renders nothing) when there is no `livingSpecs` data, so existing specs are unaffected.
+- **FR-004** — Reading the field must tolerate malformed shapes (non-array, non-string entries) and coerce to a safe `string[]`, like the existing string-array passthroughs.
+
+## Non-Functional Requirements
+
+- **NFR-001** — No new `.spec-context.json` fields are written by this change; it is read-only display.
+- **NFR-002** — Honors the CLAUDE.md webview invariants (no user data into HTML attributes via `innerHTML`; sr-only for aria; `e.target instanceof Element` guards where applicable).
+- **NFR-003** — `npm run compile && npm test` stays green; the new card has a render test that asserts the data→DOM mapping for loaded-only, loaded+synced, and none.
+- **NFR-004 (evidence)** — The data→DOM mapping is proven by automated webview render tests. The visual look is not asserted by the tests and needs manual verification.
+
+## Out of Scope
+
+- The "move a spec closer to the code" relocate action (mentioned in the ticket as a future surface) — not built here; this ticket lands the loaded/synced display.
+- Drift state display — `livingSpecs` carries only `loaded`/`synced` today; drift is surfaced by the LS·6 drift command, not this card.
+- Any writing of `livingSpecs` data (that is LS·2/LS·3, already merged).

--- a/specs/367-living-specs-gui-surfacing/tasks.md
+++ b/specs/367-living-specs-gui-surfacing/tasks.md
@@ -1,0 +1,22 @@
+# Tasks — Living Specs GUI surfacing (LS·7)
+
+## US1 — See which living specs a feature touched
+
+- [x] **T001** Add `LivingSpecsContext` interface + `SpecContext.livingSpecs` (optional) + `ViewerState.livingSpecs` to `src/core/types/specContext.ts`.
+- [x] **T002** Add `pickLivingSpecs(ctx)` to `src/features/spec-viewer/stateDerivation.ts` (coerce loaded/synced to safe `string[]`, return undefined when both empty) and wire it into `deriveViewerState`.
+- [x] **T003** Mirror the `livingSpecs` field on the webview `ViewerState` in `webview/src/spec-viewer/types.ts`.
+- [x] **T004** Create `webview/src/spec-viewer/components/cards/LivingSpecsCard.tsx` — render loaded capabilities, annotate folded-back (synced) ones, return null when empty.
+- [x] **T005** Mount `<LivingSpecsCard>` in `ActivityPanel.tsx` and extend `hasAnyData` to recognize `livingSpecs`.
+- [x] **T006** Add card styling in `webview/styles/spec-viewer/` (folded-back chip).
+
+## US2 — Read-only + safe
+
+- [x] **T007** Confirm no write path: card and derivation only read; capability names render as element text (no `innerHTML` into attributes).
+
+## Tests + docs (evidence)
+
+- [x] **T008** `stateDerivation.test.ts` — `pickLivingSpecs` coercion cases (pass-through, drop non-strings, malformed safe, absent undefined).
+- [x] **T009** jsdom render test `LivingSpecsCard.test.tsx` — loaded-only, loaded+synced, none → renders nothing.
+- [x] **T010** `LivingSpecsCard.stories.tsx` — loaded-only / loaded+synced / none stories.
+- [x] **T011** README "Activity Panel" + `docs/viewer-states.md` — document the *Living specs* card.
+- [x] **T012** Write `examples/todo-claude/bench/living-specs/evidence/LS7.json` (mode=webview-test) + append LS·7 section to vault status.html, flip row to shipped.

--- a/src/core/types/specContext.ts
+++ b/src/core/types/specContext.ts
@@ -146,6 +146,22 @@ export interface ReviewComment {
 }
 
 /**
+ * Living-specs context (LS·2/LS·3): which durable capability specs a feature
+ * loaded into context at specify time and which it folded its changes back
+ * into at completion. Written by the spec-kit side; read-only here.
+ */
+export interface LivingSpecsContext {
+    loaded?: string[];
+    synced?: string[];
+}
+
+/** Normalized living-specs view exposed on `ViewerState` (coerced string arrays). */
+export interface LivingSpecsView {
+    loaded: string[];
+    synced: string[];
+}
+
+/**
  * Canonical `.spec-context.json` document. Unknown top-level fields MUST be
  * preserved across writes (FR-013).
  */
@@ -186,6 +202,8 @@ export interface SpecContext {
     task_summaries?: Record<string, unknown>;
     /** Per-step summaries (specify/plan/etc., skill-authored). */
     step_summaries?: Record<string, Record<string, unknown>>;
+    /** Living specs this feature loaded/synced (LS·2/LS·3). Read-only here. */
+    livingSpecs?: LivingSpecsContext;
     // Unknown / legacy fields tolerated and preserved.
     [key: string]: unknown;
 }
@@ -258,6 +276,8 @@ export interface ViewerState {
     stepSummaries?: Record<string, Record<string, unknown>>;
     /** Persisted inline review comments, surfaced for restore + Activity. */
     reviewComments?: ReviewComment[];
+    /** Living specs loaded/synced for this feature (LS·7). Absent when none. */
+    livingSpecs?: LivingSpecsView;
 }
 
 /** Canonical list of substep names used by Companion prompts. */

--- a/src/features/spec-viewer/__tests__/stateDerivation.test.ts
+++ b/src/features/spec-viewer/__tests__/stateDerivation.test.ts
@@ -180,4 +180,46 @@ describe('deriveViewerState', () => {
         expect(state.highlights).toContain('plan');
         expect(state.pulse).toBeNull();
     });
+
+    describe('livingSpecs derivation', () => {
+        it('exposes loaded + synced when present', () => {
+            const ctx = makeContext({
+                livingSpecs: { loaded: ['checkout', 'cart'], synced: ['checkout'] },
+            });
+            expect(deriveViewerState(ctx).livingSpecs).toEqual({
+                loaded: ['checkout', 'cart'],
+                synced: ['checkout'],
+            });
+        });
+
+        it('defaults synced to [] when only loaded is present', () => {
+            const ctx = makeContext({ livingSpecs: { loaded: ['checkout'] } });
+            expect(deriveViewerState(ctx).livingSpecs).toEqual({
+                loaded: ['checkout'],
+                synced: [],
+            });
+        });
+
+        it('is undefined when no livingSpecs field', () => {
+            expect(deriveViewerState(makeContext()).livingSpecs).toBeUndefined();
+        });
+
+        it('is undefined when both lists are empty', () => {
+            const ctx = makeContext({ livingSpecs: { loaded: [], synced: [] } });
+            expect(deriveViewerState(ctx).livingSpecs).toBeUndefined();
+        });
+
+        it('coerces a malformed shape to safe trimmed string arrays', () => {
+            const ctx = makeContext({
+                livingSpecs: {
+                    loaded: ['  checkout  ', 42, null, '', 'cart'] as unknown as string[],
+                    synced: 'checkout' as unknown as string[],
+                },
+            });
+            expect(deriveViewerState(ctx).livingSpecs).toEqual({
+                loaded: ['checkout', 'cart'],
+                synced: [],
+            });
+        });
+    });
 });

--- a/src/features/spec-viewer/stateDerivation.ts
+++ b/src/features/spec-viewer/stateDerivation.ts
@@ -23,6 +23,7 @@ import {
     ConcernEntry,
     CheckpointStatus,
     ReviewComment,
+    LivingSpecsView,
 } from '../../core/types/specContext';
 import { getFooterActions } from './footerActions';
 import { deriveStepHistory } from '../specs/stepHistoryDerivation';
@@ -50,6 +51,27 @@ function pickStringArray(ctx: SpecContext, key: string): string[] | undefined {
     if (!Array.isArray(v)) return undefined;
     const filtered = v.filter((x): x is string => typeof x === 'string');
     return filtered.length > 0 ? filtered : undefined;
+}
+
+function coerceNameList(v: unknown): string[] {
+    if (!Array.isArray(v)) return [];
+    const out: string[] = [];
+    for (const x of v) {
+        if (typeof x !== 'string') continue;
+        const t = x.trim();
+        if (t.length > 0) out.push(t);
+    }
+    return out;
+}
+
+function pickLivingSpecs(ctx: SpecContext): LivingSpecsView | undefined {
+    const v = (ctx as Record<string, unknown>)['livingSpecs'];
+    if (!v || typeof v !== 'object' || Array.isArray(v)) return undefined;
+    const ls = v as Record<string, unknown>;
+    const loaded = coerceNameList(ls.loaded);
+    const synced = coerceNameList(ls.synced);
+    if (loaded.length === 0 && synced.length === 0) return undefined;
+    return { loaded, synced };
 }
 
 function pickRecord<T>(ctx: SpecContext, key: string): Record<string, T> | undefined {
@@ -227,5 +249,6 @@ export function deriveViewerState(
         checkpointStatus: pickCheckpointStatus(ctx),
         stepSummaries: pickRecord<Record<string, unknown>>(ctx, 'step_summaries'),
         reviewComments: pickReviewComments(ctx),
+        livingSpecs: pickLivingSpecs(ctx),
     };
 }

--- a/webview/src/spec-viewer/components/ActivityPanel.tsx
+++ b/webview/src/spec-viewer/components/ActivityPanel.tsx
@@ -7,6 +7,7 @@ import { DecisionsCard } from './cards/DecisionsCard';
 import { ConcernsCard } from './cards/ConcernsCard';
 import { FilesCard } from './cards/FilesCard';
 import { CommentsCard } from './cards/CommentsCard';
+import { LivingSpecsCard } from './cards/LivingSpecsCard';
 
 /**
  * The viewer install banner, rendered INSIDE the Activity panel (#255 — it used
@@ -36,6 +37,7 @@ function hasAnyData(state: ViewerState): boolean {
     if (state.concerns && state.concerns.length > 0) return true;
     if (state.filesModified && state.filesModified.length > 0) return true;
     if (state.reviewComments && state.reviewComments.length > 0) return true;
+    if (state.livingSpecs) return true;
     if (state.history && state.history.length > 0) return true;
     if (state.stepHistory && Object.keys(state.stepHistory).length > 0) return true;
     return false;
@@ -58,6 +60,7 @@ export function ActivityPanel() {
             <InstallBanner />
             <ApproachCard state={state} />
             <PhasesCard state={state} />
+            <LivingSpecsCard state={state} />
             <TasksCard state={state} />
             <DecisionsCard state={state} />
             <ConcernsCard state={state} />

--- a/webview/src/spec-viewer/components/cards/LivingSpecsCard.stories.tsx
+++ b/webview/src/spec-viewer/components/cards/LivingSpecsCard.stories.tsx
@@ -1,0 +1,50 @@
+import type { Meta, StoryObj } from '@storybook/preact';
+import { LivingSpecsCard } from './LivingSpecsCard';
+import type { ViewerState } from '../../types';
+
+const meta: Meta<typeof LivingSpecsCard> = {
+    title: 'Viewer/Activity/LivingSpecsCard',
+    component: LivingSpecsCard,
+    decorators: [
+        (Story) => (
+            <div style="max-width: 640px; padding: 16px; background: var(--vscode-editor-background, #1e1e1e); color: var(--vscode-foreground, #cccccc);">
+                <Story />
+            </div>
+        ),
+    ],
+};
+export default meta;
+
+type Story = StoryObj<typeof LivingSpecsCard>;
+
+const baseState = (overrides: Partial<ViewerState>): ViewerState => ({
+    status: 'implemented',
+    activeStep: 'implement',
+    steps: {},
+    pulse: null,
+    highlights: [],
+    activeSubstep: null,
+    footer: [],
+    history: [],
+    stepHistory: {},
+    ...overrides,
+});
+
+// Capabilities loaded into context at specify time, none folded back yet.
+export const LoadedOnly: Story = {
+    render: () => (
+        <LivingSpecsCard state={baseState({ livingSpecs: { loaded: ['checkout', 'cart'], synced: [] } })} />
+    ),
+};
+
+// Loaded + some folded back at completion — the "folded back" marker appears.
+export const LoadedAndSynced: Story = {
+    render: () => (
+        <LivingSpecsCard state={baseState({ livingSpecs: { loaded: ['checkout', 'cart'], synced: ['checkout'] } })} />
+    ),
+};
+
+// No living-specs data → the card renders nothing.
+export const None: Story = {
+    render: () => <LivingSpecsCard state={baseState({})} />,
+};

--- a/webview/src/spec-viewer/components/cards/LivingSpecsCard.stories.tsx
+++ b/webview/src/spec-viewer/components/cards/LivingSpecsCard.stories.tsx
@@ -44,6 +44,27 @@ export const LoadedAndSynced: Story = {
     ),
 };
 
+// A capability folded back but not loaded this run — still listed, marked.
+export const SyncedNotLoaded: Story = {
+    render: () => (
+        <LivingSpecsCard state={baseState({ livingSpecs: { loaded: ['cart'], synced: ['checkout'] } })} />
+    ),
+};
+
+// A very long capability name must truncate with an ellipsis, not overflow.
+export const LongName: Story = {
+    render: () => (
+        <LivingSpecsCard
+            state={baseState({
+                livingSpecs: {
+                    loaded: ['checkout-payment-fraud-detection-and-risk-scoring-pipeline'],
+                    synced: ['checkout-payment-fraud-detection-and-risk-scoring-pipeline'],
+                },
+            })}
+        />
+    ),
+};
+
 // No living-specs data → the card renders nothing.
 export const None: Story = {
     render: () => <LivingSpecsCard state={baseState({})} />,

--- a/webview/src/spec-viewer/components/cards/LivingSpecsCard.tsx
+++ b/webview/src/spec-viewer/components/cards/LivingSpecsCard.tsx
@@ -15,11 +15,14 @@ export function LivingSpecsCard({ state }: LivingSpecsCardProps) {
     if (!ls) return null;
 
     const synced = new Set(ls.synced);
-    // Show every capability that was loaded or synced; a name in `synced` but
-    // not `loaded` is still folded back, so include it.
-    const names = [...ls.loaded];
-    for (const s of ls.synced) {
-        if (!names.includes(s)) names.push(s);
+    // Show every capability that was loaded or synced, de-duplicated; a name in
+    // `synced` but not `loaded` is still folded back, so include it.
+    const names: string[] = [];
+    const seen = new Set<string>();
+    for (const n of [...ls.loaded, ...ls.synced]) {
+        if (seen.has(n)) continue;
+        seen.add(n);
+        names.push(n);
     }
     if (names.length === 0) return null;
 

--- a/webview/src/spec-viewer/components/cards/LivingSpecsCard.tsx
+++ b/webview/src/spec-viewer/components/cards/LivingSpecsCard.tsx
@@ -1,0 +1,47 @@
+import type { ViewerState } from '../../types';
+
+export interface LivingSpecsCardProps {
+    state: ViewerState;
+}
+
+/**
+ * Read-only surface for the living specs a feature touched (LS·7): the durable
+ * capability specs it loaded into context (LS·2) and the ones it folded its
+ * changes back into at completion (LS·3). Hides itself when there's no
+ * `livingSpecs` data, like every other Activity card.
+ */
+export function LivingSpecsCard({ state }: LivingSpecsCardProps) {
+    const ls = state.livingSpecs;
+    if (!ls) return null;
+
+    const synced = new Set(ls.synced);
+    // Show every capability that was loaded or synced; a name in `synced` but
+    // not `loaded` is still folded back, so include it.
+    const names = [...ls.loaded];
+    for (const s of ls.synced) {
+        if (!names.includes(s)) names.push(s);
+    }
+    if (names.length === 0) return null;
+
+    return (
+        <section class="activity-card activity-card--living-specs">
+            <header class="activity-card__title">
+                Living specs <span class="activity-card__count">({names.length})</span>
+            </header>
+            <div class="activity-card__body">
+                <ul class="living-specs-list">
+                    {names.map(name => (
+                        <li key={name} class="living-specs-list__item">
+                            <span class="living-specs-list__name">{name}</span>
+                            {synced.has(name) && (
+                                <span class="living-specs-list__synced" title="Folded back into the living spec">
+                                    folded back
+                                </span>
+                            )}
+                        </li>
+                    ))}
+                </ul>
+            </div>
+        </section>
+    );
+}

--- a/webview/src/spec-viewer/components/cards/__tests__/LivingSpecsCard.test.tsx
+++ b/webview/src/spec-viewer/components/cards/__tests__/LivingSpecsCard.test.tsx
@@ -28,9 +28,12 @@ function baseState(over: Partial<ViewerState> = {}): ViewerState {
     };
 }
 
+const mounted: HTMLDivElement[] = [];
+
 function renderCard(state: ViewerState): HTMLDivElement {
     const container = document.createElement('div');
     document.body.appendChild(container);
+    mounted.push(container);
     render(<LivingSpecsCard state={state} />, container);
     return container;
 }
@@ -41,6 +44,12 @@ function cleanup(container: HTMLDivElement) {
 }
 
 describe('LivingSpecsCard', () => {
+    // Unmount every rendered container even if an assertion throws first, so a
+    // failing test can't leak mounted DOM into later tests.
+    afterEach(() => {
+        while (mounted.length) cleanup(mounted.pop()!);
+    });
+
     it('lists loaded capabilities and no folded-back marker when nothing synced', () => {
         const c = renderCard(baseState({ livingSpecs: { loaded: ['checkout', 'cart'], synced: [] } }));
         const names = Array.from(c.querySelectorAll('.living-specs-list__name')).map(n => n.textContent);

--- a/webview/src/spec-viewer/components/cards/__tests__/LivingSpecsCard.test.tsx
+++ b/webview/src/spec-viewer/components/cards/__tests__/LivingSpecsCard.test.tsx
@@ -1,0 +1,75 @@
+/**
+ * @jest-environment jsdom
+ *
+ * LS·7 — the Living specs card maps `ViewerState.livingSpecs` to the DOM:
+ * loaded capabilities render; the ones in `synced` are marked folded back;
+ * with no living-specs data the card renders nothing.
+ *
+ * This asserts the data→DOM mapping, not the visual look (NFR-004 — the look
+ * needs manual verification).
+ */
+
+import { render } from 'preact';
+import { LivingSpecsCard } from '../LivingSpecsCard';
+import type { ViewerState } from '../../../types';
+
+function baseState(over: Partial<ViewerState> = {}): ViewerState {
+    return {
+        status: 'implemented',
+        activeStep: 'implement',
+        steps: {},
+        pulse: null,
+        highlights: [],
+        activeSubstep: null,
+        footer: [],
+        history: [],
+        stepHistory: {},
+        ...over,
+    };
+}
+
+function renderCard(state: ViewerState): HTMLDivElement {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    render(<LivingSpecsCard state={state} />, container);
+    return container;
+}
+
+function cleanup(container: HTMLDivElement) {
+    render(null, container);
+    container.remove();
+}
+
+describe('LivingSpecsCard', () => {
+    it('lists loaded capabilities and no folded-back marker when nothing synced', () => {
+        const c = renderCard(baseState({ livingSpecs: { loaded: ['checkout', 'cart'], synced: [] } }));
+        const names = Array.from(c.querySelectorAll('.living-specs-list__name')).map(n => n.textContent);
+        expect(names).toEqual(['checkout', 'cart']);
+        expect(c.querySelectorAll('.living-specs-list__synced')).toHaveLength(0);
+        cleanup(c);
+    });
+
+    it('marks synced capabilities as folded back', () => {
+        const c = renderCard(baseState({ livingSpecs: { loaded: ['checkout', 'cart'], synced: ['checkout'] } }));
+        const items = Array.from(c.querySelectorAll('.living-specs-list__item'));
+        const checkout = items.find(li => li.querySelector('.living-specs-list__name')?.textContent === 'checkout');
+        const cart = items.find(li => li.querySelector('.living-specs-list__name')?.textContent === 'cart');
+        expect(checkout?.querySelector('.living-specs-list__synced')).not.toBeNull();
+        expect(cart?.querySelector('.living-specs-list__synced')).toBeNull();
+        cleanup(c);
+    });
+
+    it('includes a synced capability that was not loaded this run', () => {
+        const c = renderCard(baseState({ livingSpecs: { loaded: ['cart'], synced: ['checkout'] } }));
+        const names = Array.from(c.querySelectorAll('.living-specs-list__name')).map(n => n.textContent);
+        expect(names).toEqual(['cart', 'checkout']);
+        cleanup(c);
+    });
+
+    it('renders nothing when there is no livingSpecs data', () => {
+        const c = renderCard(baseState());
+        expect(c.querySelector('.activity-card--living-specs')).toBeNull();
+        expect(c.textContent).toBe('');
+        cleanup(c);
+    });
+});

--- a/webview/src/spec-viewer/components/cards/__tests__/LivingSpecsCard.test.tsx
+++ b/webview/src/spec-viewer/components/cards/__tests__/LivingSpecsCard.test.tsx
@@ -66,6 +66,14 @@ describe('LivingSpecsCard', () => {
         cleanup(c);
     });
 
+    it('de-duplicates a capability listed in both loaded and synced', () => {
+        const c = renderCard(baseState({ livingSpecs: { loaded: ['checkout', 'cart'], synced: ['checkout', 'cart'] } }));
+        const names = Array.from(c.querySelectorAll('.living-specs-list__name')).map(n => n.textContent);
+        expect(names).toEqual(['checkout', 'cart']);
+        expect(c.querySelectorAll('.living-specs-list__item')).toHaveLength(2);
+        cleanup(c);
+    });
+
     it('renders nothing when there is no livingSpecs data', () => {
         const c = renderCard(baseState());
         expect(c.querySelector('.activity-card--living-specs')).toBeNull();

--- a/webview/src/spec-viewer/types.ts
+++ b/webview/src/spec-viewer/types.ts
@@ -217,6 +217,14 @@ export interface ViewerState {
     stepSummaries?: Record<string, Record<string, unknown>>;
     /** Persisted inline review comments, for restore + the Activity list. */
     reviewComments?: ReviewComment[];
+    /** Living specs this feature loaded/synced (LS·7). Absent when none. */
+    livingSpecs?: LivingSpecsView;
+}
+
+/** Normalized living-specs view: loaded into context + folded back at completion. */
+export interface LivingSpecsView {
+    loaded: string[];
+    synced: string[];
 }
 
 // ============================================

--- a/webview/styles/spec-viewer/_activity.css
+++ b/webview/styles/spec-viewer/_activity.css
@@ -657,9 +657,14 @@
 }
 
 .living-specs-list__name {
+    flex: 1 1 auto;
+    min-width: 0;
     font-family: var(--font-mono);
     font-size: 0.82rem;
     color: var(--text-body);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 .living-specs-list__synced {

--- a/webview/styles/spec-viewer/_activity.css
+++ b/webview/styles/spec-viewer/_activity.css
@@ -638,3 +638,41 @@
     flex: 1 1 auto;
     min-width: 0;
 }
+
+/* Living specs card (LS·7) */
+.living-specs-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.living-specs-list__item {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex-wrap: wrap;
+}
+
+.living-specs-list__name {
+    font-family: var(--font-mono);
+    font-size: 0.82rem;
+    color: var(--text-body);
+}
+
+.living-specs-list__synced {
+    display: inline-flex;
+    align-items: center;
+    padding: 1px 7px;
+    font-size: 0.7rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    border-radius: var(--radius-sm);
+    color: var(--accent);
+    border: 1px solid color-mix(in srgb, var(--accent) 50%, transparent);
+    background: color-mix(in srgb, var(--accent) 12%, transparent);
+    line-height: 1.4;
+}


### PR DESCRIPTION
Closes #367

## Summary

The viewer now *shows* the living-specs context a feature touched — Companion's lightweight answer to the OpenSpec Dashboard. When a spec's `.spec-context.json` carries living-specs data (written by LS·2/LS·3), the Activity panel gains a small read-only **"Living specs"** card listing the capabilities the feature **loaded** into context and marking the ones it **folded back** into. It's display-only and **opt-in**: a spec with no living-specs data shows no new UI at all.

## What you'll see

- Open a spec → toggle **Activity** in the nav bar.
- If the spec loaded living specs, a "Living specs" card appears (after Phases, before Tasks) listing those capability names; folded-back ones carry a "folded back" chip.
- A spec with no `livingSpecs` field → no card (existing specs are unaffected).

## Evidence + manual verification

This is a UI ticket, so it's verified by **webview/unit tests** (the data→DOM mapping): the card renders the right names/chips for loaded / loaded+synced / synced-not-loaded specs, de-dupes, truncates long names, and renders **nothing** when there's no data. **The visual look (placement, chip color/contrast, theme, truncation) still needs a real-extension eyeball** — the tests prove the mapping, not the appearance. Evidence: `examples/todo-claude/bench/living-specs/evidence/LS7.json` (mode=webview-test).

## Under the hood

- `webview/src/spec-viewer/components/cards/LivingSpecsCard.tsx` (new Preact card, pure JSX — no innerHTML) + `.stories.tsx` (LoadedOnly / LoadedAndSynced / None / LongName) + jsdom test; wired into `ActivityPanel`.
- `livingSpecs` typed through `src/core/types/specContext.ts` → `stateDerivation.ts` (defensive reader, tested via the production `deriveViewerState()`) → webview `types.ts`.
- README "Activity Panel" + `docs/viewer-states.md` updated. No root version bump.
- Review fixes: ellipsis-trio for long capability names; de-dup to avoid Preact key collisions.

## Tests
`npm test` green (1094, +webview card/derivation/dedup/long-name cases). No `speckit-extension` change, so no shape-parity/pytest needed.