### PR TITLE
docs(companion): bring the whole repo under living specs

### DIFF
--- a/capabilities/companion-commands/spec.md
+++ b/capabilities/companion-commands/spec.md
@@ -1,6 +1,6 @@
 # Companion Commands — Living Spec
 
-> [DRAFT] Surface-first draft from existing code — every requirement is observed from the code surface unless tagged otherwise. Review before trusting.
+> Adopted from existing code on 2026-07-19. Requirements describe observed behavior and have not been individually verified against tests.
 
 ## Purpose
 

--- a/capabilities/companion-commands/spec.md
+++ b/capabilities/companion-commands/spec.md
@@ -1,0 +1,167 @@
+# Companion Commands — Living Spec
+
+> [DRAFT] Surface-first draft from existing code — every requirement is observed from the code surface unless tagged otherwise. Review before trusting.
+
+## Purpose
+
+Companion Commands is the prompt surface the extension actually ships: the seventeen commands a user or the workflow engine dispatches, the reusable node and part files those command bodies are assembled from, and the preset that carries the stock command family. It exists because the extension dispatches *text* and gets no callback — so every guarantee about pipeline shape, capture, and completion has to be written into the prompt itself. Without it, the extension has no way to make a run behave, and no way to stop the same rule from being restated in nine places and drifting.
+
+## Requirements
+
+### Command bodies are assembled from single-sourced parts and nodes, and the assembly is the contract
+
+No shipped command body is hand-authored end to end. A rule that applies to more than one command SHALL live in exactly one part file, and a command's structure SHALL be expressed as an ordered list of node files, each carrying its own identity and declared reads and writes. The committed bodies stay whole and self-contained — they are what the agent reads — but they are *generated*, and a gate MUST hold each assembled region byte-identical to its source. Editing a shipped body directly is therefore a defect, not a shortcut: it forks a shared rule silently.
+
+#### Scenario: a shared rule changes
+- **WHEN** a rule embedded in several commands is edited
+- **THEN** it is edited in its single part file
+- **AND** every command body carrying it is reassembled
+
+#### Scenario: a body is edited in place
+- **WHEN** a shipped body's assembled region no longer matches its source
+- **THEN** the parity gate fails and names the command and the region
+
+### Assembly changes MUST be proved against a frozen baseline
+
+Reshaping how bodies are built MUST NOT change the instructions the agent receives. Commands not intentionally changed SHALL compare equal to a frozen capture of their prior text, after normalizing the assembly markers themselves, so a refactor of the build mechanism is demonstrably behavior-preserving. Re-freezing the baseline is a deliberate, separate act after an intentional wording change — never something the build performs on its own.
+
+#### Scenario: the assembly mechanism is refactored
+- **WHEN** the bodies are rebuilt
+- **THEN** each unchanged command matches its frozen capture byte-for-byte
+
+#### Scenario: a command's wording is intentionally changed
+- **WHEN** the change is deliberate
+- **THEN** the baseline is re-frozen explicitly, outside the build
+
+### The manifest is the command inventory's single authority, and every downstream surface is gated against it
+
+The extension manifest declares what commands exist. Every surface derived from that list — the files the installer writes into each agent's directory, the registry, the documentation tables — MUST agree with it in both directions, and a gate SHALL enforce that. Both drift directions matter: a missing entry means a command the user cannot reach, and an orphaned entry means a renamed command whose retired name stays live in the agent's list because reinstallation merges names and never deletes. The gate MUST discover install areas rather than iterating a fixed list, since a hardcoded list quietly stops covering a new agent directory — the same drift one level down. An input it cannot resolve MUST fail loudly rather than shrink the surface it scans.
+
+#### Scenario: a command is renamed
+- **WHEN** the manifest names the new command
+- **THEN** the gate reports the stale file left behind under the old name
+
+#### Scenario: a new command is added
+- **WHEN** the command file exists but the manifest does not declare it
+- **THEN** the installer would skip it, and the gate fails
+
+### Four commands are lifecycle hooks, never user-facing verbs
+
+The manifest binds four commands to spec-kit's own lifecycle events. They are state-writing only: they record where a run reached and MUST NOT create spec directories, author documents, or do any of the work the surrounding command is responsible for. Users do not invoke them directly — the host pipeline fires them — so their bodies are written for a machine trigger, not for a person choosing a next action.
+
+#### Scenario: a pipeline phase finishes
+- **WHEN** the host fires the matching lifecycle event
+- **THEN** the hook records the step and status and does nothing else
+
+### The pipeline's document shape lives in command bodies, never in document templates
+
+Shape is delivered by overriding the command bodies, not by shipping alternative document scaffolds. This is a mechanism constraint, not a preference: template overrides only resolve when a setup script invokes the resolver, and the specification command copies its template by literal path, so a template override for it would silently do nothing. Command overrides apply uniformly to every command, which makes them the only reliable single mechanism. The accepted cost is that the on-disk templates keep showing the stock shape while the Companion commands simply do not read them.
+
+#### Scenario: a Companion-shaped document is wanted
+- **WHEN** the desired shape differs from stock
+- **THEN** the change is made in the command body
+- **AND** no alternative document template is shipped for it
+
+### Both command families are always present; the workflow choice only routes dispatch
+
+The stock family and the namespaced Companion family coexist permanently. Choosing a workflow SHALL add and remove nothing — it selects which family a given spec dispatches, and that choice is recorded on the spec so every later dispatch path resolves consistently. Keeping the stock family present is enforced by an add-only reconciliation that restores it when absent and never removes it, so no configuration change can strand a project without a working command set. Where a Companion command has no counterpart, it passes through unchanged rather than being forced into a mapping.
+
+#### Scenario: a spec was created under one workflow
+- **WHEN** a later step is dispatched from any surface
+- **THEN** the spec's recorded workflow decides which family's command runs
+
+#### Scenario: the spec-kit extension is not installed
+- **WHEN** a namespaced command would be dispatched
+- **THEN** it downgrades to its stock counterpart with a visible warning rather than failing
+
+#### Scenario: the stock family is missing from a checkout
+- **WHEN** the extension activates
+- **THEN** the stock family is restored, and nothing is ever removed
+
+### Every command degrades rather than failing the host
+
+The bodies instruct the agent to treat capture, hook evaluation, and living-spec work as best-effort. A missing interpreter, an absent config, a malformed file, or an unavailable capability SHALL produce a single warning and a skip, never a halt. This tone is uniform across the family precisely so that no command becomes the one that can break a user's run.
+
+#### Scenario: a prerequisite is unavailable
+- **WHEN** a command reaches a step whose prerequisite is missing
+- **THEN** it warns once, skips that step, and completes its real work
+
+### The pipeline right-sizes itself automatically, and an unresolved size runs the full pipeline
+
+Ceremony is matched to the change without any user-facing setting. A thin classification step emits one size signal from a fixed, single-sourced guardrail, and routing picks a branch from it: a small change folds toward implementation with less ceremony, an oversized change gets a visible warning and then the *same* full pipeline, and anything else runs the full pipeline. Routing MUST never silently skip a phase, and the default branch MUST be the full pipeline so an ambiguous or unresolved size can never under-plan a change.
+
+#### Scenario: the size signal cannot be resolved
+- **WHEN** routing has no usable size
+- **THEN** the full pipeline runs
+
+#### Scenario: a change clearly exceeds the bar
+- **WHEN** the size is oversized
+- **THEN** a warning is shown and every phase still runs
+
+### Completion is an explicit terminal step with exactly one writer
+
+The Companion pipeline ends at a dedicated completion command; the stock pipeline has no terminal step and simply stops. That command writes the terminal status through the shared writer and never by hand, refuses a spec whose work is outstanding, and is a no-op on a spec already shipped. This is the pipeline's completion gate — a second writer of that status MUST NOT be introduced anywhere.
+
+#### Scenario: implementation finishes
+- **WHEN** the terminal step runs
+- **THEN** the spec is promoted to completed through the single writer
+- **AND** the recorded current step stays at the last real step
+
+#### Scenario: work remains
+- **WHEN** the terminal step runs against an unfinished spec
+- **THEN** it refuses and reports, without failing the host
+
+### Living-spec commands are opt-in, non-halting, and honest about what they did not examine
+
+The commands that adopt, move, report drift on, and report coverage for living specs SHALL act only when the project has opted in, SHALL never fail the run, and — for the reporting pair — SHALL make no edits. Their output MUST state both what was examined and what was skipped with a reason, so a clean marker can never be read as a verdict on the whole configuration. A finding is a signal a surrounding workflow may act on; these commands do not gate.
+
+#### Scenario: the project has not opted in
+- **WHEN** one of these commands runs
+- **THEN** it reports nothing and exits successfully
+
+#### Scenario: part of the configured set could not be examined
+- **WHEN** the report is rendered
+- **THEN** it names both counts and the reason for the skip
+
+### Projects extend commands at node boundaries, never by editing bodies
+
+Because a body is generated, a project customizing it would be overwritten. Instead, a project SHALL declare its own work against a command's node boundaries in a configuration file, and the assembled body carries the prose that makes the agent the runtime for those declarations — running each boundary's attachments in declared order. A recipe may also override which nodes a command runs. Attachments referencing a boundary the active node set does not contain MUST warn and be skipped rather than silently doing nothing, and the whole mechanism inherits the never-fail-the-host contract.
+
+#### Scenario: a project attaches work to a node boundary
+- **WHEN** the command reaches that node
+- **THEN** the project's attachments run in declared order at that boundary
+
+#### Scenario: an attachment names a boundary that is not in the active node set
+- **WHEN** the configuration is merged
+- **THEN** it warns and skips rather than failing or silently ignoring
+
+### Commands direct capable providers to parallelize, while bookkeeping stays serialized
+
+Where a provider can spawn workers, the bodies SHALL make concurrency the expected strategy rather than an optional optimization, and SHALL express independence structurally — waves of tasks that share no files or dependencies, with explicit join points — rather than relying on the agent to infer it from inline markers. Concurrency MUST NOT extend to the shared record: prose that fans work out MUST name who serializes the write, because "journal each as it finishes" under concurrent workers reads as a race. Hosts without workers run sequentially and produce identical artifacts.
+
+#### Scenario: a wave of independent tasks is reached
+- **WHEN** the provider supports workers
+- **THEN** the wave's tasks run concurrently and the next wave waits for it
+
+#### Scenario: the provider cannot spawn workers
+- **WHEN** the same wave is reached
+- **THEN** it runs sequentially with no error and the same result
+
+### A command that injects a step into a numbered body MUST NOT restart the numbering
+
+Node bodies are concatenated, so numbering is a property of the *assembled* command, not of any one node. A node adding a step to a command whose numbering continues downstream SHALL use a sub-bullet or an unnumbered note rather than opening a fresh top-level number, and the check is made against the assembled body.
+
+#### Scenario: a node adds a step mid-command
+- **WHEN** the assembled body is reviewed
+- **THEN** the step numbering runs continuously with no repeated number
+
+## Uncovered
+
+Read in full: the extension manifest, all part files, the node order and a sample of node bodies across all four pipeline commands, the completion and resume command bodies, one hook command body, and the inventory/parity/assembly gate contracts. Not read:
+
+- The full bodies of `speckit.companion.specify.md`, `.plan.md`, `.tasks.md`, `.implement.md`, `.auto.md`, `.living-adopt.md` (the six largest, together roughly 118 KB) — their contracts were taken from `docs/template-profiles.md`, `docs/capture-and-timing.md`, the manifest descriptions, and the node files they assemble from.
+- `speckit.companion.after-plan.md`, `.after-tasks.md`, `.after-implement.md` — read one hook body in full and treated the other three as the same shape per the manifest.
+- `speckit.companion.status.md`, `.classify.md`, `.living-move.md`, `.living-drift.md`, `.living-coverage.md`.
+- All seven `presets/companion-standard/commands/*.md` carrier bodies and `preset.yml`.
+- Most individual node bodies under `nodes/` — read the order files, frontmatter shape, and three representative bodies.
+- `speckit-extension/workflows/speckit-companion.workflow.yml`.

--- a/capabilities/extension-services/spec.md
+++ b/capabilities/extension-services/spec.md
@@ -1,0 +1,127 @@
+# Extension Services — Living Spec
+
+> [DRAFT] Surface-first draft from existing code — every requirement is observed from the code surface unless tagged otherwise. Review before trusting.
+
+## Purpose
+
+This is a grouping, not one cohesive subsystem: four small areas — agent definitions, skill definitions, extension settings and their migrations, and permission handling — collected because none has enough surface to stand alone. What they genuinely share is a contract: each manages something on the user's behalf that is *not* a spec, lives outside the extension's own storage (the user's home directory, the workspace, `settings.json`, another tool's install directory), and is authored by someone other than this extension. That shared position is why they share the same failure discipline — read defensively, degrade to empty, never break activation, and never strand a value the user already set.
+
+## Requirements
+
+### Discovering user-authored assets is best-effort and never breaks activation
+
+Enumerating agents, skills, or presets SHALL treat a missing directory, an unreadable file, or a failing external CLI as "nothing found here" and continue. These sources are outside the extension's control and are frequently absent; a hard failure would take down the whole extension for a user who simply doesn't have the directory.
+
+#### Scenario: the user has no skills directory
+- **WHEN** the skill list is requested
+- **THEN** an empty list is returned and the failure is logged, not surfaced as an error
+
+#### Scenario: the external CLI a preset operation needs is not installed
+- **WHEN** the operation runs
+- **THEN** the failure is logged and the caller continues
+- **AND** activation completes normally
+
+### A malformed definition surfaces as a flagged entry, not a missing one
+
+A skill whose definition file has absent or unparseable frontmatter SHALL still be listed, named from its containing folder and marked as needing attention. Silently dropping it is worse than showing it broken: the user's assistant may still load it, and an invisible entry gives them nothing to fix.
+
+#### Scenario: a skill's frontmatter is invalid YAML
+- **WHEN** the skill list is built
+- **THEN** the skill appears under its folder name, flagged, with an explanation available on hover
+- **AND** it is not omitted from the list
+
+### Assets are discovered at every scope and attributed to their origin
+
+Discovery SHALL cover the project scope, the user scope, and installed plugins, and SHALL record which scope each asset came from. Plugin-sourced assets SHALL be namespaced by their plugin so two plugins providing the same name remain distinguishable.
+
+#### Scenario: two plugins each provide an asset with the same name
+- **WHEN** both are discovered
+- **THEN** each is presented under its own plugin's namespace
+- **AND** neither displaces the other
+
+### Discovery follows the configured provider's layout rather than one vendor's
+
+Where an asset's on-disk location differs per AI provider, discovery SHALL resolve the directory from the active provider's path configuration. This applies to every provider-located asset type alike — no asset type may hard-code one vendor's layout, since doing so makes that feature silently empty for every other provider.
+
+#### Scenario: a non-default provider is configured
+- **WHEN** skills are enumerated
+- **THEN** the provider's own skills directory is scanned at both project and user scope
+
+#### Scenario: a provider whose on-disk layout differs from the default is active
+- **WHEN** any provider-located asset type is enumerated
+- **THEN** that provider's own directory is scanned and its assets are listed
+- **AND** the section is not shown as empty because another vendor's layout was assumed
+
+### A renamed setting key keeps reading its predecessors
+
+Every reader of a renamed configuration key SHALL go through one helper that prefers the new key when it is explicitly set at any scope and otherwise falls back, in order, to the legacy keys. The migration alone is not sufficient — it is best-effort and may not have run, in which case the new key reads as its schema default while the user's real choice still lives on the old key.
+
+#### Scenario: a user's opt-in was set before the key was renamed and the migration has not run
+- **WHEN** the setting is read
+- **THEN** the legacy value is honoured and the feature behaves as opted-in
+
+#### Scenario: the new key is explicitly set to off while a stale legacy key says on
+- **WHEN** the setting is read
+- **THEN** the explicit new value wins
+
+### A value's meaning survives a type change
+
+Where a setting's persisted representation changed shape, readers SHALL coerce through one shared helper that accepts both the old and the new representation and maps each old value to the state that preserves the user's effective behavior. A naive coercion of the old representation flips users into the opposite state.
+
+#### Scenario: a persisted value still uses the retired representation
+- **WHEN** it is read
+- **THEN** it resolves to the same effective on/off state it had before the change
+
+### Migrations rewrite only known legacy values, scope by scope, and are idempotent
+
+A migration SHALL inspect each configuration scope separately and write back at the same scope, SHALL rewrite only values it recognizes as legacy — leaving anything unrecognized for the editor to flag — and SHALL be safe to run repeatedly. It runs at activation and MUST NOT be able to fail activation.
+
+#### Scenario: a value is set at the workspace scope only
+- **WHEN** the migration runs
+- **THEN** the rewritten value lands at the workspace scope
+- **AND** no value is introduced at the global scope
+
+#### Scenario: the migration runs a second time
+- **WHEN** everything is already migrated
+- **THEN** nothing is written
+
+### Retired settings are removed from settings but tolerated if present
+
+Settings that no longer exist SHALL have their persisted values deleted at every scope where they were set, and their presence SHALL never affect behavior. Cleanup is housekeeping, not a precondition — a user whose cleanup did not run must behave identically to one whose did.
+
+#### Scenario: a retired key is still present in settings
+- **WHEN** the extension runs
+- **THEN** nothing reads it and no behavior depends on it
+
+### Reconciling the companion's command family is add-only and idempotent
+
+Bringing a project to the state where the standard command family is present SHALL add what is missing, remove only artifacts of superseded installs, and never remove the standard family itself. The decision of which operations to run SHALL be separable from executing them, and running the reconciler on an already-correct project SHALL do nothing.
+
+#### Scenario: a superseded install is still present
+- **WHEN** reconciliation runs
+- **THEN** the superseded artifact is removed and the standard family is re-asserted so its content is not left reverted
+
+#### Scenario: the project is already correct
+- **WHEN** reconciliation runs
+- **THEN** no operations are issued
+
+### An install-state gate keys on the signal that actually implies the capability
+
+A check answering "is the companion available here?" SHALL test for the presence of the thing that provides the commands the gated UI will dispatch, not a related artifact that merely correlates with it. Gating on a correlate surfaces an option that fails at dispatch with an unknown command.
+
+#### Scenario: a project has the presets but not the extension itself
+- **WHEN** the install-state gate is evaluated
+- **THEN** it reports not-installed
+- **AND** UI that would dispatch the companion command family stays hidden
+
+### Permission mode has exactly one resolver
+
+The permission mode that governs how a dispatched assistant session is launched SHALL be read through one shared helper used by every provider, rather than being re-derived per call site. This area no longer holds an implementation — it is a retired seam whose behavior moved to the provider layer — and it must not grow a second one. [inferred: the module itself is now only a note recording where the behavior went; the single-resolver contract is read from that note, not from code here.]
+
+#### Scenario: a new AI provider is added
+- **WHEN** it launches a session
+- **THEN** it reads the permission mode through the shared helper rather than reading configuration directly
+
+## Uncovered
+
+_None — every file in all four areas was read. Note that the permission area contains no implementation; it is a single note pointing to the provider layer._

