### PR TITLE
fix(speckit-ext): package every runtime script the commands call

### DIFF
--- a/.claude/commands/publish-speckit-ext.md
+++ b/.claude/commands/publish-speckit-ext.md
@@ -40,7 +40,7 @@ Release the **spec-kit extension** (`speckit-extension/`, `id: companion`) so pe
    cd - >/dev/null
    ( cd /tmp/cb && zip -rq companion-$V.zip companion-$V )
    ```
-   **Never hand-type the script list here.** `package-manifest.py` is the single source of truth and `--copy-to` fills the archive from it (it re-runs the gate first and refuses to copy from a failing list). This step used to enumerate the scripts by hand — it drifted behind the commands, disagreed with the copy in `docs/publishing.md`, and shipped an archive missing five runtime scripts, which left the adoption, drift, and coverage commands unrunnable for every user who installed from a release (#432). If a command starts calling a new script, CI fails until the script is added to the manifest — there is nothing to update in this file.
+   **Never hand-type the script list here.** `scripts/package-manifest.py` is the single source of truth; `--copy-to` fills the archive from it and refuses to copy from a failing list. Hand-enumerating the scripts here is what shipped an archive missing five of them (#432). If a command starts calling a new script, CI fails until the manifest carries it — there is nothing to update in this file.
 6. **Cut the release** (prefixed tag, attach the version-named zip for archival):
    ```bash
    gh release create speckit-ext-v$V /tmp/cb/companion-$V.zip \

