### PR TITLE
fix(spec-viewer): restore the forward button after an interrupted run is rolled back

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/383-spec-context-capture"
+  "feature_directory": "specs/393-implement-button-lost"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Fixed
+
+- **The Implement button comes back after an interrupted run** (#414): if the AI died partway through implementation (a network drop, a closed terminal), the dead run's leftover "started" record permanently hid the Implement button — forcing the status back with the sidebar gear looked like it did nothing, and the only workaround was deleting `.spec-context.json` and losing the spec's history. Forcing an earlier status now genuinely rewinds the workflow position: the forward button (Implement, or Tasks when rolling back to planned) reappears, the interrupted step stops falsely showing as completed, and the aborted attempt stays visible in the spec's history. No files to delete, recovery in two clicks.
+
 ## [0.26.0] - 2026-07-06
 
 ### Changed

--- a/docs/viewer-states.md
+++ b/docs/viewer-states.md
@@ -113,6 +113,20 @@
 > `completedAt` is set — at `implemented` the spec-scope
 > `Mark Completed` is the right surface, not `Approve`.
 >
+> **Rollback recovery (#414)**: "a later step started" is judged by
+> `history[]` *order*, not by "ever started". When an interrupted run
+> leaves a dangling step start (e.g. implement dispatched, AI died) and
+> the user forces an earlier status via the sidebar gear, the forced
+> boundary becomes the newest step-level entry — the stale start now
+> precedes it, so it no longer suppresses `Approve` and the forward
+> button (e.g. **Implement**) comes back. Derivation follows the same
+> rule: a rolled-back attempt that never completed is dropped from
+> `stepHistory` (its tab reads not-started, no phantom pulse, no
+> back-filled end time), while a step that genuinely completed before
+> the rollback keeps its own completion. The interrupted attempt stays
+> in the append-only `history[]` for the activity feed; recovery never
+> requires deleting `.spec-context.json`.
+>
 > **In-flight indicator consolidated onto the step tab (#277 Child 4)**:
 > There is no longer a "Generating…" footer pill. The single source of
 > in-flight motion is the **spinning step tab**. While the current step
@@ -258,6 +272,8 @@ footer always reflects the true workflow stage, not the viewed tab). While a ste
 is in flight the `CatalogFooter` suppresses its forward-motion button and keeps
 `Regenerate` (plus any closure/refine actions); the moment `status` settles, the
 forward button reappears — it never leaves the action bar empty.
+
+A status recovered via the sidebar gear maps to the **same row** as its normal pause stage: forcing `ready-to-implement` after an interrupted implement run restores Approve → **Implement**, and forcing `planned` restores Approve → **Tasks** — the stale start left by the interrupted run does not suppress the forward button (#414, "Rollback recovery" above). The oracle rows in `footerMatrix.fixtures.ts` pin these recovered states alongside the normal ones.
 
 The source-tab **Refine** button (`✨ Refine (N)`) still appears dynamically
 when pending inline comments are collected. Each comment is persisted to

--- a/specs/393-implement-button-lost/.spec-context.json
+++ b/specs/393-implement-button-lost/.spec-context.json
@@ -1,0 +1,259 @@
+{
+  "workflow": "speckit",
+  "specName": "implement button lost",
+  "branch": "393-implement-button-lost",
+  "currentStep": "implement",
+  "status": "completed",
+  "history": [
+    {
+      "step": "specify",
+      "substep": null,
+      "kind": "start",
+      "by": "extension",
+      "at": "2026-07-10T09:48:39.255Z"
+    },
+    {
+      "step": "specify",
+      "substep": null,
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-07-10T09:54:20.501Z"
+    },
+    {
+      "step": "plan",
+      "substep": "fast-path",
+      "kind": "start",
+      "by": "ai",
+      "at": "2026-07-10T09:54:20.588Z"
+    },
+    {
+      "step": "plan",
+      "substep": "fast-path",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-07-10T09:54:20.673Z"
+    },
+    {
+      "step": "tasks",
+      "substep": "fast-path",
+      "kind": "start",
+      "by": "ai",
+      "at": "2026-07-10T09:54:20.759Z"
+    },
+    {
+      "step": "tasks",
+      "substep": "fast-path",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-07-10T09:54:20.843Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "kind": "start",
+      "by": "extension",
+      "at": "2026-07-10T10:00:18.793Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T001",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-07-10T10:03:00.035Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T002",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-07-10T10:03:00.098Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T003",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-07-10T10:04:48.452Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T004",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-07-10T10:04:48.518Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T005",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-07-10T10:05:53.934Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T006",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-07-10T10:07:05.021Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-07-10T10:07:05.111Z"
+    }
+  ],
+  "last_action": "all 6 tasks done — 1211/1211 tests pass, tsc clean",
+  "coverage": {
+    "FR-001": {
+      "title": "Forcing status back to a settled earlier stage restores that stage's forward-motion button",
+      "tests": [
+        "src/features/spec-viewer/__tests__/footerMatrix.test.ts::recovered rows"
+      ]
+    },
+    "FR-002": {
+      "title": "A rolled-back step's dangling start must not suppress the current step's forward button",
+      "tests": [
+        "src/features/spec-viewer/__tests__/footerMatrix.test.ts::recovered rows",
+        "src/features/spec-viewer/__tests__/stateDerivation.test.ts::rollback recovery (#414)"
+      ]
+    },
+    "FR-003": {
+      "title": "An interrupted step must not display as completed after a rollback",
+      "tests": [
+        "src/features/spec-viewer/__tests__/stateDerivation.test.ts::rollback recovery (#414)"
+      ]
+    },
+    "FR-004": {
+      "title": "Recovery works without deleting/hand-editing .spec-context.json; history stays append-only",
+      "tests": [
+        "src/features/spec-viewer/__tests__/stateDerivation.test.ts::rollback recovery (#414)"
+      ]
+    },
+    "FR-005": {
+      "title": "Normal forward flow unchanged: past tabs still hide the forward button when genuinely advanced",
+      "tests": [
+        "src/features/spec-viewer/__tests__/footerMatrix.test.ts::genuinely ahead row + full matrix"
+      ]
+    },
+    "FR-006": {
+      "title": "Re-dispatch after recovery records a fresh attempt distinguishable from the interrupted one",
+      "tests": [
+        "src/features/spec-viewer/__tests__/stateDerivation.test.ts::keeps a completed retry after recovery as completed"
+      ]
+    }
+  },
+  "size": "simple",
+  "classification": {
+    "projectedFiles": 4,
+    "projectedTasks": 6,
+    "scopeSignal": "none",
+    "verdict": "simple"
+  },
+  "context": [
+    "area: src/features/spec-viewer/footerActions.ts (shouldShowApprove later-step check)",
+    "area: src/features/specs/stepHistoryDerivation.ts (deriveStepHistory back-fill)",
+    "area: src/features/specs/stepLifecycle.ts (forceStatus gear recovery, #347)",
+    "constraint: history[] is append-only — fix must live in derivation, not data rewrites",
+    "evidence: bug reproduced via throwaway jest test on main — footer showed only [regenerate], implement badge falsely completed"
+  ],
+  "intent": "Make the forward-motion (Implement) button recover after an interrupted run, so the gear force-status escape hatch actually works and nobody has to delete .spec-context.json",
+  "expectations": [
+    "No new recovery UI — the existing gear force-status stays the manual recovery surface",
+    "No migration or rewriting of stored .spec-context.json data",
+    "No change to the documented forward-flow button matrix for genuinely advanced specs"
+  ],
+  "currentTask": "T006",
+  "task_summaries": {
+    "T001": {
+      "status": "DONE",
+      "did": "Added failing footer-matrix oracle rows for the #414 recovery: forced ready-to-implement, forced planned, and repeated interruptions",
+      "files": [
+        "src/features/spec-viewer/__tests__/footerMatrix.fixtures.ts"
+      ]
+    },
+    "T002": {
+      "status": "DONE",
+      "did": "Added failing rollback-recovery derivation tests: interrupted implement not completed, no back-filled end, no phantom pulse, retry-after-recovery honored",
+      "files": [
+        "src/features/spec-viewer/__tests__/stateDerivation.test.ts"
+      ]
+    },
+    "T003": {
+      "status": "DONE",
+      "did": "shouldShowApprove now derives the workflow frontier from history[] order — a rolled-back dangling start no longer strands the forward button",
+      "files": [
+        "src/features/spec-viewer/footerActions.ts"
+      ]
+    },
+    "T004": {
+      "status": "DONE",
+      "did": "deriveStepHistory no longer finalizes an interrupted step from an earlier step's rollback boundary; rolled-back attempts derive as not-started, trust flag follows the real close entry",
+      "files": [
+        "src/features/specs/stepHistoryDerivation.ts"
+      ]
+    },
+    "T005": {
+      "status": "DONE",
+      "did": "Guard-rail tests: genuinely-ahead later step still hides Approve; re-running an earlier step keeps a completed later step completed; repeat interruption covered by the twice-recovered matrix row",
+      "files": [
+        "src/features/spec-viewer/__tests__/footerMatrix.fixtures.ts",
+        "src/features/spec-viewer/__tests__/stateDerivation.test.ts"
+      ]
+    },
+    "T006": {
+      "status": "DONE",
+      "did": "Documented rollback recovery in the viewer state machine doc (Approve advance window + footer matrix note); full suite 1211/1211 green",
+      "files": [
+        "docs/viewer-states.md"
+      ]
+    }
+  },
+  "verified": [
+    {
+      "what": "Full unit suite incl. 10 new #414 regression/guard tests",
+      "command": "npx jest",
+      "result": "1211 passed, 0 failed"
+    },
+    {
+      "what": "TypeScript strict compile",
+      "command": "npx tsc --noEmit",
+      "result": "no errors"
+    },
+    {
+      "what": "Bug reproduced on main before fixing (footer showed only regenerate, implement badge falsely completed), same scenarios now pass",
+      "command": "npx jest src/features/spec-viewer",
+      "result": "182 passed"
+    }
+  ],
+  "decisions": [
+    {
+      "decision": "Judge the workflow frontier by history[] array order (newest step-level entry wins)",
+      "why": "Array order is trustworthy even when AI-written timestamps are not; forceStatus already appends the realigning boundary",
+      "rejected": "Comparing timestamps across entries — unreliable for hand-typed AI times"
+    },
+    {
+      "decision": "Drop a rolled-back never-completed attempt from derived stepHistory entirely (reads not-started)",
+      "why": "Leaving it in-flight would fake a running pulse; back-filling an end fakes completion; the attempt stays in raw history[] for audit",
+      "rejected": "Adding an interrupted flag to StepHistoryEntry — would ripple through every renderer for the same outcome"
+    }
+  ],
+  "concerns": [
+    {
+      "note": "Task rows journaled during a rolled-back implement attempt disappear from the implement tab (the group is dropped); they remain in history[]/activity feed",
+      "step": "implement"
+    }
+  ],
+  "step_summaries": {
+    "implement": {
+      "summary": "Rollback-aware footer + derivation: forced status after an interrupted run restores the Implement button; interrupted attempts stop reading as completed"
+    }
+  }
+}

--- a/specs/393-implement-button-lost/checklists/requirements.md
+++ b/specs/393-implement-button-lost/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Recover the Implement button after an interrupted run
+
+**Purpose**: Validate Companion specification completeness before planning
+**Created**: 2026-07-10
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs) — the Approach section is the sanctioned exception for simple-mode specs; the requirement sections stay behavior-level
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed (User Scenarios, Requirements, Success Criteria)
+
+## Requirement Completeness
+
+- [x] Any [NEEDS CLARIFICATION] markers are genuine ambiguities (≤3) deferred to clarify — none needed; the bug is reproduced and root-caused
+- [x] Each Functional Requirement is a single, testable MUST/SHOULD statement
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into the specification (outside the labeled Approach section)
+
+## Notes
+
+- Bug reproduced on current `main` before drafting: the tasks-tab footer offers only Regenerate after the #414 sequence, and the interrupted implement step renders as completed. SC-001/SC-002 encode this as regression tests.

--- a/specs/393-implement-button-lost/plan.md
+++ b/specs/393-implement-button-lost/plan.md
@@ -1,0 +1,3 @@
+# Implementation Plan: Recover the Implement button after an interrupted run
+
+> Simple-change fast path — the plan lives inline in the spec: see [spec.md § Approach](./spec.md#approach) for the files to touch and the confirmed root cause, and [tasks.md](./tasks.md) for the task checklist.

--- a/specs/393-implement-button-lost/spec.md
+++ b/specs/393-implement-button-lost/spec.md
@@ -1,0 +1,105 @@
+# Feature Specification: Recover the Implement button after an interrupted run
+
+**Feature Branch**: `393-implement-button-lost`
+**Created**: 2026-07-10
+**Status**: Draft
+**Source**: [Issue #414](https://github.com/alfredoperez/speckit-companion/issues/414) — "[BUG] Implement button disappears permanently after interrupted implementation in v0.26.0"
+
+## The bug, reproduced
+
+When a user clicks Implement and the AI run dies partway (network drop, closed terminal), the run's "implement started" record stays in the spec's history with no matching completion. The history log is append-only, so nothing the user does afterward can remove it — and the viewer's rule for showing the forward-motion button ("hide it if any later step ever started") reads that dead record as "the workflow already moved past this point." Forcing the status back with the sidebar gear realigns the current step but cannot erase the record, so the Implement button never returns. Two side effects make it worse: the interrupted implement step falsely displays as **completed** (its end time gets back-filled from the forced-status write), and the only recovery users have found is deleting `.spec-context.json`, which destroys their whole history.
+
+Reproduced in an automated test on current `main`: after the sequence *implement started → interrupted → status forced to ready-to-implement*, the tasks-tab footer offers only Regenerate; Approve/Implement is gone and the implement badge reads completed.
+
+## User Scenarios & Testing
+
+### User Story 1 - Forcing the status back actually brings the button back (Priority: P1)
+
+A user's implementation run gets interrupted. They use the sidebar gear to force the spec's status back to "ready to implement." The Implement button reappears in the viewer footer, and clicking it starts a fresh implementation run.
+
+**Why this priority**: This is the exact recovery path we already tell users to take (it's the first suggestion in the issue thread), and today it silently does nothing. Fixing it turns the existing escape hatch into a real one.
+
+**Independent Test**: Interrupt an implement run on a demo spec, force the status via the gear, and confirm the Implement button is visible and dispatches.
+
+**Acceptance Scenarios**:
+
+1. **Given** a spec whose implement run started but never completed, **When** the user forces the status to "ready to implement", **Then** the tasks tab shows the Implement button again.
+2. **Given** the same stranded spec, **When** the user forces the status to "planned", **Then** the plan tab shows the Tasks button again.
+3. **Given** a recovered spec, **When** the user clicks Implement, **Then** a new implementation run starts and is recorded as a fresh attempt.
+
+### User Story 2 - The viewer tells the truth about an interrupted step (Priority: P2)
+
+After the rollback, the user looks at the step indicators. The implement step must not claim it finished — it should read as not done, so the user understands where the workflow actually stands.
+
+**Why this priority**: A "completed" badge on a step that died halfway misleads the user into thinking the work is done, compounding the stuck-button confusion.
+
+**Independent Test**: In the stranded-then-forced state, inspect the step badges: implement must not show as completed.
+
+**Acceptance Scenarios**:
+
+1. **Given** an implement run that started but never completed, **When** the user forces the status back to an earlier stage, **Then** the implement step is not displayed as completed.
+2. **Given** the same state, **When** the viewer derives per-step timing, **Then** the interrupted attempt's end time is not invented from a later unrelated write.
+
+### User Story 3 - Recovery never requires deleting files (Priority: P3)
+
+A user hits the interruption but doesn't know about the gear. The state they're left in must still offer a path forward from the viewer itself, and no recovery step may require hand-deleting `.spec-context.json` or losing history.
+
+**Why this priority**: File deletion is the community's current workaround; it loses history and telemetry identity and signals the product can't recover itself.
+
+**Independent Test**: From the stranded state (before any forcing), confirm the viewer still offers at least one working forward action, and that the full recovery flow touches no files by hand.
+
+**Acceptance Scenarios**:
+
+1. **Given** a freshly interrupted implement run (no forcing yet), **When** the user opens the viewer, **Then** at least one visible action can restart or resume the run.
+2. **Given** a spec recovered via the gear, **When** the user inspects the history afterward, **Then** the interrupted attempt is still recorded (nothing was erased).
+
+## Edge Cases
+
+- A run is interrupted, recovered, re-dispatched, and interrupted again — recovery must work repeatedly, with multiple dead start records in history.
+- The user forces a status *forward* (e.g. to "implementing") instead of backward — the viewer must stay coherent, not resurrect a phantom running state.
+- Legacy context files written before the current history schema (entries missing kind/task fields) must keep rendering as they do today.
+- Task-level finish records were journaled during the interrupted run — they must not change the recovery behavior or double-count on the retry.
+- The spec is completed or archived — forced-status recovery rules must not alter terminal-state behavior.
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: When a user forces a spec's status back to a settled earlier stage, the viewer MUST show that stage's forward-motion button again (e.g. "ready to implement" → Implement on the tasks tab; "planned" → Tasks on the plan tab).
+- **FR-002**: A step-start record left behind by an interrupted, rolled-back run MUST NOT suppress the current step's forward-motion button. The workflow's position is its most recent step-level boundary, not the furthest step ever started.
+- **FR-003**: An interrupted step MUST NOT display as completed after a rollback; its badge and derived timing MUST reflect that it did not finish.
+- **FR-004**: Recovery MUST work without deleting or hand-editing `.spec-context.json`; the history log remains append-only and the interrupted attempt stays visible in it.
+- **FR-005**: The normal forward flow MUST be unchanged: when the workflow has genuinely advanced, past tabs still hide the forward-motion button exactly as documented today.
+- **FR-006**: Re-dispatching a step after recovery MUST record a fresh attempt, distinguishable in history from the interrupted one.
+
+## Key Entities
+
+- **Spec context**: the per-spec record of workflow position — current step, status, and the append-only history log the viewer derives everything from.
+- **History entry**: one lifecycle event (which step, start or complete, who wrote it, when). The dangling implement start with no matching complete is the artifact this feature must tolerate.
+- **Footer action**: a viewer button whose visibility is derived from spec context; the Approve/Implement button is the one that gets stranded.
+
+## Success Criteria
+
+### Measurable Outcomes
+
+- **SC-001**: In the reproduced #414 sequence (implement started, no completion, status forced to "ready to implement"), the Implement button is visible — asserted by an automated regression test that fails on today's build and passes after the fix.
+- **SC-002**: The interrupted implement step reports as not-completed in the same scenario — asserted by automated test.
+- **SC-003**: All existing footer-matrix and state-derivation tests continue to pass (zero regressions in the documented button matrix).
+- **SC-004**: A user following the documented gear recovery reaches a working Implement button in at most 2 actions, deleting zero files.
+
+## Assumptions
+
+- The history log stays append-only; the fix lives in how state is *derived* from history, not in rewriting or migrating stored data.
+- The sidebar gear (force status) remains the sanctioned manual recovery surface; this feature makes it work rather than adding a new recovery UI.
+- The forced-status write already realigns the current step correctly (verified in reproduction); only the derivation layers that ignore that realignment need to change.
+
+## Approach
+
+Root cause is confirmed by a failing test on `main`, in two derivation-layer spots:
+
+- `src/features/spec-viewer/footerActions.ts` — `shouldShowApprove`'s "any later step has `startedAt` → hide" loop treats a dead, rolled-back implement start as the workflow frontier. Replace it with a rollback-aware frontier: a later step blocks Approve only if its step-level activity is *newer* than the current step's latest step-level boundary (the newest step-level entry in history — which `forceStatus` already appends — defines the position).
+- `src/features/specs/stepHistoryDerivation.ts` — `deriveStepHistory` back-fills a step's `completedAt` from the *next step's first transition* even when that "next" transition is a rollback boundary belonging to an **earlier** step. Don't finalize an interrupted step from an earlier step's boundary; leave it not-completed so badges/timing tell the truth (FR-003).
+- Regression tests in `src/features/spec-viewer/__tests__/` covering the full #414 sequence (button back after forcing ready-to-implement and planned; implement badge not completed; genuine forward flow unchanged; repeat-interruption).
+- `docs/viewer-states.md` — document the rollback/recovery behavior in the footer matrix section.
+
+Dependencies: none beyond existing modules; both changes are pure-derivation and test-covered. See [tasks](./tasks.md).

--- a/specs/393-implement-button-lost/tasks.md
+++ b/specs/393-implement-button-lost/tasks.md
@@ -1,0 +1,10 @@
+# Tasks: Recover the Implement button after an interrupted run
+
+**Input**: [spec.md](./spec.md) (Approach section) — root cause confirmed by reproduction on `main`
+
+- [x] **T001** Add failing regression tests for the #414 sequence: implement started → no completion → status forced to `ready-to-implement` shows Approve/Implement on the tasks tab, and forced to `planned` shows Tasks on the plan tab (FR-001, FR-002, SC-001) + `src/features/spec-viewer/__tests__/footerMatrix.test.ts`
+- [x] **T002** Add failing regression test: interrupted implement step derives as not-completed after a rollback — no back-filled `completedAt` from an earlier step's boundary, badge not `completed` (FR-003, SC-002) + `src/features/spec-viewer/__tests__/stateDerivation.test.ts`
+- [x] **T003** Make `shouldShowApprove`'s later-step check rollback-aware: a later step blocks Approve only when its step-level activity is newer than the current step's latest step-level boundary (FR-002, FR-005) + `src/features/spec-viewer/footerActions.ts`
+- [x] **T004** Stop `deriveStepHistory` finalizing a step's `completedAt` from a chronologically-later boundary that belongs to an earlier step (rollback); leave the interrupted step not-completed (FR-003) + `src/features/specs/stepHistoryDerivation.ts`
+- [x] **T005** Cover the guard rails: genuine forward flow still hides Approve on past tabs, repeat interruption recovers repeatedly, terminal statuses unaffected, legacy entries render unchanged (FR-004, FR-005, FR-006, SC-003) + `src/features/spec-viewer/__tests__/footerMatrix.test.ts`
+- [x] **T006** Update the viewer state machine doc with the rollback/recovery behavior (footer matrix + interrupted-run note) and run the full test suite (SC-003) + `docs/viewer-states.md`

--- a/src/features/spec-viewer/__tests__/footerMatrix.fixtures.ts
+++ b/src/features/spec-viewer/__tests__/footerMatrix.fixtures.ts
@@ -34,6 +34,10 @@ function start(step: StepName, from: StepName | null): HistoryEntry {
 function complete(step: StepName): HistoryEntry {
     return { step, substep: null, kind: 'complete', by: 'extension', at: T };
 }
+/** The gear's force-status rollback boundary (`forceStatus` → `setStepCompleted(step, 'user')`). */
+function forcedComplete(step: StepName): HistoryEntry {
+    return { step, substep: null, kind: 'complete', by: 'user', at: T };
+}
 
 /** Append-only history for every step up to (and including completion of) `through`. */
 function historyThrough(through: StepName): HistoryEntry[] {
@@ -90,6 +94,51 @@ export const FOOTER_MATRIX: FooterMatrixRow[] = [
         left: ['regenerate'],
         right: ['approve'],
         approveLabel: 'Implement',
+    },
+    {
+        // implement dispatched, run interrupted (dangling start), user forces
+        // ready-to-implement via the gear — the Implement button must come back.
+        name: 'ready-to-implement (recovered after interrupted implement)',
+        status: 'ready-to-implement',
+        currentStep: 'tasks',
+        history: [...historyThrough('tasks'), start('implement', 'tasks'), forcedComplete('tasks')],
+        left: ['regenerate'],
+        right: ['approve'],
+        approveLabel: 'Implement',
+    },
+    {
+        name: 'planned (recovered after interrupted implement)',
+        status: 'planned',
+        currentStep: 'plan',
+        history: [...historyThrough('tasks'), start('implement', 'tasks'), forcedComplete('plan')],
+        left: ['regenerate'],
+        right: ['approve'],
+        approveLabel: 'Tasks',
+    },
+    {
+        name: 'ready-to-implement (recovered twice after repeated interruptions)',
+        status: 'ready-to-implement',
+        currentStep: 'tasks',
+        history: [
+            ...historyThrough('tasks'),
+            start('implement', 'tasks'),
+            forcedComplete('tasks'),
+            start('implement', 'tasks'),
+            forcedComplete('tasks'),
+        ],
+        left: ['regenerate'],
+        right: ['approve'],
+        approveLabel: 'Implement',
+    },
+    {
+        // Guard rail: a LATER step genuinely ahead (its start follows this step's
+        // last boundary — no rollback in between) must still hide Approve.
+        name: 'tasks tab while implement is genuinely ahead (stale currentStep)',
+        status: 'ready-to-implement',
+        currentStep: 'tasks',
+        history: [...historyThrough('tasks'), start('implement', 'tasks')],
+        left: ['regenerate'],
+        right: [],
     },
     {
         name: 'implemented',

--- a/src/features/spec-viewer/__tests__/stateDerivation.test.ts
+++ b/src/features/spec-viewer/__tests__/stateDerivation.test.ts
@@ -332,6 +332,83 @@ describe('malformed optional fields are coerced, never crash the renderer', () =
     });
 });
 
+describe('rollback recovery (#414) — interrupted step after a forced status', () => {
+    // implement dispatched, run interrupted (dangling start), user forces
+    // ready-to-implement via the gear (forceStatus realigns currentStep=tasks
+    // and appends a user tasks-complete).
+    function strandedThenForced(): SpecContext {
+        return makeContext({
+            currentStep: 'tasks',
+            status: 'ready-to-implement',
+            history: [
+                { step: 'specify', substep: null, kind: 'start', by: 'extension', at: '2026-07-09T10:00:00Z' },
+                { step: 'specify', substep: null, kind: 'complete', by: 'extension', at: '2026-07-09T10:05:00Z' },
+                { step: 'plan', substep: null, kind: 'start', by: 'extension', at: '2026-07-09T10:06:00Z' },
+                { step: 'plan', substep: null, kind: 'complete', by: 'extension', at: '2026-07-09T10:15:00Z' },
+                { step: 'tasks', substep: null, kind: 'start', by: 'extension', at: '2026-07-09T10:16:00Z' },
+                { step: 'tasks', substep: null, kind: 'complete', by: 'extension', at: '2026-07-09T10:20:00Z' },
+                { step: 'implement', substep: null, kind: 'start', by: 'extension', at: '2026-07-09T10:21:00Z' },
+                { step: 'tasks', substep: null, kind: 'complete', by: 'user', at: '2026-07-09T11:00:00Z' },
+            ],
+        });
+    }
+
+    it('does not display the interrupted implement step as completed', () => {
+        const badges = deriveStepBadges(strandedThenForced());
+        expect(badges['implement']).toBe('not-started');
+        expect(badges['tasks']).toBe('completed');
+    });
+
+    it('does not back-fill the interrupted attempt\'s end from the rollback boundary', () => {
+        const state = deriveViewerState(strandedThenForced(), 'tasks');
+        expect(state.stepHistory['implement']).toBeUndefined();
+    });
+
+    it('does not pulse the rolled-back step as if it were running', () => {
+        expect(derivePulse(strandedThenForced())).toBeNull();
+    });
+
+    it('keeps a completed retry after recovery as completed', () => {
+        const ctx = strandedThenForced();
+        ctx.history = [
+            ...ctx.history,
+            { step: 'implement', substep: null, kind: 'start', by: 'extension', at: '2026-07-09T11:05:00Z' },
+            { step: 'implement', substep: null, kind: 'complete', by: 'extension', at: '2026-07-09T11:30:00Z' },
+        ];
+        ctx.currentStep = 'implement';
+        ctx.status = 'implemented';
+        const badges = deriveStepBadges(ctx);
+        expect(badges['implement']).toBe('completed');
+    });
+
+    it('re-running an earlier step keeps a genuinely completed later step completed', () => {
+        // late clarify after plan finished — a rollback only trims *incomplete* attempts
+        const ctx = makeContext({
+            currentStep: 'clarify',
+            status: 'specifying',
+            history: [
+                { step: 'specify', substep: null, kind: 'start', by: 'extension', at: '2026-07-09T10:00:00Z' },
+                { step: 'specify', substep: null, kind: 'complete', by: 'extension', at: '2026-07-09T10:05:00Z' },
+                { step: 'plan', substep: null, kind: 'start', by: 'extension', at: '2026-07-09T10:06:00Z' },
+                { step: 'plan', substep: null, kind: 'complete', by: 'extension', at: '2026-07-09T10:15:00Z' },
+                { step: 'clarify', substep: null, kind: 'start', by: 'extension', at: '2026-07-09T10:20:00Z' },
+            ],
+        });
+        const state = deriveViewerState(ctx, 'clarify');
+        expect(state.stepHistory['plan']?.completedAt).toBe('2026-07-09T10:15:00Z');
+        expect(deriveStepBadges(ctx)['plan']).toBe('completed');
+    });
+
+    it('keeps a genuinely in-flight current step in flight (no rollback involved)', () => {
+        const ctx = strandedThenForced();
+        ctx.history = ctx.history.slice(0, 7); // ends at the dangling implement start
+        ctx.currentStep = 'implement';
+        ctx.status = 'implementing';
+        expect(derivePulse(ctx)).toBe('implement');
+        expect(deriveStepBadges(ctx)['implement']).toBe('in-progress');
+    });
+});
+
 describe('context (ICE C) passthrough', () => {
     it('passes context strings through and drops non-strings', () => {
         const state = deriveViewerState(makeContext({

--- a/src/features/spec-viewer/footerActions.ts
+++ b/src/features/spec-viewer/footerActions.ts
@@ -23,6 +23,7 @@ import {
 } from '../../core/types/specContext';
 import { SpecStatuses, FooterActionIds } from '../../core/constants';
 import { deriveStepHistory } from '../specs/stepHistoryDerivation';
+import { isStepLevelEntry } from '../specs/historyHelpers';
 import type { WorkflowStepConfig } from '../workflows/types';
 
 type DerivedHistory = Record<string, StepHistoryEntry>;
@@ -62,8 +63,8 @@ function isSpecDone(ctx: SpecContext): boolean {
  *
  * Visible when:
  * - the step has been started, AND
- * - no later step in `STEP_NAMES` has acquired a `startedAt` (the
- *   workflow has not moved past this tab), AND
+ * - no later step is ahead of this one in `history[]` order (the
+ *   workflow has not moved past this tab — see `laterStepIsAhead`), AND
  * - either the step is in flight (no `completedAt`) OR there's still
  *   a later step in the workflow to advance to.
  *
@@ -89,14 +90,47 @@ function shouldShowApprove(
     if (!entry?.startedAt) return false;
     const idx = STEP_NAMES.indexOf(step);
     if (idx < 0) return false;
-    // Any later step started → workflow has moved past this tab.
-    for (let i = idx + 1; i < STEP_NAMES.length; i++) {
-        if (stepHistory[STEP_NAMES[i]]?.startedAt) return false;
-    }
+    if (laterStepIsAhead(ctx, step, idx, stepHistory)) return false;
     // Step in flight → always show.
     if (!entry.completedAt) return true;
     // Step is done → only show if there's a later step left to dispatch.
     return idx < STEP_NAMES.length - 1;
+}
+
+/**
+ * "Has the workflow moved past this tab?" — a later step blocks Approve only
+ * when its activity is newer than the current step's latest step-level boundary
+ * in the append-only `history[]`. A dangling start left by an interrupted run
+ * that the user rolled back via force-status precedes that boundary, so
+ * it no longer strands the forward button. Contexts without a usable history
+ * fall back to the historical "any later step ever started" rule.
+ */
+function laterStepIsAhead(
+    ctx: SpecContext,
+    step: StepName,
+    idx: number,
+    stepHistory: DerivedHistory
+): boolean {
+    const history = ctx.history ?? [];
+    if (history.length === 0) {
+        for (let i = idx + 1; i < STEP_NAMES.length; i++) {
+            if (stepHistory[STEP_NAMES[i]]?.startedAt) return true;
+        }
+        return false;
+    }
+    let lastOwnIdx = -1;
+    for (let i = history.length - 1; i >= 0; i--) {
+        const e = history[i];
+        if (e.step === step && isStepLevelEntry(e)) {
+            lastOwnIdx = i;
+            break;
+        }
+    }
+    for (let j = history.length - 1; j > lastOwnIdx; j--) {
+        const jIdx = STEP_NAMES.indexOf(history[j].step as StepName);
+        if (jIdx > idx) return true;
+    }
+    return false;
 }
 
 /**

--- a/src/features/specs/stepHistoryDerivation.ts
+++ b/src/features/specs/stepHistoryDerivation.ts
@@ -265,6 +265,8 @@ export function deriveStepHistory(
         const startedAt = g.transitions[0].at;
 
         let completedAt: string | null = null;
+        // The entry whose clock closed the span — drives `durationTrusted`.
+        let closeEntry: HistoryEntry | null = null;
         // A "completion" entry is one whose `from.step` matches its own
         // `step` — that's how setStepCompleted writes the close-boundary.
         // If the most recent entry for this step is a completion, the step
@@ -278,20 +280,35 @@ export function deriveStepHistory(
         const lastOwnIsCompletion = lastStepLevel?.kind === 'complete';
 
         if (g.nextStepFirstIdx !== -1) {
-            // A later step exists in transitions — that step's first transition
-            // is this step's real boundary. Index refers to the de-duplicated
-            // array that `groupStepsInOrder` walked.
-            completedAt = deduped[g.nextStepFirstIdx].at;
+            // Another step's transition follows this group — normally that is
+            // this step's real close boundary. But when that boundary belongs to
+            // an EARLIER step (a force-status rollback), it must not
+            // finalize this step: close at this step's own last completion, or —
+            // if the trailing attempt never completed — treat the attempt as
+            // rolled back and emit no entry at all (the step reads not-started).
+            const boundary = deduped[g.nextStepFirstIdx];
+            const gIdx = STEP_NAMES.indexOf(g.step as StepName);
+            const bIdx = STEP_NAMES.indexOf(boundary.step as StepName);
+            const rolledBack = gIdx >= 0 && bIdx >= 0 && bIdx < gIdx && isStepLevelEntry(boundary);
+            if (rolledBack) {
+                if (!lastOwnIsCompletion) continue;
+                closeEntry = lastStepLevel!;
+            } else {
+                closeEntry = boundary;
+            }
+            completedAt = closeEntry.at;
         } else if (lastOwnIsCompletion) {
             // No later step yet, but this step has a real completion entry —
             // honor it (covers `setStepCompleted` calls before the user has
             // clicked the next-phase button).
-            completedAt = lastStepLevel!.at;
+            closeEntry = lastStepLevel!;
+            completedAt = closeEntry.at;
         } else if (isLastSeen && isCurrent && isTerminal) {
             // Most recently seen step, currentStep matches, AND the spec is in
             // a terminal status → finalize to this step's last real transition
             // instead of leaving it in flight.
-            completedAt = g.transitions[g.transitions.length - 1].at;
+            closeEntry = g.transitions[g.transitions.length - 1];
+            completedAt = closeEntry.at;
         } else if (isLastSeen && isCurrent) {
             // Most recently seen step, and currentStep matches → in flight.
             completedAt = null;
@@ -299,7 +316,8 @@ export function deriveStepHistory(
             // Last seen step but we've already moved past it (currentStep
             // points elsewhere or is undefined). Best fallback: the last
             // transition for that step.
-            completedAt = g.transitions[g.transitions.length - 1].at;
+            closeEntry = g.transitions[g.transitions.length - 1];
+            completedAt = closeEntry.at;
         }
 
         const substeps = buildSubsteps(g.transitions, completedAt, startedAt);
@@ -310,14 +328,7 @@ export function deriveStepHistory(
         // ordering-true, duration-false. Renderers must not show elapsed time
         // for an untrusted span.
         const startTrusted = g.transitions[0].by === 'extension';
-        let endTrusted = false;
-        if (g.nextStepFirstIdx !== -1) {
-            endTrusted = deduped[g.nextStepFirstIdx].by === 'extension';
-        } else if (lastOwnIsCompletion) {
-            endTrusted = lastStepLevel!.by === 'extension';
-        } else if (completedAt !== null) {
-            endTrusted = g.transitions[g.transitions.length - 1].by === 'extension';
-        }
+        const endTrusted = closeEntry?.by === 'extension';
 
         const entry: StepHistoryEntry = { startedAt, completedAt };
         entry.durationTrusted = startTrusted && (completedAt === null || endTrusted);


### PR DESCRIPTION
## Summary
If the AI died partway through an implementation run (network drop, closed terminal), the Implement button vanished for good — forcing the status back with the sidebar gear looked like it did nothing, and the only community workaround was deleting `.spec-context.json` and losing the spec's history. Forcing an earlier status now genuinely rewinds the workflow: the forward button comes back, the interrupted step stops falsely showing as completed, and the aborted attempt stays visible in the history. Reproduced with a failing test on `main` before fixing.

## Technical
- `footerActions.ts` — `shouldShowApprove`'s "any later step ever started → hide" loop replaced by `laterStepIsAhead`: the workflow frontier is judged by `history[]` **order** (a later step blocks Approve only if it has an entry newer than the current step's last step-level boundary). `forceStatus` already appends that realigning boundary, so the gear recovery now works; contexts with no usable history keep the old rule.
- `stepHistoryDerivation.ts` — `deriveStepHistory` no longer finalizes a step's `completedAt` from a following boundary that belongs to an **earlier** step (a rollback): a rolled-back never-completed attempt is dropped from the derived map (badge reads not-started, no phantom pulse), while a step that genuinely completed before the rollback keeps its own completion. A new `closeEntry` threads through so `durationTrusted` follows the entry that actually closed the span.
- Oracle rows in `footerMatrix.fixtures.ts` pin the recovered states (forced `ready-to-implement`, forced `planned`, twice-recovered, genuinely-ahead guard); a `rollback recovery (#414)` suite in `stateDerivation.test.ts` covers badges, back-fill, pulse, completed-retry, and late-clarify-keeps-plan.

## Review checklist
- ✅ **VS Code extension · viewer** — affected
    - `src/features/spec-viewer/footerActions.ts`: rollback-aware Approve visibility
    - `src/features/specs/stepHistoryDerivation.ts`: rollback-aware step-history derivation
    - no webview/`.stories.tsx` component touched (pure extension-side derivation)
- — **SpecKit extension** — not touched
- ✅ **Changelog** — root `CHANGELOG.md` (Unreleased → Fixed), user-voice entry
- ✅ **Docs**
    - `docs/viewer-states.md`: new "Rollback recovery" note in the Approve advance window + footer-matrix mapping for recovered statuses
    - `docs/sidebar.md` "Set status…" section re-read: its un-strand claim is what this fix makes true — no drift
- ✅ **Verify**
    - `npx jest`: 1211 passed, 0 failed (10 new regression/guard tests; the 8 bug tests fail on `main`)
    - `npx tsc --noEmit`: clean
    - no version bump (belongs to /ship)

## Gaps / how to see it
- Task rows journaled during a rolled-back implement attempt no longer render on the implement tab (the derived group is dropped); they remain in the raw history/activity feed.
- Try: open a spec at ready-to-implement, click Implement, kill the terminal mid-run, then gear → Set status… → "ready-to-implement" — the Implement button reappears and the implement tab reads not-started.

Closes #414

🤖 Generated with [Claude Code](https://claude.com/claude-code)
