### PR TITLE
feat(sponsor): add Sponsor link to Marketplace, sidebar, and palette

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: alfredoperez

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- **Support the project from inside the editor** (#388): if SpecKit Companion saves you time, there's now an easy way to chip in. A "Sponsor" button appears on the Marketplace listing and the extension details view, the Specs sidebar welcome screen has a "Support this project" link, and there's a "Sponsor SpecKit Companion" command in the Command Palette. All of them open the project's GitHub Sponsors page. Nothing changes if you'd rather not — it's entirely optional.
 - **Recover a stranded spec with "Set status…"** (#347): an out-of-order or double click could leave a spec in a state where the lifecycle buttons wouldn't let you continue, and the only fix was hand-editing a JSON file. Every spec in the sidebar now has a **Set status…** action — on the right-click menu and as a hover gear — that lets you force the spec to any lifecycle status (specifying through completed) after a `"Force status to X?"` confirm. The override is recorded just like any other lifecycle change and the sidebar updates immediately, so a mis-click is no longer a dead end.
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -722,6 +722,10 @@ npm run package
 
 PRs welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for local setup, the `F5` dev-host loop, test conventions, the Conventional Commit style this repo uses, and the README docs map you should follow before opening a PR.
 
+## Support
+
+SpecKit Companion is free and open source. If it saves you time, you can support its development through [GitHub Sponsors](https://github.com/sponsors/alfredoperez). You'll also find a "Sponsor" button on the Marketplace listing and a "Support this project" link in the Specs sidebar.
+
 ## Acknowledgments
 
 This project started from the amazing work at https://github.com/notdp/kiro-for-cc

--- a/package.json
+++ b/package.json
@@ -14,6 +14,9 @@
   "bugs": {
     "url": "https://github.com/alfredoperez/speckit-companion/issues"
   },
+  "sponsor": {
+    "url": "https://github.com/sponsors/alfredoperez"
+  },
   "keywords": [
     "speckit",
     "spec-driven",
@@ -94,7 +97,7 @@
       },
       {
         "view": "speckit.views.explorer",
-        "contents": "Welcome to SpecKit\n\nA spec turns an idea into a plan and tasks your AI assistant can implement, step by step.\n\n[$(plus) Create your first spec](command:speckit.create)\n\n[$(book) Read the docs](https://github.com/alfredoperez/speckit-companion#readme)",
+        "contents": "Welcome to SpecKit\n\nA spec turns an idea into a plan and tasks your AI assistant can implement, step by step.\n\n[$(plus) Create your first spec](command:speckit.create)\n\n[$(book) Read the docs](https://github.com/alfredoperez/speckit-companion#readme)\n\n[$(heart) Support this project](command:speckit.sponsor)",
         "when": "speckit.detected && !speckit.constitutionNeedsSetup"
       },
       {
@@ -364,6 +367,12 @@
         "title": "Rate SpecKit on Marketplace",
         "category": "SpecKit",
         "icon": "$(star-empty)"
+      },
+      {
+        "command": "speckit.sponsor",
+        "title": "Sponsor SpecKit Companion",
+        "category": "SpecKit",
+        "icon": "$(heart)"
       },
       {
         "command": "speckit.upgradeCli",
@@ -686,6 +695,9 @@
         },
         {
           "command": "speckit.feedback.review"
+        },
+        {
+          "command": "speckit.sponsor"
         },
         {
           "command": "speckit.upgradeCli",

--- a/src/speckit/utilityCommands.ts
+++ b/src/speckit/utilityCommands.ts
@@ -29,6 +29,7 @@ export function registerUtilityCommands(
         bugReport: 'https://github.com/alfredoperez/speckit-companion/issues/new?template=bug_report.md',
         featureRequest: 'https://github.com/alfredoperez/speckit-companion/issues/new?labels=enhancement&template=feature_request.md',
         review: 'https://marketplace.visualstudio.com/items?itemName=alfredoperez.speckit-companion&ssr=false#review-details',
+        sponsor: 'https://github.com/sponsors/alfredoperez',
     } as const;
 
     context.subscriptions.push(
@@ -40,6 +41,9 @@ export function registerUtilityCommands(
         }),
         vscode.commands.registerCommand('speckit.feedback.review', async () => {
             await vscode.env.openExternal(vscode.Uri.parse(FEEDBACK_URLS.review));
+        }),
+        vscode.commands.registerCommand('speckit.sponsor', async () => {
+            await vscode.env.openExternal(vscode.Uri.parse(FEEDBACK_URLS.sponsor));
         })
     );
 }


### PR DESCRIPTION
Closes #388

## Summary

Adds a one-click way for users to support the project, surfaced in three places — the VS Code Marketplace listing/extension view, the GitHub repo page, and inside the extension itself. Everything points at the project's GitHub Sponsors page and is entirely optional.

- **Marketplace + extension-view "Sponsor" button** — via the native `sponsor` manifest field.
- **Repo "Sponsor" button** — via `.github/FUNDING.yml`.
- **"Support this project" link** in the Specs sidebar welcome view, alongside "Create your first spec" / "Read the docs".
- **"Sponsor SpecKit Companion"** Command Palette command.
- **README** "Support" section.

## Technical

- `package.json`: top-level `sponsor.url`; new `speckit.sponsor` command in `contributes.commands` + `contributes.menus.commandPalette`; "Support this project" link added to the `speckit.detected && !speckit.constitutionNeedsSetup` `viewsWelcome` entry.
- `src/speckit/utilityCommands.ts`: registers `speckit.sponsor`, mirroring the existing `speckit.feedback.*` `openExternal` pattern (no signature change).
- `.github/FUNDING.yml`: `github: alfredoperez`.
- All targets: `https://github.com/sponsors/alfredoperez`.

## Verify

- Reload the dev host → Command Palette → "Sponsor SpecKit Companion" opens the sponsors page.
- Specs sidebar welcome view shows "$(heart) Support this project".
- `npm run compile` clean; `npm test` → 1122 passing.

## Open item

The Sponsor button only resolves if the GitHub Sponsors page for `alfredoperez` is actually enabled. If it isn't live yet, the URL can be repointed (e.g. Buy Me a Coffee) before release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)