### PR TITLE
fix(viewer): make the Overview intent read as a summary, not a title

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ The spec viewer is built for fast scanning of long-form specs:
 
 A spec with recorded activity **lands on its Overview** — a **durable-context dossier** of everything `.spec-context.json` carries, ordered by what a future session needs. It sits at the top of the document rail as a destination like any other, so moving between it and a document is one click either way. The one-line **run strip** above the content keeps the frequently scanned facts (phase, tasks, requirements traced to tests, checks, concerns, honest active time, PR link) in view in both. A spec whose context holds only a work log opens on its documents instead:
 
-- **Intent** — why the spec exists, set as one prominent statement, with the approach, working area, and sizing beside it.
+- **Intent** — why the spec exists, set as a lead summary line beneath the header title, with the approach, working area, and sizing beside it.
 - **Expectations** — the fence around the work: constraints that must stay true paired with the deliberately out-of-scope list, as peers.
 - **Verified** — a ledger of what was checked: each check keeps its result and evidence command visually connected (warnings surface amber).
 - **Decisions** — numbered choices future work should not have to rediscover, each with its reasoning and the rejected alternative.

--- a/webview/src/spec-viewer/components/OverviewDossier.tsx
+++ b/webview/src/spec-viewer/components/OverviewDossier.tsx
@@ -43,8 +43,8 @@ export function IntentSection({ state }: { state: ViewerState }) {
 
     return (
         <section class="dossier-intent" aria-label="Intent">
-            <p class="dossier-kicker">Durable context · Intent</p>
-            {intent && <h2 class="dossier-intent__statement">{intent}</h2>}
+            <p class="dossier-kicker">Intent</p>
+            {intent && <p class="dossier-intent__statement">{intent}</p>}
             {(approach || area || classification) && (
                 <div class="dossier-intent__meta">
                     {approach && (

--- a/webview/styles/spec-viewer/_overview-dossier.css
+++ b/webview/styles/spec-viewer/_overview-dossier.css
@@ -28,14 +28,13 @@
 }
 
 .dossier-intent__statement {
-    max-width: 890px;
+    max-width: 72ch;
     margin: var(--space-3) 0 var(--space-5);
-    font-size: clamp(24px, 3.2cqi, 38px);
-    font-weight: 600;
-    line-height: 1.16;
-    letter-spacing: -0.03em;
-    color: var(--text-primary);
-    text-wrap: balance;
+    font-size: clamp(16px, 1.5cqi, 19px);
+    font-weight: 500;
+    line-height: 1.45;
+    color: var(--text-body);
+    text-wrap: pretty;
 }
 
 .dossier-intent__meta {


### PR DESCRIPTION
## Summary

On the spec Overview, the intent sentence was the biggest text on the page — a full sentence set at title scale — even though the real title sits up in the header. So the largest text wasn't the title, and a paragraph read like a heading. And the eyebrow above it said "Durable context · Intent", using an internal term the page never defines.

This makes the opening read like a summary:
- The intent statement drops from title scale to lead-paragraph scale, so the header title is clearly the largest text and the intent reads as a one-line summary. Its tag also changes from `<h2>` to `<p>` to match that role.
- The eyebrow is now just **Intent** — the unexplained "Durable context" term is removed rather than replaced with more jargon.

Closes #489.

## Technical

- `OverviewDossier.tsx` `IntentSection`: `<h2 class="dossier-intent__statement">` → `<p>`; kicker text `Durable context · Intent` → `Intent`.
- `_overview-dossier.css` `.dossier-intent__statement`: `font-size` clamp 24–38px → 16–19px, weight 600 → 500, `line-height` 1.16 → 1.45, color `--text-primary` → `--text-body` (readable-content token per the repo's design-token rule), `text-wrap: balance` → `pretty`, `max-width` 890px → 72ch.
- README "Reading Specs" Intent bullet updated to describe the new lead-summary scale.

## Verify

Open a spec that lands on its Overview. The spec title in the header should now visibly outrank the intent line, the intent should read as a summary sentence, and the eyebrow should say "Intent". Check both light and dark.

## Notes

Presentation-only (typography + copy + one README line); no logic touched. `npm run compile` + full suite (1692 tests) green. No `OverviewDossier.stories.tsx` exists, so no story update needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)