### PR TITLE
docs(readme): remove unsupported --force from extension install

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,13 +169,13 @@ There are **two** installs, and they're independent:
 # 1. github-source spec-kit CLI (required: stock PyPI specify-cli lacks `extension`)
 uv tool install specify-cli --from git+https://github.com/github/spec-kit.git --force
 
-# 2. the companion spec-kit extension (installs/updates; --force is idempotent)
-specify extension add companion --from https://github.com/alfredoperez/speckit-companion/releases/download/companion-latest/companion.zip --force
+# 2. the companion spec-kit extension (installs/updates)
+specify extension add companion --from https://github.com/alfredoperez/speckit-companion/releases/download/companion-latest/companion.zip
 ```
 
-> The `companion-latest/companion.zip` URL is a stable rolling asset — it always serves the newest build, so the same command installs **and** updates (re-run with `--force`). Once the extension is listed in the spec-kit catalog, it shortens to `specify extension add companion --force`.
+> The `companion-latest/companion.zip` URL is a stable rolling asset — it always serves the newest build, so the same command installs **and** updates. Once the extension is listed in the spec-kit catalog, it shortens to `specify extension add companion`.
 
-**Update it later** from the Specs view **Upgrade…** menu → *Update spec-kit Extension* (runs the same install with `--force`).
+**Update it later** from the Specs view **Upgrade…** menu → *Update spec-kit Extension* (runs the same install command).
 
 ![What installing the spec-kit extension unlocks: live progress capture, status, resume, the lean Companion pipeline, the complexity fast-path, and honest state recovery](https://raw.githubusercontent.com/alfredoperez/speckit-companion/main/docs/screenshots/install-banner.jpg)
 


### PR DESCRIPTION
## Related Issue

Follow-up to #420

## Description

The in-editor installer stopped passing the unsupported `--force` flag to `specify extension add`, but the manual README instructions still included it. This updates the copy-paste command and update wording to match `buildInstallCommand()`.

The `uv tool install ... --force` prerequisite is unchanged because that flag belongs to `uv` and is supported there.

## Type of Change

- [ ] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [x] Documentation update
- [ ] Refactor / internal-only

## Testing

1. `npx jest src/speckit/specKitExtensionInstall.test.ts --runInBand` - 9 passed
2. `npx jest tests/integration/docs-consistency.test.ts --runInBand` - 6 passed
3. `npm run compile` - passed
4. Verified `README.md` has no `specify extension add companion ... --force` command.
5. `git diff --check` - passed

A full Windows `npm test -- --runInBand` run passed 94/99 suites (1248/1266 tests). The remaining failures are existing Windows path-separator and filesystem timestamp assumptions in unrelated code; this PR changes README text only.

## Checklist

- [x] Code follows the project's style guidelines (see `CONTRIBUTING.md`)
- [x] Self-review completed
- [ ] Tests pass (`npm test`) - targeted tests and compile pass; see the Windows baseline note above
- [x] Updated `README.md` per the "Feature -> README section map" in `CLAUDE.md`
- [x] Documentation updated under `docs/` (N/A - root README-only correction)
- [x] Tests added/updated (N/A - existing regression test already covers the command)
- [x] No new warnings generated