--- a/capabilities/extension-services/spec.md
+++ b/capabilities/extension-services/spec.md
@@ -1,6 +1,6 @@
 # Extension Services — Living Spec
 
-> [DRAFT] Surface-first draft from existing code — every requirement is observed from the code surface unless tagged otherwise. Review before trusting.
+> Adopted from existing code on 2026-07-19. Requirements describe observed behavior and have not been individually verified against tests.
 
 ## Purpose
 

--- a/capabilities/webview-shared/spec.md
+++ b/capabilities/webview-shared/spec.md
@@ -1,0 +1,150 @@
+# Webview Shared — Living Spec
+
+> [DRAFT] Surface-first draft from existing code — every requirement is observed from the code surface unless tagged otherwise. Review before trusting.
+
+## Purpose
+
+The common foundation every SpecKit Companion webview is built on: it turns spec markdown into an interactive, line-addressable document, supplies the reusable interaction primitives, and carries the correctness contracts — escaping, contrast, accessibility, cleanup — that each consuming webview would otherwise get subtly wrong on its own. Without it, every webview reinvents markdown rendering and its own escaping, and the invariants that keep untrusted spec content from injecting into the sandbox would hold in one place and fail in the next.
+
+## Requirements
+
+### Rendered documents stay addressable back to their source lines
+
+Rendering MUST preserve the mapping from each interactive element to the line number it came from in the original markdown, and consumers MUST act on that number rather than on the rendered DOM. Editing, deleting, and refinement all mutate a file on disk; the rendered tree is a lossy projection of that file, so anything derived from the DOM instead of the source position will eventually target the wrong line.
+
+#### Scenario: a line is edited in place
+- **WHEN** the user commits an inline edit
+- **THEN** the request identifies the source line and the new plain text
+- **AND** the extension — not the webview — is what rewrites the file
+
+#### Scenario: content the user cannot act on
+- **WHEN** a region is not individually editable (a fenced block, a rule, a top-level title)
+- **THEN** it renders without per-line controls rather than with controls that would misfire
+
+### One classifier decides what each line is and what may be done to it
+
+Whether a line can be deleted and whether it can be refined MUST come from a single classification pass, and both the renderer and any consumer offering those affordances MUST read the same answer. Two independent opinions about "is this removable" drift, and the failure is silent: a control appears that the handler will not honour, or a legitimate action is hidden.
+
+#### Scenario: a structural heading is rendered
+- **WHEN** the line defines document or section structure
+- **THEN** no delete affordance is offered, because deleting it would orphan everything beneath
+
+#### Scenario: an unrecognised line shape appears
+- **WHEN** content matches no known markdown shape
+- **THEN** it still renders as readable prose with the affordances its classification grants, rather than being dropped
+
+### Spec content is untrusted input and must never reach an attribute through string markup
+
+Spec files, workflow definitions, filenames, and fence languages are all authored outside this codebase, and fenced regions in particular MUST render as displayed content that is never live in the page — highlighting and diagram rendering are applied after the content is safely in the DOM. The shared escaping helper is safe **only for element content** — it neutralises angle brackets and ampersands but not attribute quotes — so any markup that carries such a value into an attribute MUST be built with DOM APIs (create element, set property, set text) rather than assembled as a string. Treating the helper as a general-purpose sanitiser is the recurring way injection gets reintroduced here. Link destinations and other URL-shaped values additionally require an allow-list of safe schemes, since escaping alone does not make a destination safe to navigate to.
+
+#### Scenario: user content is placed inside an element
+- **WHEN** a value is rendered as visible text
+- **THEN** the shared escaping helper is sufficient
+
+#### Scenario: user content becomes an attribute value
+- **WHEN** a value must land in an attribute — a label, a title, an image source, a link destination, a data value
+- **THEN** the element is constructed programmatically and the value assigned as an attribute
+- **AND** no string-concatenated markup carrying that value is assigned to a container's inner HTML
+
+#### Scenario: a link destination is rendered
+- **WHEN** markdown supplies an inline link
+- **THEN** only destinations with an allowed scheme produce a navigable link; anything else renders as inert text
+
+#### Scenario: a fence contains markup
+- **WHEN** a spec includes HTML or script text inside a code fence
+- **THEN** it is visible as code and is not live in the page
+
+#### Scenario: a fence declares an unusual language
+- **WHEN** the language token is arbitrary text
+- **THEN** it is treated as an opaque label and cannot alter the surrounding element's structure
+
+### Webviews talk to the extension through one typed channel
+
+Consumers MUST send extension-bound messages through the shared dispatcher rather than reaching for the host bridge directly. A single funnel is what makes message shapes type-checked, lets tests stub one seam instead of every call site, and leaves room to add cross-cutting behaviour (logging, de-duplication, rate limiting) without touching consumers.
+
+#### Scenario: a component needs to trigger extension work
+- **WHEN** it must notify the extension
+- **THEN** it dispatches a typed message through the shared channel
+- **AND** the host bridge handle does not appear inline in the component
+
+### Destructive and automatic actions are reversible before they commit
+
+Any action a user cannot undo through ordinary editing MUST be guarded — either by requiring a second deliberate confirmation within a short window, or by deferring the effect behind a visible countdown the user can cancel. Both patterns MUST fire their effect at most once and MUST release their timers when the surface goes away, so a dismissed or unmounted affordance can never act later.
+
+#### Scenario: the confirmation window lapses
+- **WHEN** a user arms a destructive action and then does nothing
+- **THEN** the action silently disarms without firing
+
+#### Scenario: the user reverses a deferred action
+- **WHEN** they cancel during the countdown, by button or by keyboard dismissal
+- **THEN** the deferred effect never runs and no completion is reported
+
+#### Scenario: the surface disappears mid-window
+- **WHEN** the component unmounts while a timer is pending
+- **THEN** the timer is cleared and nothing fires afterwards
+
+### Transient overlays are singletons with a complete teardown
+
+Popovers, backdrops, and inline editors MUST replace any predecessor rather than stacking, MUST be dismissible by keyboard as well as by pointer, and MUST restore whatever they displaced when they close — including on the cancel path. An overlay that leaves the original content hidden turns a cancelled edit into apparent data loss.
+
+#### Scenario: a second overlay is opened
+- **WHEN** one is already open
+- **THEN** the existing overlay and its backdrop are torn down first
+
+#### Scenario: an edit is abandoned
+- **WHEN** the user dismisses by keyboard, clicks the backdrop, or moves focus away
+- **THEN** the overlay is removed and the original rendered content is visible again unchanged
+
+### Readable content meets contrast; low-contrast tokens are for metadata only
+
+Anything a user is expected to read MUST use the body or primary text tokens. The secondary and muted tokens inherit VS Code's deliberately de-emphasised colours, which fall below WCAG AA on dark themes, so they are reserved for true chrome — timestamps, counts, labels beside a value. Because these tokens are theme-derived and composited, their contrast MUST be documented as a ratio; naming an "effective" colour is a cross-theme guarantee the tokens cannot make.
+
+#### Scenario: a card or panel shows explanatory prose
+- **WHEN** the text carries meaning the user must read to act
+- **THEN** it uses a readable text token even if it is visually secondary in the layout
+
+#### Scenario: a semi-transparent token is introduced
+- **WHEN** a token is defined by blending toward transparency
+- **THEN** it is documented by its contrast ratio against the surfaces it is used on
+
+### Accessible names and states survive the way they are hidden
+
+Anything referenced by an accessibility relationship MUST remain in the accessibility tree — visually hidden by clipping, never by the mechanisms that remove a node from it. Busy state MUST be placed on the content region that becomes unavailable, not on the loading overlay that appears over it, and live announcements MUST cover changes that are otherwise visual only. Decorative marks MUST be hidden from assistive technology so they are not read as content.
+
+#### Scenario: a control is described by adjacent text
+- **WHEN** that description is not meant to be visible
+- **THEN** it is hidden by a visually-hidden treatment so the description is still announced
+
+#### Scenario: a region becomes unavailable while work runs
+- **WHEN** an operation blocks interaction
+- **THEN** the content region carries the busy state for its whole duration
+
+### Consumers compose shared primitives instead of re-implementing them
+
+New interactive surfaces MUST reach for an existing primitive — pill, container, empty state, button, input, transient message — before hand-rolling markup, and a new primitive MUST arrive with a story exercising its variants. This is what keeps one visual pass able to change every consumer at once; each bespoke re-implementation is a place a later design change will silently miss. Where existing bespoke markup has been routed through a primitive without adopting its styling, that is a deliberate staging step, not the end state.
+
+#### Scenario: a webview needs a new status indicator
+- **WHEN** the shape already exists as a primitive
+- **THEN** it composes that primitive rather than styling a fresh element
+
+#### Scenario: a primitive gains a variant
+- **WHEN** a new visual or semantic variant is added
+- **THEN** its story is extended in the same change so the variant has a visible baseline
+
+### Progress indicators are derived from the document, not stored alongside it
+
+Completion state shown against phases or steps MUST be computed from the document's own contents on each render rather than tracked as separate state. One fact with two derivations will disagree, and the disagreement surfaces as a header claiming a phase is finished while the items beneath it are not. [inferred]
+
+Known gap: the step-progress surface still encodes a fixed phase set that predates the configurable pipeline, so it cannot represent a workflow of a different shape. Aligning it is outstanding work, tied to the same change that makes the document panel's phase stepper follow the spec's recorded workflow.
+
+#### Scenario: an item is checked off
+- **WHEN** the underlying document changes
+- **THEN** the phase's progress and completion indicator follow from a fresh reading of it
+
+#### Scenario: a phase contains no trackable items
+- **WHEN** there is nothing to count
+- **THEN** it is not reported as complete merely because nothing is outstanding
+
+## Uncovered
+
+_None — every file in the area was read._

--- a/capabilities/webview-shared/spec.md
+++ b/capabilities/webview-shared/spec.md
@@ -1,6 +1,6 @@
 # Webview Shared — Living Spec
 
-> [DRAFT] Surface-first draft from existing code — every requirement is observed from the code surface unless tagged otherwise. Review before trusting.
+> Adopted from existing code on 2026-07-19. Requirements describe observed behavior and have not been individually verified against tests.
 
 ## Purpose
 

--- a/capabilities/workflows/spec.md
+++ b/capabilities/workflows/spec.md
@@ -1,6 +1,6 @@
 # Workflows — Living Spec
 
-> [DRAFT] Surface-first draft from existing code — every requirement is observed from the code surface unless tagged otherwise. Review before trusting.
+> Adopted from existing code on 2026-07-19. Requirements describe observed behavior and have not been individually verified against tests.
 
 ## Purpose
 

--- a/capabilities/workflows/spec.md
+++ b/capabilities/workflows/spec.md
@@ -1,0 +1,129 @@
+# Workflows — Living Spec
+
+> [DRAFT] Surface-first draft from existing code — every requirement is observed from the code surface unless tagged otherwise. Review before trusting.
+
+## Purpose
+
+A workflow is the ordered pipeline a spec travels — which step comes next, which command that step dispatches, and which document it produces. This capability owns the definition, validation, selection, and persistence of those pipelines, plus the editor panel that renders a spec document inside its pipeline. Without it every surface (sidebar, viewer, editor, dispatch) would each guess at the pipeline shape and disagree about what "next" means.
+
+## Requirements
+
+### Two workflows ship, custom ones are additive, and one setting names the default
+
+The extension SHALL provide the stock SpecKit pipeline and the SpecKit Companion pipeline as built-ins, and SHALL merge any user-defined workflows from settings alongside them. The default for new specs is named by a single configuration key, `speckit.defaultWorkflow`; an unrecognized value falls back to the first available workflow with a logged note rather than leaving a spec pipeline-less.
+
+#### Scenario: the configured default names a workflow that no longer exists
+- **WHEN** a spec's workflow is resolved and the configured default is not among the available workflows
+- **THEN** the first available workflow is used
+- **AND** the substitution is logged rather than surfaced as an error
+
+#### Scenario: the Companion pipeline is chosen
+- **WHEN** a spec selects it
+- **THEN** each step dispatches the Companion command family
+- **AND** the pipeline ends at a terminal step that marks the spec complete
+
+### Built-in names are reserved at every scope
+
+A custom workflow SHALL NOT be able to claim a built-in workflow's name, including the legacy alias for the stock pipeline, and SHALL NOT be able to claim a name already taken by an earlier custom entry. Shadowing a built-in id would silently redirect the dispatch of every spec that recorded that name.
+
+#### Scenario: a user defines a workflow using a built-in's name
+- **WHEN** the workflow list is assembled
+- **THEN** the custom entry is rejected with a logged reason
+- **AND** the built-in definition remains the one that resolves under that name
+
+### Selection filters, resolution does not
+
+Surfaces that let a user *pick* a workflow SHALL hide workflows the active provider cannot run and built-ins whose prerequisites are absent. Resolving a workflow a spec has *already recorded* SHALL NOT filter. A spec that loses its real steps because the user switched providers would render the wrong pipeline and dispatch the wrong command.
+
+#### Scenario: an existing spec is opened under a provider that could not have selected its workflow
+- **WHEN** the spec's recorded workflow is resolved for display
+- **THEN** its real steps are returned unchanged
+- **AND** the same workflow is still absent from the picker
+
+#### Scenario: the Companion pipeline's prerequisites are not met
+- **WHEN** its enabling setting is off, or the companion spec-kit extension is not installed in the project
+- **THEN** it is not offered for selection
+- **AND** every surface that builds a picker uses the same predicate, so no picker can offer it while another hides it
+
+### An invalid workflow definition is skipped, never fatal
+
+Workflow settings are user-authored text. Validation SHALL reject a definition with a malformed name, a non-string step command, or a malformed checkpoint, SHALL warn (not reject) on an unrecognized provider id, and SHALL log every rejection with its reason. Activation and the workflow list MUST survive any combination of bad definitions.
+
+#### Scenario: settings contain one valid and one malformed workflow
+- **WHEN** the list is assembled
+- **THEN** the valid workflow is available and the malformed one is omitted with its errors logged
+- **AND** the built-ins remain available
+
+#### Scenario: a workflow restricts itself to a provider id that does not exist
+- **WHEN** it is validated
+- **THEN** it is accepted with a warning explaining the id will never match
+
+### Legacy per-step keys resolve to the same pipeline as an explicit step list
+
+A workflow written with the older one-key-per-step shape SHALL normalize to the ordered step list before use, and normalization SHALL be a no-op when an explicit list is already present. Users who wrote workflows against the older shape must not have their pipelines silently emptied.
+
+#### Scenario: a workflow declares only legacy step keys
+- **WHEN** its steps or a step's command is resolved
+- **THEN** the same pipeline is produced as an equivalent explicit step list
+- **AND** a step the legacy shape omits falls back to the stock pipeline's command for that step
+
+### A step command resolves to one canonical form regardless of how the user typed it
+
+Step commands SHALL be normalized to a bare command id at the single point every step command is resolved, tolerating a leading slash. Dispatch sites add their own prefix, so tolerating the variation anywhere but one place produces a malformed command.
+
+#### Scenario: a step command is written with a leading slash
+- **WHEN** that step is dispatched
+- **THEN** the emitted command carries exactly one leading slash
+
+### Read paths never write; only explicit user actions persist a selection
+
+Resolving a workflow for rendering — tree rows, viewer initialization — SHALL have no disk side effects. Persisting a workflow choice onto a spec SHALL happen only from an explicit user action such as running a step or picking from the workflow picker.
+
+#### Scenario: a spec with no recorded workflow is rendered in the sidebar
+- **WHEN** its workflow is resolved for display
+- **THEN** the default workflow is returned
+- **AND** the spec's context file is not created or modified
+
+### Persisting a workflow choice must never destroy existing spec context
+
+Writing a workflow selection SHALL read-modify-write the spec's context, and SHALL refuse to write when the existing context is present but unreadable or not valid JSON. Only a genuinely absent file may be treated as a first write. A transient read failure that fell through to a fresh minimal write would erase the spec's whole recorded lifecycle.
+
+#### Scenario: the context file exists but cannot be parsed
+- **WHEN** a workflow selection is saved
+- **THEN** the write is refused with an explanatory error
+- **AND** the file on disk is left untouched
+
+#### Scenario: no context file exists yet
+- **WHEN** a workflow selection is saved
+- **THEN** a minimal context recording the workflow and the time of choice is written
+
+### Checkpoints run at their declared trigger, ask before acting, and record their outcome
+
+A workflow MAY declare checkpoints bound to pipeline events. Each SHALL prompt for approval unless the definition explicitly opts out, SHALL record its resulting status on the spec, and on failure SHALL offer retry, skip, or cancel rather than silently continuing. A declined checkpoint is recorded as skipped, not as a failure.
+
+#### Scenario: the user declines a checkpoint
+- **WHEN** the approval prompt is dismissed or answered no
+- **THEN** no git or PR action is taken
+- **AND** the checkpoint is recorded as skipped
+
+#### Scenario: a checkpoint fails mid-sequence
+- **WHEN** more checkpoints remain for the same trigger
+- **THEN** the user chooses to retry, skip to the next, or cancel the remaining sequence
+
+### The editor panel's pipeline stepper follows the spec's own recorded workflow
+
+The document panel SHALL derive its phase stepper, document tabs, and next-document decision from the workflow the spec actually recorded, so that any pipeline — including one whose steps go beyond the common set, and one that ends in a terminal step — is representable in the panel exactly as it runs. A panel that could only render a fixed shape would hide the steps that distinguish a pipeline from the stock one, and would misrepresent every custom workflow.
+
+#### Scenario: a document is opened that matches a pipeline step's output file
+- **WHEN** the panel renders
+- **THEN** the phase, the completed phases, and the tab set derive from the recorded workflow's step order and the files present on disk
+- **AND** files that are not step outputs surface as related documents rather than as phases
+
+#### Scenario: a spec is on a workflow whose pipeline ends in a terminal step
+- **WHEN** the panel renders that spec's document
+- **THEN** the stepper includes that terminal step alongside the earlier ones
+- **AND** the next-document decision accounts for it rather than ending the pipeline early
+
+## Uncovered
+
+_None — every file in both areas was read._