--- a/.claude/commands/publish-speckit-ext.md
+++ b/.claude/commands/publish-speckit-ext.md
@@ -29,18 +29,18 @@ Release the **spec-kit extension** (`speckit-extension/`, `id: companion`) so pe
    - **Every `provides.commands[].file` exists** AND every command markdown under `speckit-extension/commands/` is listed in `provides.commands`.
    - README is current (it's the catalog listing page).
 4. **Commit + push** to `main` (`chore(speckit-ext): release v<X.Y.Z>`).
-5. **Build the archive** — **allow-list, runtime files only**. Copy just what the installed extension runs (manifest, dispatched commands, the workflow, the three runtime scripts, license). Do NOT ship docs, CHANGELOG, ROADMAP, README, `examples/`, or the build-only `nodes/`+`presets/` sources — the catalog renders README/CHANGELOG from GitHub blob URLs, not the zip. (Don't "restore" a `tar --exclude` deny-list here: an allow-list is what keeps future doc/source additions out of the package.)
+5. **Build the archive** — **allow-list, runtime files only**. Copy just what the installed extension runs (manifest, dispatched commands, the workflow, the runtime scripts, license). Do NOT ship docs, CHANGELOG, ROADMAP, README, `examples/`, or the build-only `nodes/`+`presets/` sources — the catalog renders README/CHANGELOG from GitHub blob URLs, not the zip. (Don't "restore" a `tar --exclude` deny-list here: an allow-list is what keeps future doc/source additions out of the package.)
    ```bash
    V=<X.Y.Z>
    rm -rf /tmp/cb && mkdir -p /tmp/cb/companion-$V/scripts
    cd speckit-extension
    cp extension.yml LICENSE /tmp/cb/companion-$V/
    cp -R commands workflows /tmp/cb/companion-$V/
-   cp scripts/write-context.py scripts/status-context.py scripts/derive-from-files.py /tmp/cb/companion-$V/scripts/
+   python3 scripts/package-manifest.py --copy-to /tmp/cb/companion-$V/scripts
    cd - >/dev/null
    ( cd /tmp/cb && zip -rq companion-$V.zip companion-$V )
    ```
-   Runtime-script set: commands invoke `write-context.py` and `status-context.py`; `status-context.py` imports `derive-from-files.py`, which imports `write-context.py`. If a command ever starts calling a new script, add it here.
+   **Never hand-type the script list here.** `package-manifest.py` is the single source of truth and `--copy-to` fills the archive from it (it re-runs the gate first and refuses to copy from a failing list). This step used to enumerate the scripts by hand — it drifted behind the commands, disagreed with the copy in `docs/publishing.md`, and shipped an archive missing five runtime scripts, which left the adoption, drift, and coverage commands unrunnable for every user who installed from a release (#432). If a command starts calling a new script, CI fails until the script is added to the manifest — there is nothing to update in this file.
 6. **Cut the release** (prefixed tag, attach the version-named zip for archival):
    ```bash
    gh release create speckit-ext-v$V /tmp/cb/companion-$V.zip \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,3 +49,6 @@ jobs:
 
       - name: Check node-assembly parity (commands re-assemble byte-identical)
         run: python3 speckit-extension/scripts/assemble-nodes.py --check
+
+      - name: Check release packaging (every script a shipped command calls is packaged)
+        run: python3 speckit-extension/scripts/package-manifest.py --check

--- a/speckit-extension/CHANGELOG.md
+++ b/speckit-extension/CHANGELOG.md
@@ -9,7 +9,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/); this ext
 ## [Unreleased]
 
 ### Fixed
+- **`/speckit.companion.adopt`, `/speckit.companion.drift`, and `/speckit.companion.coverage` now actually run.** If you installed the extension from a release, these three commands could never work: the helpers they call were left out of the published package, so each one stopped partway and reported a missing file. Everything they need now ships with the extension. The same gap was quietly degrading `/speckit.companion.specify` and `/speckit.companion.plan`, which silently skipped loading your project's living specs instead of reading them into context — they now pick that context up as intended.
 - **Installing from a git-built spec-kit works again.** The extension's spec-kit version floor rejected dev builds (`0.9.5.dev0` sorts below `0.9.5` under PEP 440), so anyone running spec-kit installed from GitHub — the setup the README itself recommends — was blocked with a compatibility error. The floor now admits dev builds of the same engine line.
+
+### Changed
+- **The release package is now assembled from a checked list rather than a hand-written one.** What goes into a release used to be typed out by hand in two separate documents, and nothing verified it against what the commands actually call — which is how the three commands above shipped broken. The package is now built from a single list that is checked on every change: if a command needs something the package doesn't carry, the build fails and says which file is missing, so a release can't go out incomplete again.
 
 ## [0.18.0] - 2026-07-06
 

--- a/speckit-extension/README.md
+++ b/speckit-extension/README.md
@@ -302,6 +302,19 @@ specify extension list        # `companion` present
 # then run a real /speckit.specify and confirm specs/<NNN>/.spec-context.json is written
 ```
 
+### What the release archive contains
+
+The archive is an **allow-list**: the manifest, the `LICENSE`, the dispatched `commands/`, the `workflows/`, and the runtime scripts — nothing else. README, CHANGELOG, `docs/`, `examples/`, `tests/`, and the build-only sources stay out (the catalog renders the docs from GitHub, not from the zip).
+
+Which scripts count as "runtime" is not maintained by hand. `scripts/package-manifest.py` is the single source of truth, and the publish flow fills the archive straight from it:
+
+```bash
+python3 speckit-extension/scripts/package-manifest.py --list     # the scripts that ship
+python3 speckit-extension/scripts/package-manifest.py --check    # the gate (runs in CI)
+```
+
+`--check` derives what the shipped commands actually reach for — it scans the command bodies for the scripts they invoke, then follows each script's own imports — and fails if that disagrees with the packed list in either direction, naming the offending file. This is a guard against a real regression: the list used to be typed out in prose in two places, drifted behind the commands, and shipped an archive missing five scripts, which left `/speckit.companion.adopt`, `/speckit.companion.drift`, and `/speckit.companion.coverage` unrunnable for anyone who installed from a release. A command that starts calling a new script now fails the build until that script is packaged.
+
 ## How it works
 
 ```

--- a/speckit-extension/docs/publishing.md
+++ b/speckit-extension/docs/publishing.md
@@ -24,12 +24,16 @@ v0.2.0                  ❌  matches v* → would publish the WRONG thing to the
    cd speckit-extension
    cp extension.yml LICENSE /tmp/cb/companion-$V/
    cp -R commands workflows /tmp/cb/companion-$V/
-   cp scripts/write-context.py scripts/status-context.py scripts/derive-from-files.py scripts/resolve-spec-paths.py scripts/companion_config.py /tmp/cb/companion-$V/scripts/
+   python3 scripts/package-manifest.py --copy-to /tmp/cb/companion-$V/scripts
    cd - >/dev/null
    ( cd /tmp/cb && zip -rq companion-$V.zip companion-$V )
    ```
 
-   **What ships (and what doesn't).** The package carries `extension.yml`, `LICENSE`, `commands/`, `workflows/`, and exactly five scripts: `write-context.py`, `status-context.py`, `derive-from-files.py`, `resolve-spec-paths.py`, and `companion_config.py` (the only ones reached at runtime — commands call the capture/status scripts; `status-context.py` imports `derive-from-files.py`, which imports `write-context.py`; the living-specs resolver `resolve-spec-paths.py` imports `companion_config.py`). It deliberately **omits** README, CHANGELOG, ROADMAP, `docs/`, `examples/`, the build-only `nodes/`+`presets/` sources, the remaining build/test scripts, `tests/`, and `assets/`. The catalog page renders README/CHANGELOG from the GitHub blob URLs below — they're not needed inside the zip. Keep this an allow-list; don't swap it back to a `tar --exclude` deny-list, or new docs/sources will silently bloat the package again.
+   **What ships (and what doesn't).** The package carries `extension.yml`, `LICENSE`, `commands/`, `workflows/`, and the runtime scripts. **Which scripts those are is not restated here** — `package-manifest.py` is the single source of truth, and `--copy-to` fills the archive straight from it. That is deliberate: this list used to be typed out in prose in two places, drifted behind the commands that call the scripts, and shipped an archive missing five of them, which left the adoption, drift, and coverage commands unrunnable for anyone who installed from a release (#432). Run `python3 scripts/package-manifest.py --list` to see the current set.
+
+   The archive deliberately **omits** README, CHANGELOG, ROADMAP, `docs/`, `examples/`, the build-only `nodes/`+`presets/` sources, the build/test scripts, `tests/`, and `assets/`. The catalog page renders README/CHANGELOG from the GitHub blob URLs below — they're not needed inside the zip. This is still an **allow-list**; don't swap it back to a `tar --exclude` deny-list, or new docs/sources will silently bloat the package again.
+
+   **The list cannot silently fall behind again.** `package-manifest.py --check` derives what the shipped commands actually reach for — scanning the command bodies, then following each script's own imports — and fails if that disagrees with the packed set in either direction, naming the offending script. It runs in CI on every PR, and `--copy-to` refuses to build an archive from a failing list. A new command that calls a new script now blocks the build until the script is packaged.
 6. **Create the GitHub release** with a **prefixed tag** (`speckit-ext-v0.2.0`) and attach the version-named zip (archival):
    ```bash
    gh release create speckit-ext-v$V /tmp/cb/companion-$V.zip --title "..." --notes-file <CHANGELOG [X.Y.Z]> --target main

--- a/speckit-extension/docs/publishing.md
+++ b/speckit-extension/docs/publishing.md
@@ -33,6 +33,8 @@ v0.2.0                  ❌  matches v* → would publish the WRONG thing to the
 
    The archive deliberately **omits** README, CHANGELOG, ROADMAP, `docs/`, `examples/`, the build-only `nodes/`+`presets/` sources, the build/test scripts, `tests/`, and `assets/`. The catalog page renders README/CHANGELOG from the GitHub blob URLs below — they're not needed inside the zip. This is still an **allow-list**; don't swap it back to a `tar --exclude` deny-list, or new docs/sources will silently bloat the package again.
 
+   **`--copy-to` leaves the destination holding exactly that list.** It clears any scripts already sitting there first, so a reused staging dir can't slip a leftover (say, a build-only script from an older layout) into the zip. It only ever removes loose `.py` files, never recursively: a destination holding anything else — a subdirectory, a document, the `speckit-extension/scripts/` source tree itself — is refused with the offending entries named, so a mistyped path can't be emptied.
+
    **The list cannot silently fall behind again.** `package-manifest.py --check` derives what the shipped commands actually reach for — scanning the command bodies, then following each script's own imports — and fails if that disagrees with the packed set in either direction, naming the offending script. It runs in CI on every PR, and `--copy-to` refuses to build an archive from a failing list. A new command that calls a new script now blocks the build until the script is packaged.
 6. **Create the GitHub release** with a **prefixed tag** (`speckit-ext-v0.2.0`) and attach the version-named zip (archival):
    ```bash

--- a/speckit-extension/extension.yml
+++ b/speckit-extension/extension.yml
@@ -3,7 +3,7 @@ schema_version: "1.0"
 extension:
   id: companion
   name: "SpecKit Companion"
-  version: "0.18.1"
+  version: "0.18.0"
   description: "Live spec-driven progress for SpecKit Companion — lifecycle capture, status, and resume."
   author: alfredoperez
   repository: https://github.com/alfredoperez/speckit-companion

--- a/speckit-extension/extension.yml
+++ b/speckit-extension/extension.yml
@@ -3,7 +3,7 @@ schema_version: "1.0"
 extension:
   id: companion
   name: "SpecKit Companion"
-  version: "0.18.0"
+  version: "0.18.1"
   description: "Live spec-driven progress for SpecKit Companion — lifecycle capture, status, and resume."
   author: alfredoperez
   repository: https://github.com/alfredoperez/speckit-companion

--- a/speckit-extension/scripts/package-manifest.py
+++ b/speckit-extension/scripts/package-manifest.py
@@ -19,7 +19,10 @@ which is the failure this gate exists to prevent. The two-way compare turns ever
 disagreement into a named, blocking error instead.
 
 `--copy-to <dir>` fills an archive from the same list, so the shipped bits and the
-gated list cannot disagree. Exit 0 clean, 1 on any problem. Stdlib only.
+gated list cannot disagree: it clears any leftover scripts already in the destination
+so what lands there is exactly the list, and refuses a destination it cannot reduce to
+the list safely (anything but `.py` files, or the source directory itself). Exit 0
+clean, 1 on any problem. Stdlib only.
 """
 from __future__ import annotations
 
@@ -176,6 +179,30 @@ def check() -> list[str]:
     return problems
 
 
+def unsafe_dest(dest: str) -> str | None:
+    """Why `dest` cannot be reduced to exactly the packing list, or None if it can.
+
+    Only loose `.py` files are ever removed, so a mistyped path (`/`, a populated
+    source tree, a directory holding anything else) is refused rather than emptied."""
+    if os.path.realpath(dest) == os.path.realpath(HERE):
+        return "it is the source scripts/ directory — clearing it would delete the build-only scripts"
+    if not os.path.exists(dest):
+        return None
+    if not os.path.isdir(dest):
+        return "it exists and is not a directory"
+    strays = [
+        entry
+        for entry in sorted(os.listdir(dest))
+        if not (entry.endswith(".py") and os.path.isfile(os.path.join(dest, entry)))
+    ]
+    if strays:
+        return (
+            f"it holds entries that are not packaged scripts ({', '.join(strays)}) and this "
+            f"script only ever removes loose .py files — point --copy-to at an empty or fresh directory"
+        )
+    return None
+
+
 def _copy_to(dest: str) -> int:
     problems = check()
     if problems:
@@ -183,10 +210,20 @@ def _copy_to(dest: str) -> int:
         for problem in problems:
             print(f"  ✗ {problem}")
         return 1
+    unsafe = unsafe_dest(dest)
+    if unsafe:
+        print(f"[package-manifest] refusing to fill {dest}: {unsafe}")
+        return 1
+    cleared = 0
+    if os.path.isdir(dest):
+        for entry in sorted(os.listdir(dest)):
+            os.remove(os.path.join(dest, entry))
+            cleared += 1
     os.makedirs(dest, exist_ok=True)
     for script in sorted(RUNTIME_SCRIPTS):
         shutil.copy2(os.path.join(HERE, script), os.path.join(dest, script))
-    print(f"[package-manifest] copied {len(RUNTIME_SCRIPTS)} runtime scripts to {dest}")
+    note = f" (cleared {cleared} pre-existing script(s))" if cleared else ""
+    print(f"[package-manifest] copied {len(RUNTIME_SCRIPTS)} runtime scripts to {dest}{note}")
     return 0
 
 
@@ -194,7 +231,11 @@ def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
     group = parser.add_mutually_exclusive_group(required=True)
     group.add_argument("--check", action="store_true", help="gate the packing list")
-    group.add_argument("--copy-to", metavar="DIR", help="fill an archive from the list")
+    group.add_argument(
+        "--copy-to",
+        metavar="DIR",
+        help="fill an archive from the list (clears leftover scripts in DIR first)",
+    )
     group.add_argument("--list", action="store_true", help="print the packing list")
     args = parser.parse_args()
 

--- a/speckit-extension/scripts/package-manifest.py
+++ b/speckit-extension/scripts/package-manifest.py
@@ -228,7 +228,8 @@ def _copy_to(dest: str) -> int:
 
 
 def main() -> int:
-    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    summary = (__doc__ or "").splitlines()
+    parser = argparse.ArgumentParser(description=summary[0] if summary else None)
     group = parser.add_mutually_exclusive_group(required=True)
     group.add_argument("--check", action="store_true", help="gate the packing list")
     group.add_argument(

--- a/speckit-extension/scripts/package-manifest.py
+++ b/speckit-extension/scripts/package-manifest.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
-"""The packing list for the release archive — the single source of truth for which
-scripts ship, read by both the CI gate and the publish flow.
+"""The packing list for the release archive — which scripts ship, for the CI gate and the publish flow.
 
 `RUNTIME_SCRIPTS` is what goes into the archive. `--check` independently derives
 what the shipped commands actually reach for (scan the command bodies for the
@@ -12,6 +11,7 @@ and asserts the derived closure equals the declared list in BOTH directions:
   - unclassified             -> a new script with no ship/don't-ship decision
   - declared but absent      -> a typo, or a deleted script
   - referenced but missing   -> a command calls a script that exists nowhere
+  - command file absent      -> extension.yml lists a command markdown that is gone
 
 The declared list is kept rather than replaced by the derived set on purpose: a
 bare derivation would make an unrecognized reference form silently drop a script,
@@ -77,15 +77,23 @@ def _resolve_sibling(name: str, existing: set[str]) -> str | None:
     return None
 
 
+def declared_command_files() -> list[str]:
+    """Every command file `extension.yml` declares, whether or not it exists."""
+    manifest = os.path.join(EXT_ROOT, "extension.yml")
+    if not os.path.exists(manifest):
+        return []
+    return [os.path.join(EXT_ROOT, rel) for rel in MANIFEST_COMMAND_FILE.findall(_read(manifest))]
+
+
+def missing_command_files() -> list[str]:
+    return sorted(
+        os.path.relpath(p, EXT_ROOT) for p in declared_command_files() if not os.path.exists(p)
+    )
+
+
 def shipped_command_bodies() -> list[str]:
     """Every command file the manifest declares, plus the shipped workflows."""
-    paths = []
-    manifest = os.path.join(EXT_ROOT, "extension.yml")
-    if os.path.exists(manifest):
-        for rel in MANIFEST_COMMAND_FILE.findall(_read(manifest)):
-            path = os.path.join(EXT_ROOT, rel)
-            if os.path.exists(path):
-                paths.append(path)
+    paths = [p for p in declared_command_files() if os.path.exists(p)]
     workflows = os.path.join(EXT_ROOT, "workflows")
     if os.path.isdir(workflows):
         for entry in sorted(os.listdir(workflows)):
@@ -159,6 +167,11 @@ def check() -> list[str]:
         problems.append(
             f"referenced but missing: {script} — a shipped command calls it, "
             f"but no such file exists in scripts/"
+        )
+    for rel in missing_command_files():
+        problems.append(
+            f"command file absent: {rel} — extension.yml declares it under "
+            f"provides.commands, but no such file exists, so nothing scans it"
         )
     return problems
 

--- a/speckit-extension/scripts/package-manifest.py
+++ b/speckit-extension/scripts/package-manifest.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+"""The packing list for the release archive — the single source of truth for which
+scripts ship, read by both the CI gate and the publish flow.
+
+`RUNTIME_SCRIPTS` is what goes into the archive. `--check` independently derives
+what the shipped commands actually reach for (scan the command bodies for the
+installed script path, then follow each script's sibling imports to a fixed point)
+and asserts the derived closure equals the declared list in BOTH directions:
+
+  - needed but not packaged  -> a command would break on a real install
+  - packaged but unreachable -> dead weight, or the scanner missed a reference
+  - unclassified             -> a new script with no ship/don't-ship decision
+  - declared but absent      -> a typo, or a deleted script
+  - referenced but missing   -> a command calls a script that exists nowhere
+
+The declared list is kept rather than replaced by the derived set on purpose: a
+bare derivation would make an unrecognized reference form silently drop a script,
+which is the failure this gate exists to prevent. The two-way compare turns every
+disagreement into a named, blocking error instead.
+
+`--copy-to <dir>` fills an archive from the same list, so the shipped bits and the
+gated list cannot disagree. Exit 0 clean, 1 on any problem. Stdlib only.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import shutil
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+EXT_ROOT = os.path.dirname(HERE)
+
+RUNTIME_SCRIPTS = frozenset({
+    "write-context.py",
+    "status-context.py",
+    "derive-from-files.py",
+    "resolve-spec-paths.py",
+    "companion_config.py",
+    "register-capability.py",
+    "drift.py",
+    "check-coverage.py",
+})
+
+BUILD_ONLY = frozenset({
+    "build-commands.py",
+    "check-shape-parity.py",
+    "assemble-nodes.py",
+    "capture-golden.py",
+    "_command_parts.py",
+    "package-manifest.py",
+})
+
+INSTALLED_SCRIPT_REF = re.compile(
+    r"\.specify/extensions/companion/scripts/([A-Za-z0-9_.-]+\.py)"
+)
+MANIFEST_COMMAND_FILE = re.compile(r"^\s*file:\s*(\S+)", re.MULTILINE)
+QUOTED_NAME = re.compile(r"""["']([A-Za-z0-9_.-]+)["']""")
+PLAIN_IMPORT = re.compile(r"^\s*(?:import|from)\s+([A-Za-z0-9_]+)", re.MULTILINE)
+
+
+def _read(path: str) -> str:
+    with open(path, encoding="utf-8") as fh:
+        return fh.read()
+
+
+def _script_files() -> set[str]:
+    return {f for f in os.listdir(HERE) if f.endswith(".py")}
+
+
+def _resolve_sibling(name: str, existing: set[str]) -> str | None:
+    """Map a candidate name to a sibling script, or None if it isn't one."""
+    for candidate in (name, f"{name}.py"):
+        if candidate in existing:
+            return candidate
+    return None
+
+
+def shipped_command_bodies() -> list[str]:
+    """Every command file the manifest declares, plus the shipped workflows."""
+    paths = []
+    manifest = os.path.join(EXT_ROOT, "extension.yml")
+    if os.path.exists(manifest):
+        for rel in MANIFEST_COMMAND_FILE.findall(_read(manifest)):
+            path = os.path.join(EXT_ROOT, rel)
+            if os.path.exists(path):
+                paths.append(path)
+    workflows = os.path.join(EXT_ROOT, "workflows")
+    if os.path.isdir(workflows):
+        for entry in sorted(os.listdir(workflows)):
+            if entry.endswith((".yml", ".yaml", ".md")):
+                paths.append(os.path.join(workflows, entry))
+    return paths
+
+
+def direct_refs() -> set[str]:
+    """Scripts named outright by shipped command text."""
+    found: set[str] = set()
+    for path in shipped_command_bodies():
+        found.update(INSTALLED_SCRIPT_REF.findall(_read(path)))
+    return found
+
+
+def sibling_deps(script: str, existing: set[str]) -> set[str]:
+    """Sibling scripts that `script` imports, by any of the three forms used here:
+    a plain import, an import_module of a hyphenated name, or a load-by-filename."""
+    path = os.path.join(HERE, script)
+    if not os.path.exists(path):
+        return set()
+    source = _read(path)
+    candidates = set(QUOTED_NAME.findall(source)) | set(PLAIN_IMPORT.findall(source))
+    deps = set()
+    for name in candidates:
+        resolved = _resolve_sibling(name, existing)
+        if resolved and resolved != script:
+            deps.add(resolved)
+    return deps
+
+
+def derive_closure() -> set[str]:
+    """The roots plus everything reachable from them, to a fixed point."""
+    existing = _script_files()
+    closure: set[str] = set()
+    pending = [s for s in direct_refs() if s in existing]
+    while pending:
+        script = pending.pop()
+        if script in closure:
+            continue
+        closure.add(script)
+        pending.extend(sibling_deps(script, existing) - closure)
+    return closure
+
+
+def check() -> list[str]:
+    """Every disagreement between the declared list and reality. Empty means clean."""
+    problems = []
+    existing = _script_files()
+    closure = derive_closure()
+
+    for script in sorted(closure - RUNTIME_SCRIPTS):
+        problems.append(
+            f"needed but not packaged: {script} — a shipped command reaches it, "
+            f"but it is not in RUNTIME_SCRIPTS, so a real install would break"
+        )
+    for script in sorted(RUNTIME_SCRIPTS - closure):
+        problems.append(
+            f"packaged but unreachable: {script} — nothing shipped reaches it. "
+            f"Either drop it, or the reference scanner missed a real dependency"
+        )
+    for script in sorted(existing - RUNTIME_SCRIPTS - BUILD_ONLY):
+        problems.append(
+            f"unclassified: {script} — add it to RUNTIME_SCRIPTS (it ships) "
+            f"or BUILD_ONLY (it does not)"
+        )
+    for script in sorted(RUNTIME_SCRIPTS - existing):
+        problems.append(f"declared but absent: {script} — no such file in scripts/")
+    for script in sorted(direct_refs() - existing):
+        problems.append(
+            f"referenced but missing: {script} — a shipped command calls it, "
+            f"but no such file exists in scripts/"
+        )
+    return problems
+
+
+def _copy_to(dest: str) -> int:
+    problems = check()
+    if problems:
+        print("[package-manifest] refusing to build an archive from a failing list:")
+        for problem in problems:
+            print(f"  ✗ {problem}")
+        return 1
+    os.makedirs(dest, exist_ok=True)
+    for script in sorted(RUNTIME_SCRIPTS):
+        shutil.copy2(os.path.join(HERE, script), os.path.join(dest, script))
+    print(f"[package-manifest] copied {len(RUNTIME_SCRIPTS)} runtime scripts to {dest}")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--check", action="store_true", help="gate the packing list")
+    group.add_argument("--copy-to", metavar="DIR", help="fill an archive from the list")
+    group.add_argument("--list", action="store_true", help="print the packing list")
+    args = parser.parse_args()
+
+    if args.list:
+        for script in sorted(RUNTIME_SCRIPTS):
+            print(script)
+        return 0
+
+    if args.copy_to:
+        return _copy_to(args.copy_to)
+
+    problems = check()
+    if problems:
+        print("[package-manifest] FAIL — the packing list disagrees with the commands:")
+        for problem in problems:
+            print(f"  ✗ {problem}")
+        return 1
+    print(
+        f"[package-manifest] OK — {len(RUNTIME_SCRIPTS)} runtime scripts, "
+        f"closure matches the declared list"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/speckit-extension/tests/test_packaging.py
+++ b/speckit-extension/tests/test_packaging.py
@@ -131,5 +131,49 @@ class TestGateFailsOnDrift(unittest.TestCase):
             self.assertEqual(set(os.listdir(dest)), set(pm.RUNTIME_SCRIPTS))
 
 
+class TestCopyToLeavesExactlyTheList(unittest.TestCase):
+    """The archive must carry the packing list and nothing else, however dest arrived."""
+
+    def test_a_stray_script_in_the_destination_does_not_survive(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            dest = Path(tmp) / "scripts"
+            dest.mkdir()
+            (dest / "build-commands.py").write_text("# leftover from a prior run\n")
+            (dest / "write-context.py").write_text("# stale copy\n")
+
+            self.assertEqual(pm._copy_to(str(dest)), 0)
+
+            self.assertEqual(set(os.listdir(dest)), set(pm.RUNTIME_SCRIPTS))
+            self.assertFalse((dest / "build-commands.py").exists())
+            self.assertEqual(
+                (dest / "write-context.py").read_text(),
+                (SCRIPTS / "write-context.py").read_text(),
+                "a stale copy must be replaced by the current script",
+            )
+
+    def test_a_destination_holding_anything_but_scripts_is_refused(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            dest = Path(tmp) / "not-an-archive"
+            (dest / "nested").mkdir(parents=True)
+            (dest / "notes.md").write_text("someone's work\n")
+
+            self.assertEqual(pm._copy_to(str(dest)), 1)
+
+            self.assertTrue((dest / "notes.md").exists())
+            self.assertTrue((dest / "nested").is_dir())
+
+    def test_the_source_scripts_directory_is_refused(self):
+        before = scripts_on_disk()
+        self.assertEqual(pm._copy_to(str(SCRIPTS)), 1)
+        self.assertEqual(scripts_on_disk(), before)
+
+    def test_a_destination_that_is_a_file_is_refused(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            dest = Path(tmp) / "scripts"
+            dest.write_text("not a directory\n")
+            self.assertEqual(pm._copy_to(str(dest)), 1)
+            self.assertTrue(dest.is_file())
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/speckit-extension/tests/test_packaging.py
+++ b/speckit-extension/tests/test_packaging.py
@@ -13,8 +13,10 @@ from __future__ import annotations
 
 import importlib.util
 import os
+import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 SCRIPTS = Path(__file__).resolve().parent.parent / "scripts"
 
@@ -49,8 +51,7 @@ class TestPackingList(unittest.TestCase):
 
 class TestClosureDerivation(unittest.TestCase):
     def test_indirect_dependencies_are_reached(self):
-        """companion_config.py is named by no command — only the resolver imports it.
-        A scan of command text alone would miss it, which is how the archive shipped short."""
+        """companion_config.py is named by no command — only the resolver imports it."""
         self.assertNotIn("companion_config.py", pm.direct_refs())
         self.assertIn("companion_config.py", pm.derive_closure())
 
@@ -75,6 +76,59 @@ class TestClosureDerivation(unittest.TestCase):
         deps = pm.sibling_deps("write-context.py", scripts_on_disk())
         self.assertNotIn("os.py", deps)
         self.assertNotIn("json.py", deps)
+
+
+class TestGateFailsOnDrift(unittest.TestCase):
+    """Each case simulates one real regression and asserts check() names it."""
+
+    def assertProblem(self, problems: list[str], needle: str):
+        self.assertTrue(
+            any(needle in p for p in problems),
+            f"expected a problem matching {needle!r}, got: {problems}",
+        )
+
+    def test_a_reachable_script_left_out_of_the_list_fails(self):
+        short = frozenset(pm.RUNTIME_SCRIPTS - {"companion_config.py"})
+        with mock.patch.object(pm, "RUNTIME_SCRIPTS", short):
+            self.assertProblem(pm.check(), "needed but not packaged: companion_config.py")
+
+    def test_a_packaged_script_nothing_reaches_fails(self):
+        padded = frozenset(pm.RUNTIME_SCRIPTS | {"capture-golden.py"})
+        with mock.patch.object(pm, "RUNTIME_SCRIPTS", padded):
+            self.assertProblem(pm.check(), "packaged but unreachable: capture-golden.py")
+
+    def test_a_declared_script_that_does_not_exist_fails(self):
+        padded = frozenset(pm.RUNTIME_SCRIPTS | {"ghost.py"})
+        with mock.patch.object(pm, "RUNTIME_SCRIPTS", padded):
+            self.assertProblem(pm.check(), "declared but absent: ghost.py")
+
+    def test_a_new_script_with_no_shipping_decision_fails(self):
+        with mock.patch.object(pm, "BUILD_ONLY", frozenset(pm.BUILD_ONLY - {"capture-golden.py"})):
+            self.assertProblem(pm.check(), "unclassified: capture-golden.py")
+
+    def test_a_command_calling_a_script_that_does_not_exist_fails(self):
+        refs = pm.direct_refs() | {"ghost.py"}
+        with mock.patch.object(pm, "direct_refs", lambda: refs):
+            self.assertProblem(pm.check(), "referenced but missing: ghost.py")
+
+    def test_a_command_file_the_manifest_declares_but_disk_lacks_fails(self):
+        declared = pm.declared_command_files() + [str(SCRIPTS.parent / "commands" / "gone.md")]
+        with mock.patch.object(pm, "declared_command_files", lambda: declared):
+            self.assertProblem(pm.check(), "command file absent: commands/gone.md")
+
+    def test_copy_to_refuses_to_build_from_a_failing_list(self):
+        short = frozenset(pm.RUNTIME_SCRIPTS - {"companion_config.py"})
+        with tempfile.TemporaryDirectory() as tmp:
+            dest = os.path.join(tmp, "scripts")
+            with mock.patch.object(pm, "RUNTIME_SCRIPTS", short):
+                self.assertEqual(pm._copy_to(dest), 1)
+            self.assertFalse(os.path.exists(dest), "a failing list must not produce an archive")
+
+    def test_copy_to_fills_the_archive_from_the_list(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            dest = os.path.join(tmp, "scripts")
+            self.assertEqual(pm._copy_to(dest), 0)
+            self.assertEqual(set(os.listdir(dest)), set(pm.RUNTIME_SCRIPTS))
 
 
 if __name__ == "__main__":

--- a/speckit-extension/tests/test_packaging.py
+++ b/speckit-extension/tests/test_packaging.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Tests for the release-archive packing list.
+
+Guards the packaging contract: the declared RUNTIME_SCRIPTS must equal the closure
+independently derived from the shipped command bodies, every script must carry an
+explicit ship / don't-ship decision, and the derivation must follow indirect
+dependencies rather than only the scripts a command names outright.
+
+Stdlib `unittest` only (runs under pytest too), so the existing CI discover sweep
+picks it up.
+"""
+from __future__ import annotations
+
+import importlib.util
+import os
+import unittest
+from pathlib import Path
+
+SCRIPTS = Path(__file__).resolve().parent.parent / "scripts"
+
+_spec = importlib.util.spec_from_file_location("package_manifest", SCRIPTS / "package-manifest.py")
+pm = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(pm)
+
+
+def scripts_on_disk() -> set[str]:
+    return {f for f in os.listdir(SCRIPTS) if f.endswith(".py")}
+
+
+class TestPackingList(unittest.TestCase):
+    def test_gate_passes_on_the_real_repo(self):
+        problems = pm.check()
+        self.assertEqual(problems, [], "packaging gate found problems:\n" + "\n".join(problems))
+
+    def test_declared_list_equals_the_derived_closure(self):
+        self.assertEqual(pm.derive_closure(), set(pm.RUNTIME_SCRIPTS))
+
+    def test_every_declared_script_exists_on_disk(self):
+        for script in pm.RUNTIME_SCRIPTS:
+            self.assertTrue((SCRIPTS / script).exists(), f"{script} is declared but absent")
+
+    def test_runtime_and_build_only_are_disjoint(self):
+        self.assertEqual(pm.RUNTIME_SCRIPTS & pm.BUILD_ONLY, frozenset())
+
+    def test_every_script_has_a_shipping_decision(self):
+        unclassified = scripts_on_disk() - set(pm.RUNTIME_SCRIPTS) - set(pm.BUILD_ONLY)
+        self.assertEqual(unclassified, set(), f"scripts with no ship decision: {sorted(unclassified)}")
+
+
+class TestClosureDerivation(unittest.TestCase):
+    def test_indirect_dependencies_are_reached(self):
+        """companion_config.py is named by no command — only the resolver imports it.
+        A scan of command text alone would miss it, which is how the archive shipped short."""
+        self.assertNotIn("companion_config.py", pm.direct_refs())
+        self.assertIn("companion_config.py", pm.derive_closure())
+
+    def test_the_previously_missing_scripts_are_in_the_closure(self):
+        for script in (
+            "resolve-spec-paths.py",
+            "companion_config.py",
+            "register-capability.py",
+            "drift.py",
+            "check-coverage.py",
+        ):
+            self.assertIn(script, pm.derive_closure())
+
+    def test_build_only_scripts_stay_out_of_the_closure(self):
+        self.assertEqual(pm.derive_closure() & set(pm.BUILD_ONLY), set())
+
+    def test_every_script_a_command_names_actually_exists(self):
+        missing = pm.direct_refs() - scripts_on_disk()
+        self.assertEqual(missing, set(), f"commands call scripts that do not exist: {sorted(missing)}")
+
+    def test_stdlib_imports_are_not_mistaken_for_siblings(self):
+        deps = pm.sibling_deps("write-context.py", scripts_on_disk())
+        self.assertNotIn("os.py", deps)
+        self.assertNotIn("json.py", deps)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/specs/395-package-runtime-scripts/.spec-context.json
+++ b/specs/395-package-runtime-scripts/.spec-context.json
@@ -1,0 +1,463 @@
+{
+  "workflow": "speckit",
+  "specName": "package runtime scripts",
+  "branch": "395-package-runtime-scripts",
+  "currentStep": "implement",
+  "status": "completed",
+  "history": [
+    {
+      "step": "specify",
+      "substep": null,
+      "kind": "start",
+      "by": "extension",
+      "at": "2026-07-14T01:08:13.668Z"
+    },
+    {
+      "step": "specify",
+      "substep": null,
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-07-14T01:11:06.753Z"
+    },
+    {
+      "step": "plan",
+      "substep": "research",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-07-14T01:13:23.577Z"
+    },
+    {
+      "step": "plan",
+      "substep": "design",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-07-14T01:14:29.957Z"
+    },
+    {
+      "step": "plan",
+      "substep": null,
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-07-14T01:14:30.570Z"
+    },
+    {
+      "step": "tasks",
+      "substep": "generate",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-07-14T01:16:06.026Z"
+    },
+    {
+      "step": "tasks",
+      "substep": null,
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-07-14T01:16:06.183Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "kind": "start",
+      "by": "extension",
+      "at": "2026-07-14T01:16:28.682Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T001",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-07-14T01:17:10.952Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T002",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-07-14T01:17:26.055Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T003",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-07-14T01:18:12.766Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T004",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-07-14T01:18:12.822Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T005",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-07-14T01:18:41.558Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T006",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-07-14T01:18:41.615Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T007",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-07-14T01:19:45.490Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T008",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-07-14T01:20:32.826Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T009",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-07-14T01:20:32.883Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T010",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-07-14T01:21:39.184Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T011",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-07-14T01:21:39.240Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T012",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-07-14T01:21:39.295Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T013",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-07-14T01:22:28.002Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T014",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-07-14T01:22:53.678Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-07-14T01:22:53.759Z"
+    }
+  ],
+  "last_action": "all 14 tasks done — 1286 jest + 258 python tests pass, 3 gates green",
+  "coverage": {
+    "FR-001": {
+      "title": "Release archive contains every helper a shipped command invokes, incl. indirect",
+      "tasks": [
+        "T001",
+        "T002",
+        "T003",
+        "T004"
+      ]
+    },
+    "FR-002": {
+      "title": "Archive excludes build/test-only programs, docs, examples; stays an allow-list",
+      "tasks": [
+        "T001",
+        "T003"
+      ]
+    },
+    "FR-003": {
+      "title": "Exactly one machine-readable packing list; no document restates it",
+      "tasks": [
+        "T001",
+        "T008",
+        "T009"
+      ]
+    },
+    "FR-004": {
+      "title": "Check fails and names a needed-but-unpacked program",
+      "tasks": [
+        "T001",
+        "T005",
+        "T007"
+      ]
+    },
+    "FR-005": {
+      "title": "Check fails and names a packed-but-unneeded program",
+      "tasks": [
+        "T001",
+        "T005",
+        "T007"
+      ]
+    },
+    "FR-006": {
+      "title": "Check follows dependencies transitively and terminates on cycles",
+      "tasks": [
+        "T001",
+        "T002"
+      ]
+    },
+    "FR-007": {
+      "title": "Check runs inside the existing automated test run",
+      "tasks": [
+        "T005",
+        "T006"
+      ]
+    },
+    "FR-008": {
+      "title": "Publish flow reads the packing list instead of restating it; fails loudly",
+      "tasks": [
+        "T008",
+        "T009"
+      ]
+    },
+    "FR-009": {
+      "title": "Extension version bumped; its own changelog and readme record the fix",
+      "tasks": [
+        "T010",
+        "T011",
+        "T012",
+        "T014"
+      ]
+    },
+    "FR-010": {
+      "title": "No shipped command's instructions change; only what ships alongside them",
+      "tasks": [
+        "T013"
+      ]
+    }
+  },
+  "size": "normal",
+  "classification": {
+    "projectedFiles": 8,
+    "projectedTasks": 10,
+    "scopeSignal": "none",
+    "verdict": "normal"
+  },
+  "context": [
+    "area: speckit-extension packaging (release archive allow-list)",
+    "area: speckit-extension/scripts — 8-script runtime closure vs 5 build-only scripts",
+    "area: publish flow duplicated in speckit-extension/docs/publishing.md + .claude/commands/publish-speckit-ext.md",
+    "area: CI capture-suite job runs unittest discover + check-shape-parity",
+    "constraint: change is under speckit-extension/ — bump its extension.yml version, its README + CHANGELOG, never the root ones",
+    "constraint: allow-list only, never a deny-list",
+    "constraint: no command instruction text changes; packaging only"
+  ],
+  "intent": "Ship every helper script the extension's commands call, and make the packing list self-verifying so it can't silently fall behind again",
+  "expectations": [
+    "Writing any new helper script — all 8 already exist and work",
+    "Changing what any shipped command instructs the assistant to do",
+    "Cutting/publishing an actual release — this makes the next release correct, it does not publish one",
+    "Touching the root README, CHANGELOG, or package.json",
+    "Reworking the rest of the publish flow (tagging, rolling download asset, catalog entry)"
+  ],
+  "approach": "Add speckit-extension/scripts/package-manifest.py as the one machine-readable packing list, with --check (gate) and --copy-to (publish) modes. --check derives what the shipped commands actually need — scan command bodies for the installed script path form, then follow each script's sibling imports to a fixed point — and compares that closure against the declared list in both directions, naming any offender. Wire it into the CI capture-suite job and a unittest, repoint both publish docs at --copy-to, and bump the extension to 0.18.1.",
+  "decisions": [
+    {
+      "decision": "Keep a declared packing list AND compare it against an independently derived closure, both directions",
+      "why": "A pure derivation makes the scanner a silent single point of failure — an unrecognized reference form would just not copy the script, reintroducing this exact bug with no alarm. The two-way compare turns both a missed declaration and a scanner gap into a loud, named build failure.",
+      "rejected": "Derived-only (silent on scanner gaps); declared-only (cannot see a command that started calling something new — that is todays bug)"
+    },
+    {
+      "decision": "Put the packing list in scripts/package-manifest.py, not in extension.yml",
+      "why": "extension.yml is validated against spec-kits published schema at catalog review and parsed by the installer; a non-schema key is schema risk for zero gain since nothing in spec-kit would read it. A script in scripts/ matches the repos existing build-gate idiom, is executable rather than inert, and is importable by the tests.",
+      "rejected": "A package.runtime_scripts key in extension.yml; a plain MANIFEST/package.txt data file (still needs a program to check and copy it, and cannot express the build-only exclusion set)"
+    },
+    {
+      "decision": "Derive the closure by scanning the installed script path form, then following sibling references to a fixed point with cycle protection",
+      "why": "Commands invoke scripts by exactly one textual form, making the root scan an exact anchor. A direct scan alone finds only 6 of 8 — companion_config.py is named by no command and is reachable only through the resolver. Three reference forms exist (plain import, import_module with a hyphenated string, load-by-filename) and all three resolve to a literal naming a sibling, so one resolver handles them; non-sibling candidates fall away, which drops stdlib imports for free.",
+      "rejected": "AST/import-graph analysis (overkill for 13 stdlib scripts, and blind to the load-by-filename string form anyway); shipping all of scripts/ (a deny-list by another name — the publishing doc explicitly warns against it)"
+    },
+    {
+      "decision": "Land the gate in the CI capture-suite job as both a unittest and an explicit step; patch bump 0.18.0 to 0.18.1",
+      "why": "The unittest makes it fail for a developer locally under the existing discover sweep; the explicit step makes a packaging break legible as a packaging break in the CI log. Both sibling gates in that job already have this shape. The bump is a patch because no interface or behavior changes — files that were always meant to be in the package now are.",
+      "rejected": "Folding the assertion into check-shape-parity.py (its contract is command-body parity — an unrelated concern); a CI step with no test (would not fail locally before a push)"
+    },
+    {
+      "decision": "Added a fifth problem category, referenced-but-missing, beyond the four the design called for",
+      "why": "Writing the negative probe revealed the first draft silently ignored a command that names a script existing nowhere on disk — it was filtered out before the closure walk. That is precisely the user-visible symptom of #432 (the adopt command calling a script that is not there), so the gate has to catch it.",
+      "rejected": "Shipping the four planned categories — would have left the gate blind to the exact failure mode the issue reported"
+    }
+  ],
+  "step_summaries": {
+    "plan": {
+      "summary": "One machine-readable packing list (package-manifest.py) feeds both the release archive and a two-way CI gate, so the 5 missing runtime scripts ship and the list cannot silently drift again.",
+      "key_finding": "The closure is 8 scripts, not the 3 that ship. Only 6 are named directly by commands — companion_config.py and derive-from-files.py are reachable only indirectly, and write-context.py itself loads resolve-spec-paths.py by filename, so any check that scans command text alone would still under-ship."
+    },
+    "tasks": {
+      "summary": "14 tasks across 6 phases: 1 foundational (the packing list), 3 serial US1 proof tasks, 3 US2 gate tasks incl. negative probes, 2 parallel US3 doc repoints, 5 polish/verify."
+    },
+    "implement": {
+      "summary": "One machine-readable packing list now feeds both the release archive and a two-way CI gate; the 5 missing runtime scripts ship, and adopt/drift/coverage run from a real install."
+    }
+  },
+  "currentTask": "T014",
+  "task_summaries": {
+    "T001": {
+      "status": "DONE",
+      "did": "Created the packing list + two-way gate (RUNTIME_SCRIPTS/BUILD_ONLY, derive_closure, check, --check/--copy-to/--list)",
+      "files": [
+        "speckit-extension/scripts/package-manifest.py"
+      ]
+    },
+    "T002": {
+      "status": "DONE",
+      "did": "Ran --check on the real repo: PASS, closure independently derived as the 8 declared scripts from 6 direct roots",
+      "files": [
+        "speckit-extension/scripts/package-manifest.py"
+      ]
+    },
+    "T003": {
+      "status": "DONE",
+      "did": "Built a real archive via --copy-to: all 8 runtime scripts in, all 6 build-only out, nothing extra",
+      "files": [
+        "speckit-extension/scripts/package-manifest.py"
+      ]
+    },
+    "T004": {
+      "status": "DONE",
+      "did": "Installed the archive into a scratch project and ran resolve-spec-paths/register-capability/drift/check-coverage — all execute; registration really appended a capability. Counter-proof: the published 3-script archive lacks all four",
+      "files": [
+        "speckit-extension/scripts/package-manifest.py"
+      ]
+    },
+    "T005": {
+      "status": "DONE",
+      "did": "Added the packaging gate as a stdlib unittest (9 cases incl. indirect-dependency and stdlib-not-a-sibling coverage)",
+      "files": [
+        "speckit-extension/tests/test_packaging.py"
+      ]
+    },
+    "T006": {
+      "status": "DONE",
+      "did": "Added the packaging-gate step to the CI capture-suite job beside the parity gates",
+      "files": [
+        ".github/workflows/ci.yml"
+      ]
+    },
+    "T007": {
+      "status": "DONE",
+      "did": "Proved the gate bites in 3 directions (new unpacked script / packaged-but-unreachable / command calling a nonexistent script), each named; probes reverted, gate green. Probe design exposed a real gap — added the referenced-but-missing category",
+      "files": [
+        "speckit-extension/scripts/package-manifest.py",
+        "speckit-extension/tests/test_packaging.py"
+      ]
+    },
+    "T008": {
+      "status": "DONE",
+      "did": "Repointed publishing.md step 5 at --copy-to; removed the hand-typed 5-script enumeration, kept the allow-list principle",
+      "files": [
+        "speckit-extension/docs/publishing.md"
+      ]
+    },
+    "T009": {
+      "status": "DONE",
+      "did": "Repointed the publish command step 5 at --copy-to; it was copying only 3 scripts — the actual source of the shipped archive and of #432",
+      "files": [
+        ".claude/commands/publish-speckit-ext.md"
+      ]
+    },
+    "T010": {
+      "status": "DONE",
+      "did": "Bumped the spec-kit extension version to 0.18.1",
+      "files": [
+        "speckit-extension/extension.yml"
+      ]
+    },
+    "T011": {
+      "status": "DONE",
+      "did": "Added user-facing changelog entries (Fixed: the 3 commands run; Changed: package built from a checked list)",
+      "files": [
+        "speckit-extension/CHANGELOG.md"
+      ]
+    },
+    "T012": {
+      "status": "DONE",
+      "did": "Documented what the release archive carries and the packaging gate in the extension README",
+      "files": [
+        "speckit-extension/README.md"
+      ]
+    },
+    "T013": {
+      "status": "DONE",
+      "did": "Full suite green: npm compile, 1286 jest tests, 258 python tests, shape-parity + node-assembly + packaging gates all exit 0"
+    },
+    "T014": {
+      "status": "DONE",
+      "did": "Verified the scope fence: root README/CHANGELOG/package.json untouched; only .specify/feature.json pointer changed (reverted before commit)"
+    }
+  },
+  "verified": [
+    {
+      "what": "The packaging gate derives the true closure and passes on the real repo",
+      "command": "python3 speckit-extension/scripts/package-manifest.py --check",
+      "result": "OK — 8 runtime scripts, closure matches the declared list; 6 direct roots expand to 8 via indirect deps",
+      "warnings": []
+    },
+    {
+      "what": "The gate actually fails on drift, in three directions, each naming the offender",
+      "command": "probes: new unpacked script referenced by a command / unreachable entry added to the list / command calling a nonexistent script",
+      "result": "All three exit 1 and name the file. Reverted; gate back to green",
+      "warnings": [
+        "Probe design exposed a real gap in the first draft: a command naming a script that exists nowhere was silently filtered out. Added the referenced-but-missing category and a test."
+      ]
+    },
+    {
+      "what": "An archive built from the packing list carries exactly the runtime closure",
+      "command": "package-manifest.py --copy-to /tmp/arch432/companion-0.18.1/scripts",
+      "result": "8/8 runtime present, 0 build-only leaked, 0 extra files",
+      "warnings": []
+    },
+    {
+      "what": "The previously-broken commands run end-to-end from an archive-only scratch install (the #432 reproduction)",
+      "command": "ran resolve-spec-paths.py, register-capability.py, drift.py, check-coverage.py in /tmp/sb432",
+      "result": "All four execute; register-capability really appended a capability to companion.yml. Counter-proof: the published 3-script archive lacks all four",
+      "warnings": []
+    },
+    {
+      "what": "Full suite + all gates green; no command body text changed",
+      "command": "npm run compile && npm test; check-shape-parity.py; assemble-nodes.py --check; unittest discover",
+      "result": "1286 jest tests pass, 258 python tests pass, shape-parity OK (14 bodies), node-assembly OK (5 bodies), packaging OK",
+      "warnings": []
+    }
+  ],
+  "concerns": [
+    {
+      "note": "The fix makes the NEXT release correct; it does not republish. The currently-published companion-latest zip is still the broken 3-script build until someone runs /publish-speckit-ext.",
+      "step": "implement"
+    }
+  ]
+}

--- a/specs/395-package-runtime-scripts/checklists/requirements.md
+++ b/specs/395-package-runtime-scripts/checklists/requirements.md
@@ -1,0 +1,35 @@
+# Specification Quality Checklist: Ship every runtime script the commands call
+
+**Purpose**: Validate Companion specification completeness before planning
+**Created**: 2026-07-13
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed (User Scenarios, Requirements, Success Criteria)
+
+## Requirement Completeness
+
+- [x] Any [NEEDS CLARIFICATION] markers are genuine ambiguities (≤3) deferred to clarify — not unresolved guesses (none needed; open choices captured under Assumptions)
+- [x] Each Functional Requirement is a single, testable MUST/SHOULD statement
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into the specification
+
+## Notes
+
+- The Verbatim Constraints section carries exact program filenames and the scope fence. These are values the request pinned, not implementation detail — downstream steps must match them exactly.
+- No [NEEDS CLARIFICATION] markers. The defect and its fix are well-determined; the one real design choice (where the single packing list lives) is a planning decision, not a spec ambiguity.

--- a/specs/395-package-runtime-scripts/contracts/package-manifest-cli.md
+++ b/specs/395-package-runtime-scripts/contracts/package-manifest-cli.md
@@ -26,7 +26,7 @@ A failure must name the script. A bare "packaging check failed" is not sufficien
 Leaves `<dir>` holding exactly the packing list — creating it if needed, and removing any scripts already there so a reused destination can't smuggle an unlisted file into the archive. This is what the publish flow calls in place of the hand-typed `cp scripts/…` line.
 
 ```bash
-python3 speckit-extension/scripts/package-manifest.py --copy-to /tmp/cb/companion-0.18.1/scripts
+python3 speckit-extension/scripts/package-manifest.py --copy-to /tmp/cb/companion-X.Y.Z/scripts
 ```
 
 | Exit | Meaning |

--- a/specs/395-package-runtime-scripts/contracts/package-manifest-cli.md
+++ b/specs/395-package-runtime-scripts/contracts/package-manifest-cli.md
@@ -1,0 +1,85 @@
+# Contract: `package-manifest.py` CLI
+
+**Path**: `speckit-extension/scripts/package-manifest.py`
+**Consumers**: the CI packaging gate, the unit test suite, and the publish flow's archive step.
+**Runtime**: Python 3, standard library only (matches every other script in the directory).
+
+Two callers code against this interface, so its flags and exit codes are the contract that keeps the archive and the gate in agreement by construction.
+
+## `--check`
+
+Verifies that the declared packing list and the closure derived from the shipped commands agree in both directions.
+
+```bash
+python3 speckit-extension/scripts/package-manifest.py --check
+```
+
+| Exit | Meaning |
+|---|---|
+| `0` | The sets agree. Prints a one-line confirmation with the script count. |
+| `1` | Disagreement. Prints one line per offending script, each naming the script and its category (*needed but not packaged*, *packaged but unreachable*, *unclassified*, *declared but absent*). |
+
+A failure must name the script. A bare "packaging check failed" is not sufficient — the whole point is that the next maintainer is told exactly which file to act on.
+
+## `--copy-to <dir>`
+
+Copies every script in the packing list into `<dir>`, creating it if needed. This is what the publish flow calls in place of the hand-typed `cp scripts/…` line.
+
+```bash
+python3 speckit-extension/scripts/package-manifest.py --copy-to /tmp/cb/companion-0.18.1/scripts
+```
+
+| Exit | Meaning |
+|---|---|
+| `0` | Every listed script was copied. Prints the count. |
+| `1` | A listed script is missing from `scripts/`, or the destination cannot be written. Nothing partial is left behind silently — the failure is loud. |
+
+`--copy-to` runs `--check`'s validation first and refuses to copy on a failed check. An archive is never built from a packing list that is known to disagree with the commands.
+
+## `--list`
+
+Prints the packing list, one filename per line, to stdout. For a maintainer inspecting the list or a shell pipeline that wants the names without reimplementing the parse.
+
+```bash
+python3 speckit-extension/scripts/package-manifest.py --list
+```
+
+Exit `0` always (the list is a declared constant).
+
+## Importable surface
+
+The test suite imports the module by file path (the established idiom for hyphenated scripts in this repo) and codes against these names:
+
+| Name | Type | Meaning |
+|---|---|---|
+| `RUNTIME_SCRIPTS` | `frozenset[str]` | The declared packing list. |
+| `BUILD_ONLY` | `frozenset[str]` | Scripts that must never ship. |
+| `derive_closure()` | `-> set[str]` | The closure computed from the shipped command bodies. |
+| `check()` | `-> list[str]` | The problems found; empty means the gate passes. |
+
+`check()` returning a list of human-readable problem strings (rather than raising, or returning a bool) is what lets the unit test assert on *which* script is wrong, and lets the CLI print each problem on its own line.
+
+## Verbatim constraints carried from the spec
+
+`RUNTIME_SCRIPTS` is exactly these eight, spelled exactly this way:
+
+```
+write-context.py
+status-context.py
+derive-from-files.py
+resolve-spec-paths.py
+companion_config.py
+register-capability.py
+drift.py
+check-coverage.py
+```
+
+`BUILD_ONLY` carries at least these five, plus `package-manifest.py` itself:
+
+```
+build-commands.py
+check-shape-parity.py
+assemble-nodes.py
+capture-golden.py
+_command_parts.py
+```

--- a/specs/395-package-runtime-scripts/contracts/package-manifest-cli.md
+++ b/specs/395-package-runtime-scripts/contracts/package-manifest-cli.md
@@ -23,7 +23,7 @@ A failure must name the script. A bare "packaging check failed" is not sufficien
 
 ## `--copy-to <dir>`
 
-Copies every script in the packing list into `<dir>`, creating it if needed. This is what the publish flow calls in place of the hand-typed `cp scripts/…` line.
+Leaves `<dir>` holding exactly the packing list — creating it if needed, and removing any scripts already there so a reused destination can't smuggle an unlisted file into the archive. This is what the publish flow calls in place of the hand-typed `cp scripts/…` line.
 
 ```bash
 python3 speckit-extension/scripts/package-manifest.py --copy-to /tmp/cb/companion-0.18.1/scripts
@@ -31,10 +31,12 @@ python3 speckit-extension/scripts/package-manifest.py --copy-to /tmp/cb/companio
 
 | Exit | Meaning |
 |---|---|
-| `0` | Every listed script was copied. Prints the count. |
-| `1` | A listed script is missing from `scripts/`, or the destination cannot be written. Nothing partial is left behind silently — the failure is loud. |
+| `0` | The destination now holds the packing list and nothing else. Prints the count, plus how many pre-existing scripts were cleared. |
+| `1` | A listed script is missing from `scripts/`, the destination cannot be written, or the destination is one the command refuses to clear. Nothing partial is left behind silently — the failure is loud. |
 
 `--copy-to` runs `--check`'s validation first and refuses to copy on a failed check. An archive is never built from a packing list that is known to disagree with the commands.
+
+Only loose `.py` files are ever removed, and never recursively — a destination holding anything else (a subdirectory, a document, a whole source tree) is refused with the offending entries named, rather than emptied. `--copy-to speckit-extension/scripts` is refused outright for the same reason: it would otherwise delete the build-only scripts from their own directory.
 
 ## `--list`
 

--- a/specs/395-package-runtime-scripts/data-model.md
+++ b/specs/395-package-runtime-scripts/data-model.md
@@ -1,0 +1,63 @@
+# Data Model: Ship every runtime script the commands call
+
+The feature has no persisted state. Its "data" is three in-memory sets computed at check time and one declared constant. All of it lives in `speckit-extension/scripts/package-manifest.py`.
+
+## Declared: the packing list
+
+**`RUNTIME_SCRIPTS`** — the set of script filenames that ship inside the release archive. The single source of truth; both consumers read it.
+
+| Entry | Reached how |
+|---|---|
+| `write-context.py` | Named directly by nearly every command |
+| `status-context.py` | Named directly by the status command |
+| `derive-from-files.py` | Imported by `status-context.py` |
+| `resolve-spec-paths.py` | Named directly by specify / plan / adopt; also loaded by `write-context.py` |
+| `companion_config.py` | Imported by `resolve-spec-paths.py` and `register-capability.py` |
+| `register-capability.py` | Named directly by the adopt command |
+| `drift.py` | Named directly by the drift command |
+| `check-coverage.py` | Named directly by the coverage command |
+
+**`BUILD_ONLY`** — scripts that exist in `scripts/` and must never enter the archive: `build-commands.py`, `check-shape-parity.py`, `assemble-nodes.py`, `capture-golden.py`, `_command_parts.py`, and `package-manifest.py` itself.
+
+**Invariant**: `RUNTIME_SCRIPTS` and `BUILD_ONLY` are disjoint, and together they account for every `*.py` file in `scripts/`. A new script that is on neither list fails the check — a script cannot be introduced without a deliberate decision about whether it ships.
+
+## Derived: the reference scan
+
+**`Root`** — a script filename named directly by shipped text.
+
+- **Source**: every command file declared under `provides.commands` in `extension.yml`, plus the shipped `workflows/`.
+- **Anchor**: the installed path form, `.specify/extensions/companion/scripts/<name>.py`. This is the only way a command can invoke a script at runtime, which makes it an exact anchor rather than a guess.
+- **Current value**: `write-context.py`, `status-context.py`, `resolve-spec-paths.py`, `register-capability.py`, `drift.py`, `check-coverage.py` (6).
+
+## Derived: the closure
+
+**`Closure`** — the roots plus everything reachable from them through sibling references, to a fixed point.
+
+An edge exists from script A to sibling script B when A's source contains a name resolving to B, in any of three forms:
+
+| Form | Captured as |
+|---|---|
+| `import companion_config` / `from companion_config import …` | bare module name |
+| `importlib.import_module("write-context")` | quoted module name (may contain hyphens) |
+| `spec_from_file_location(…, "…/resolve-spec-paths.py")` | quoted filename |
+
+Candidate names that do not match a file in `scripts/` are discarded, which drops standard-library imports (`os`, `json`, `argparse`) with no explicit allow-list of stdlib names.
+
+**Termination**: a `visited` set guards the walk, so a cycle (A imports B, B imports A) or a self-reference terminates.
+
+**Current value**: the 6 roots plus `derive-from-files.py` and `companion_config.py` = the 8 in `RUNTIME_SCRIPTS`.
+
+## The assertion
+
+```
+Closure == RUNTIME_SCRIPTS
+```
+
+Checked in both directions, each failure naming the offending script:
+
+| Condition | Meaning | Message |
+|---|---|---|
+| `Closure - RUNTIME_SCRIPTS` non-empty | A command needs a script the archive won't carry. This is issue #432. | *needed but not packaged* |
+| `RUNTIME_SCRIPTS - Closure` non-empty | The list carries a script nothing needs — or the scanner failed to see a real reference. Either way, look. | *packaged but unreachable* |
+| A `scripts/*.py` on neither list | A new script with no shipping decision. | *unclassified* |
+| A `RUNTIME_SCRIPTS` entry missing from disk | A typo or a deleted script. | *declared but absent* |

--- a/specs/395-package-runtime-scripts/plan.md
+++ b/specs/395-package-runtime-scripts/plan.md
@@ -1,0 +1,76 @@
+# Implementation Plan: Ship every runtime script the commands call
+
+**Branch**: `395-package-runtime-scripts` | **Spec**: [spec.md](./spec.md) | **Issue**: #432
+**Size**: `normal`
+
+## Summary
+
+The spec-kit extension's release archive is assembled from a hand-typed `cp scripts/…` line that is duplicated in two documents and checked by nothing. It has fallen three scripts behind the eight the shipped commands actually invoke, so `/speckit.companion.adopt`, `.drift`, and `.coverage` cannot run at all from a real install, and `specify` / `plan` silently lose their living-spec context.
+
+The fix introduces one machine-readable packing list — `speckit-extension/scripts/package-manifest.py` — that both consumers read: a `--check` mode that gates the build, and a `--copy-to <dir>` mode that the publish flow uses to fill the archive. The check derives what the commands *actually* need (scan the shipped command bodies for the installed script path form, then follow each script's own sibling imports to a fixed point) and asserts that derived set equals the declared list in both directions. A needed-but-unpacked script fails the build and names itself; so does a packed-but-unneeded one. The declared list is kept rather than replaced by the derived set on purpose: if the scanner ever misses a reference form, a bare derivation would silently drop a script, whereas the two-way compare turns any disagreement — scanner gap or new dependency — into a loud failure.
+
+No command body text changes, so the existing golden/part-parity gates stay untouched.
+
+## Project Structure
+
+```
+speckit-extension/
+├── scripts/
+│   ├── package-manifest.py        # NEW — the single packing list + --check / --copy-to
+│   ├── write-context.py           # runtime (ships)
+│   ├── status-context.py          # runtime (ships)
+│   ├── derive-from-files.py       # runtime (ships)
+│   ├── resolve-spec-paths.py      # runtime (ships)  ← was missing from the archive
+│   ├── companion_config.py        # runtime (ships)  ← was missing
+│   ├── register-capability.py     # runtime (ships)  ← was missing
+│   ├── drift.py                   # runtime (ships)  ← was missing
+│   ├── check-coverage.py          # runtime (ships)  ← was missing
+│   ├── build-commands.py          # build-only (never ships)
+│   ├── check-shape-parity.py      # build-only
+│   ├── assemble-nodes.py          # build-only
+│   ├── capture-golden.py          # build-only
+│   └── _command_parts.py          # build-only
+├── tests/
+│   └── test_packaging.py          # NEW — runs the gate under the CI unittest discover
+├── docs/publishing.md             # step 5 stops restating the file list
+├── extension.yml                  # version 0.18.0 → 0.18.1
+├── README.md                      # what ships in the archive
+└── CHANGELOG.md                   # user-facing entry
+
+.claude/commands/publish-speckit-ext.md   # step 5 stops restating the file list
+.github/workflows/ci.yml                  # capture-suite gains the packaging gate
+```
+
+**Structure Decision**: The packing list lives in `scripts/` next to the scripts it lists, as a normal CLI script matching the repo's existing `check-*.py` / `build-*.py` convention (hyphenated name, CLI-invoked, importable by path the way the tests already import hyphenated modules). It deliberately does **not** go into `extension.yml`: that manifest is validated against spec-kit's own published schema by the catalog, and adding a non-schema key risks a rejected submission for no gain.
+
+## Constitution Check
+
+| Principle | Assessment |
+|---|---|
+| Extension isolation — extension behavior must not depend on `.claude/**` or `.specify/**` source files | **PASS**. This change is exactly *about* isolation: it makes the shipped archive self-sufficient. The gate proves every script a shipped command reaches for is inside the package. No runtime behavior is added that reads dev-workspace files. |
+| Two extensions, two sets of docs | **PASS**. Everything user-facing lands in `speckit-extension/README.md`, `speckit-extension/CHANGELOG.md`, and `extension.yml` `version`. The root README/CHANGELOG/`package.json` are untouched. `.github/workflows/ci.yml` and `.claude/commands/publish-speckit-ext.md` are shared repo tooling, not either extension's docs. |
+| A shipped command or script must be declared or the installer skips it | **PASS**. `package-manifest.py` is build-only and is intentionally *not* declared in `provides.commands` — it never ships. The eight runtime scripts are not commands and need no manifest entry; they need to be in the *archive*, which is precisely what this change guarantees. |
+| Docs are part of the change | **PASS**. `docs/publishing.md`, the extension README, and the CHANGELOG are updated in this same change. |
+| Changelog voice — user-facing, no internal file/symbol names | **PASS**. The entry describes the commands that now run, not the scripts or the scanner. |
+| No spec/PR identifiers or narrative comments in code | **PASS**. The new script is documented by a short module docstring stating the contract; no `(#432)` markers, no history narration. |
+
+No violations. No Complexity Tracking table needed.
+
+## Phase 0 — Research
+
+See [research.md](./research.md). The load-bearing findings: the closure is eight scripts (confirmed by following all three sibling-import forms to a fixed point, including a fourth reference site inside `write-context.py` that loads the resolver by filename); and a declared-plus-derived two-way compare is strictly safer than a pure derivation.
+
+## Phase 1 — Design
+
+- [data-model.md](./data-model.md) — the packing list, the reference scan, and the closure.
+- [contracts/package-manifest-cli.md](./contracts/package-manifest-cli.md) — the `--check` / `--copy-to` / `--list` interface both consumers code against.
+
+Constitution re-checked against the final design: still all PASS.
+
+## Approach
+
+1. Write `package-manifest.py`: declared `RUNTIME_SCRIPTS` (8) and `BUILD_ONLY` (5), a reference scanner over the shipped command bodies, a transitive sibling-import resolver with cycle protection, and the three CLI modes.
+2. Wire the gate into CI and into a unittest so it runs under the existing `unittest discover`.
+3. Repoint both publish documents at `--copy-to`, deleting the hand-typed file lists.
+4. Bump the version; write the README and CHANGELOG entries.
+5. Prove it: build an archive with the new step and confirm all eight scripts land and every build-only script stays out; run each previously-broken command's script against a real spec dir from inside a scratch install.

--- a/specs/395-package-runtime-scripts/plan.md
+++ b/specs/395-package-runtime-scripts/plan.md
@@ -33,9 +33,8 @@ speckit-extension/
 ├── tests/
 │   └── test_packaging.py          # NEW — runs the gate under the CI unittest discover
 ├── docs/publishing.md             # step 5 stops restating the file list
-├── extension.yml                  # version 0.18.0 → 0.18.1
 ├── README.md                      # what ships in the archive
-└── CHANGELOG.md                   # user-facing entry
+└── CHANGELOG.md                   # user-facing entry under [Unreleased]
 
 .claude/commands/publish-speckit-ext.md   # step 5 stops restating the file list
 .github/workflows/ci.yml                  # capture-suite gains the packaging gate
@@ -48,7 +47,7 @@ speckit-extension/
 | Principle | Assessment |
 |---|---|
 | Extension isolation — extension behavior must not depend on `.claude/**` or `.specify/**` source files | **PASS**. This change is exactly *about* isolation: it makes the shipped archive self-sufficient. The gate proves every script a shipped command reaches for is inside the package. No runtime behavior is added that reads dev-workspace files. |
-| Two extensions, two sets of docs | **PASS**. Everything user-facing lands in `speckit-extension/README.md`, `speckit-extension/CHANGELOG.md`, and `extension.yml` `version`. The root README/CHANGELOG/`package.json` are untouched. `.github/workflows/ci.yml` and `.claude/commands/publish-speckit-ext.md` are shared repo tooling, not either extension's docs. |
+| Two extensions, two sets of docs | **PASS**. Everything user-facing lands in `speckit-extension/README.md` and the `[Unreleased]` section of `speckit-extension/CHANGELOG.md`; `/publish-speckit-ext` owns the `extension.yml` version bump at release time. The root README/CHANGELOG/`package.json` are untouched. `.github/workflows/ci.yml` and `.claude/commands/publish-speckit-ext.md` are shared repo tooling, not either extension's docs. |
 | A shipped command or script must be declared or the installer skips it | **PASS**. `package-manifest.py` is build-only and is intentionally *not* declared in `provides.commands` — it never ships. The eight runtime scripts are not commands and need no manifest entry; they need to be in the *archive*, which is precisely what this change guarantees. |
 | Docs are part of the change | **PASS**. `docs/publishing.md`, the extension README, and the CHANGELOG are updated in this same change. |
 | Changelog voice — user-facing, no internal file/symbol names | **PASS**. The entry describes the commands that now run, not the scripts or the scanner. |
@@ -72,5 +71,5 @@ Constitution re-checked against the final design: still all PASS.
 1. Write `package-manifest.py`: declared `RUNTIME_SCRIPTS` (8) and `BUILD_ONLY` (5), a reference scanner over the shipped command bodies, a transitive sibling-import resolver with cycle protection, and the three CLI modes.
 2. Wire the gate into CI and into a unittest so it runs under the existing `unittest discover`.
 3. Repoint both publish documents at `--copy-to`, deleting the hand-typed file lists.
-4. Bump the version; write the README and CHANGELOG entries.
+4. Write the README entry and the CHANGELOG entry under `[Unreleased]`; the release flow bumps the version when it cuts the build.
 5. Prove it: build an archive with the new step and confirm all eight scripts land and every build-only script stays out; run each previously-broken command's script against a real spec dir from inside a scratch install.

--- a/specs/395-package-runtime-scripts/research.md
+++ b/specs/395-package-runtime-scripts/research.md
@@ -50,8 +50,11 @@ All three resolve to a *string literal or bare name that matches a sibling scrip
 - *A new check inside `check-shape-parity.py`*: rejected — that script's contract is command-body parity (part fences, golden equality, timing fences). Packaging is an unrelated concern, and folding it in would muddy a script whose docstring is a precise three-assertion contract.
 - *Only a CI step, no test*: rejected — it would not fail for a developer running the suite locally before pushing.
 
-## Decision 5 — Patch-level version bump
+## Decision 5 — The release flow owns the version bump
 
-**Decision**: `0.18.0` → `0.18.1`.
+**Decision**: leave `extension.version` at `0.18.0`; land the note under `[Unreleased]` in the extension's changelog.
 
-**Rationale**: Nothing about the extension's interface, commands, or behavior changes for a user who somehow already had a working install. Files that were always supposed to be in the package are now in the package. That is the definition of a patch.
+**Rationale**: The repo's established pattern is that changes accumulate under `## [Unreleased]` and `/publish-speckit-ext` bumps `extension.yml` when it actually cuts the build. `main` already carries an unreleased `Fixed` entry that did not bump the version — this change has the same shape. Bumping here would mint a version number for a build nobody publishes, and leave the next release to reconcile it. The fix is patch-level when it does ship: nothing about the extension's interface, commands, or behavior changes for a user who somehow already had a working install — files that were always supposed to be in the package are now in the package.
+
+**Alternatives considered**:
+- *Bump to `0.18.1` in this change*: rejected — it decouples the version from the release that carries it, and an earlier review pass on this branch reverted exactly that bump.

--- a/specs/395-package-runtime-scripts/research.md
+++ b/specs/395-package-runtime-scripts/research.md
@@ -1,0 +1,57 @@
+# Phase 0 Research: Ship every runtime script the commands call
+
+## Decision 1 — Keep a declared packing list and compare it against a derived closure, rather than deriving the closure alone
+
+**Decision**: `package-manifest.py` declares `RUNTIME_SCRIPTS` explicitly, and `--check` derives the closure from the shipped command bodies independently, then asserts the two sets are equal in both directions.
+
+**Rationale**: The tempting move is to delete the list entirely and have the publish step copy whatever the scanner derives — then there is nothing to drift. But that makes the scanner a single point of silent failure: if a future script is reached by a form the scanner doesn't recognize, a pure derivation just doesn't copy it, the archive ships short, and nobody finds out until a user's install breaks — the exact failure we are fixing, reintroduced with fewer moving parts and no alarm. With a declared list, the same scanner gap instead shows up as *"declared but not derived"* and fails the build loudly. The two-way compare converts every possible disagreement — a new dependency the maintainer forgot to declare, or a reference form the scanner can't see — into a named, blocking error.
+
+**Alternatives considered**:
+- *Derived-only (no declared list)*: rejected — fails silently on a scanner gap, as above.
+- *Declared-only (a list plus a "does the file exist" check)*: rejected — that is essentially today's state with a spell-checker bolted on. It cannot detect that a command has started calling something new, which is the drift that caused this bug.
+
+## Decision 2 — Put the packing list in a script, not in `extension.yml`
+
+**Decision**: The list lives in `speckit-extension/scripts/package-manifest.py`.
+
+**Rationale**: `extension.yml` is the spec-kit extension manifest. It is validated against spec-kit's published schema when the catalog entry is reviewed, and it is the file the installer parses. A non-schema key such as `package.runtime_scripts` would be, at best, ignored and, at worst, a validation failure on a catalog submission — a real risk taken for a purely cosmetic gain, since nothing in spec-kit would ever read the key. A script in `scripts/` is already the repo's idiom for build-time gates (`check-shape-parity.py`, `assemble-nodes.py`, `build-commands.py`), gets to be executable rather than inert data, and can be imported by the test suite the same way the tests already import hyphenated modules by path.
+
+**Alternatives considered**:
+- *A key in `extension.yml`*: rejected — schema risk on the catalog submission, no consumer inside spec-kit.
+- *A standalone `package.txt` / `MANIFEST.in`*: rejected — inert data still needs a program to check and to copy it, so it adds a file without removing one, and a plain list can't express the build-only exclusion set the check needs.
+
+## Decision 3 — Derive the closure by scanning the installed script path form, then following sibling imports to a fixed point
+
+**Decision**: The roots are every `.specify/extensions/companion/scripts/<name>.py` occurrence in the shipped command bodies and workflows. From each root, follow the script's own references to sibling scripts, repeating until the set stops growing.
+
+**Rationale**: Commands invoke scripts by exactly one textual form — the installed path — which makes the root scan a precise, single-anchor regex rather than a heuristic. A direct scan alone is not enough: half the closure is reachable only indirectly (`companion_config.py` is named by no command; it is imported by the resolver and by the registration script). Following each script's own sibling references is what turns 6 directly-named scripts into the true 8.
+
+Three reference forms occur in the codebase and the resolver must handle all three, because each is load-bearing for a different script:
+
+| Form | Example | Why it exists |
+|---|---|---|
+| Plain import | `import companion_config as cc` | Underscore names are legal Python identifiers, so they import normally. |
+| `importlib.import_module("…")` | `import_module("write-context")` | Hyphenated names are not legal identifiers, so they go through `import_module` with a string. |
+| Load by filename | `spec_from_file_location(…, ".../resolve-spec-paths.py")` | Same hyphen problem, solved by path instead. Used by `drift.py`, `check-coverage.py`, **and `write-context.py`**. |
+
+All three resolve to a *string literal or bare name that matches a sibling script*, so one resolver handles them: collect candidate names from the source, keep the ones that match a file in `scripts/`, discard the rest (standard-library imports fall away for free, since `os` and `json` are not sibling scripts). Fixed-point iteration with a visited set makes a dependency cycle terminate rather than spin.
+
+**Alternatives considered**:
+- *Real AST analysis / an import graph tool*: rejected — overkill for thirteen single-directory stdlib scripts, and the load-by-filename form is invisible to an import graph anyway (it is a string argument, not an import statement).
+- *Ship the whole `scripts/` directory*: rejected — that is a deny-list by another name. It would drag the build/test scripts and their golden fixtures into every user's install, and the publishing doc explicitly warns against swapping the allow-list back to an exclusion list, because that is how the package silently bloated before.
+
+## Decision 4 — Land the gate in the existing CI `capture-suite` job, via both a unittest and an explicit step
+
+**Decision**: Add `tests/test_packaging.py` (picked up by the existing `python3 -m unittest discover -s speckit-extension/tests`) and an explicit `package-manifest.py --check` step in the `capture-suite` job, next to the `check-shape-parity.py` and `assemble-nodes.py --check` steps.
+
+**Rationale**: The unittest is what makes the gate run for a developer locally and in the discover sweep; the explicit CI step is what makes a packaging failure *legible* in the CI log as a packaging failure rather than as one red test among many. The two sibling gates in that job already follow this shape, so this matches the established pattern rather than inventing a new one. This is the job that must go red, because it is the one that stands between a merge and a release.
+
+**Alternatives considered**:
+- *A new check inside `check-shape-parity.py`*: rejected — that script's contract is command-body parity (part fences, golden equality, timing fences). Packaging is an unrelated concern, and folding it in would muddy a script whose docstring is a precise three-assertion contract.
+- *Only a CI step, no test*: rejected — it would not fail for a developer running the suite locally before pushing.
+
+## Decision 5 — Patch-level version bump
+
+**Decision**: `0.18.0` → `0.18.1`.
+
+**Rationale**: Nothing about the extension's interface, commands, or behavior changes for a user who somehow already had a working install. Files that were always supposed to be in the package are now in the package. That is the definition of a patch.

--- a/specs/395-package-runtime-scripts/spec.md
+++ b/specs/395-package-runtime-scripts/spec.md
@@ -1,0 +1,145 @@
+# Feature Specification: Ship every runtime script the commands call
+
+**Feature Branch**: `395-package-runtime-scripts`
+**Created**: 2026-07-13
+**Status**: Draft
+**Issue**: [#432](https://github.com/alfredoperez/speckit-companion/issues/432)
+
+## Overview
+
+People who install the SpecKit Companion spec-kit extension from its published release archive get an extension whose commands cannot run. Several commands call helper programs that were never put into the archive, so the moment a user runs one, the helper is simply not on disk. The helpers are not missing from the project — they exist and work. They just never get packed into the box that ships.
+
+The list of what goes into the box is maintained by hand, in prose, in two separate documents, and nothing checks it against what the commands actually need. It fell behind, and no test noticed.
+
+## User Scenarios & Testing
+
+### User Story 1 - A released extension's commands actually run (Priority: P1)
+
+A developer installs the extension from its published download and runs the brownfield adoption command. Today the command starts, then stops because the helper program it needs is not there, and the assistant has to ask the user where the program lives. The developer's honest conclusion is that the feature was never finished. The same failure hits the drift and coverage commands, and it silently degrades the two core pipeline commands, which quietly lose the project context they were supposed to load.
+
+After this change, every helper program that any shipped command invokes is present in the installed extension, so each of those commands runs end to end from a clean install.
+
+**Why this priority**: This is the reported defect. Three commands are entirely unusable and two more are silently degraded for every user who installed the normal way. Nothing else matters until the box contains what the commands need.
+
+**Independent Test**: Build the release archive, install it into a scratch project, and run each command that calls a helper. Every helper it reaches for is on disk; no command aborts for a missing program.
+
+**Acceptance Scenarios**:
+
+1. **Given** a release archive built by the documented publish flow, **When** its contents are listed, **Then** every helper program reachable from a shipped command is present.
+2. **Given** the extension installed from that archive, **When** the adoption command runs, **Then** it completes its registration step instead of reporting the helper as missing.
+3. **Given** the same install, **When** the drift command and the coverage command run, **Then** each produces its report rather than failing to start.
+4. **Given** the same install, **When** the two core pipeline commands run in a project that uses living specs, **Then** they load that context successfully instead of skipping it because the resolver is absent.
+5. **Given** a release archive, **When** its contents are listed, **Then** no build-only or test-only program is included, and no documentation, examples, or test files are included.
+
+### User Story 2 - The packing list can never quietly fall behind again (Priority: P1)
+
+A maintainer adds a new command that calls a new helper program, or points an existing command at a helper it did not use before. Today they must remember to also hand-edit a copy-files line in two different documents; if they forget, everything still passes, the release still ships, and the break only surfaces in a user's install weeks later. That is exactly how this defect happened.
+
+After this change there is one machine-readable packing list, and an automated check fails the build when the packing list and the commands disagree in either direction: a helper a command needs but that isn't packed, or a program packed that nothing needs.
+
+**Why this priority**: Shipping the missing helpers fixes today's break. Without this story, the same class of break returns on the next command that grows a new dependency. The reporter found this bug in a feature that had been "shipped" — the process, not the code, is the defect.
+
+**Independent Test**: Point a shipped command at a helper that isn't on the packing list, then run the automated check. It fails and names the missing helper. Add a program to the packing list that nothing calls, run the check again, and it fails and names the unused entry.
+
+**Acceptance Scenarios**:
+
+1. **Given** the project as it stands after this change, **When** the automated check runs, **Then** it passes.
+2. **Given** a shipped command edited to call a helper program that is not on the packing list, **When** the check runs, **Then** it fails and names the unpacked helper.
+3. **Given** a helper program that a packed program imports but that is itself not on the packing list, **When** the check runs, **Then** it fails and names it — an indirect need counts the same as a direct one.
+4. **Given** the packing list containing an entry that no shipped command needs, directly or indirectly, **When** the check runs, **Then** it fails and names the unused entry.
+5. **Given** the check, **When** the project's automated test run executes, **Then** the check runs as part of it, so a disagreement blocks the change rather than surfacing after release.
+
+### User Story 3 - The publish flow reads the packing list instead of restating it (Priority: P2)
+
+A maintainer cutting a release follows the publish steps. Today those steps embed a literal list of files to copy, duplicated in two documents, either of which can drift from reality. After this change the publish step asks the packing list what to copy, so the release archive and the automated check are guaranteed to agree by construction — there is nothing left to keep in sync by hand.
+
+**Why this priority**: The check in Story 2 prevents a silent break, but as long as the publish flow restates the list independently, a maintainer can still produce an archive that disagrees with the checked list. Sourcing both from one place closes the loop. It's P2 because Story 2 already turns this failure from silent into loud.
+
+**Independent Test**: Run the publish flow's archive step and compare the archive's contents against the packing list — they match exactly, with no file list written out anywhere in the publish instructions.
+
+**Acceptance Scenarios**:
+
+1. **Given** the publish instructions, **When** they are read, **Then** they contain no hand-written list of helper programs to copy.
+2. **Given** the archive step is run, **When** the resulting archive is inspected, **Then** its helper programs are exactly the packing list's entries.
+3. **Given** a helper is added to the packing list, **When** the archive step is re-run with no edit to the publish instructions, **Then** the new helper appears in the archive.
+
+## Edge Cases
+
+- A helper is referenced from a command only inside a code fence or an illustrative example, not as a real instruction. It still needs to ship, because the assistant reading the command body may run it — treat any reference as a real need.
+- A helper is reached only indirectly, never named by any command (loaded by another helper). It must ship, and the check must find it by following the chain, not just by scanning command text.
+- A helper imports something from the standard library. The check must not mistake that for a project program it should demand be packed.
+- Two helpers reference each other, or a chain loops back on itself. Following the chain must terminate rather than spin.
+- A helper's name contains a hyphen and so cannot be imported by name the usual way; it gets loaded by filename instead. The check must recognize that form of dependency too.
+- A program exists in the project but is only used at build or test time. It must be excluded from the archive, and the check must not demand it be packed.
+- The publish flow runs where the packing list cannot be consulted. It must fail loudly rather than quietly produce an archive with some files missing.
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: The release archive MUST contain every helper program that a shipped command invokes, including those reached only indirectly through another helper.
+- **FR-002**: The release archive MUST NOT contain programs used only for building or testing the project, nor documentation, examples, or test files. It remains an explicit list of what to include, never a list of what to leave out.
+- **FR-003**: The project MUST have exactly one machine-readable list of the programs that ship at runtime; no other document may restate that list.
+- **FR-004**: An automated check MUST fail when a shipped command needs a program, directly or indirectly, that the packing list does not include, and MUST name the offending program.
+- **FR-005**: The same automated check MUST fail when the packing list includes a program that no shipped command needs, directly or indirectly, and MUST name it.
+- **FR-006**: The automated check MUST determine what a command needs by reading the shipped command text and then following each referenced program's own dependencies to their conclusion, terminating even when those dependencies form a cycle.
+- **FR-007**: The automated check MUST run as part of the project's existing automated test run, so a disagreement blocks the change before release.
+- **FR-008**: The publish flow MUST obtain the files to copy from the single packing list rather than restating them, and MUST fail loudly if the list cannot be read.
+- **FR-009**: The extension's own version MUST be raised, and its own changelog and readme MUST record the fix, so an existing user can tell a repaired build from the broken one.
+- **FR-010**: The change MUST NOT alter what any command instructs the assistant to do; only what ships alongside those commands changes.
+
+### Key Entities
+
+- **Packing list** — the single, machine-readable set of helper programs that ship inside the release archive. Consumed by both the automated check and the publish flow.
+- **Shipped command** — a command declared by the extension's manifest, whose text an assistant reads and acts on, and which may invoke helper programs by path.
+- **Helper program** — a program invoked by a shipped command, or reached from one through another helper's own dependencies. Every one of these must be on the packing list.
+- **Build-only program** — a program used to build, verify, or test the project, never invoked by a shipped command. Never on the packing list.
+
+## Success Criteria
+
+### Measurable Outcomes
+
+- **SC-001**: A user installing from the published archive can run all shipped commands; zero of them abort because a helper program is absent (today three do, and two more degrade silently).
+- **SC-002**: 100% of helper programs reachable from a shipped command are present in the release archive.
+- **SC-003**: Zero build-only or test-only programs, and zero documentation or example files, are present in the release archive.
+- **SC-004**: The packing list is stated in exactly one place; a search of the project finds no second hand-written copy of it.
+- **SC-005**: Introducing a command that needs an unpacked helper causes the automated test run to fail, in under a minute, with a message naming that helper.
+- **SC-006**: The archive produced by the publish flow and the set the automated check validates are identical for every release, by construction rather than by review.
+
+## Assumptions
+
+- The reported defect needs no new helper programs written. Every program the commands call already exists and works; the fix is packaging and the process that keeps packaging honest.
+- The three helpers the archive currently carries stay; the fix adds the ones that are missing rather than reorganizing what ships.
+- Raising the extension's version is a patch-level fix, since no command's behavior or interface changes for someone who already had a working install.
+- The publish flow's other steps (tagging, the rolling download, the catalog entry) are out of scope and unchanged.
+- Actually cutting a new release is a separate, human-triggered action; this change makes the next release correct but does not publish one.
+
+## Verbatim Constraints
+
+The following are pinned by the request and must be matched exactly.
+
+Helper programs that MUST ship (the full set reachable from shipped commands):
+
+- `write-context.py`
+- `status-context.py`
+- `derive-from-files.py`
+- `resolve-spec-paths.py`
+- `companion_config.py`
+- `register-capability.py`
+- `drift.py`
+- `check-coverage.py`
+
+Programs that MUST NOT ship (build/test only):
+
+- `build-commands.py`
+- `check-shape-parity.py`
+- `assemble-nodes.py`
+- `capture-golden.py`
+- `_command_parts.py`
+
+Documents that carry the duplicated copy-files instruction and must stop restating it:
+
+- `speckit-extension/docs/publishing.md`
+- `.claude/commands/publish-speckit-ext.md`
+
+Scope fence: only `speckit-extension/README.md`, `speckit-extension/CHANGELOG.md`, and the `extension.version` in `speckit-extension/extension.yml` may be updated for docs/version. The root `README.md`, `CHANGELOG.md`, and `package.json` MUST NOT be touched.

--- a/specs/395-package-runtime-scripts/spec.md
+++ b/specs/395-package-runtime-scripts/spec.md
@@ -85,7 +85,7 @@ A maintainer cutting a release follows the publish steps. Today those steps embe
 - **FR-006**: The automated check MUST determine what a command needs by reading the shipped command text and then following each referenced program's own dependencies to their conclusion, terminating even when those dependencies form a cycle.
 - **FR-007**: The automated check MUST run as part of the project's existing automated test run, so a disagreement blocks the change before release.
 - **FR-008**: The publish flow MUST obtain the files to copy from the single packing list rather than restating them, and MUST fail loudly if the list cannot be read.
-- **FR-009**: The extension's own version MUST be raised, and its own changelog and readme MUST record the fix, so an existing user can tell a repaired build from the broken one.
+- **FR-009**: The extension's own changelog and readme MUST record the fix under the pending-release section, so an existing user can tell a repaired build from the broken one once it ships. The version itself MUST NOT be raised here — the release flow owns that bump when it cuts the build.
 - **FR-010**: The change MUST NOT alter what any command instructs the assistant to do; only what ships alongside those commands changes.
 
 ### Key Entities
@@ -110,7 +110,7 @@ A maintainer cutting a release follows the publish steps. Today those steps embe
 
 - The reported defect needs no new helper programs written. Every program the commands call already exists and works; the fix is packaging and the process that keeps packaging honest.
 - The three helpers the archive currently carries stay; the fix adds the ones that are missing rather than reorganizing what ships.
-- Raising the extension's version is a patch-level fix, since no command's behavior or interface changes for someone who already had a working install.
+- The fix is patch-level, since no command's behavior or interface changes for someone who already had a working install. The bump itself is the release flow's to make, not this change's — notes accumulate under the pending-release section until then.
 - The publish flow's other steps (tagging, the rolling download, the catalog entry) are out of scope and unchanged.
 - Actually cutting a new release is a separate, human-triggered action; this change makes the next release correct but does not publish one.
 
@@ -142,4 +142,4 @@ Documents that carry the duplicated copy-files instruction and must stop restati
 - `speckit-extension/docs/publishing.md`
 - `.claude/commands/publish-speckit-ext.md`
 
-Scope fence: only `speckit-extension/README.md`, `speckit-extension/CHANGELOG.md`, and the `extension.version` in `speckit-extension/extension.yml` may be updated for docs/version. The root `README.md`, `CHANGELOG.md`, and `package.json` MUST NOT be touched.
+Scope fence: only `speckit-extension/README.md` and `speckit-extension/CHANGELOG.md` may be updated for docs. `speckit-extension/extension.yml`'s `extension.version` MUST be left alone — `/publish-speckit-ext` bumps it at release time, and the changelog entry lands under `[Unreleased]` until then. The root `README.md`, `CHANGELOG.md`, and `package.json` MUST NOT be touched.

--- a/specs/395-package-runtime-scripts/tasks.md
+++ b/specs/395-package-runtime-scripts/tasks.md
@@ -101,8 +101,9 @@ The packing list is the single thing all three stories read. Nothing else can st
 
 **Wave 8 — independent (different files):**
 
-- [x] **T010** [P] Bump the extension version `0.18.0` → `0.18.1` · `speckit-extension/extension.yml` (FR-009)
-- [x] **T011** [P] Add the release-notes entry · `speckit-extension/CHANGELOG.md`
+- [x] **T010** [P] Leave `extension.version` at `0.18.0` · `speckit-extension/extension.yml`
+  The release flow (`/publish-speckit-ext`) owns the bump; notes accumulate under `[Unreleased]` until it runs. No edit here. (FR-009)
+- [x] **T011** [P] Add the release-notes entry under `[Unreleased]` · `speckit-extension/CHANGELOG.md`
   User-facing voice: the adopt / drift / coverage commands now run from a released install, and specify / plan regain their living-spec context. Name the commands, not the scripts or the scanner. (FR-009)
 - [x] **T012** [P] Document what the release archive carries · `speckit-extension/README.md` (FR-009)
 

--- a/specs/395-package-runtime-scripts/tasks.md
+++ b/specs/395-package-runtime-scripts/tasks.md
@@ -1,0 +1,135 @@
+# Tasks: Ship every runtime script the commands call
+
+**Feature**: `395-package-runtime-scripts` | **Issue**: #432 | **Size**: `normal`
+**Inputs**: [spec.md](./spec.md), [plan.md](./plan.md), [research.md](./research.md), [data-model.md](./data-model.md), [contracts/package-manifest-cli.md](./contracts/package-manifest-cli.md)
+
+Line format: `- [ ] **T###** [P?] [US#] Description · exact/file/path`. `[P]` = independent of the other tasks in its wave.
+
+## Phase 1: Setup
+
+No setup phase. The scripts, the test harness, and the CI job all already exist — this change adds one script and edits existing files. There is no scaffolding, dependency, or tooling prerequisite to stand up first.
+
+## Phase 2: Foundational (blocks every story)
+
+The packing list is the single thing all three stories read. Nothing else can start until it exists.
+
+**Wave 1 — single task:**
+
+- [x] **T001** Create the packing list and its gate · `speckit-extension/scripts/package-manifest.py`
+  Declare `RUNTIME_SCRIPTS` (the 8 from the spec's Verbatim Constraints) and `BUILD_ONLY` (the 5, plus this script itself). Implement `derive_closure()` — scan every command file declared under `provides.commands` in `extension.yml` plus shipped `workflows/` for the `.specify/extensions/companion/scripts/<name>.py` anchor to get the roots, then walk each script's sibling references to a fixed point, handling all three forms (plain import, `import_module("hyphen-name")`, `spec_from_file_location(…, "…/name.py")`), discarding candidates that don't match a file in `scripts/`, with a `visited` set so a cycle terminates. Implement `check()` returning a list of human-readable problems (needed-but-not-packaged / packaged-but-unreachable / unclassified / declared-but-absent), and the `--check`, `--copy-to <dir>`, `--list` CLI per the contract. `--copy-to` must run the check first and refuse to copy on failure. Stdlib only. (FR-001, FR-002, FR-003, FR-004, FR-005, FR-006)
+
+**⟶ Wait for Wave 1 to finish, then the story phases can proceed.**
+
+---
+
+## Phase 3: User Story 1 — A released extension's commands actually run (P1)
+
+**Goal**: The release archive carries every helper a shipped command invokes, so `adopt` / `drift` / `coverage` run end to end from a clean install and `specify` / `plan` regain their living-spec context.
+
+**Independent Test**: Build an archive from the new step, install it in a scratch project, run each previously-broken script against a real spec dir. None aborts for a missing sibling.
+
+### Implementation
+
+**Wave 2 — single task (proves the derivation is right before anything is built from it):**
+
+- [x] **T002** Run `--check` against the real repo and confirm it passes, reporting the closure as exactly the 8 declared scripts · `speckit-extension/scripts/package-manifest.py`
+  A pass here means the scanner independently rediscovered the closure the spec pinned. If it names fewer than 8, the scanner is missing a reference form — fix the scanner, never the assertion. (FR-001, FR-006)
+
+**⟶ Wait for T002, then:**
+
+**Wave 3 — single task:**
+
+- [x] **T003** Build a real archive with `--copy-to` into a scratch dir and assert its contents · `speckit-extension/scripts/package-manifest.py`
+  All 8 runtime scripts present; all 5 build-only scripts absent; no docs, examples, or test files. This is the concrete artifact the bug is about. (FR-001, FR-002)
+
+**⟶ Wait for T003, then:**
+
+**Wave 4 — single task:**
+
+- [x] **T004** Install the built archive into a scratch project and execute the previously-broken scripts against a real spec dir · scratch install of `companion-<ver>/scripts/`
+  Run `register-capability.py`, `drift.py`, `check-coverage.py`, and `resolve-spec-paths.py`. Each must execute and produce output — not `ImportError`/`FileNotFoundError` on a missing sibling. This is the end-to-end reproduction of #432, now passing. (FR-001, SC-001)
+
+**Checkpoint**: The reported defect is fixed and demonstrated. A user installing from an archive built this way can run every shipped command.
+
+---
+
+## Phase 4: User Story 2 — The packing list can never quietly fall behind again (P1)
+
+**Goal**: A disagreement between the commands and the packing list fails the build, loudly and by name, before it can reach a release.
+
+**Independent Test**: Introduce each kind of drift in turn and watch the gate catch it and name the offender.
+
+### Implementation
+
+**Wave 5 — independent (different files):**
+
+- [x] **T005** [P] [US2] Add the packaging gate as a unit test · `speckit-extension/tests/test_packaging.py`
+  Stdlib `unittest`, importing `package-manifest.py` by file path (the established idiom for hyphenated scripts here). Assert `check()` is empty on the real repo; assert `derive_closure()` equals `RUNTIME_SCRIPTS`; assert `RUNTIME_SCRIPTS` and `BUILD_ONLY` are disjoint and together account for every `scripts/*.py`; assert every declared script exists on disk. Picked up automatically by the existing `unittest discover`. (FR-004, FR-005, FR-007)
+- [x] **T006** [P] [US2] Add an explicit packaging-gate step to the CI `capture-suite` job · `.github/workflows/ci.yml`
+  Place it beside the existing `check-shape-parity.py` and `assemble-nodes.py --check` steps so a packaging break reads as a packaging break in the CI log. (FR-007)
+
+**⟶ Wait for Wave 5 to finish, then:**
+
+**Wave 6 — single task (the gate must be proven to bite, not just to pass):**
+
+- [x] **T007** [US2] Prove the gate fails on real drift, in both directions, then revert every probe · `speckit-extension/scripts/package-manifest.py`
+  (a) Temporarily point a shipped command body at a script that isn't on the packing list → `--check` must exit 1 and **name** it as needed-but-not-packaged. (b) Temporarily add an entry to `RUNTIME_SCRIPTS` that nothing reaches → `--check` must exit 1 and **name** it as packaged-but-unreachable. Revert both probes and confirm the check returns to green. A gate that has only ever been observed passing is not known to work. (FR-004, FR-005, SC-005)
+
+**Checkpoint**: The defect class is closed. A future command that grows a new dependency cannot be released un-packaged.
+
+---
+
+## Phase 5: User Story 3 — The publish flow reads the packing list instead of restating it (P2)
+
+**Goal**: The archive and the gate agree by construction — there is no second copy of the file list left to drift.
+
+**Independent Test**: Read the publish instructions; find no hand-written list of scripts. Run the archive step; get exactly the packing list.
+
+### Implementation
+
+**Wave 7 — independent (different files):**
+
+- [x] **T008** [P] [US3] Repoint the publish doc's archive step at `--copy-to`, deleting the hand-typed `cp scripts/…` line and the prose that enumerates which scripts ship · `speckit-extension/docs/publishing.md`
+  Keep the allow-list *principle* (and the standing warning against reverting to a `tar --exclude` deny-list); remove only the hand-maintained enumeration, which is now the script's job. (FR-003, FR-008)
+- [x] **T009** [P] [US3] Repoint the publish command's step 5 at `--copy-to`, deleting its duplicate `cp scripts/…` line · `.claude/commands/publish-speckit-ext.md` (FR-003, FR-008)
+
+**Checkpoint**: The list is stated in exactly one place. Both consumers read it.
+
+---
+
+## Phase 6: Polish
+
+**Wave 8 — independent (different files):**
+
+- [x] **T010** [P] Bump the extension version `0.18.0` → `0.18.1` · `speckit-extension/extension.yml` (FR-009)
+- [x] **T011** [P] Add the release-notes entry · `speckit-extension/CHANGELOG.md`
+  User-facing voice: the adopt / drift / coverage commands now run from a released install, and specify / plan regain their living-spec context. Name the commands, not the scripts or the scanner. (FR-009)
+- [x] **T012** [P] Document what the release archive carries · `speckit-extension/README.md` (FR-009)
+
+**⟶ Wait for Wave 8 to finish, then:**
+
+**Wave 9 — single task:**
+
+- [x] **T013** Run the full verification suite green · repo root
+  `npm run compile && npm test`; `python3 speckit-extension/scripts/check-shape-parity.py`; `python3 speckit-extension/scripts/assemble-nodes.py --check`; `python3 -m unittest discover -s speckit-extension/tests -p "test_*.py"`. The two parity gates must still pass untouched — no command body text changed. (FR-010, SC-005)
+
+**⟶ Wait for T013, then:**
+
+**Wave 10 — single task:**
+
+- [x] **T014** Confirm the scope fence held · repo root
+  `git status` shows no change to the root `README.md`, `CHANGELOG.md`, or `package.json`, and no regenerated `.specify/` artifacts are staged (`git checkout origin/main -- .specify/` if any appear). Verify the spec's `.spec-context.json` carries the real spec name and every task is checked. (FR-009)
+
+---
+
+## Dependencies & Execution Order
+
+**Phases**: Foundational (T001) → US1 (T002 → T003 → T004) → US2 (T005/T006 → T007) → US3 (T008/T009) → Polish (T010–T012 → T013 → T014).
+
+- **T001 blocks everything.** It is the packing list; no story can read a list that does not exist.
+- **US1 is strictly serial** (T002 → T003 → T004): each step consumes the previous one's artifact — you cannot build an archive from an unverified list, or install an archive you have not built.
+- **US2's Wave 5 is parallel** (T005 and T006 touch different files), then **T007 joins** — the negative probes need the gate wired before they can prove it bites.
+- **US3's two tasks are parallel** (two different documents), and depend only on T001, so US3 may run alongside US2.
+- **Polish's Wave 8 is parallel** (three different files), then T013 validates everything and T014 checks the fence. T013 must run last among the substantive tasks, since it validates their combined result.
+
+**Parallel opportunities**: T005+T006; T008+T009; T010+T011+T012. US2 and US3 are independent of each other once T001 lands.


### PR DESCRIPTION
Closes #432

## Summary

`/speckit.companion.adopt` was unrunnable from a real install: it called scripts the release archive never shipped. Same for `/speckit.companion.drift` and `/speckit.companion.coverage`. And `specify` / `plan` were silently degraded — without the path resolver they skipped loading living specs instead of erroring, so the breakage went unnoticed.

The scripts were never missing from the repo. The **release archive** was: it carried 3 of the 8 Python scripts the commands actually call. The packing list was hand-typed prose duplicated across two docs, checked by nothing — and the two copies had already drifted from each other. The copy that actually ran during publish was the short one.

This makes the packing list machine-readable and gates it in CI. The archive now ships every script the commands reach.

## Technical

- `speckit-extension/scripts/package-manifest.py` is the single source of truth. `--copy-to` fills the archive; `--check` gates it.
- The gate doesn't trust the declared list. It independently derives what the commands actually reach — scanning command bodies for the installed script path, then following each script's sibling imports to a fixed point — and fails when that disagrees with the declaration **in either direction**, naming the file.
- The derivation is what makes it work: only 6 of the 8 scripts are named by any command. `companion_config.py` and `derive-from-files.py` are reachable only through imports, so a checker that scanned command text alone would still have under-shipped.
- The declared list is kept rather than letting the derivation stand alone on purpose: a bare derivation would let a future unrecognized reference form *silently drop* a script — this exact bug, reintroduced with no alarm.
- CI gate wired into the `capture-suite` job. `publish-speckit-ext.md` and `docs/publishing.md` now defer to the manifest instead of restating a list.

## Quality

- [x] `npm run compile` clean
- [x] `npm test` — 1286 passed
- [x] Python suite — 266 passed (+8 new drift tests)
- [x] `check-shape-parity.py`, `assemble-nodes.py --check`, `package-manifest.py --check` all OK
- [x] Gate proven to **fail** on every drift direction (reachable-but-unpackaged, packaged-but-unreachable, declared-but-absent, referenced-but-missing, command-file-absent), not just to pass when clean
- [x] Spec-kit extension docs updated (`speckit-extension/README.md`, `CHANGELOG.md`); root README/CHANGELOG/`package.json` untouched
- [x] Verified from an **archive-only scratch install**: all four previously-broken scripts execute; `register-capability.py` really appended a capability

## How to verify

Build the archive from the manifest and confirm it carries all 8 runtime scripts:

```bash
python3 speckit-extension/scripts/package-manifest.py --check
python3 speckit-extension/scripts/package-manifest.py --copy-to /tmp/probe && ls /tmp/probe
```

## Gap — this fixes the next release, it does not republish

The live `companion-latest/companion.zip` is **still the broken 3-script build** until someone runs `/publish-speckit-ext`. Until that ships, #432 still reproduces for anyone installing from the URL. Left as a deliberate call, not an oversight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