--- a/living-specs.yml
+++ b/living-specs.yml
@@ -1,0 +1,41 @@
+enabled: true
+exempt: ["*.config.*", "*.test.*", "**/migrations/**"]
+capabilities:
+  - name: core
+    match: ["src/core/**"]
+    spec: src/core/core.spec.md
+  - name: specs
+    match: ["src/features/specs/**"]
+    spec: src/features/specs/specs.spec.md
+  - name: spec-viewer
+    match: ["src/features/spec-viewer/**"]
+    spec: src/features/spec-viewer/spec-viewer.spec.md
+  - name: spec-editor
+    match: ["src/features/spec-editor/**"]
+    spec: src/features/spec-editor/spec-editor.spec.md
+  - name: steering
+    match: ["src/features/steering/**"]
+    spec: src/features/steering/steering.spec.md
+  - name: ai-providers
+    match: ["src/ai-providers/**"]
+    spec: src/ai-providers/ai-providers.spec.md
+  - name: speckit-cli
+    match: ["src/speckit/**"]
+    spec: src/speckit/speckit-cli.spec.md
+  - name: viewer-ui
+    match: ["webview/src/spec-viewer/**"]
+    spec: webview/src/spec-viewer/viewer-ui.spec.md
+  - name: editor-ui
+    match: ["webview/src/spec-editor/**"]
+    spec: webview/src/spec-editor/editor-ui.spec.md
+  - name: capture-runtime
+    match: ["speckit-extension/scripts/**"]
+    spec: speckit-extension/scripts/capture-runtime.spec.md
+  - name: companion-commands
+    match: ["speckit-extension/commands/**", "speckit-extension/nodes/**", "speckit-extension/presets/**"]
+  - name: extension-services
+    match: ["src/features/agents/**", "src/features/skills/**", "src/features/settings/**", "src/features/permission/**"]
+  - name: webview-shared
+    match: ["webview/src/markdown/**", "webview/src/render/**", "webview/src/shared/**", "webview/src/ui/**"]
+  - name: workflows
+    match: ["src/features/workflows/**", "src/features/workflow-editor/**", "speckit-extension/workflows/**"]

--- a/speckit-extension/scripts/capture-runtime.spec.md
+++ b/speckit-extension/scripts/capture-runtime.spec.md
@@ -1,6 +1,6 @@
 # Capture Runtime — Living Spec
 
-> [DRAFT] Surface-first draft from existing code — every requirement is observed from the code surface unless tagged otherwise. Review before trusting.
+> Adopted from existing code on 2026-07-19. Requirements describe observed behavior and have not been individually verified against tests.
 
 ## Purpose
 

--- a/speckit-extension/scripts/capture-runtime.spec.md
+++ b/speckit-extension/scripts/capture-runtime.spec.md
@@ -1,0 +1,179 @@
+# Capture Runtime — Living Spec
+
+> [DRAFT] Surface-first draft from existing code — every requirement is observed from the code surface unless tagged otherwise. Review before trusting.
+
+## Purpose
+
+The capture runtime is the set of Python scripts that turn an AI-driven spec-kit run into a durable, trustworthy record on disk — what step the spec is on, when each step and task really finished, what the run decided, and how those decisions fold back into long-lived living specs. Without it the extension is blind: it dispatches command text and receives no completion callback, so anything it cannot read from a file it does not know. And because these scripts run *inside* the user's own pipeline, a bug here does not merely lose data — it can break the run it was supposed to observe.
+
+## Requirements
+
+### Recording state MUST NOT be able to break the run it observes
+
+Every script in this runtime is a passenger on the user's command. A missing interpreter, an unresolvable spec directory, a malformed config, a git repository that cannot answer a question — none of these MUST fail the host command. The scripts SHALL report the problem on stderr and exit successfully, so a capture defect degrades into a gap in the record rather than a halted pipeline. The read-side and report-side tools (status resolution, drift, coverage) carry the same contract and are documented as never raising and never exiting non-zero.
+
+#### Scenario: the interpreter is absent
+- **WHEN** a command reaches its capture step in an environment without `python3`
+- **THEN** the command warns once and continues its real work
+- **AND** the user's run completes normally with an incomplete record
+
+#### Scenario: the spec directory cannot be resolved
+- **WHEN** the writer cannot determine which spec a lifecycle write belongs to
+- **THEN** it declines to write, names the problem on stderr, and exits successfully
+
+### The context file is append-only, crash-safe, and tolerant of fields it does not own
+
+The spec context is a shared document written by several independent producers — this runtime, the VS Code extension, and future readers. Writers SHALL read-merge-write rather than rebuild: unknown top-level keys and previously written history entries survive untouched, and the lifecycle log is only ever appended to, never rewritten or shrunk. Every write MUST be atomic (write a temporary file, then rename) so an interrupted run can never leave a half-written or truncated context behind.
+
+#### Scenario: a newer writer adds a field this runtime does not know
+- **WHEN** an older script updates a context file carrying an unfamiliar top-level key
+- **THEN** that key is present and unchanged after the write
+
+#### Scenario: the process dies mid-write
+- **WHEN** a write is interrupted before it completes
+- **THEN** the on-disk context is either the previous state or the new state, never a partial one
+
+### Lifecycle status moves forward only, and the terminal state has exactly one writer
+
+Any path that sets a spec's status MUST check that the spec has not already moved past the step being written, not merely that it is non-terminal. Re-running an earlier step, or a hook firing twice, records the finish but MUST NOT drag the spec backwards. Promotion to the terminal completed state is reserved to a single explicit writer (`--mark-complete`), which refuses a spec with work outstanding and is a no-op on a spec already shipped. Generic field-setting MUST refuse lifecycle keys outright, so no side door exists around this guard.
+
+#### Scenario: an earlier step is re-advanced
+- **WHEN** an already-advanced spec receives a completion for a step it passed
+- **THEN** the finish is recorded in history
+- **AND** the status and current step are left where they were
+
+#### Scenario: a caller tries to set the terminal status through a generic setter
+- **WHEN** a generic field write names a lifecycle key
+- **THEN** the write is refused and the refusal is reported
+
+### Timing is stamped by a script, never hand-authored
+
+Durations are only meaningful if a clock produced them. Every timing entry SHALL be written by running a writer script that reads the real clock at write time; no caller — human or AI — writes timing into the context by editing the file. This is the runtime's central reliability lever: running a command is something an AI does faithfully, while pausing mid-work to hand-author a timestamped JSON entry is not. It is also what keeps the file structurally valid, since hand-editing is what corrupted it in practice.
+
+#### Scenario: a step's work finishes
+- **WHEN** the step's own work ends and its completion must be recorded
+- **THEN** the writer script is invoked and stamps the entry from its own clock
+
+#### Scenario: an entry is de-duplicated
+- **WHEN** the same step completion is recorded twice
+- **THEN** history carries it once
+
+### Per-task progress is finish-only, contention-free, and folded idempotently
+
+A task records a single finish, never a start/finish pair stamped at one instant — a pair produces zero-length ticks and hides real cadence, so each task's duration is the gap to the previous finish. Finishes are appended as single lines to a separate event log rather than read-modify-written into the shared context, so concurrent workers never contend and the hot loop never stalls. Those lines are folded into the durable record through the same code path a live write would take, so folding is byte-equivalent to inline journaling and re-folding the whole log never double-counts.
+
+#### Scenario: several workers finish at once
+- **WHEN** parallel workers each record a task finish simultaneously
+- **THEN** every finish lands and none corrupts the shared context
+
+#### Scenario: the log is folded more than once
+- **WHEN** the same event log is folded repeatedly
+- **THEN** the durable record is unchanged after the first fold
+
+#### Scenario: the append log is garbage-collected
+- **WHEN** the spec reaches its terminal state
+- **THEN** pending lines are folded first and only then is the log removed
+- **AND** the terminal state prevents the log from being recreated
+
+### Derived artifacts have exactly one writer
+
+Anything computed from the journal — most visibly the task checklist's checkboxes — SHALL be written by one place, derived from the event record, and never hand-edited by the agent doing the work. Two producers of the same fact will disagree eventually; making the checklist *derived* rather than a second source of truth is what keeps the file and the record from diverging. Task-marker parsing MUST accept every marker format the shipped command families emit, since a format the parser silently misses produces no journal at all and strands the step.
+
+#### Scenario: a task is completed by a fanned-out worker
+- **WHEN** a worker finishes its task
+- **THEN** it records only its finish
+- **AND** the checkbox is flipped later by the single derivation pass
+
+### The spec a write lands on is resolved by a fixed precedence, and a conflict refuses rather than guesses
+
+Several signals can name the active spec, and they can disagree — especially when a later spec is "active" while an earlier one is being settled. The runtime SHALL apply one documented precedence, and where a caller supplies a signal that is authoritative for the operation (the task list being synced names its own spec), that signal MUST override the ambient pointers. When two explicit signals conflict, the writer MUST refuse to write and name the mismatch, rather than silently picking one and settling the wrong spec.
+
+#### Scenario: two explicit signals disagree
+- **WHEN** an explicit spec directory and an explicit task list point at different specs
+- **THEN** nothing is written and the mismatch is reported
+
+#### Scenario: an older spec settles while a newer one is active
+- **WHEN** a task list belonging to an earlier spec is synced
+- **THEN** the earlier spec settles, regardless of which spec the ambient pointers name
+
+### Additive capture composes; lifecycle modes are exclusive
+
+The runtime distinguishes two kinds of write. Additive capture — decisions, verifications, concerns, expectations, requirement coverage, step summaries, size classification — SHALL all take effect when passed together, each reporting itself, because they are independent facts about the same run. Lifecycle modes are alternative readings of one invocation and MUST stay first-match-wins. When a capture flag accompanies a lifecycle flag, the lifecycle write is skipped and named on stderr rather than half-performed. All additive capture is de-duplicated on its identity value, so re-running a command never doubles up.
+
+#### Scenario: several capture facts arrive in one call
+- **WHEN** a caller records a decision, a verification, and a summary together
+- **THEN** all three are stored
+
+#### Scenario: capture and a lifecycle transition are mixed
+- **WHEN** a completion flag and a capture flag arrive in one call
+- **THEN** the capture is applied and the skipped lifecycle write is reported
+
+### Folding a feature spec's requirement deltas into a living spec is idempotent for every verb combination
+
+At completion, a feature spec's requirement deltas become part of the durable living spec. Re-applying the same delta set to its own output MUST be a byte-for-byte no-op — for a single verb, for any ordered pair, and for any combination. Verbs SHALL apply in a fixed pipeline order regardless of the order they appear in the document, and an addition MUST resolve its heading through the delta set's own renames before deciding whether that section already exists. A rename chain that loops back on itself names no destination and its entries are dropped as unsatisfiable rather than applied.
+
+#### Scenario: a delta set both adds and renames the same heading
+- **WHEN** the set is folded a second time
+- **THEN** the living spec is unchanged and no section is duplicated
+
+#### Scenario: the same heading is both added and modified
+- **WHEN** the fold resolves the conflict
+- **THEN** the modified body wins over the added body
+
+### A probe that cannot determine an answer MUST report "unknown", never the negative
+
+Boundary and capability probes throughout this runtime — is this a shallow clone, is this directory a separate project, does this file exist — MUST distinguish "no" from "I could not tell." Only the error that genuinely *means* absence may return the negative; every other failure MUST surface a third state so the caller can skip loudly. The failure shape this guards against is that the negative branch is usually also the keep-going branch, so a swallowed error silently produces a confident wrong answer.
+
+#### Scenario: history is unreachable
+- **WHEN** a shallow clone means a capability's baseline cannot be compared
+- **THEN** that capability is reported as skipped with the reason, not as in sync
+
+#### Scenario: a nested config is unreadable
+- **WHEN** a boundary probe cannot read a directory's config
+- **THEN** the directory is still treated as a boundary rather than descended into
+
+### A report MUST NOT claim success for work it did not do
+
+Summary output SHALL state both what was examined and what was not. A run that skipped every capability reports zero checked rather than a clean verdict, and a partly-skipped run states both counts so a success marker can never read as a verdict on the whole configuration. Skips carry their reason, and reasons that are actionable carry a hint. Reporting tools always exit successfully — a finding is a signal for a surrounding workflow to act on, not a gate these commands enforce.
+
+#### Scenario: some capabilities could not be checked
+- **WHEN** a drift run examines part of the configured set
+- **THEN** the summary names both the checked and unchecked counts and the reason
+
+### Living-spec path resolution stops at a nested project boundary
+
+A directory carrying its own companion config is a separate project. Discovery SHALL stop there and never report, claim, or promote anything inside it — otherwise a sample or vendored project nested in the tree gets its specs attributed to the parent. Resolution is the single source of these rules; the sync, fold, drift, and coverage tools call it rather than re-interpreting the configuration themselves.
+
+#### Scenario: a sample project is nested in the tree
+- **WHEN** discovery walks into a directory holding its own companion config
+- **THEN** the walk stops and nothing inside is reported as the parent's
+
+### Each product ships every module its own entry points reach
+
+This repository ships two products from one tree, and each has its own list of files to include. The two lists are deliberately different sizes: a product's list MUST carry the modules ITS entry points need, and no list is obliged to match the other. What is not optional is closure — a module that a runtime script imports MUST appear on the list of every product that ships that script, or a released build dies on first use while every gate stays green. Modules SHALL be imported by plain name rather than loaded dynamically, precisely so a packing gate can derive what ships by following imports to a fixed point; a dynamically loaded module is invisible to it.
+
+Where a capability is deliberately left out of one build, attempting it MUST report clearly that it is unavailable in this context. A missing module SHALL NOT degrade into a silent no-op that reports success while doing nothing.
+
+#### Scenario: a script gains a new import
+- **WHEN** a runtime script starts importing a new sibling
+- **THEN** every product that ships that script names the new module on its own list before release
+
+#### Scenario: a build omits a capability on purpose
+- **WHEN** something asks that build to perform it
+- **THEN** it fails loudly with an explanation that the capability is unavailable here
+- **AND** it does not quietly do nothing and report success
+
+#### Scenario: a module is loaded by file path instead of imported
+- **WHEN** the archive gate derives the shipping closure
+- **THEN** the dynamically loaded module is not discovered and the archive is incomplete
+
+## Uncovered
+
+- `check-coverage.py` — read only its contract docstring, not its matching logic.
+- `relocate-capability.py` — read only its opening docstring.
+- `register-capability.py` — read only its contract docstring.
+- `companion_config.py` — read its contract docstring and failure table, not its YAML reader.
+- `status-context.py` — read its docstring and function list, not its resolution logic.
+- `derive-from-files.py` — read its docstring only.
+- `capture-golden.py`, `assemble-nodes.py`, `build-commands.py`, `check-shape-parity.py`, `_command_parts.py` — build-time tooling, covered by the companion-commands spec rather than here.
+- The Python test suite under `speckit-extension/tests/` was not read.

--- a/src/ai-providers/ai-providers.spec.md
+++ b/src/ai-providers/ai-providers.spec.md
@@ -1,0 +1,138 @@
+# Ai Providers — Living Spec
+
+> [DRAFT] Surface-first draft from existing code — every requirement is observed from the code surface unless tagged otherwise. Review before trusting.
+
+## Purpose
+
+This capability is how the extension hands work to whatever AI coding assistant the user actually has — a terminal CLI, the host editor's built-in chat, or a GUI chat panel. Without it every feature would have to know which assistant is configured and how that assistant takes input, and the extension would only ever work with one tool.
+
+## Requirements
+
+### Dispatch is one-way and unobservable
+
+A provider SHALL be treated as a write-only channel: the extension composes text, hands it to the assistant, and cannot observe what the assistant does with it. No caller may depend on a return value as evidence that the work happened. Providers that dispatch somewhere other than a terminal MUST still satisfy the same interface, reporting a non-failure result rather than an error, because "the assistant did nothing" is indistinguishable from "the assistant succeeded" from here.
+
+#### Scenario: a step is dispatched to a chat surface
+- **WHEN** the configured provider routes to the host editor's chat or a GUI panel instead of a terminal
+- **THEN** the dispatch call resolves without a terminal handle and without throwing
+- **AND** callers treat the absence of a failure signal as success, never as confirmation of completion
+
+#### Scenario: the assistant ignores the instruction
+- **WHEN** the assistant never acts on the dispatched text
+- **THEN** the extension has no way to detect this and does not claim the step completed
+- **AND** completion is established by the assistant writing spec context, not by the dispatch returning
+
+### Every assistant is reached through one provider contract
+
+All assistants SHALL be reached through a single provider interface covering installation check, interactive dispatch, background dispatch, slash-command dispatch, and permission-flag resolution. A feature MUST NOT branch on which assistant is configured; adding an assistant means adding a provider, not editing call sites.
+
+#### Scenario: a new assistant is supported
+- **WHEN** support for another AI tool is added
+- **THEN** it is introduced as a new provider registered in the factory and the paths registry
+- **AND** no existing feature code changes to accommodate it
+
+### Terminal CLIs share one dispatch lifecycle
+
+Providers that drive a CLI in a terminal SHALL inherit a common lifecycle — verify the CLI is present, stage the prompt to a temporary file, build the shell line, create the terminal, wait for the shell to be ready before sending, then clean the temporary file up on a delay. A concrete provider MUST override only the parts that genuinely differ for its CLI. Assistants whose interaction model does not fit this shape (an interactive TUI that must boot before accepting input, a reused long-lived session) may stay outside the shared lifecycle rather than being forced through it.
+
+#### Scenario: a CLI provider needs a different command line
+- **WHEN** a CLI takes its prompt in a form the shared line does not produce
+- **THEN** the provider overrides the dispatch-preparation step and returns its own command line plus the temp files to clean
+- **AND** install verification, terminal creation, shell readiness, and cleanup remain inherited
+
+#### Scenario: the CLI is not installed
+- **WHEN** a provider that declares an install hint dispatches and its binary is absent
+- **THEN** the user is told what to install with a copyable install command and the dispatch fails loudly rather than sending text into a shell that cannot act on it
+
+### The prompt is never pasted into visible terminal scrollback
+
+Assembled prompt text SHALL be delivered through a temporary file read by the shell at invocation time rather than inlined into the command line, so long instructions do not flood the terminal and shell quoting cannot corrupt them. The substitution form MUST be chosen from the detected shell family. Where a shell offers no such substitution, the provider MUST fall back to inlining with that shell's escaping and MUST refuse — with an actionable message naming a shell to switch to — rather than silently truncating when the resulting line exceeds what the shell accepts.
+
+#### Scenario: a long prompt on a shell without file substitution
+- **WHEN** the assembled command line would exceed the shell's command-length limit
+- **THEN** dispatch fails with a message naming the limit and suggesting a different terminal shell
+- **AND** no truncated command is sent
+
+### Bookkeeping instructions travel separately from the user-facing command
+
+The extension prepends spec-context bookkeeping to the prompt, delimited by markers so it can be separated again. Every surface a human reads — a chat input, a GUI panel prefill, a TUI input line — MUST show only the command, never the bookkeeping. Surfaces that can carry the bookkeeping out of band SHOULD do so; surfaces that cannot MUST drop it rather than display it.
+
+#### Scenario: dispatching to a chat the user is looking at
+- **WHEN** the prompt carries a bookkeeping preamble
+- **THEN** the chat input receives only the command
+- **AND** the bookkeeping is either routed through a side channel the assistant still reads, or dropped
+
+#### Scenario: a CLI that accepts a system-prompt channel
+- **WHEN** the prompt carries a preamble and the CLI supports appending to its system prompt
+- **THEN** the preamble is staged separately and passed through that channel so it neither pollutes scrollback nor interferes with slash-command resolution
+
+### Command names are rewritten to whatever the target actually registered
+
+The canonical dotted command form SHALL be translated to the form the target assistant resolves — some tools register these commands with dots, others as dash-named skills. The translation MUST be driven by per-target configuration and MUST be overridable by an explicit user setting. It MUST apply to the command verb only, never to its argument, and MUST leave non-SpecKit commands untouched.
+
+#### Scenario: a namespaced command reaches a dash-form target
+- **WHEN** a multi-segment SpecKit command is dispatched to a target whose commands are dash-named
+- **THEN** every separator in the verb becomes a hyphen so the whole name matches the registered skill
+- **AND** an argument that happens to contain a dot or the word "companion" is not rewritten
+
+### Arguments are reshaped for the surface that will display them
+
+An argument that is a filesystem path is meaningful to a terminal agent but useless in a chat input a human reads, and unreadable to a CLI sandboxed to the project directory. Providers SHALL reshape the argument for their surface: inline a staged description file's contents where the target cannot open it, shorten a spec directory path to the spec's name where a human will read it, and leave free-text arguments alone.
+
+#### Scenario: creating a spec from a staged description file
+- **WHEN** the create flow dispatches a command whose argument is a path to a staged description outside the project
+- **THEN** a chat or panel surface receives the description text inlined, with the appended bookkeeping stripped
+- **AND** a project-sandboxed CLI receives the file's full contents inlined rather than the unreadable path
+
+### The provider registry is validated at activation, not at first dispatch
+
+Per-provider configuration SHALL be checked when the extension loads, and a malformed entry MUST throw immediately with the offending provider and field named. Silent misconfiguration is the failure mode this guards against — a flag that runs into the next argument, an icon that renders as nothing, a directory declared without the pattern that enumerates it.
+
+#### Scenario: a provider entry is edited incorrectly
+- **WHEN** an entry declares a command format outside the allowed set, or a flag that would concatenate into the following argument
+- **THEN** activation fails with a message naming that provider and every failing field at once
+- **AND** the extension never reaches a dispatch built from the bad value
+
+### A stale or unknown provider setting never breaks activation
+
+The configured provider value is user-editable and survives renames, so every read SHALL tolerate a value that no longer exists by falling back to the default provider. An unrecognized setting MUST degrade to a working assistant, never to a crash on every dispatch.
+
+#### Scenario: a persisted provider id was renamed or removed
+- **WHEN** the setting holds an identifier the registry does not know
+- **THEN** the default provider is used
+- **AND** the extension activates and dispatches normally
+
+### Permission mode is honored where it can be, and overridden loudly where it cannot
+
+The single permission-mode setting SHALL resolve to the target CLI's own flag. When a CLI cannot honor interactive approval in scripted mode, the provider MUST apply the auto-approve flag anyway and warn once per provider, rather than dispatching something that will hang waiting for a prompt nobody can answer. The user SHOULD be offered the matching setting change once, with their decision remembered.
+
+#### Scenario: interactive mode on a CLI that cannot prompt
+- **WHEN** the user has interactive permissions selected and the configured CLI cannot honor it
+- **THEN** the dispatch carries the auto-approve flag and the override is logged once
+- **AND** the user is offered a one-time prompt to switch the setting, and declining is remembered
+
+### Dispatch targets are probed at dispatch time, not assumed
+
+Surfaces the extension does not own — a host editor's chat, another extension's panel — SHALL be resolved by checking what is actually registered at the moment of dispatch, in a per-target preference order, degrading through fallbacks. When no target resolves, the provider MUST surface an actionable message naming a way forward and MUST NOT throw. `[inferred]` The degradation ladder ends at copying the command to the clipboard and opening the surface, so a target that accepts no programmatic input still works with one user paste.
+
+#### Scenario: the host editor exposes no chat command
+- **WHEN** none of the candidate chat commands are registered in the running editor
+- **THEN** the user is warned that no built-in chat was found and told to switch to a CLI provider
+- **AND** nothing throws
+
+#### Scenario: the host drops the prompt it is handed
+- **WHEN** a target opens its chat but discards the supplied query
+- **THEN** the command is placed on the clipboard and the user is told to paste and press Enter
+
+### Commands are not auto-submitted into a surface that cannot resolve them
+
+Before a SpecKit command is fired into a host editor's chat, the extension SHALL check that spec-kit has scaffolded those commands for that editor. When it has not, the command MUST be prefilled rather than submitted, and the user MUST be told why, with a route to initialize.
+
+#### Scenario: the workspace is not spec-kit initialized
+- **WHEN** a command is dispatched to a host chat with no spec-kit scaffolding present
+- **THEN** the chat opens with the command prefilled but not submitted
+- **AND** the user is warned and offered the initialize action
+
+## Uncovered
+
+_None — every file in the area was read._

--- a/src/ai-providers/ai-providers.spec.md
+++ b/src/ai-providers/ai-providers.spec.md
@@ -1,6 +1,6 @@
 # Ai Providers — Living Spec
 
-> [DRAFT] Surface-first draft from existing code — every requirement is observed from the code surface unless tagged otherwise. Review before trusting.
+> Adopted from existing code on 2026-07-19. Requirements describe observed behavior and have not been individually verified against tests.
 
 ## Purpose
 

--- a/src/core/core.spec.md
+++ b/src/core/core.spec.md
@@ -1,6 +1,6 @@
 # Core — Living Spec
 
-> [DRAFT] Surface-first draft from existing code — every requirement is observed from the code surface unless tagged otherwise. Review before trusting.
+> Adopted from existing code on 2026-07-19. Requirements describe observed behavior and have not been individually verified against tests.
 
 ## Purpose
 

--- a/src/core/core.spec.md
+++ b/src/core/core.spec.md
@@ -1,0 +1,160 @@
+# Core — Living Spec
+
+> [DRAFT] Surface-first draft from existing code — every requirement is observed from the code surface unless tagged otherwise. Review before trusting.
+
+## Purpose
+
+Core is the shared ground every feature stands on: where a spec lives on disk, what a spec's recorded state means, how the extension notices the filesystem changing, and the small set of primitives (terminals, temp files, context keys, errors) features would otherwise each reinvent. Without it, every feature would carry its own idea of "what is a spec directory" and they would disagree.
+
+## Requirements
+
+### Spec locations are configured, not assumed
+
+The extension SHALL locate specs from a user-configurable list of directory patterns rather than a fixed path, because the workflows it supports place specs in several different layouts. Both plain directory names and glob patterns MUST be supported, and their meanings differ: a plain name's *children* are specs, while each glob *match* is itself a spec. Any hardcoded fallback for these patterns MUST list every layout the shipped configuration lists, since a divergence silently makes a whole layout invisible.
+
+#### Scenario: a workspace uses a nested change-based layout
+- **WHEN** a configured pattern has wildcards and a real directory matches it
+- **THEN** that directory is treated as a spec directory itself, not as a container of specs
+
+#### Scenario: a configured directory holds spec folders
+- **WHEN** a configured pattern is a plain directory name
+- **THEN** each of its immediate subdirectories is a candidate spec
+- **AND** a subdirectory is only accepted once it has markdown content or a recorded spec context, so empty scaffolding does not appear as a spec
+
+### Spec discovery and file-to-spec attribution agree
+
+Resolving the specs in a workspace and deciding which spec a given file belongs to SHALL be driven by the same configured patterns and the same exclusions. A file is attributed to a spec only when it sits *inside* a matched spec directory, never when it merely sits at the pattern's own depth.
+
+#### Scenario: a document is edited inside a spec
+- **WHEN** an edited file's path lies under a directory matching a configured pattern
+- **THEN** that spec directory's path is returned as the file's owning spec
+
+#### Scenario: the same path is queried twice through different patterns
+- **WHEN** two configured patterns would both match a directory
+- **THEN** it is reported exactly once — discovery de-duplicates by resolved path
+
+### Reference material declared by a workflow is never mistaken for a spec
+
+A workflow may declare folders it reads for background context. Those folders SHALL be excluded from spec detection across all configured workflows, regardless of which workflow a given spec chose. Without this, a reference folder that happens to sit under a spec pattern surfaces as a phantom spec with a lifecycle it does not have.
+
+#### Scenario: a workflow's reference folder sits under a spec pattern
+- **WHEN** spec discovery runs
+- **THEN** that folder and everything beneath it is skipped
+- **AND** files inside it are not attributed to any spec
+
+### Recorded spec state has one on-disk shape and one append-only log
+
+A spec's lifecycle SHALL be recorded in a single per-spec context file whose history is append-only — entries are never reordered, edited, or removed. Per-step and per-substep timing SHALL be derived in memory from that log rather than persisted alongside it, so there is exactly one source of truth and no second field to drift. Unknown and legacy fields MUST be preserved across writes, so an older or newer writer never loses another's data.
+
+#### Scenario: a step's timing is displayed
+- **WHEN** the viewer needs how long a step took
+- **THEN** it derives that from the history log rather than reading a stored duration
+
+#### Scenario: a writer that predates a field updates the file
+- **WHEN** a component rewrites the context file
+- **THEN** fields it does not recognize survive the write unchanged
+
+### The recorded status and the recorded step must not disagree
+
+Status values and step names SHALL form one lifecycle where each non-terminal status names the step that owns it and whether that step is still running or settled. A status ahead of the history log is an invalid state and MUST NOT be written: it renders as work in progress that nobody is doing.
+
+#### Scenario: a step is advanced
+- **WHEN** the current step changes
+- **THEN** a matching history entry is appended in the same write
+
+#### Scenario: a step is still running
+- **WHEN** the status is one of the in-progress forms
+- **THEN** the extension reports that step as active rather than settled
+
+### A duration is only shown when the extension itself stamped both ends
+
+A span SHALL be reported as trustworthy only when both of its boundaries were stamped by the extension's own clock. Timestamps journaled by the assistant or a CLI order events correctly but record when the write ran, not when the work happened, so a duration computed from them is fiction and MUST NOT be displayed as elapsed time.
+
+#### Scenario: the assistant journaled a step's completion
+- **WHEN** a step's start or end was written by something other than the extension
+- **THEN** the span is marked untrusted and no elapsed time is rendered for it
+
+### The extension notices spec changes wherever specs live
+
+File watchers SHALL be registered from the configured spec patterns, not from a single hardcoded directory, so a workspace using any supported layout still gets live updates. Watching only one layout is a known regression shape: a context write goes unobserved, the open viewer never refreshes, and a newly created spec never clears the empty state.
+
+#### Scenario: a spec's context file is written under any configured layout
+- **WHEN** the write lands
+- **THEN** an open viewer showing that spec re-derives its state without a reload
+
+#### Scenario: a spec's context file appears for the first time
+- **WHEN** the file is created
+- **THEN** the sidebar re-scans so the new spec appears and any empty state clears
+
+Filesystem events arrive in bursts, so refresh work driven by a watcher SHALL be debounced. Every watcher handler MUST swallow and log its own failures — a malformed file, a partial write, a missing directory — because a throwing handler silently kills the watcher for the rest of the session.
+
+#### Scenario: a context file is observed mid-write
+- **WHEN** its contents do not parse
+- **THEN** the event is ignored and the watcher keeps working
+
+#### Scenario: a file is saved repeatedly in quick succession
+- **WHEN** several change events fire close together
+- **THEN** the dependent refresh runs once after the burst settles
+
+### The completion of the implement step is closed by observing the work, not by trusting a report
+
+Because the extension is blind to what the assistant does, the implement step SHALL be closed by watching the task list itself: when every task is checked and implement is underway, the extension writes the terminal close. This path MUST work regardless of how the run was driven, and MUST be idempotent and forward-only so it can never move a spec backward.
+
+#### Scenario: the last task is checked off
+- **WHEN** the task document changes and no unchecked tasks remain while implement is in progress
+- **THEN** the extension records the implement step's completion
+- **AND** re-running the same check does not duplicate or regress the recorded state
+
+### Settings survive being renamed, retyped, and retired
+
+Configuration keys change shape across releases, so a reader SHALL be correct for a persisted value from any generation without waiting for a migration to run. Migrations MUST preserve the scope a value was set at, MUST be idempotent, and MUST NOT fail activation. A retired key's persisted value SHOULD be cleaned up rather than left to confuse the user.
+
+#### Scenario: a setting was persisted in its old form
+- **WHEN** a reader asks for it before any migration has run
+- **THEN** the legacy form is coerced to the current type and the user's effective choice is preserved, never flipped
+
+#### Scenario: a renamed key is migrated
+- **WHEN** the old key was set at the workspace level
+- **THEN** the new key is written at the workspace level and the old one is removed there
+- **AND** re-running the migration changes nothing
+
+### Telemetry carries shapes, never content
+
+Every telemetry payload SHALL contain only enum-like values, booleans, versions, counts, and a random per-spec identifier. User-authored text — prompt content, file paths, spec names, custom workflow and step names — MUST never be sent. Any value read from disk or settings that could be free text MUST be coerced to a known allow-list before reporting, with anything unrecognized reduced to a neutral placeholder.
+
+#### Scenario: a user-defined workflow step runs
+- **WHEN** an event reports which phase it belongs to
+- **THEN** built-in phase names are sent verbatim and any other step name is reported as a generic marker
+
+#### Scenario: a spec has no correlation identifier yet
+- **WHEN** an event fires for it
+- **THEN** a random identifier is minted and persisted so later events for the same spec correlate
+- **AND** a failure to persist it does not block the event
+
+### Context keys have one writer and one catalogue
+
+VS Code context keys SHALL be written through a single wrapper that accepts only catalogued key names and logs failures. Activation MUST reset every catalogued key, so a value from a previous session cannot leak into the new one and leave a menu affordance stuck.
+
+#### Scenario: a key is set from a feature
+- **WHEN** the write fails
+- **THEN** the failure is logged rather than silently swallowed
+
+#### Scenario: the extension activates
+- **WHEN** startup runs
+- **THEN** every catalogued key is reset to its default
+
+### Shared primitives absorb host and shell differences
+
+Terminal readiness, temp-file staging, path translation for cross-environment shells, shell-family detection, and task-checkbox parsing SHALL live in core and be the only implementations. Callers MUST NOT re-derive them. Waiting for a shell MUST have a timeout fallback so a host that never reports readiness still dispatches.
+
+#### Scenario: a checkbox appears inside a code block
+- **WHEN** task counts are computed for a document
+- **THEN** checkboxes inside fenced blocks or inline code are not counted as work
+
+#### Scenario: shell integration never signals ready
+- **WHEN** the readiness wait exceeds its timeout
+- **THEN** dispatch proceeds anyway rather than hanging
+
+## Uncovered
+
+_None — every file in the area was read._

--- a/src/features/spec-editor/spec-editor.spec.md
+++ b/src/features/spec-editor/spec-editor.spec.md
@@ -1,0 +1,105 @@
+# Spec Editor — Living Spec
+
+> [DRAFT] Surface-first draft from existing code — every requirement is observed from the code surface unless tagged otherwise. Review before trusting.
+
+## Purpose
+
+This is the extension-side host for the "describe your feature" panel: it turns whatever the user typed and pasted into a durable artifact on disk, hands the AI a command pointing at that artifact, and cleans up afterwards. Without it, spec creation would be a raw string shoved at a terminal — no images, no record of which workflow was chosen, and no way to recover from a provider that cannot read the files it was handed.
+
+## Requirements
+
+### Submitted intent becomes a durable artifact, not a terminal string
+
+On submit, the host SHALL materialize the user's content and attachments into a self-contained document on disk and dispatch a command that *points at* that document, rather than inlining the text into the command. This is what makes arbitrarily long specs, pasted images, and trailing machine-readable instructions possible at all — a shell command line is not a viable transport for any of them.
+
+#### Scenario: a long spec with several pasted images is submitted
+- **WHEN** the user submits
+- **THEN** a document containing the content and references to each stored image is written
+- **AND** the dispatched command carries the document's path, not its contents
+
+#### Scenario: submission is attempted with empty content
+- **WHEN** the user submits
+- **THEN** nothing is written or dispatched
+- **AND** the panel is told why
+
+### The chosen workflow is recorded with the spec, verbatim
+
+The workflow the user picked SHALL be carried into the new spec's own state record as part of the creation instruction, so every later step resolves its command from the spec's recorded choice rather than from whatever the project default happens to be at that moment. The picked name is recorded as picked, even when the piece that implements it is missing — each step then applies the same fallback independently, so one absent dependency cannot silently rewrite the spec's identity.
+
+#### Scenario: the user picks the Companion workflow
+- **WHEN** the spec is created
+- **THEN** the creation instruction seeds that workflow into the spec's record
+- **AND** later steps dispatch from that recorded choice
+
+### The picker offers only workflows that can actually run
+
+The workflow list SHALL be built from what the active AI provider supports and what is genuinely installed, so the picker never lists an option that would silently degrade to something else. Every builder that feeds a workflow list MUST share one predicate — this repo has shipped a bug where one of two independent list builders was gated and the other was not, and the ungated one was the one that rendered.
+
+#### Scenario: the companion piece is not installed
+- **WHEN** the panel builds its workflow list
+- **THEN** the Companion entry is absent rather than present-and-degrading
+
+#### Scenario: a user-defined workflow names a step the active provider cannot run
+- **WHEN** the list is built
+- **THEN** that workflow is omitted
+
+### A missing dependency degrades or refuses, but never dispatches something unresolvable
+
+When a chosen action needs the companion piece and it is absent, the host SHALL either downgrade to the equivalent stock action or, when there is no equivalent, refuse to start at all. Either way the user gets a non-blocking explanation and a one-click way to install. Dispatching a command the AI cannot resolve is never acceptable.
+
+#### Scenario: the Companion entry point is chosen without the companion piece
+- **WHEN** the user submits
+- **THEN** the stock equivalent runs
+- **AND** a dismissible warning offers to install the missing piece
+
+#### Scenario: the hands-off run is requested without the companion piece
+- **WHEN** the user triggers it
+- **THEN** nothing runs, because it has no stock equivalent
+- **AND** the panel surfaces the reason rather than appearing to start
+
+### Attachments live outside the workspace unless a provider's sandbox forces otherwise
+
+Stored attachments SHALL default to extension-owned storage outside the user's repository, falling back to a system temporary location when that storage is not writable. Only when the active provider sandboxes its reads to the project root are the attachments copied *into* the workspace, and then only into a cache directory that ignores itself from version control on first use. If that copy cannot be made, the original references stand rather than the submission failing.
+
+#### Scenario: the active provider cannot read outside the project root
+- **WHEN** a spec with images is submitted
+- **THEN** the images are copied into a self-ignoring workspace cache
+- **AND** the document's references are rewritten to the in-project copies
+
+#### Scenario: no workspace folder is open, or the copy fails
+- **WHEN** staging is attempted
+- **THEN** the original references are kept and the submission proceeds
+
+### Every temporary artifact is tracked with an expiry and reclaimed later, never immediately
+
+Each artifact set SHALL be registered in a manifest carrying its own distinct key, its paths, and when it expires; expired, orphaned, and finished sets are swept on activation. Cleanup MUST NOT be an immediate post-dispatch delete — the AI reads the files asynchronously after the command is handed off, so deleting on dispatch races the read. Each registered set needs a key of its own: reusing an existing set's key clobbers that set's record and leaks the directory it pointed at.
+
+#### Scenario: a submission finishes and the panel closes
+- **WHEN** dispatch completes
+- **THEN** the set is marked submitted and left on disk to be reclaimed on a later sweep
+
+#### Scenario: a follow-on staged copy is registered for an existing set
+- **WHEN** it is written to the manifest
+- **THEN** it uses a derived key distinct from the original set's
+- **AND** the original set's record and directory survive
+
+#### Scenario: the editor is closed mid-session and the extension restarts
+- **WHEN** activation runs
+- **THEN** stale artifact sets past their expiry are deleted and the deletion count is logged
+
+### The panel is a single live session, and every failure reaches it
+
+At most one editor panel SHALL exist at a time — a second request reveals the existing one rather than starting a competing session. Every failure path — an unreadable attachment, a size limit, a missing dependency, a failed dispatch — MUST be reported back to the panel as a message the UI can render, never swallowed into a log the user will not see. The panel's markup is served under a strict content policy with a per-load nonce and an explicit allow-list of resource locations.
+
+#### Scenario: the editor is opened while a session is already running
+- **WHEN** the open action fires
+- **THEN** the existing panel is revealed with its content intact
+- **AND** no second session is created
+
+#### Scenario: an attached image exceeds the per-image limit
+- **WHEN** it is processed
+- **THEN** the panel receives an error message describing the failure
+
+## Uncovered
+
+- `installBanner.test.ts` and the contents of `__tests__/` — not read; every non-test file in the area was read in full.

--- a/src/features/spec-editor/spec-editor.spec.md
+++ b/src/features/spec-editor/spec-editor.spec.md
@@ -1,6 +1,6 @@
 # Spec Editor — Living Spec
 
-> [DRAFT] Surface-first draft from existing code — every requirement is observed from the code surface unless tagged otherwise. Review before trusting.
+> Adopted from existing code on 2026-07-19. Requirements describe observed behavior and have not been individually verified against tests.
 
 ## Purpose
 

--- a/src/features/spec-viewer/spec-viewer.spec.md
+++ b/src/features/spec-viewer/spec-viewer.spec.md
@@ -1,0 +1,201 @@
+# Spec Viewer — Living Spec
+
+> [DRAFT] Surface-first draft from existing code — every requirement is observed from the code surface unless tagged otherwise. Review before trusting.
+
+## Purpose
+
+The spec viewer is the extension-side host for the reading surface: it owns a spec's panel, decides what the reader is allowed to see and do next, and hands the webview a complete picture of the spec's true state. Without it the workflow's state would only exist as files on disk, and the reader would have to infer where a spec stands from what happens to be present in a directory — which is exactly how the viewer and the sidebar used to disagree with each other.
+
+## Requirements
+
+### One panel per spec, revealed rather than duplicated
+
+Opening any document of a spec MUST resolve to that spec's own panel. A second open — of the same document, a sibling document, or the spec as a whole — SHALL reuse and reveal the existing panel rather than creating another. Panels are keyed by the spec's directory so a spec can never end up with two disagreeing views of itself, and closing a panel MUST release everything scoped to it (pending timers, per-spec notification memory).
+
+#### Scenario: opening a sub-document of an open spec
+- **WHEN** the reader opens a document that lives under a directory a panel already owns
+- **THEN** that panel switches to the document and comes to the front
+- **AND** no second panel is created
+
+#### Scenario: the panel is closed
+- **WHEN** a panel is disposed
+- **THEN** its pending work and its per-spec notification state are discarded
+- **AND** reopening the spec starts from a clean panel
+
+### Viewer state is derived from the spec's recorded run, not from files on disk
+
+Everything the reader sees about *where the spec stands* — the status badge, which step is running, which steps are done, and which actions the footer offers — MUST be derived from the spec's recorded context. The presence or absence of a document file SHALL NOT be read as evidence that a step completed. File existence remains meaningful only for what it actually proves: whether a document can be opened, and whether a step tab has something behind it.
+
+#### Scenario: a document exists but the step never ran
+- **WHEN** a plan document is present but the run never recorded the plan step
+- **THEN** the plan step reads as not started
+- **AND** the footer still offers the forward action for the step the spec is actually on
+
+#### Scenario: an external tool advanced the run without per-step detail
+- **WHEN** the recorded context names a later current step but carries no entries for the steps before it
+- **THEN** those earlier steps are treated as completed by their position in the ordering
+- **AND** no step is left falsely pulsing
+
+### One fact has exactly one derivation
+
+Any fact this feature shares with another surface — the sidebar tree, the Living Specs panel, task counting, in-flight detection — MUST be read from that fact's single owning module rather than recomputed here. Two independent derivations of the same fact will drift, and every time this repo has shipped one, the two surfaces eventually contradicted each other in front of the user.
+
+#### Scenario: a capability's coverage is shown in two places
+- **WHEN** the viewer header and the Living Specs tree both display a capability's coverage
+- **THEN** both obtain it from the same capability-health reader
+- **AND** the two numbers cannot disagree
+
+#### Scenario: a requirement count and a coverage denominator are displayed together
+- **WHEN** the header shows both a requirement count and a covered-of-total ratio
+- **THEN** both are counted off the same requirement identifiers
+- **AND** the count and the denominator always match
+
+### Every refresh ships a complete state snapshot from one builder
+
+Both refresh paths — a document switch and a change to the spec's recorded context — MUST build their payload through one shared builder and send a *complete* state, never a partial merged onto whatever the webview last held. A payload that omits a state-bearing field would let the webview keep a stale value beside fresh ones, which is how the footer once offered an action the spec's real state did not permit.
+
+#### Scenario: the recorded context changes on disk
+- **WHEN** a watcher reports a change to an open spec's recorded context
+- **THEN** the viewer re-derives state and posts a complete snapshot
+- **AND** the reader sees the settled state without switching tabs or reloading
+
+#### Scenario: a refresh that carries no document content
+- **WHEN** the refresh is triggered by state alone
+- **THEN** document and staleness reads are skipped as unnecessary work
+- **AND** the snapshot remains internally consistent by reusing the panel's cached values for the fields it did not recompute
+
+### The action catalog is the authority on what the reader may do
+
+The set of actions offered at the bottom of the viewer MUST be computed as a function of the spec's state alone, and the same true state SHALL always yield the same set. Each action declares whether it affects the whole spec or only the current step, and that scope is surfaced to the reader. Closure actions appear only once the spec has reached its final approval gate; the forward action targets the spec's real current step and disappears when the workflow has genuinely moved past it.
+
+#### Scenario: a step is still running
+- **WHEN** the spec's status names a step as in flight
+- **THEN** the catalog still offers the re-run action for that step
+- **AND** the reader is not offered a way to advance a step that has not settled
+
+#### Scenario: an interrupted run is rolled back by hand
+- **WHEN** an earlier status is forced after a run died mid-step
+- **THEN** the abandoned later start no longer suppresses the forward action
+- **AND** the reader gets the same forward action a normal pause at that stage would offer
+
+#### Scenario: the reader is looking at an earlier step's document
+- **WHEN** a completed earlier step's document is displayed
+- **THEN** the forward action still reflects the spec's true stage, not the tab being viewed
+
+### Reading a spec must never damage its record
+
+The viewer SHALL treat the spec's recorded context as read-only after the first open. It MAY create a minimal record when none exists at all, but a record that exists and cannot be parsed MUST be rendered from an in-memory stand-in and left untouched on disk. Repairing a corrupt record is the reader's explicit decision, taken through an offer that backs up the original first.
+
+#### Scenario: the record is unreadable mid-write
+- **WHEN** the record cannot be parsed during a render
+- **THEN** the panel renders from a minimal in-memory stand-in
+- **AND** nothing is written over the file on disk
+
+#### Scenario: the reader accepts a reset
+- **WHEN** the reader chooses to reset a corrupt record
+- **THEN** the original is backed up before a fresh record is written
+- **AND** the open panel refreshes onto the repaired state
+
+### Pipeline actions target the spec's real step, and degrade safely when the pipeline is unavailable
+
+Re-running or advancing a step MUST resolve its target from the spec's recorded current step — never from the document the reader happens to be looking at — and MUST record an honest start (and, when advancing, a completion) before dispatching. When a dispatch names a command that belongs to the companion pipeline and that pipeline is not installed, the viewer SHALL fall back to the standard equivalent and say so, and SHALL suppress the dispatch entirely rather than send a command that cannot resolve.
+
+#### Scenario: re-run is clicked from a child document
+- **WHEN** the reader triggers a re-run while viewing a supporting document
+- **THEN** the spec's current step is re-run
+- **AND** no start is recorded against the wrong step
+
+#### Scenario: the companion pipeline is not installed
+- **WHEN** a dispatch would name a companion-only command with no standard equivalent
+- **THEN** nothing is dispatched
+- **AND** the reader is told what is missing and offered a way to install it
+
+### Review comments persist through the single writer, one mutation at a time
+
+An inline comment MUST be persisted to the spec's record the moment it is added, edited, or removed, and MUST reach disk through the sanctioned writer rather than a direct write. Mutations for a given spec SHALL be serialized so two comments added in quick succession cannot read the same baseline and clobber each other, and a failed mutation MUST NOT wedge the queue for the ones behind it. A mutation SHALL be refused outright when the existing record cannot be read.
+
+#### Scenario: two comments are added in quick succession
+- **WHEN** the webview posts two comment mutations back to back
+- **THEN** they apply in order against successive baselines
+- **AND** neither is lost
+
+#### Scenario: refinement is dispatched for a document
+- **WHEN** a document's pending comments are sent to the assistant
+- **THEN** the prompt asks for targeted in-place edits and explicitly forbids regenerating the document from a template
+- **AND** the dispatched comments are marked applied rather than deleted
+
+### Best-effort facts are omitted, never rendered as zeros
+
+Any fact the viewer cannot determine — a count, a date, a coverage ratio, a drift verdict — MUST be left out of the surface rather than shown as an empty or zero value. A zero the reader can trust and a fact nobody could compute are different claims, and rendering them identically makes the surface lie.
+
+#### Scenario: a capability's health cannot be computed
+- **WHEN** the repository has no version control, or the check times out
+- **THEN** the coverage and drift facts are simply absent from the header
+- **AND** nothing renders as `0`
+
+### Slow facts arrive after first paint and are discarded if the panel moved on
+
+A fact that costs real time to compute MUST NOT block the panel's first render. It SHALL be resolved afterwards and pushed to the panel, and the push MUST be dropped if the panel has since been re-anchored to a different subject — otherwise a slow answer about one capability lands on another.
+
+#### Scenario: two capabilities share a panel
+- **WHEN** the reader switches to a second capability while the first one's health check is still running
+- **THEN** the late result is discarded
+- **AND** the header keeps showing only facts belonging to what is on screen
+
+### Staleness is advisory, document-local, and silent once the spec settles
+
+A staleness verdict compares one document against the documents it was generated from, and is reported per document so the notice can sit with the document it describes. It MUST NOT be computed at all for a completed or archived spec — "regenerate this, the source moved on" is advice about work still to do, and a finished spec has none. Every surface that reads staleness therefore goes quiet together.
+
+#### Scenario: a spec is marked completed
+- **WHEN** staleness is requested for a settled spec
+- **THEN** an empty verdict is returned
+- **AND** both the notice and the per-step mark disappear
+
+### Quiet-run recovery states a suspicion, never acts on it
+
+When a step is in flight but nothing belonging to the spec has changed for a long time, the viewer MAY surface a hedged prompt offering to resume or to set the status by hand. It MUST NOT change the spec's status on its own, MUST derive the judgement purely at render time from what is on disk (no polling), and SHOULD use a longer fuse for steps that think for a long time between writes than for steps that write frequently. Past the point where "is it still running?" stops being a plausible question, the prompt SHALL change its framing to closing the spec out instead of resuming it.
+
+#### Scenario: a long-abandoned run
+- **WHEN** an in-flight spec has been quiet for days
+- **THEN** the prompt says the run looks abandoned and leads with marking it done
+- **AND** the spec's status is unchanged until the reader acts
+
+#### Scenario: every task is checked but the spec still reads in flight
+- **WHEN** the work is finished and nobody closed the step
+- **THEN** the prompt leads with marking the spec complete regardless of how long it has been quiet
+
+### A step's completion is announced exactly once
+
+When a step's recorded completion appears, the viewer SHOULD tell the reader, with an offer to open the spec. The announcement MUST be de-duplicated per spec, step, and run so reopening a panel never re-announces history, and the first observation of an already-finished spec MUST seed the memory silently rather than firing a burst of stale notices. The announcement is gated by a setting the reader controls.
+
+#### Scenario: a panel is reopened on a finished spec
+- **WHEN** the viewer first observes a spec whose steps are already complete
+- **THEN** nothing is announced
+- **AND** a genuinely new completion after that is announced once
+
+### A living spec is presented as a capability, not a run
+
+A living-spec panel MUST drop the workflow machinery entirely — no run state, no phases, no forward actions — and present the capability's tiers as the only navigation. Its title comes from the capability's own spec document whichever tier is displayed, so the title belongs to the capability rather than to the tab on screen. A document that declares itself a draft SHALL be badged as one rather than presented as settled.
+
+#### Scenario: the architecture tier is selected
+- **WHEN** a non-spec tier is displayed
+- **THEN** the header still shows the capability's title as authored in its spec tier
+- **AND** no workflow status or forward action appears
+
+#### Scenario: the document carries a draft banner near its top
+- **WHEN** the spec declares itself a draft
+- **THEN** the header badges it as a draft
+- **AND** the in-document banner is left intact
+
+### The webview shell is generated under a locked-down policy
+
+Each render MUST emit its own content-security policy with a freshly generated per-render nonce, restrict resource loading to the extension's own assets plus the explicitly named script sources, and escape every value interpolated into the shell — including values placed inside HTML attributes, which need stricter escaping than element content. Regenerating the shell is also what resets the webview's in-memory selection, so any navigation meant to preserve that selection MUST go through a message instead.
+
+#### Scenario: a pipeline entry is selected
+- **WHEN** the reader picks a document from the pipeline rail
+- **THEN** only the content is swapped by message
+- **AND** the shell is not regenerated, so the reader's current view is preserved
+
+## Uncovered
+
+_None — every file in the area was read, though the test files under `__tests__/` were read only for the contracts they pin, not line by line._

--- a/src/features/spec-viewer/spec-viewer.spec.md
+++ b/src/features/spec-viewer/spec-viewer.spec.md
@@ -1,6 +1,6 @@
 # Spec Viewer — Living Spec
 
-> [DRAFT] Surface-first draft from existing code — every requirement is observed from the code surface unless tagged otherwise. Review before trusting.
+> Adopted from existing code on 2026-07-19. Requirements describe observed behavior and have not been individually verified against tests.
 
 ## Purpose
 

--- a/src/features/specs/specs.spec.md
+++ b/src/features/specs/specs.spec.md
@@ -1,6 +1,6 @@
 # Specs — Living Spec
 
-> [DRAFT] Surface-first draft from existing code — every requirement is observed from the code surface unless tagged otherwise. Review before trusting.
+> Adopted from existing code on 2026-07-19. Requirements describe observed behavior and have not been individually verified against tests.
 
 ## Purpose
 

--- a/src/features/specs/specs.spec.md
+++ b/src/features/specs/specs.spec.md
@@ -1,0 +1,201 @@
+# Specs — Living Spec
+
+> [DRAFT] Surface-first draft from existing code — every requirement is observed from the code surface unless tagged otherwise. Review before trusting.
+
+## Purpose
+
+This capability owns a spec's whole life: creating it, listing it, showing where it is in the pipeline, and — most importantly — recording what actually happened to it in a durable per-spec state file. Without it the extension would have to guess a spec's progress from which files happen to exist on disk, which is exactly the guessing that produced the repo's worst class of bug: two parts of the UI confidently disagreeing about the same spec.
+
+## Requirements
+
+### A spec's lifecycle state is recorded, never inferred from files
+
+Each spec directory SHALL carry one state record holding the workflow it runs, the step it is on, its canonical status, and an ordered log of lifecycle events. Step completion MUST NOT be inferred from the presence of a document on disk: an AI can write `plan.md` and never finish planning, and a finished step can leave no new file at all. Where a document's own content matters (a stub vs. a real document), it refines what a *document row* renders, never what the *workflow* believes.
+
+#### Scenario: a spec has a plan document but no recorded plan step
+- **WHEN** the sidebar or viewer asks whether planning is done
+- **THEN** the answer comes from the recorded log, not from the file listing
+- **AND** the spec continues to read as still planning
+
+#### Scenario: a spec has no state record at all
+- **WHEN** the extension first encounters it
+- **THEN** it backfills only facts it can verify — the workflow, the name, the branch — and starts the spec at the beginning
+- **AND** it never fabricates completed steps to make the record look further along
+
+### The lifecycle log is append-only and every write is atomic
+
+The event log SHALL only grow. A write that would shorten it, or that would alter any entry already in it, MUST be rejected outright rather than silently accepted. Every write MUST land whole — a reader that opens the file mid-write must see either the old record or the new one, never a partial one. This is what lets a hook, a watcher, and a user action all write to the same record without one of them destroying another's history.
+
+#### Scenario: a caller submits a rewritten history
+- **WHEN** the proposed record's log disagrees with an entry already on disk
+- **THEN** the write is refused with an explicit append-only error
+- **AND** the on-disk record is unchanged
+
+#### Scenario: the file exists but cannot be read or parsed
+- **WHEN** a write is attempted
+- **THEN** the writer refuses rather than treating the unreadable file as absent
+- **AND** the caller is told why, so a transient read failure can never be mistaken for a first write
+
+### One fact has exactly one derivation
+
+Every derived quantity — a step's start and end, whether a step is complete, what a document row shows, what a spec's effective status is — SHALL be computed in one place and read by every consumer. Two consumers that each compute the same fact WILL eventually disagree, and this repo has shipped that bug (a row's icon and its own tooltip contradicting each other). Adding a second surface that needs a derived fact means reading the existing resolved value, not re-deriving it.
+
+#### Scenario: the sidebar and the viewer both show a step's state
+- **WHEN** each renders a step
+- **THEN** both read the same derived value from the same derivation
+- **AND** it is not possible for them to show contradictory states
+
+#### Scenario: a new consumer needs "is this step complete?"
+- **WHEN** it is written
+- **THEN** it calls the shared query rather than re-reading the log itself
+
+### Status moves forward and never regresses out of a terminal state
+
+Status transitions SHALL be forward-only. A re-run, a double-fired hook, or a late-arriving write for an earlier step MUST record its event honestly in the log while leaving status and current step alone if the spec has already moved past that step. A spec that has reached a terminal state MUST NOT be dragged backwards by any subsequent write.
+
+The furthest a step can carry a spec on its own is "implementation finished". The final closed state is written only by an explicit terminal step that ran and decided; no recovery, repair, or reconciliation path may infer it from what it finds on disk. When a recorded status is unreadable, such a path SHALL restore the highest state a step can reach on its own and leave the closing act to the terminal step. This is what lets the Companion pipeline finish a spec by itself — it does so *through* its terminal step, not by inference.
+
+#### Scenario: a repair path meets an unreadable status
+- **WHEN** it reconstructs the spec's state
+- **THEN** it settles no higher than "implementation finished"
+- **AND** it never writes the final closed state on its own
+
+#### Scenario: an earlier step's completion arrives late
+- **WHEN** a plan-step completion is written for a spec already at tasks
+- **THEN** the completion is appended to the log
+- **AND** the spec's status and current step stay where they were
+
+### Reaching the pipeline's end is a real end state, not a bug
+
+The Companion pipeline finishes by marking the spec complete at its last step — that is the intended behavior and the whole point of the pipeline, and MUST NOT be treated as an error to undo. Separately, the extension's *own* autonomous finish (a watcher or hook observing that the work is done) SHALL stop at "implementation finished" and leave the final closing act to the sanctioned completion path. The distinction is who decided: a pipeline that ran to its terminal step decided; a watcher that merely noticed the tasks are all checked did not.
+
+#### Scenario: a Companion run reaches its terminal step
+- **WHEN** the pipeline's last step executes
+- **THEN** the spec is recorded as complete
+- **AND** nothing later reverts it
+
+#### Scenario: a watcher sees every task checked
+- **WHEN** it settles the spec
+- **THEN** it records the implementation as finished
+- **AND** it does not itself declare the spec closed
+
+### The implementation step settles from a signal that fires in every mode
+
+The implementation step is the one step with no successor to close it, and the host gets no completion callback from any dispatch surface. Its settle MUST therefore hang off the one always-on, mode-agnostic signal — the task list's own file changing — rather than off a terminal handle or a workflow hook that only some modes have. The settle SHALL be guarded so it fires exactly once and only when warranted.
+
+#### Scenario: implementation runs through a chat surface with no terminal
+- **WHEN** the last task is checked off
+- **THEN** the step still settles
+- **AND** the spec does not sit stranded mid-implementation forever
+
+#### Scenario: a spec parked before implementation has a fully-checked task list
+- **WHEN** the watcher fires
+- **THEN** nothing settles, because implementation was never underway
+- **AND** the spec keeps its parked position
+
+#### Scenario: the task list is re-saved after the step already closed
+- **WHEN** the watcher fires again
+- **THEN** no second closing event is recorded
+
+### Recording state never blocks the user's work
+
+Every lifecycle write SHALL be best-effort with respect to the user's action: a failure is logged where a maintainer can find it and then swallowed, so a dispatch, a click, or a tree refresh is never aborted because the record could not be updated. Losing one entry costs fidelity; failing the action costs the user their work.
+
+#### Scenario: the state file is locked by another process during a dispatch
+- **WHEN** the step-start write fails
+- **THEN** the failure is logged
+- **AND** the command still dispatches
+
+### A corrupt state record is preserved and replaced, never overwritten
+
+Because the writer refuses to overwrite an unparseable record, recovery MUST move the broken bytes aside to a non-colliding backup before writing a fresh minimal record in its place. The user keeps the original for manual salvage and gets a working spec back in one action.
+
+#### Scenario: the record is truncated to invalid JSON
+- **WHEN** recovery runs
+- **THEN** the broken file is renamed to a timestamped backup beside it
+- **AND** a fresh minimal record takes its place
+- **AND** a second recovery in the same second does not clobber the first backup
+
+### Commands that need the companion piece are gated by family, not by list
+
+Any command belonging to the Companion namespace SHALL be recognized by its shared prefix rather than by an enumerated set, so a newly added member can never slip past the gate. When the companion piece is absent, such a command MUST either downgrade to its stock equivalent or — if it has none — be suppressed entirely with a non-blocking explanation. It MUST NEVER be dispatched in a form the AI cannot resolve.
+
+#### Scenario: a Companion step runs without the companion piece installed
+- **WHEN** the step has a stock equivalent
+- **THEN** the stock command runs instead
+- **AND** the user is warned without being blocked, and offered the install
+
+#### Scenario: a Companion-only action runs without the companion piece
+- **WHEN** it has no stock equivalent
+- **THEN** nothing is dispatched at all
+- **AND** the user is told why
+
+### Reading a record is tolerant; writing one is strict
+
+The reader SHALL accept records written by older versions, by other tools, and by an AI that got a field's shape slightly wrong — normalizing legacy field names, superseded status vocabulary, and loosely-typed values into the canonical shape in memory. Unknown top-level fields MUST survive a read/write round-trip, because another writer may own them. A genuinely absent record and a record that could not be read MUST be distinguishable to the caller, so a transient read failure is never mistaken for "no record here."
+
+#### Scenario: a record uses a retired field name for its log
+- **WHEN** it is read
+- **THEN** it presents in the canonical shape
+- **AND** the next write migrates it on disk without losing entries
+
+#### Scenario: a field the extension does not know about is present
+- **WHEN** the extension updates the record
+- **THEN** that field is still there afterwards
+
+### The specs tree presents recorded state, and its view controls are per-workspace and idempotent
+
+The tree SHALL group specs by their recorded status, and offer filtering and ordering over that set. View state (the active filter, the chosen order, expansion) persists per workspace. Any command whose *name* asserts an end state MUST enforce that state unconditionally rather than toggling — a command called "collapse all" must never expand.
+
+#### Scenario: a spec finishes while the tree is open
+- **WHEN** its record changes on disk
+- **THEN** a debounced refresh moves it to the matching group
+
+#### Scenario: "collapse all" is invoked on an already-collapsed tree
+- **WHEN** the command runs
+- **THEN** the tree stays collapsed
+
+### A workflow that records nothing still shows progress
+
+Workflows the user defines themselves run commands that write documents but never touch the state record, which would strand them at their first step forever. For those workflows only, progression SHALL be reconstructed from the one signal they do leave — their step outputs on disk — and only ever *forward* of what the record already says. Workflows that do record their own progress MUST be left entirely alone.
+
+#### Scenario: a user's workflow has produced its third step's output
+- **WHEN** the record still says step one
+- **THEN** a reconstructed progression advances it to the third step so the forward action appears
+- **AND** the built-in pipelines are untouched by this path
+
+#### Scenario: the record is already at or ahead of what disk shows
+- **WHEN** reconstruction runs
+- **THEN** the real record wins and nothing is rewritten
+
+### Destructive and bulk spec actions confirm, skip no-ops, and stay inside the workspace
+
+Deleting a spec or changing many specs' status at once SHALL confirm first, then apply only to targets the action would actually change. Any path that turns a stored or user-supplied relative path into a file operation MUST resolve it against the workspace root and confirm the target exists before acting, surfacing a visible error rather than failing silently.
+
+#### Scenario: archiving a group where some specs are already archived
+- **WHEN** the bulk action runs
+- **THEN** only the not-yet-archived specs are touched
+- **AND** the reported count reflects what actually changed
+
+#### Scenario: revealing a spec folder that has been deleted outside the editor
+- **WHEN** the reveal action runs
+- **THEN** the user gets an explicit "does not exist" error instead of a silent no-op
+
+### Living-spec listings are read-only, bounded, and honest about what they could not compute
+
+The living-specs listing SHALL read the project's capability configuration without executing any project tooling, resolving each capability's document path and confining every resolved path to the workspace. [inferred] — how the listing is *presented* as tree rows is taken from the model and command surfaces; the view provider itself was not read. Derived health — coverage counts, drift — MUST be reported as *absent* when it cannot be computed, never as zero or false: a missing count and a genuine zero mean opposite things to a reader. Any external call it makes to compute health MUST be time-bounded.
+
+#### Scenario: a capability's document has never been committed
+- **WHEN** drift is computed
+- **THEN** drift is reported as unknown rather than as "no drift"
+
+#### Scenario: a configured document path points outside the workspace
+- **WHEN** the listing resolves it
+- **THEN** the entry is dropped rather than read
+
+## Uncovered
+
+- `specExplorerProvider.ts` — read in part (public surface, grouping, filtering, and the status/context-value derivation). The middle of the file, covering per-item tree construction, icons, and related-document display naming, was skimmed rather than read line by line.
+- `specCommands.ts` — read in part (registration surface, lifecycle/bulk commands, phase dispatch, custom-command runner). The trailing helper section was not read line by line.
+- `livingSpecsExplorerProvider.ts` — not read; its contract is inferred here from `livingSpecsModel.ts` and `livingSpecsCommands.ts`.
+- All files under `__tests__/` were listed but not read.

--- a/src/features/steering/steering.spec.md
+++ b/src/features/steering/steering.spec.md
@@ -1,6 +1,6 @@
 # Steering — Living Spec
 
-> [DRAFT] Surface-first draft from existing code — every requirement is observed from the code surface unless tagged otherwise. Review before trusting.
+> Adopted from existing code on 2026-07-19. Requirements describe observed behavior and have not been individually verified against tests.
 
 ## Purpose
 

--- a/src/features/steering/steering.spec.md
+++ b/src/features/steering/steering.spec.md
@@ -1,0 +1,122 @@
+# Steering — Living Spec
+
+> [DRAFT] Surface-first draft from existing code — every requirement is observed from the code surface unless tagged otherwise. Review before trusting.
+
+## Purpose
+
+Steering is the extension's window onto the persistent guidance an AI assistant reads before it does anything: the provider's rules files, its agents and skills, the SpecKit project scaffolding, the Companion extension's configuration and commands, and the reference folders a custom workflow consults. Without it those files stay invisible — scattered across the workspace and the user's home directory, under names that differ per provider — so users can't tell what context their assistant actually has, and can't correct it.
+
+## Requirements
+
+### Steering is a window over files on disk, never a second source of truth
+
+The view SHALL render only what exists on disk at read time and SHALL NOT cache guidance content in its own store. Every row either opens a real file or offers the action that creates one, so what the user sees is what the assistant reads.
+
+#### Scenario: a guidance file is edited outside the extension
+- **WHEN** a rules file, agent, skill, or the Companion configuration changes on disk
+- **THEN** the next render reflects the new content
+- **AND** no extension-owned copy of that content survives to disagree with it
+
+#### Scenario: a row's file was deleted
+- **WHEN** the file backing a row no longer exists
+- **THEN** the row is omitted rather than offering a click that fails
+
+### The tree names the configured provider's own files, never a hard-coded vendor filename
+
+Every file-name label, create-action title, and scope path SHALL be resolved from the active provider's path configuration. Guidance filenames differ per provider, so a hard-coded name would tell the user to create a file their assistant will never read.
+
+#### Scenario: a non-default provider is configured and its project rule file is missing
+- **WHEN** the project scope has no rules file for the configured provider
+- **THEN** the create action appears inside that scope's group
+- **AND** its title names the provider's real filename
+
+### Sections appear only when they hold content, except the two stable entry points
+
+The root SHALL omit any section with nothing in it, and SHALL always show the Companion and provider nodes so those two remain findable. An always-visible empty section trains users to ignore the view; a disappearing entry point makes install and configuration undiscoverable.
+
+#### Scenario: a workspace with no SpecKit scaffolding
+- **WHEN** the project has no constitution, scripts, or templates
+- **THEN** the SpecKit project-files section is absent entirely
+- **AND** the Companion and provider nodes are still present
+
+### A provider's label and its mark resolve from one decision
+
+The row's display name and its icon SHALL derive from the same provider resolution, and an unrecognized provider or host SHALL fall back to a neutral glyph. Two independent lookups would drift, and a fallback that lands on a specific vendor's mark ships that vendor's branding for a product that isn't theirs.
+
+#### Scenario: the host editor is not one the extension recognizes
+- **WHEN** the in-editor chat provider is active in an unknown host
+- **THEN** the row shows the neutral chat glyph
+- **AND** never another vendor's logo
+
+#### Scenario: a provider ships no official mark
+- **WHEN** that provider is configured
+- **THEN** the neutral glyph is chosen deliberately rather than reached by falling through the lookup
+
+### The Companion node reports install state and reads the installed extension live
+
+The node SHALL distinguish "installed" from "not installed" from the extension's on-disk presence, offer the install action when absent, and when present derive its configuration groups, command list, and preset templates by reading the installed manifest and configuration rather than a list compiled into this extension. A compiled-in list goes stale the moment the Companion ships a new command.
+
+#### Scenario: the Companion adds a command in a later release
+- **WHEN** the installed manifest lists a command this extension has never heard of
+- **THEN** it appears under the Companion node with its own description
+- **AND** clicking it opens that command's body file
+
+#### Scenario: the Companion is installed while the view is open
+- **WHEN** the install completes
+- **THEN** the node switches to its installed presentation and populates its children with no window reload
+
+### Every path the tree opens is confined to the root that owns it
+
+A path assembled from user- or manifest-supplied text SHALL be rejected unless it resolves inside its owning root — the workspace for configuration and reference sources, the installed extension directory for command bodies and templates. Manifests and settings are editable text, so a relative escape must not turn a tree click into an arbitrary-file open.
+
+#### Scenario: a manifest points a command body outside the extension directory
+- **WHEN** the declared path traverses out of the extension root
+- **THEN** the row renders without an open action rather than opening the escaped path
+
+#### Scenario: a workflow declares a reference folder outside the workspace
+- **WHEN** the declared path resolves outside the workspace root
+- **THEN** that source is skipped and no reference row is created for it
+
+### The tree refreshes itself when the files behind it change
+
+The view SHALL watch the directories and files it renders — the provider's agent and skill locations at both scopes, the Companion configuration, and the Companion install marker — and re-render on create, change, or delete. Requiring a manual refresh means the view is routinely wrong about the assistant's context.
+
+#### Scenario: a skill is added in the user scope
+- **WHEN** the skill's definition file appears on disk
+- **THEN** the tree re-renders and the skill is listed without a manual refresh
+
+### Only the steering documents the extension generates are destructive-actionable
+
+Refine and delete SHALL be offered exclusively on generated steering documents. Provider-owned and SpecKit-owned files SHALL be openable and revealable but never deletable from this view, because deleting them breaks the user's assistant setup or their SpecKit project, and the extension did not create them.
+
+#### Scenario: right-clicking a SpecKit-owned file
+- **WHEN** the user opens the context menu on the constitution, a script, or a template
+- **THEN** reveal and open are offered
+- **AND** no delete or refine action is present
+
+### Authoring and refining steering documents is delegated to the AI provider
+
+Creating, initializing, refining, and cleaning up after deleting a steering document SHALL be expressed as a prompt dispatched to the configured provider, not as extension-side templating. The value of a steering document is that it reflects this project; a canned template cannot.
+
+#### Scenario: the user asks for a new steering document
+- **WHEN** they describe the guidance they need
+- **THEN** the destination directory is created and a prompt describing the task is dispatched to the provider
+- **AND** the extension does not write document content itself
+
+#### Scenario: a generated steering document is deleted
+- **WHEN** the deletion succeeds
+- **THEN** a follow-up prompt asks the assistant to drop references to it from the project rules file
+- **AND** a failure of that follow-up is surfaced without leaving the deletion half-reported
+
+### Unreadable or malformed configuration degrades to an empty section
+
+Any parse or read failure while assembling a section SHALL yield an empty result for that section rather than an error dialog or a failed render. The steering view is ambient context, so one broken YAML file must not take the tree down.
+
+#### Scenario: the Companion configuration file is not valid YAML
+- **WHEN** the configuration group list is requested
+- **THEN** no group entries are produced
+- **AND** the rest of the tree renders normally
+
+## Uncovered
+
+_None — every file in the area was read._

--- a/src/speckit/speckit-cli.spec.md
+++ b/src/speckit/speckit-cli.spec.md
@@ -1,0 +1,124 @@
+# Speckit CLI — Living Spec
+
+> [DRAFT] Surface-first draft from existing code — every requirement is observed from the code surface unless tagged otherwise. Review before trusting.
+
+## Purpose
+
+This capability is the extension's relationship with an external tool it does not own: the SpecKit CLI and its companion CLI extension. It exists so the editor can detect, install, upgrade, and stay out of the way of that CLI — and so a missing, outdated, or failing CLI degrades the experience instead of breaking the editor.
+
+## Requirements
+
+### A missing or broken CLI degrades the extension, never the host
+
+Every interaction with the external CLI SHALL be treated as optional. Detection MUST resolve to a plain answer rather than an error, and a CLI that is absent, on an old build, or failing MUST leave the extension activated and usable. Nothing here may throw into activation.
+
+#### Scenario: the CLI is not installed
+- **WHEN** detection runs on a machine without it
+- **THEN** the extension reports "not installed", records that in a context key, and continues activating
+- **AND** the affordances that depend on the CLI surface an install route instead of failing
+
+#### Scenario: the CLI exists but does not answer the probe
+- **WHEN** the primary detection probe errors
+- **THEN** a second, differently-shaped probe is attempted before concluding it is absent
+
+### Detection distinguishes "the tool exists" from "this project uses it"
+
+Whether the CLI is installed on the machine and whether the open workspace has been scaffolded by it SHALL be separate answers, checked separately and exposed separately. A third check — whether the project's constitution still holds placeholder text — SHALL only run once the workspace is known to be initialized.
+
+#### Scenario: an initialized workspace on a machine without the CLI
+- **WHEN** detection runs
+- **THEN** the workspace reports as initialized while the CLI reports as absent
+- **AND** the two drive different affordances
+
+#### Scenario: the workspace was scaffolded for a chat-based assistant
+- **WHEN** the canonical scaffolding directory is absent
+- **THEN** initialization is still detected from the per-assistant command files the CLI emits
+
+### The extension drives the CLI through a visible terminal, never silently
+
+Install, initialize, and upgrade actions SHALL run as commands in a terminal the user can see, because they are long-running, may prompt, and may fail in ways only their own output explains. The extension MUST NOT claim these succeeded — after dispatching it tells the user what is happening and offers to reload once they judge it complete.
+
+#### Scenario: the user triggers an upgrade
+- **WHEN** the action runs
+- **THEN** a named terminal opens showing the command and its output
+- **AND** the extension offers a reload rather than asserting the upgrade finished
+
+#### Scenario: a workspace path contains shell metacharacters
+- **WHEN** a command must run in the workspace directory
+- **THEN** the directory is supplied as structured terminal configuration rather than interpolated into the command text
+
+### Re-scaffolding targets the assistant the user actually configured
+
+When the extension asks the CLI to regenerate a project's scaffolding, the assistant identifier it passes SHALL be derived from the configured provider — and, for the chat-routing provider, from the detected host editor. The resolution MUST be explicit for every supported provider: each one the product ships SHALL have its own entry, so the identifier passed matches the assistant the user actually chose. The resolution MUST also be total — a value the product does not recognize at all resolves to a safe default rather than passing through an identifier the CLI would reject. The default exists only for genuinely unknown values; a supported provider that falls through to it is a defect, not a fallback, because the workspace is then scaffolded for the wrong assistant. No dispatch site may hardcode an identifier.
+
+#### Scenario: the workspace is upgraded under a chat-routing provider
+- **WHEN** the upgrade command is built
+- **THEN** the identifier is chosen from the detected host editor
+- **AND** an unrecognized host falls back to a known-valid identifier
+
+#### Scenario: a supported provider has no entry of its own
+- **WHEN** the identifier is resolved for it
+- **THEN** reaching the default is a defect rather than acceptable behavior
+- **AND** the provider must be given its own explicit entry
+
+### The companion CLI extension has exactly one install path and one target
+
+The companion spec-kit extension is a CLI extension, not an editor extension, so it SHALL be installed only by running the CLI's own extension-add command. Its install target MUST live in a single place so a release changes nothing here, and the command MUST NOT carry flags the CLI does not accept. Install is already an install-or-update, so re-running it MUST be safe.
+
+#### Scenario: the user installs from any surface
+- **WHEN** the install action runs from a banner, the sidebar, or the upgrade menu
+- **THEN** the same command is built from the same shared definition
+
+#### Scenario: the user is on a CLI build without the extension subcommand
+- **WHEN** the install runs
+- **THEN** the prerequisite is printed — not executed — before the install command, so the resulting failure is self-explanatory
+
+### The install nudge is gated on presence, not on opt-in
+
+The prompt to install the companion CLI extension SHALL be shown when the prompt preference is on **and** the extension is absent. It MUST NOT be gated behind any workflow opt-in, since the audience that has not opted in is exactly the one that needs the discovery. An explicit opt-out MUST suppress it entirely, with no residual warning.
+
+#### Scenario: the extension is already installed
+- **WHEN** the gate is evaluated
+- **THEN** no prompt is shown regardless of the preference
+
+#### Scenario: the user has opted out
+- **WHEN** the gate is evaluated with the extension absent
+- **THEN** nothing is shown — no banner and no fallback warning
+
+### Two products share one release list and must never be confused
+
+This repository publishes two independently-versioned products into a single releases list. Any release lookup SHALL filter to the tag shape belonging to the product being asked about, and MUST reject drafts and prereleases. A lookup that resolves "the latest release" across both namespaces is a defect shape that has shipped before and MUST NOT be reintroduced anywhere — including links opened for the user.
+
+#### Scenario: an update check runs
+- **WHEN** releases are enumerated
+- **THEN** only tags matching the editor extension's own shape are considered, and the highest version among them wins
+- **AND** the other product's releases, drafts, and prereleases are ignored
+
+### Update checks are throttled, skippable, and never noisy on failure
+
+The update check SHALL run at most once per interval unless explicitly forced, SHALL respect a version the user chose to skip, and SHALL fail silently to the log when the network or the API is unavailable.
+
+#### Scenario: the user skips a version
+- **WHEN** that version is later seen again
+- **THEN** no notification is shown
+- **AND** a newer version than the skipped one still notifies
+
+#### Scenario: the releases API is unreachable
+- **WHEN** the check runs
+- **THEN** the failure is logged and no user-facing error appears
+
+### Task progress is derived from the task document and only reported on transitions
+
+Phase completion SHALL be computed by parsing the task document into phases and counting only genuine task checkboxes — items inside code blocks are documentation, not work. A notification MUST fire only when a phase newly becomes complete relative to the last observed state, and the cache MUST be seeded on first sight of a file so opening an already-finished project announces nothing.
+
+#### Scenario: an already-complete task file is opened
+- **WHEN** its state is first observed
+- **THEN** the cache is seeded and no completion is announced
+
+#### Scenario: the final task of a phase is checked
+- **WHEN** the file changes
+- **THEN** that phase alone is reported as newly complete, and re-saving the file reports nothing further
+
+## Uncovered
+
+_None — every file in the area was read._

--- a/src/speckit/speckit-cli.spec.md
+++ b/src/speckit/speckit-cli.spec.md
@@ -1,6 +1,6 @@
 # Speckit CLI — Living Spec
 
-> [DRAFT] Surface-first draft from existing code — every requirement is observed from the code surface unless tagged otherwise. Review before trusting.
+> Adopted from existing code on 2026-07-19. Requirements describe observed behavior and have not been individually verified against tests.
 
 ## Purpose
 

--- a/webview/src/spec-editor/editor-ui.spec.md
+++ b/webview/src/spec-editor/editor-ui.spec.md
@@ -1,0 +1,114 @@
+# Editor UI — Living Spec
+
+> [DRAFT] Surface-first draft from existing code — every requirement is observed from the code surface unless tagged otherwise. Review before trusting.
+
+## Purpose
+
+The browser-side half of the Create Spec panel: it is the first thing a user touches in the spec pipeline, so it has to take a free-form description (plus pasted images and a workflow choice), keep that draft safe while the panel is hidden or the window is reloaded, and hand a well-formed submission to the extension. Without it there is no in-editor entry point to the pipeline — a user would have to type slash commands into a terminal and would lose an in-progress description any time the panel lost focus.
+
+## Requirements
+
+### A typed message channel is the editor's only way to affect anything
+
+The editor UI SHALL cause no side effect outside its own document. Every outcome a user asks for — creating a spec, running a workflow command, attaching or removing an image, cancelling, opening docs — MUST be expressed as a message on the webview→extension channel, and every change to the editor's own contents MUST arrive as a message back. The webview has no filesystem, no workspace, and no credentials; keeping the boundary total is what lets the extension remain the single place where authority and validation live.
+
+#### Scenario: the user asks for something with an effect
+- **WHEN** any control in the editor is activated
+- **THEN** the editor posts a message describing the intent and performs no privileged work itself
+- **AND** it waits for the extension's reply rather than optimistically assuming success
+
+#### Scenario: an attachment is accepted
+- **WHEN** the extension confirms an image was stored
+- **THEN** the editor learns the attachment's identity and preview location from that reply
+- **AND** it never constructs those itself from the local file
+
+### One gate decides whether the description can be submitted
+
+Submittability MUST be computed by a single pure predicate — non-empty after trimming, within the length limit — and every path that can start a submission MUST consult it. Keyboard shortcut, primary button, hands-off button, and workflow command buttons are entry points to the same decision, not four independent opinions. The predicate lives outside the DOM so it can be tested without a webview harness.
+
+#### Scenario: description is only whitespace
+- **WHEN** the user has typed nothing but spaces or newlines
+- **THEN** every submission affordance is disabled
+- **AND** the keyboard shortcut is inert rather than silently submitting an empty spec
+
+#### Scenario: description exceeds the length limit
+- **WHEN** the content passes the maximum
+- **THEN** submission is refused on every path
+- **AND** the counter tells the user how many characters must be removed, not merely that they are over
+
+#### Scenario: the description is short
+- **WHEN** the content is well under the limit
+- **THEN** the character counter is not visible as clutter, but remains reachable to assistive technology rather than removed from the accessibility tree
+
+### Typed work is never lost without the user choosing to lose it
+
+Typed content and cursor position MUST be persisted to webview state as the user types, debounced so persistence never competes with typing, and restored when the panel is revived. The panel can be hidden, backgrounded, or reloaded by VS Code at any time; losing a half-written feature description to that is the single most expensive failure this surface can have. Discarding MUST likewise be deliberate: cancelling with content present requires confirmation, on the keyboard path as much as the button path, because the keyboard path is the one a user reaches by reflex.
+
+#### Scenario: the panel is hidden and reopened
+- **WHEN** the user switches away and returns
+- **THEN** the description and the caret position are as they were
+- **AND** the character counter reflects the restored content immediately
+
+#### Scenario: attachments outlive the same interruption
+- **WHEN** the panel is restored with images already attached
+- **THEN** the extension re-supplies the attachment list and the previews reappear
+
+#### Scenario: cancel with content present
+- **WHEN** the user cancels while the description is non-empty
+- **THEN** they are asked to confirm the discard
+- **AND** declining leaves the draft untouched
+
+#### Scenario: cancel with an empty editor
+- **WHEN** there is nothing typed
+- **THEN** the panel closes without a prompt
+
+### Attachments are screened before they leave the webview
+
+The editor MUST reject unsupported image formats and oversized files locally, with a message naming the actual problem, rather than forwarding them and letting the extension fail. Pasting an image and picking one from the file dialog MUST behave identically. This is a responsiveness guarantee, not a security one — the extension is still required to re-validate, since the webview's checks are advisory.
+
+#### Scenario: an unsupported file is pasted
+- **WHEN** the clipboard carries a non-image or an unsupported image type
+- **THEN** the editor reports what was wrong and sends nothing
+
+#### Scenario: an attachment's name carries markup
+- **WHEN** a filename contains quotes or angle brackets
+- **THEN** the preview, its label, and its remove control are constructed through DOM APIs so the name can never escape into markup or an attribute
+
+### The chosen workflow determines which submission affordances exist
+
+Submission affordances MUST be derived from the selected workflow's own declaration rather than hard-coded. A workflow that declares a hands-off orchestrator gets the hands-off affordance; a workflow that declares named entry commands gets a button per command; a workspace with only one workflow hides the chooser entirely instead of showing a one-item control. Adding a workflow must not require editing this surface.
+
+#### Scenario: the selected workflow has no hands-off mode
+- **WHEN** the user picks such a workflow
+- **THEN** the hands-off affordance is not offered
+- **AND** the ordinary create path stays available
+
+#### Scenario: only one workflow is configured
+- **WHEN** the workspace offers no alternative
+- **THEN** the chooser is hidden and that workflow's affordances are applied directly
+
+### A submission in flight locks the surface and announces itself
+
+While the extension is working, the editor MUST prevent a second submission from any path, mark the content region busy for assistive technology, and announce the state change in a live region. Announcements MUST also cover attachment add/remove, since those are otherwise silent visual-only changes. Busy state belongs on the content region — not on the transient overlay that appears during the wait.
+
+#### Scenario: the user double-submits
+- **WHEN** a submission is already running and the user presses the shortcut again
+- **THEN** nothing further is sent
+
+#### Scenario: submission fails
+- **WHEN** the extension reports an error
+- **THEN** the busy state is released, the message is shown as escaped text, and focus moves to the control that dismisses it
+
+### The Storybook mock stays a faithful stand-in for the real form
+
+Because the shipped editor is imperative DOM rather than a component tree, a separate Preact mock exists purely as the visual baseline. That mock MUST reflect the real form's states — empty, over-limit, submitting, and hands-off-available-or-not — so a reviewer reading Storybook is not shown an arrangement the product never produces. When the real form gains or loses a state, updating the mock is part of that change, not a follow-up. [inferred]
+
+This duplication is accepted for now and its cost is recorded plainly: the mock is hand-maintained, nothing enforces that it matches, and a stale mock misrepresents the product to every reviewer who trusts it.
+
+#### Scenario: a submission state is added or changed
+- **WHEN** the real form gains a new visual state
+- **THEN** the mock gains a matching story in the same change
+
+## Uncovered
+
+_None — every file in the area was read._

--- a/webview/src/spec-editor/editor-ui.spec.md
+++ b/webview/src/spec-editor/editor-ui.spec.md
@@ -1,6 +1,6 @@
 # Editor UI — Living Spec
 
-> [DRAFT] Surface-first draft from existing code — every requirement is observed from the code surface unless tagged otherwise. Review before trusting.
+> Adopted from existing code on 2026-07-19. Requirements describe observed behavior and have not been individually verified against tests.
 
 ## Purpose
 

--- a/webview/src/spec-viewer/viewer-ui.spec.md
+++ b/webview/src/spec-viewer/viewer-ui.spec.md
@@ -1,0 +1,224 @@
+# Viewer UI — Living Spec
+
+> [DRAFT] Surface-first draft from existing code — every requirement is observed from the code surface unless tagged otherwise. Review before trusting.
+
+## Purpose
+
+This is the reading surface itself: it turns a spec's markdown into a document a person can actually read and annotate, and reflects the run's state back at them without ever deciding what that state is. Without it the extension would have accurate state and nothing to show it on; with it drifting from the extension's state, the reader would be shown a spec that does not exist.
+
+## Requirements
+
+### The viewer is one page whose content is swapped, never reloaded
+
+The webview MUST behave as a single long-lived page. Navigation between documents, and between the overview and the documents, SHALL swap content in place and leave the shell's in-memory state — the reader's current view, mounted comments, scroll memory — intact. Any new navigation path must preserve this: a path that causes the host to regenerate the page loses that state and bounces the reader back to whatever the landing rule picks.
+
+#### Scenario: a document is picked while the overview is showing
+- **WHEN** the reader selects a pipeline document from the rail
+- **THEN** the document renders and the overview is hidden
+- **AND** the reader is not snapped back to the overview
+
+#### Scenario: the reader switches back to the overview
+- **WHEN** the overview is re-selected
+- **THEN** it appears immediately because the document pane was hidden rather than unmounted
+
+### The webview never decides the run's state — it renders the state it is given
+
+Status, which step is running, which actions exist, and their labels MUST come from the state the extension sends. The webview SHALL NOT re-derive any of them from documents, file presence, or progress numbers. Its own local derivations are limited to presentation: which of the given facts to show, in what order, and how to word them.
+
+#### Scenario: an action set arrives
+- **WHEN** the extension sends the catalog of available actions
+- **THEN** exactly those actions render, in their declared zones, with their declared scope surfaced in the tooltip
+- **AND** no action is invented, suppressed, or relabelled on the basis of anything the webview computed itself
+
+#### Scenario: a step is reported in flight
+- **WHEN** the state says the current step is running
+- **THEN** the forward-motion action is withheld until the step settles
+- **AND** the re-run and closure actions remain available
+
+### A state message replaces the snapshot, it never merges into it
+
+Each state message MUST be treated as complete and applied wholesale. The webview SHALL NOT merge an incoming message onto the snapshot it already holds, and MUST tolerate a state message arriving before any content message. Merging is what allows a fresh field to sit beside a stale one and produce a combination the real spec was never in.
+
+#### Scenario: a state update arrives before the first content
+- **WHEN** a state message is the first thing the webview receives
+- **THEN** it renders from that state alone
+- **AND** nothing waits for a content message that may not come
+
+### One derivation decides whether a step is running
+
+"Is this step in flight?" MUST be answered in exactly one place, and every surface that shows motion — the step's spinner, its live progress label, its elapsed timer, and the footer's forward-motion gate — MUST read that one answer. A settled spec-level status SHALL stop every one of them, even when a step's own completion record never landed. Progress numbers are labels, not run signals: a percentage below complete MUST NOT on its own be read as evidence that anything is running.
+
+#### Scenario: a spec settles with a step's completion unrecorded
+- **WHEN** the status names a settled state
+- **THEN** no step spins and no elapsed timer runs
+- **AND** the forward action reappears
+
+#### Scenario: a status value that names no step
+- **WHEN** the status gives no guidance
+- **THEN** the answer falls back to local signals — a recorded completion settles the step, an active-step match runs it
+- **AND** the step that produces no document of its own is read as running only while the workflow sits on it with work outstanding
+
+### Status values from the record are untrusted keys
+
+Any value that originated in the spec's record or in user configuration — a status, a step name, a document type — MUST NOT be used as a key into a plain object literal for lookups, because inherited properties resolve as truthy hits and an arbitrary value then reads as a legitimate one. Such lookups SHALL use a prototype-free structure.
+
+#### Scenario: a record carries an unexpected status
+- **WHEN** a status value that matches an inherited property name is looked up
+- **THEN** the lookup misses
+- **AND** the surface falls back to its neutral default rather than rendering an inherited value
+
+### Rendered markdown is a commentable document, not just formatted text
+
+The rendering pipeline MUST emit each source line as an addressable, hoverable unit carrying its own line number and an affordance to attach a comment, so annotation works anywhere in the document without a separate mode. Authoring scaffolding that belongs to the generator rather than the reader — front matter, notation legends, metadata already shown in the header — SHALL be stripped rather than rendered. Structured passages the specs use repeatedly (user stories, phased task lists, requirement blocks, acceptance scenarios, callouts) SHOULD be recognised and rendered as their own components rather than as generic prose, and those components stay commentable too.
+
+#### Scenario: a document written with foreign line endings
+- **WHEN** the source uses carriage returns
+- **THEN** line endings are normalised before any block-level parsing
+- **AND** the document renders as structure, not as one long paragraph
+
+#### Scenario: the header already shows the spec's metadata
+- **WHEN** the state carries the spec's identity
+- **THEN** the document's own metadata block is stripped from the rendered body
+- **AND** the reader does not see the same facts twice
+
+### User text must never reach an HTML attribute unescaped
+
+Markup that carries content from the document — a link target, an image description, a file reference, a title — MUST be built so the value cannot terminate the attribute it sits in. The escaping used for element *content* does not escape attribute quotes and is not sufficient here; such markup SHALL be assembled with DOM APIs, or escaped with an attribute-safe routine. The content policy is not a substitute for this and MUST NOT be relied on as one.
+
+A destination taken from the document — a link target, an image source — MUST additionally be restricted to schemes that are safe to navigate to or load. A destination carrying a script-executing scheme SHALL NOT render as an active link or a loading image; it is rendered as inert text instead.
+
+#### Scenario: a document contains a quote inside a file reference
+- **WHEN** the value is placed into an attribute
+- **THEN** the quote cannot close the attribute
+- **AND** no additional attribute or handler can be introduced from document text
+
+#### Scenario: a link points at a script-executing destination
+- **WHEN** the document supplies a `javascript:` target
+- **THEN** it is not rendered as an activatable link
+- **AND** nothing the reader can click executes it
+
+### Comments survive re-render by re-anchoring, and the card speaks for where it sits
+
+Persisted comments MUST be restored inline on every render and after every state change, and restoration MUST be idempotent so repeated calls do not duplicate cards. Anchoring is best-effort and follows a fixed precedence — the stored line when its content still matches, else any line matching the stored text, else the first line under the stored heading, else the stored line if it still exists. A comment that matches nothing stays available in the consolidated list rather than being dropped. A restored card MUST describe the line it actually mounted onto; the stored anchor is the *input* to re-anchoring, never its output.
+
+#### Scenario: the document drifts by a line
+- **WHEN** a comment's stored line no longer matches but its text is found elsewhere
+- **THEN** the card mounts on the line where the text now lives
+- **AND** the card reports that line, not the stored one
+
+#### Scenario: a document switch replaces the rendered body
+- **WHEN** new content renders
+- **THEN** stale mounts are cleared before comments are re-anchored
+- **AND** no comment is left pointing at a removed element
+
+### A teardown must unmount what it marked, not re-find it
+
+Anything that marks an element on open — an editor, a comment container — MUST remember the element it marked and act on that reference when closing. Re-deriving the target on teardown by walking the DOM fails whenever the mount is not an ancestor-reachable relative of the trigger, and leaves the element stuck in its opened state forever.
+
+#### Scenario: an editor opened next to a table row is closed
+- **WHEN** the editor's container was inserted as a sibling rather than a descendant
+- **THEN** the close path still finds and unmounts it
+- **AND** the row loses its editing mark
+
+### Comment mutations are posted to the extension, which owns the record
+
+Adding, editing, or removing a comment MUST post the change to the extension rather than write anything itself; the local card is a rendering of the record, not the record. An edit that changes nothing, or that resolves to no target, SHALL be a no-op rather than a posted mutation. Dispatching refinement for a document MUST clear the local cards and let the refreshed record re-render them, so what is shown after the round trip is what was actually persisted.
+
+#### Scenario: a comment is deleted
+- **WHEN** the reader deletes a card
+- **THEN** the removal is posted, the card unmounts, and focus returns to the line's own control
+- **AND** the pending count updates
+
+### A settled spec is readable but not annotatable
+
+Once a spec is completed or archived, its comments MUST still be visible — they are the record of what was asked — but every path that would create or change one SHALL be closed: the composer refuses to open, and mounted cards render without their action controls. This read-only decision SHALL follow the spec's live status, exactly as the footer's actions already do — it is re-evaluated when the status changes inside an open panel, never fixed at the moment the page was built.
+
+#### Scenario: a completed spec is opened
+- **WHEN** the reader hovers a line
+- **THEN** the composer does not open
+- **AND** existing comments remain visible without edit or delete controls
+
+#### Scenario: a spec settles while its panel is open
+- **WHEN** the status becomes completed during the session
+- **THEN** the annotation paths close in place
+- **AND** the reader does not have to reopen the panel for it to take effect
+
+### Overview and documents are one selection axis
+
+The overview MUST be a destination alongside the documents, not a mode layered over them, so selection can never get stuck between the two. Which one is shown on open is decided by the data — a spec carrying durable context lands on the overview, a spec with only a work log lands on its document — until the reader picks, after which their pick wins. The overview MUST mount lazily on first reveal so it never delays the first document render, and MUST NOT be offered at all for a spec with no recorded run or when the reader has turned it off.
+
+#### Scenario: a spec with only a work log
+- **WHEN** the viewer opens
+- **THEN** it lands on the document
+- **AND** the overview remains reachable from the rail
+
+#### Scenario: any rail item is selected
+- **WHEN** the reader picks a document
+- **THEN** the overview deselects
+- **AND** exactly one rail item reads as current
+
+### The overview degrades section by section, and a failure never blanks the page
+
+Every section of the overview MUST hide itself when its data is empty, so a spec that recorded little shows a short page rather than a page of empty headings. A render-time failure anywhere in the overview subtree MUST be caught, reported back to the extension for diagnosis, and replaced with an inline notice — one bad section may not take the reading surface down with it.
+
+#### Scenario: a section's data is absent
+- **WHEN** a spec recorded no decisions
+- **THEN** the decisions section does not render at all
+
+#### Scenario: a section throws while rendering
+- **WHEN** the overview subtree fails
+- **THEN** an inline notice replaces it, the error is reported to the extension, and the rest of the viewer keeps working
+
+### A living spec's title is authored, not derived
+
+A living spec's header MUST show the title as written in the document's own top-level heading and MUST NOT re-case it. Feature specs are named by directory slugs and are capitalised for display; a heading-derived title is a human's own words, and applying slug capitalisation to it silently mangles deliberate casing. The two cases are therefore distinguished explicitly rather than treated alike.
+
+#### Scenario: a capability whose name carries internal capitals
+- **WHEN** the title comes from the document's heading
+- **THEN** it renders exactly as authored
+- **AND** the slug capitalisation applied to feature-spec titles is switched off
+
+### Delegated click handling must survive non-element targets and late mounts
+
+Handlers that delegate from the document MUST confirm the event target is an element before walking up from it, since it can be neither. Delegation — rather than binding to an element at load — is also required for any control that mounts after the page's scripts run, because a direct binding would silently no-op against a control that does not exist yet.
+
+#### Scenario: a click lands on a non-element target
+- **WHEN** the delegated handler receives it
+- **THEN** it returns without throwing
+
+### Presentation must stay legible and announced
+
+Readable content MUST use the body and primary text tokens; the secondary and muted tokens fall below the accessibility contrast floor on dark themes and are reserved for genuine metadata. Anything a control points at for its accessible description MUST be visually hidden rather than removed from the accessibility tree. Truncation MUST carry its full set of rules or it silently wraps instead. Motion MUST have a still equivalent for readers who ask for reduced motion, and purely decorative glyphs MUST be hidden from assistive technology.
+
+#### Scenario: a status glyph accompanies a label
+- **WHEN** the glyph carries no information the label does not
+- **THEN** it is hidden from assistive technology
+- **AND** the label alone conveys the state
+
+#### Scenario: a reader has asked for reduced motion
+- **WHEN** a step is in flight
+- **THEN** the in-flight indicator renders without animation
+
+## Uncovered
+
+The following files were not read in full — their exported surface and role were established, but their bodies were not reviewed line by line:
+
+- `webview/src/spec-viewer/markdown/preprocessors.ts` (read partially; only the first ~60 lines and the export inventory)
+- `webview/src/spec-viewer/toc.ts`
+- `webview/src/spec-viewer/highlighting.ts`
+- `webview/src/spec-viewer/timelineEvents.ts`
+- `webview/src/spec-viewer/relativeTime.ts`
+- `webview/src/spec-viewer/activityHeroModel.ts`
+- `webview/src/spec-viewer/elapsedFormat.ts`
+- `webview/src/spec-viewer/types.ts`
+- `webview/src/spec-viewer/components/InlineEditor.tsx`
+- `webview/src/spec-viewer/components/TimelineEvent.tsx`
+- `webview/src/spec-viewer/components/cards/TasksCard.tsx`
+- `webview/src/spec-viewer/components/cards/FilesCard.tsx`
+- `webview/src/spec-viewer/components/cards/ConcernsCard.tsx`
+- `webview/src/spec-viewer/components/cards/CommentsCard.tsx`
+- `webview/src/spec-viewer/components/cards/LivingSpecsCard.tsx`
+- `webview/src/spec-viewer/components/cards/PhasesCard.tsx`
+- `webview/src/spec-viewer/components/cards/toStringArray.ts`
+- `webview/src/spec-viewer/components/index.ts`
+- All `*.stories.tsx` files and all files under `__tests__/`

--- a/webview/src/spec-viewer/viewer-ui.spec.md
+++ b/webview/src/spec-viewer/viewer-ui.spec.md
@@ -1,6 +1,6 @@
 # Viewer UI — Living Spec
 
-> [DRAFT] Surface-first draft from existing code — every requirement is observed from the code surface unless tagged otherwise. Review before trusting.
+> Adopted from existing code on 2026-07-19. Requirements describe observed behavior and have not been individually verified against tests.
 
 ## Purpose
 


### PR DESCRIPTION
## Summary

Turns living specs on for this repo. Fourteen capabilities now describe what each part of the codebase guarantees, and a registry tells the tooling where to find them. This is dogfooding — the same feature we ship, pointed at ourselves.

The specs were adopted from a read of the existing code. Their banner says so plainly: they describe observed behavior and have not been individually verified against tests.

## Technical

- `living-specs.yml` at the repo root: `enabled: true`, 14 capabilities. Ten colocated ones carry an explicit `spec:` path; four central ones default to `capabilities/<name>/spec.md`.
- Ten colocated `*.spec.md` next to the code they describe: `core`, `specs`, `spec-viewer`, `spec-editor`, `steering`, `ai-providers`, `speckit-cli`, `viewer-ui`, `editor-ui`, `capture-runtime`.
- Four central specs under `capabilities/`: `companion-commands`, `extension-services`, `webview-shared`, `workflows`.
- Each carries a `## Purpose` and named intent-level requirements with scenarios — invariants rather than prop lists.
- Registry lives in `living-specs.yml`, not the `livingSpecs` block in `companion.yml` (per #484).
- Second commit replaces the `[DRAFT]` banner with an adopted-from-code line. Only the viewer badge (`livingDocs.ts` `DRAFT_BANNER_LINE`) reads that banner; `drift.py`, `living_spec_fold.py`, and `check-coverage.py` never consulted it, so this is presentation only.

## Review checklist

- ✅ **Documentation / specs** — affected
    - 14 new spec documents
    - new root registry `living-specs.yml`
    - banner promoted from `[DRAFT]` to adopted-from-code
- — **VS Code extension** — no runtime code touched
- — **SpecKit extension** — no runtime code touched
- — **Changelog** — n/a
    - no user-facing behavior change; adds repo-local spec documents and their registry
- — **Docs** — no docs-map trigger matches
    - no settings, provider, sidebar, viewer, or capture changes
- ✅ **Verify**
    - `resolve-spec-paths.py --changed src/features/spec-viewer/index.ts --json` returns exactly one match: `spec-viewer`, `location: colocated`, `specificity: 24`
    - viewer draft-banner regex run over all 14 files — no match
    - `npx jest livingDocs` — 27 passed
    - no version bump in `package.json` or `extension.yml`
    - no runtime dependence added on `.claude/**` or `.specify/**`

## Gaps / how to see it

- The specs are first drafts from a surface read of the code. Requirements should be corrected as they prove wrong.
- Specific-beats-general capability precedence is **not** exercised by this layout — there is no broad `src/features/**` capability competing with `spec-viewer`. Untested, not passed.
- Try: open any file under `src/features/spec-viewer/` and check the Living Specs view resolves to `spec-viewer`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
