### PR TITLE
fix(viewer): run log shows loaded living specs as compact chips, not a full dump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- **The run log's Living specs section is a scannable list again, not a wall of text.** Opening a finished run used to reprint the entire text of every living spec it loaded — the purpose and every requirement, in full — so the useful signal (which specs were loaded) drowned in content you can already read in the Living Specs viewer. It now shows one compact chip per capability, right under the phase timeline, and clicking a chip opens that capability in the Living Specs viewer.
+
 - **A broken `living-specs.yml` no longer looks like an empty one.** If your capability registry had a typo in it, the Living Specs sidebar showed `Living Specs are off` and suggested you set `enabled: true` — advice that couldn't help, because the file already said that and simply wasn't parsing. The sidebar now shows `Can't read living-specs.yml` with the parse error in the tooltip, so you go fix the file instead of hunting for a setting.
 
 ### Improved

--- a/docs/viewer-states.md
+++ b/docs/viewer-states.md
@@ -327,7 +327,7 @@ inline comments still work and still persist.
 
 ### Living specs (Activity panel)
 
-When a feature touches **living specs** (durable capability specs), the spec-kit side records which capabilities were loaded into context at specify time (`livingSpecs.loaded`) and which were folded back at completion (`livingSpecs.synced`). The viewer surfaces this read-only in the Activity panel's *Living specs* card: it lists each capability and marks the synced ones as *folded back*. A capability that appears in `synced` but not `loaded` is still shown. The card hides itself when there is no `livingSpecs` data, like every other Activity card, so existing specs see no new UI. The viewer never writes `livingSpecs` — it only displays what LS·2/LS·3 wrote.
+When a feature touches **living specs** (durable capability specs), the spec-kit side records which capabilities were loaded into context at specify time (`livingSpecs.loaded`) and which were folded back at completion (`livingSpecs.synced`). The viewer surfaces this read-only in the Activity panel's *Living specs* card as a compact row of capability chips — one per capability — with the synced ones marked *folded back*. A capability that appears in `synced` but not `loaded` is still shown. Each chip that resolves to a capability spec in the workspace is clickable and opens that capability in the Living Specs viewer; the full capability content lives there, so the run log never reprints its requirements. The card hides itself when there is no `livingSpecs` data, like every other Activity card, so existing specs see no new UI. The viewer never writes `livingSpecs` — it only displays what LS·2/LS·3 wrote.
 
 ---
 

--- a/src/core/types/specContext.ts
+++ b/src/core/types/specContext.ts
@@ -230,15 +230,13 @@ export interface LivingSpecsView {
     capabilities?: CapabilityContentView[];
 }
 
-/** One touched capability, pre-parsed for rendering: plain text only. */
+/** One touched capability, resolved to a clickable run-log chip. */
 export interface CapabilityContentView {
     name: string;
-    /** False when the spec file is missing, unreadable, out-of-root, oversized, or unresolved. */
+    /** False when the capability couldn't be resolved to a spec path within the workspace. */
     available: boolean;
-    /** Intro paragraph before the requirements section, marker-stripped. */
-    purpose?: string;
-    /** One row per requirement heading; text is the first body paragraph, marker-stripped. */
-    requirements?: { id: string; text: string }[];
+    /** Workspace-relative path to the capability spec; absent when unresolved/out-of-root. */
+    specPath?: string;
     synced: boolean;
     /** Fold-back counts from the feature spec's delta blocks; absent when none (never zeros). */
     delta?: { added?: number; modified?: number; removed?: number; renamed?: number };

--- a/src/core/types/specContext.ts
+++ b/src/core/types/specContext.ts
@@ -223,9 +223,10 @@ export interface LivingSpecsView {
     loaded: string[];
     synced: string[];
     /**
-     * Per-capability readable content, resolved and parsed extension-side.
-     * Absent when content loading wasn't attempted (legacy payloads render the
-     * names-only list). Every loaded/synced name appears exactly once.
+     * Per-capability run-log chip metadata (name, resolved spec path, synced /
+     * delta state) — never the spec text itself, which the Living Specs viewer
+     * shows. Absent on legacy payloads (render the names-only list). Every
+     * loaded/synced name appears exactly once.
      */
     capabilities?: CapabilityContentView[];
 }

--- a/src/features/spec-viewer/__tests__/livingSpecsContent.test.ts
+++ b/src/features/spec-viewer/__tests__/livingSpecsContent.test.ts
@@ -3,9 +3,7 @@ import * as os from 'os';
 import * as path from 'path';
 import {
     enrichLivingSpecs,
-    parseCapabilitySpec,
     parseDeltaCounts,
-    stripInlineMarkdown,
 } from '../livingSpecsContent';
 
 const LIVING_SPEC = [
@@ -46,48 +44,6 @@ const CONFIG = [
     '      match: ["src/ui/**"]',
 ].join('\n');
 
-describe('parseCapabilitySpec', () => {
-    it('parses the purpose paragraph and one row per requirement heading', () => {
-        const parsed = parseCapabilitySpec(LIVING_SPEC);
-        expect(parsed.purpose).toBe('Task list behavior: everything the todos area guarantees today.');
-        expect(parsed.requirements).toEqual([
-            {
-                id: 'A note can carry one tag',
-                text: 'Each note stores at most one tag, editable from the note form. Continuation line of the same paragraph.',
-            },
-            { id: 'Notes can be filtered by tag', text: 'The list view filters by tag.' },
-        ]);
-    });
-
-    it('ignores ### headings outside the Requirements section', () => {
-        const md = [
-            '# Cap — Living Spec',
-            '',
-            '## Requirements',
-            '### Real requirement',
-            'Body.',
-            '',
-            '## Scenarios',
-            '### Not a requirement',
-            'Scenario body.',
-        ].join('\n');
-        const parsed = parseCapabilitySpec(md);
-        expect(parsed.requirements.map(r => r.id)).toEqual(['Real requirement']);
-    });
-
-    it('handles a spec with no intro and no requirements', () => {
-        const parsed = parseCapabilitySpec('# Bare — Living Spec\n\n## Requirements\n');
-        expect(parsed.purpose).toBeUndefined();
-        expect(parsed.requirements).toEqual([]);
-    });
-});
-
-describe('stripInlineMarkdown', () => {
-    it('removes emphasis, code, and link markers but keeps the text', () => {
-        expect(stripInlineMarkdown('**bold** and _it_ and `code` and [txt](url)')).toBe('bold and it and code and txt');
-    });
-});
-
 describe('parseDeltaCounts', () => {
     const SPEC_WITH_DELTAS = [
         '# Feature',
@@ -122,7 +78,7 @@ describe('parseDeltaCounts', () => {
 describe('enrichLivingSpecs', () => {
     afterEach(() => jest.restoreAllMocks());
 
-    it('loads, parses, and orders capabilities loaded-first with synced tagging', () => {
+    it('resolves a clickable spec path per capability without dumping its content', () => {
         const root = scaffold(CONFIG);
         fs.mkdirSync(path.join(root, 'capabilities', 'todos'), { recursive: true });
         fs.writeFileSync(path.join(root, 'capabilities', 'todos', 'spec.md'), LIVING_SPEC);
@@ -133,8 +89,10 @@ describe('enrichLivingSpecs', () => {
         expect(cap.name).toBe('todos');
         expect(cap.available).toBe(true);
         expect(cap.synced).toBe(true);
-        expect(cap.purpose).toContain('Task list behavior');
-        expect(cap.requirements).toHaveLength(2);
+        expect(cap.specPath).toBe('capabilities/todos/spec.md');
+        // The run log carries the name + path only — never the parsed content.
+        expect(cap).not.toHaveProperty('purpose');
+        expect(cap).not.toHaveProperty('requirements');
         fs.rmSync(root, { recursive: true, force: true });
     });
 
@@ -160,20 +118,12 @@ describe('enrichLivingSpecs', () => {
         fs.rmSync(root, { recursive: true, force: true });
     });
 
-    it('degrades to available:false for unresolved names and missing files', () => {
+    it('degrades to available:false (no specPath) for unresolved names and missing files', () => {
         const root = scaffold(CONFIG);
         const view = enrichLivingSpecs({ loaded: ['todos', 'ghost'], synced: [] }, root);
         expect(view.capabilities).toHaveLength(2);
         expect(view.capabilities!.every(c => c.available === false)).toBe(true);
-        fs.rmSync(root, { recursive: true, force: true });
-    });
-
-    it('degrades oversized files to available:false', () => {
-        const root = scaffold(CONFIG);
-        fs.mkdirSync(path.join(root, 'capabilities', 'todos'), { recursive: true });
-        fs.writeFileSync(path.join(root, 'capabilities', 'todos', 'spec.md'), 'x'.repeat(300 * 1024));
-        const view = enrichLivingSpecs({ loaded: ['todos'], synced: [] }, root);
-        expect(view.capabilities![0].available).toBe(false);
+        expect(view.capabilities!.every(c => c.specPath === undefined)).toBe(true);
         fs.rmSync(root, { recursive: true, force: true });
     });
 

--- a/src/features/spec-viewer/livingSpecsContent.ts
+++ b/src/features/spec-viewer/livingSpecsContent.ts
@@ -1,9 +1,8 @@
 import * as fs from 'fs';
-import * as path from 'path';
 import { LivingSpecsView, CapabilityContentView } from '../../core/types/specContext';
 import { readLivingSpecs, isPathWithinRoot, ResolvedCapability } from '../specs/livingSpecsModel';
 
-/** Read cap per capability spec — a partial render would lie, so bigger files degrade to unavailable. */
+/** Cap on the feature spec read for delta counts — an oversized spec skips deltas. */
 const MAX_SPEC_BYTES = 256 * 1024;
 
 const DELTA_HEADER_RE = /^##\s+(ADDED|MODIFIED|REMOVED|RENAMED)\s+Requirements\s*$/i;
@@ -15,80 +14,6 @@ export interface DeltaCounts {
     modified?: number;
     removed?: number;
     renamed?: number;
-}
-
-/** Strip inline markdown markers so the webview renders plain text nodes. */
-export function stripInlineMarkdown(text: string): string {
-    return text
-        .replace(/!?\[([^\]]*)\]\([^)]*\)/g, '$1')
-        .replace(/(\*\*|__)(.*?)\1/g, '$2')
-        .replace(/(\*|_)(.*?)\1/g, '$2')
-        .replace(/`([^`]*)`/g, '$1')
-        .trim();
-}
-
-/**
- * Parse a living-spec document into purpose + requirement rows. Mirrors the
- * fold-back writer's shape: title line, optional intro paragraph, then
- * `### <heading>` blocks (span ends at the next `###`/`##` or EOF) whose first
- * body paragraph becomes the row text.
- */
-export function parseCapabilitySpec(md: string): { purpose?: string; requirements: { id: string; text: string }[] } {
-    const lines = md.split(/\r?\n/);
-    const requirements: { id: string; text: string }[] = [];
-    let purpose: string | undefined;
-
-    const introLines: string[] = [];
-    for (const line of lines) {
-        if (/^#{1,3}\s/.test(line)) {
-            if (line.startsWith('# ')) continue;
-            break;
-        }
-        introLines.push(line);
-    }
-    const intro = firstParagraph(introLines);
-    if (intro) purpose = stripInlineMarkdown(intro);
-
-    // Requirement rows live only under `## Requirements` — a `###` heading in
-    // any other section (Scenarios, Notes) is not a requirement.
-    let inRequirements = false;
-    let current: { id: string; body: string[] } | null = null;
-    const flush = () => {
-        if (!current) return;
-        const text = firstParagraph(current.body);
-        requirements.push({ id: stripInlineMarkdown(current.id), text: text ? stripInlineMarkdown(text) : '' });
-        current = null;
-    };
-    for (const line of lines) {
-        if (line.startsWith('## ')) {
-            flush();
-            inRequirements = /^##\s+Requirements\s*$/i.test(line);
-            continue;
-        }
-        if (!inRequirements) continue;
-        const m = REQ_HEADING_RE.exec(line);
-        if (m) {
-            flush();
-            current = { id: m[1].trim(), body: [] };
-            continue;
-        }
-        if (current) current.body.push(line);
-    }
-    flush();
-    return { purpose, requirements };
-}
-
-function firstParagraph(lines: string[]): string | null {
-    const out: string[] = [];
-    for (const line of lines) {
-        const t = line.trim();
-        if (t === '') {
-            if (out.length > 0) break;
-            continue;
-        }
-        out.push(t);
-    }
-    return out.length > 0 ? out.join(' ') : null;
 }
 
 /**
@@ -146,10 +71,12 @@ function readCapped(absPath: string): string | null {
 }
 
 /**
- * Enrich a names-only living-specs view with per-capability readable content.
- * Best-effort everywhere: unresolved/missing/oversized specs yield
- * `available: false`; any unexpected failure returns the view unchanged so the
- * panel falls back to the names-only list.
+ * Resolve a names-only living-specs view to clickable run-log chips: each
+ * capability gets a workspace-relative `specPath` when it resolves within the
+ * workspace, so a chip can open it in the Living Specs viewer. The full content
+ * lives there, not in the run log. Best-effort: an unresolved/out-of-root
+ * capability stays `available: false`; any unexpected failure returns the view
+ * unchanged so the panel falls back to the names-only list.
  */
 export function enrichLivingSpecs(
     view: LivingSpecsView,
@@ -178,17 +105,10 @@ export function enrichLivingSpecs(
             if (base.synced && delta && Object.keys(delta).length > 0) base.delta = delta;
 
             const resolved = byName.get(name);
-            if (!resolved || !resolved.spec || !isPathWithinRoot(workspaceRoot, resolved.spec)) return base;
-            const md = readCapped(path.join(workspaceRoot, resolved.spec));
-            if (md === null) return base;
-            const parsed = parseCapabilitySpec(md);
-            return {
-                ...base,
-                available: true,
-                ...(parsed.purpose ? { purpose: parsed.purpose } : {}),
-                // Absent over empty: an empty list is omitted like every optional field.
-                ...(parsed.requirements.length > 0 ? { requirements: parsed.requirements } : {}),
-            };
+            if (!resolved || !resolved.spec || !resolved.exists || !isPathWithinRoot(workspaceRoot, resolved.spec)) {
+                return base;
+            }
+            return { ...base, available: true, specPath: resolved.spec };
         });
 
         return { ...view, capabilities };

--- a/src/features/spec-viewer/messageHandlers.ts
+++ b/src/features/spec-viewer/messageHandlers.ts
@@ -32,6 +32,7 @@ import {
 } from "../specs/specContextReader";
 import { updateSpecContext } from "../specs/specContextWriter";
 import { synthesizeCustomProgress, stepHasOutput } from "../specs/customWorkflowProgress";
+import { isPathWithinRoot } from "../specs/livingSpecsModel";
 import { resolveDispatchWithFallback } from "../specs/profileDispatch";
 import { lastEntryIsCompletionFor } from "../specs/historyHelpers";
 import {
@@ -156,6 +157,7 @@ function buildHandlerMap(): DispatcherMap<ViewerToExtensionMessage, [string, Mes
       await vscode.commands.executeCommand('speckit.specs.setStatus', { specPath: toWorkspaceRelativeSpecPath(dir) });
     },
     openFile: (msg, _dir, deps) => handleOpenFile(msg.filename, deps),
+    openLivingSpec: (msg, _dir, deps) => handleOpenLivingSpec(msg.specPath, deps),
     webviewError: async (msg, _dir, deps) => {
       deps.outputChannel.appendLine(
         `[SpecViewer] Webview error (${msg.source}): ${msg.message}` +
@@ -735,6 +737,28 @@ async function handleOpenFile(
       `[SpecViewer] Error opening file ref: ${error}`,
     );
   }
+}
+
+/**
+ * Open a living-spec capability document in the viewer (living mode) from a
+ * run-log chip. The path is workspace-relative and confined within the root
+ * before it reaches the filesystem — the same guard the tree's open command uses.
+ */
+async function handleOpenLivingSpec(
+  specPath: string,
+  deps: MessageHandlerDependencies,
+): Promise<void> {
+  const root = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+  if (!root || !isPathWithinRoot(root, specPath)) {
+    deps.outputChannel.appendLine(
+      `[SpecViewer] Refusing to open living spec outside workspace: ${specPath}`,
+    );
+    return;
+  }
+  const absPath = path.join(root, specPath);
+  await vscode.commands.executeCommand("speckit.viewSpecDocument", absPath, {
+    living: true,
+  });
 }
 
 /**

--- a/src/features/spec-viewer/types.ts
+++ b/src/features/spec-viewer/types.ts
@@ -465,6 +465,11 @@ export type ViewerToExtensionMessage =
           type: 'openFile';
           filename: string;
       }
+    // Living-specs chip click — open the capability in the Living Specs viewer
+    | {
+          type: 'openLivingSpec';
+          specPath: string;
+      }
     // Webview render-time error (reported by error boundaries)
     | {
           type: 'webviewError';

--- a/webview/src/spec-viewer/components/ActivityPanel.tsx
+++ b/webview/src/spec-viewer/components/ActivityPanel.tsx
@@ -114,10 +114,10 @@ export function ActivityPanel() {
                         {state.lastAction && <p class="dossier-log__last-action">{state.lastAction}</p>}
                         <LatestFeed />
                         <PhasesCard state={state} />
+                        <LivingSpecsCard state={state} />
                         <TasksCard state={state} />
                         <FilesCard state={state} />
                         <CommentsCard state={state} />
-                        <LivingSpecsCard state={state} />
                     </div>
                 </details>
             )}

--- a/webview/src/spec-viewer/components/cards/LivingSpecsCard.stories.tsx
+++ b/webview/src/spec-viewer/components/cards/LivingSpecsCard.stories.tsx
@@ -30,9 +30,9 @@ const baseState = (overrides: Partial<ViewerState>): ViewerState => ({
     ...overrides,
 });
 
-// Full readable content: purpose + requirement rows per capability, one synced
-// with fold-back delta counts.
-export const RichContent: Story = {
+// Resolved capabilities: each renders a clickable chip that opens the Living
+// Specs viewer; one is folded back with delta counts.
+export const ResolvedChips: Story = {
     render: () => (
         <LivingSpecsCard
             state={baseState({
@@ -45,20 +45,13 @@ export const RichContent: Story = {
                             available: true,
                             synced: true,
                             delta: { added: 1, modified: 2 },
-                            purpose: 'Task list behavior: everything the todos area guarantees today.',
-                            requirements: [
-                                { id: 'A note can carry one tag', text: 'Each note stores at most one tag, editable from the note form.' },
-                                { id: 'Notes can be filtered by tag', text: 'The list view filters by tag and remembers the choice per session.' },
-                            ],
+                            specPath: 'capabilities/todos/spec.md',
                         },
                         {
                             name: 'notes-ui',
                             available: true,
                             synced: false,
-                            purpose: 'Rendering rules for the notes surface.',
-                            requirements: [
-                                { id: 'Notes render newest first', text: 'The default sort is creation time, descending.' },
-                            ],
+                            specPath: 'capabilities/notes-ui/spec.md',
                         },
                     ],
                 },
@@ -67,9 +60,9 @@ export const RichContent: Story = {
     ),
 };
 
-// Content could not be loaded (unresolved name / missing file / oversized) —
-// names render with the quiet unavailable note.
-export const ContentUnavailable: Story = {
+// Capabilities that could not be resolved (unknown name / missing file) render
+// as plain, non-clickable names.
+export const Unresolved: Story = {
     render: () => (
         <LivingSpecsCard
             state={baseState({

--- a/webview/src/spec-viewer/components/cards/LivingSpecsCard.tsx
+++ b/webview/src/spec-viewer/components/cards/LivingSpecsCard.tsx
@@ -1,99 +1,80 @@
-import type { ViewerState, CapabilityContentView } from '../../types';
+import type { ViewerState, VSCodeApi, CapabilityContentView, LivingSpecsView } from '../../types';
+
+declare const vscode: VSCodeApi;
 
 export interface LivingSpecsCardProps {
     state: ViewerState;
 }
 
-function deltaLabel(delta: NonNullable<CapabilityContentView['delta']>): string {
-    const parts: string[] = [];
-    if (delta.added) parts.push(`+${delta.added} added`);
-    if (delta.modified) parts.push(`${delta.modified} modified`);
-    if (delta.removed) parts.push(`${delta.removed} removed`);
-    if (delta.renamed) parts.push(`${delta.renamed} renamed`);
-    return parts.join(' · ');
-}
-
-function CapabilitySection({ cap }: { cap: CapabilityContentView }) {
-    return (
-        <details class="living-specs-cap" open>
-            <summary class="living-specs-cap__summary">
-                <span class="living-specs-cap__name">{cap.name}</span>
-                {cap.synced && (
-                    <span class="living-specs-list__synced" title="Folded back into the living spec">
-                        folded back
-                    </span>
-                )}
-                {cap.delta && <span class="living-specs-cap__delta">{deltaLabel(cap.delta)}</span>}
-            </summary>
-            {cap.available ? (
-                <div class="living-specs-cap__body">
-                    {cap.purpose && <p class="living-specs-cap__purpose">{cap.purpose}</p>}
-                    {cap.requirements && cap.requirements.length > 0 ? (
-                        <ul class="living-specs-req-list">
-                            {cap.requirements.map(r => (
-                                <li key={r.id} class="living-specs-req">
-                                    <span class="living-specs-req__id">{r.id}</span>
-                                    {r.text && <span class="living-specs-req__text">{r.text}</span>}
-                                </li>
-                            ))}
-                        </ul>
-                    ) : (
-                        <p class="living-specs-cap__unavailable">No requirements recorded yet.</p>
-                    )}
-                </div>
-            ) : (
-                <p class="living-specs-cap__unavailable">Content unavailable in this workspace.</p>
-            )}
-        </details>
-    );
+interface Chip {
+    name: string;
+    synced: boolean;
+    specPath?: string;
 }
 
 /**
- * Read-only surface for the living specs a feature touched (LS·7): the durable
- * capability specs it loaded into context (LS·2) and the ones it folded its
- * changes back into at completion (LS·3). Renders readable content when the
- * provider could load it; degrades to the names-only list for legacy payloads.
- * Hides itself when there's no `livingSpecs` data, like every other card.
+ * Collapse a living-specs view to one chip per capability. Prefers the resolved
+ * `capabilities` (which carry the clickable spec path); falls back to the
+ * names-only `loaded`/`synced` arrays for legacy payloads.
+ */
+function toChips(ls: LivingSpecsView): Chip[] {
+    if (ls.capabilities && ls.capabilities.length > 0) {
+        return ls.capabilities.map((cap: CapabilityContentView) => ({
+            name: cap.name,
+            synced: cap.synced,
+            ...(cap.available && cap.specPath ? { specPath: cap.specPath } : {}),
+        }));
+    }
+    const synced = new Set(ls.synced);
+    const seen = new Set<string>();
+    const chips: Chip[] = [];
+    for (const name of [...ls.loaded, ...ls.synced]) {
+        if (seen.has(name)) continue;
+        seen.add(name);
+        chips.push({ name, synced: synced.has(name) });
+    }
+    return chips;
+}
+
+/**
+ * Compact run-log surface for the living specs a feature touched (LS·7): one
+ * chip per capability loaded into context (LS·2) or folded back at completion
+ * (LS·3). The full capability content lives in the Living Specs viewer, so a
+ * chip opens it there rather than reprinting it here. Hides itself when there's
+ * no `livingSpecs` data, like every other card.
  */
 export function LivingSpecsCard({ state }: LivingSpecsCardProps) {
     const ls = state.livingSpecs;
     if (!ls) return null;
 
-    if (ls.capabilities && ls.capabilities.length > 0) {
-        return (
-            <section class="activity-card activity-card--living-specs">
-                <h3 class="activity-card__title">Living specs</h3>
-                <div class="activity-card__body">
-                    {ls.capabilities.map(cap => (
-                        <CapabilitySection key={cap.name} cap={cap} />
-                    ))}
-                </div>
-            </section>
-        );
-    }
+    const chips = toChips(ls);
+    if (chips.length === 0) return null;
 
-    const synced = new Set(ls.synced);
-    // Show every capability that was loaded or synced, de-duplicated; a name in
-    // `synced` but not `loaded` is still folded back, so include it.
-    const names: string[] = [];
-    const seen = new Set<string>();
-    for (const n of [...ls.loaded, ...ls.synced]) {
-        if (seen.has(n)) continue;
-        seen.add(n);
-        names.push(n);
-    }
-    if (names.length === 0) return null;
+    const openSpec = (specPath: string) => {
+        vscode.postMessage({ type: 'openLivingSpec', specPath });
+    };
 
     return (
         <section class="activity-card activity-card--living-specs">
             <h3 class="activity-card__title">Living specs</h3>
             <div class="activity-card__body">
-                <ul class="living-specs-list">
-                    {names.map(name => (
-                        <li key={name} class="living-specs-list__item">
-                            <span class="living-specs-list__name">{name}</span>
-                            {synced.has(name) && (
-                                <span class="living-specs-list__synced" title="Folded back into the living spec">
+                <ul class="living-specs-chips">
+                    {chips.map(chip => (
+                        <li key={chip.name} class="living-specs-chips__item">
+                            {chip.specPath ? (
+                                <button
+                                    type="button"
+                                    class="living-specs-chip living-specs-chip--link"
+                                    title={`Open ${chip.name} in the Living Specs viewer`}
+                                    onClick={() => openSpec(chip.specPath!)}
+                                >
+                                    {chip.name}
+                                </button>
+                            ) : (
+                                <span class="living-specs-chip">{chip.name}</span>
+                            )}
+                            {chip.synced && (
+                                <span class="living-specs-chip__synced" title="Folded back into the living spec">
                                     folded back
                                 </span>
                             )}

--- a/webview/src/spec-viewer/components/cards/__tests__/LivingSpecsCard.test.tsx
+++ b/webview/src/spec-viewer/components/cards/__tests__/LivingSpecsCard.test.tsx
@@ -1,12 +1,11 @@
 /**
  * @jest-environment jsdom
  *
- * LS·7 — the Living specs card maps `ViewerState.livingSpecs` to the DOM:
- * loaded capabilities render; the ones in `synced` are marked folded back;
- * with no living-specs data the card renders nothing.
- *
- * This asserts the data→DOM mapping, not the visual look (NFR-004 — the look
- * needs manual verification).
+ * LS·7 — the Living specs run-log card maps `ViewerState.livingSpecs` to a
+ * COMPACT list of clickable capability chips: one chip per loaded/synced
+ * capability, no requirement bodies (that content lives in the Living Specs
+ * viewer). A resolved chip posts `openLivingSpec`; the ones in `synced` are
+ * marked folded back; with no living-specs data the card renders nothing.
  */
 
 import { render } from 'preact';
@@ -44,49 +43,106 @@ function cleanup(container: HTMLDivElement) {
 }
 
 describe('LivingSpecsCard', () => {
-    // Unmount every rendered container even if an assertion throws first, so a
-    // failing test can't leak mounted DOM into later tests.
     afterEach(() => {
         while (mounted.length) cleanup(mounted.pop()!);
+        delete (globalThis as { vscode?: unknown }).vscode;
     });
 
-    it('lists loaded capabilities and no folded-back marker when nothing synced', () => {
+    it('renders one compact chip per loaded capability, no folded-back marker when nothing synced', () => {
         const c = renderCard(baseState({ livingSpecs: { loaded: ['checkout', 'cart'], synced: [] } }));
-        const names = Array.from(c.querySelectorAll('.living-specs-list__name')).map(n => n.textContent);
-        expect(names).toEqual(['checkout', 'cart']);
-        expect(c.querySelectorAll('.living-specs-list__synced')).toHaveLength(0);
-        cleanup(c);
+        const chips = Array.from(c.querySelectorAll('.living-specs-chip')).map(n => n.textContent);
+        expect(chips).toEqual(['checkout', 'cart']);
+        expect(c.querySelectorAll('.living-specs-chip__synced')).toHaveLength(0);
     });
 
     it('marks synced capabilities as folded back', () => {
         const c = renderCard(baseState({ livingSpecs: { loaded: ['checkout', 'cart'], synced: ['checkout'] } }));
-        const items = Array.from(c.querySelectorAll('.living-specs-list__item'));
-        const checkout = items.find(li => li.querySelector('.living-specs-list__name')?.textContent === 'checkout');
-        const cart = items.find(li => li.querySelector('.living-specs-list__name')?.textContent === 'cart');
-        expect(checkout?.querySelector('.living-specs-list__synced')).not.toBeNull();
-        expect(cart?.querySelector('.living-specs-list__synced')).toBeNull();
-        cleanup(c);
+        const items = Array.from(c.querySelectorAll('.living-specs-chips__item'));
+        const checkout = items.find(li => li.querySelector('.living-specs-chip')?.textContent === 'checkout');
+        const cart = items.find(li => li.querySelector('.living-specs-chip')?.textContent === 'cart');
+        expect(checkout?.querySelector('.living-specs-chip__synced')).not.toBeNull();
+        expect(cart?.querySelector('.living-specs-chip__synced')).toBeNull();
     });
 
-    it('includes a synced capability that was not loaded this run', () => {
-        const c = renderCard(baseState({ livingSpecs: { loaded: ['cart'], synced: ['checkout'] } }));
-        const names = Array.from(c.querySelectorAll('.living-specs-list__name')).map(n => n.textContent);
-        expect(names).toEqual(['cart', 'checkout']);
-        cleanup(c);
+    it('includes a synced capability that was not loaded this run, de-duplicated', () => {
+        const c = renderCard(baseState({ livingSpecs: { loaded: ['cart', 'checkout'], synced: ['checkout'] } }));
+        const chips = Array.from(c.querySelectorAll('.living-specs-chip')).map(n => n.textContent);
+        expect(chips).toEqual(['cart', 'checkout']);
+        expect(c.querySelectorAll('.living-specs-chips__item')).toHaveLength(2);
     });
 
-    it('de-duplicates a capability listed in both loaded and synced', () => {
-        const c = renderCard(baseState({ livingSpecs: { loaded: ['checkout', 'cart'], synced: ['checkout', 'cart'] } }));
-        const names = Array.from(c.querySelectorAll('.living-specs-list__name')).map(n => n.textContent);
-        expect(names).toEqual(['checkout', 'cart']);
-        expect(c.querySelectorAll('.living-specs-list__item')).toHaveLength(2);
-        cleanup(c);
+    it('renders an available capability as a clickable chip that opens the Living Specs viewer', () => {
+        const postMessage = jest.fn();
+        (globalThis as { vscode?: unknown }).vscode = { postMessage };
+        const c = renderCard(
+            baseState({
+                livingSpecs: {
+                    loaded: ['todos'],
+                    synced: [],
+                    capabilities: [
+                        { name: 'todos', available: true, synced: false, specPath: 'capabilities/todos/spec.md' },
+                    ],
+                },
+            }),
+        );
+        const btn = c.querySelector<HTMLButtonElement>('button.living-specs-chip--link');
+        expect(btn).not.toBeNull();
+        expect(btn!.textContent).toBe('todos');
+        btn!.click();
+        expect(postMessage).toHaveBeenCalledWith({
+            type: 'openLivingSpec',
+            specPath: 'capabilities/todos/spec.md',
+        });
+    });
+
+    it('renders an unresolved capability as a plain, non-clickable name', () => {
+        const c = renderCard(
+            baseState({
+                livingSpecs: {
+                    loaded: ['ghost'],
+                    synced: [],
+                    capabilities: [{ name: 'ghost', available: false, synced: false }],
+                },
+            }),
+        );
+        expect(c.querySelector('button.living-specs-chip--link')).toBeNull();
+        expect(c.querySelector('.living-specs-chip')?.textContent).toBe('ghost');
+    });
+
+    it('shows only the capability names — never the full requirement bodies', () => {
+        // Regression: even a payload that still carries parsed content must render
+        // a compact chip list, not the wall of requirement text.
+        const c = renderCard(
+            baseState({
+                livingSpecs: {
+                    loaded: ['viewer-ui', 'spec-viewer'],
+                    synced: [],
+                    capabilities: [
+                        {
+                            name: 'viewer-ui',
+                            available: true,
+                            synced: false,
+                            specPath: 'capabilities/viewer-ui/spec.md',
+                            purpose: 'PURPOSE PARAGRAPH THAT MUST NOT APPEAR',
+                            requirements: [
+                                { id: 'FR-001', text: 'FULL REQUIREMENT BODY THAT MUST NOT APPEAR' },
+                                { id: 'FR-002', text: 'ANOTHER REQUIREMENT BODY THAT MUST NOT APPEAR' },
+                            ],
+                        },
+                        { name: 'spec-viewer', available: true, synced: false, specPath: 'capabilities/spec-viewer/spec.md' },
+                    ],
+                } as unknown as ViewerState['livingSpecs'],
+            }),
+        );
+        const chips = Array.from(c.querySelectorAll('.living-specs-chip')).map(n => n.textContent);
+        expect(chips).toEqual(['viewer-ui', 'spec-viewer']);
+        expect(c.textContent).not.toContain('MUST NOT APPEAR');
+        expect(c.textContent).not.toContain('FR-001');
     });
 
     it('renders nothing when there is no livingSpecs data', () => {
         const c = renderCard(baseState());
         expect(c.querySelector('.activity-card--living-specs')).toBeNull();
         expect(c.textContent).toBe('');
-        cleanup(c);
     });
 });

--- a/webview/src/spec-viewer/types.ts
+++ b/webview/src/spec-viewer/types.ts
@@ -297,15 +297,13 @@ export interface LivingSpecsView {
     capabilities?: CapabilityContentView[];
 }
 
-/** One touched capability, pre-parsed for rendering: plain text only. */
+/** One touched capability, resolved to a clickable run-log chip. */
 export interface CapabilityContentView {
     name: string;
-    /** False when the spec file is missing, unreadable, out-of-root, oversized, or unresolved. */
+    /** False when the capability couldn't be resolved to a spec path within the workspace. */
     available: boolean;
-    /** Intro paragraph before the requirements section, marker-stripped. */
-    purpose?: string;
-    /** One row per requirement heading; text is the first body paragraph, marker-stripped. */
-    requirements?: { id: string; text: string }[];
+    /** Workspace-relative path to the capability spec; absent when unresolved/out-of-root. */
+    specPath?: string;
     synced: boolean;
     /** Fold-back counts from the feature spec's delta blocks; absent when none (never zeros). */
     delta?: { added?: number; modified?: number; removed?: number; renamed?: number };
@@ -349,6 +347,8 @@ export type ViewerToExtensionMessage =
     | { type: 'runDocRefinement'; doc: DocumentType }
     // File reference click
     | { type: 'openFile'; filename: string }
+    // Living-specs chip click — open the capability in the Living Specs viewer
+    | { type: 'openLivingSpec'; specPath: string }
     // Webview render-time error (reported by error boundaries)
     | { type: 'webviewError'; source: string; message: string; stack?: string };
 

--- a/webview/src/spec-viewer/types.ts
+++ b/webview/src/spec-viewer/types.ts
@@ -290,9 +290,10 @@ export interface LivingSpecsView {
     loaded: string[];
     synced: string[];
     /**
-     * Per-capability readable content, resolved and parsed extension-side.
-     * Absent when content loading wasn't attempted (legacy payloads render the
-     * names-only list). Every loaded/synced name appears exactly once.
+     * Per-capability run-log chip metadata (name, resolved spec path, synced /
+     * delta state) — never the spec text itself, which the Living Specs viewer
+     * shows. Absent on legacy payloads (render the names-only list). Every
+     * loaded/synced name appears exactly once.
      */
     capabilities?: CapabilityContentView[];
 }

--- a/webview/styles/spec-viewer/_activity.css
+++ b/webview/styles/spec-viewer/_activity.css
@@ -308,6 +308,67 @@
 }
 
 /* ============================================
+   Living specs card — compact chips
+
+   One chip per capability the run loaded/folded back. The full content lives
+   in the Living Specs viewer, so a resolved chip links there rather than
+   reprinting requirements here.
+   ============================================ */
+
+.living-specs-chips {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-2);
+}
+
+.living-specs-chips__item {
+    display: inline-flex;
+    align-items: baseline;
+    gap: 4px;
+    min-width: 0;
+}
+
+.living-specs-chip {
+    max-width: 22em;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    font-family: var(--font-mono);
+    font-size: 0.78rem;
+    font-weight: 600;
+    padding: 2px 8px;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    background: var(--bg-primary);
+    color: var(--text-body);
+}
+
+.living-specs-chip--link {
+    cursor: pointer;
+}
+
+.living-specs-chip--link:hover {
+    color: var(--accent);
+    border-color: color-mix(in srgb, var(--accent) 50%, transparent);
+}
+
+.living-specs-chip--link:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 1px;
+}
+
+.living-specs-chip__synced {
+    font-size: 0.66rem;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: var(--text-muted);
+}
+
+/* ============================================
    Redesign: hero strip, plan section, tabs
    ============================================ */
 

--- a/webview/styles/spec-viewer/_activity.css
+++ b/webview/styles/spec-viewer/_activity.css
@@ -332,10 +332,12 @@
 }
 
 .living-specs-chip {
+    display: inline-block;
     max-width: 22em;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+    vertical-align: middle;
     font-family: var(--font-mono);
     font-size: 0.78rem;
     font-weight: 600;


### PR DESCRIPTION
## Summary

When you open a finished run in the viewer, the Run log's **Living specs** section reprinted the entire text of every capability it loaded — the purpose paragraph and all requirements, in full. On a real feature that loads two capabilities with a dozen requirements each, it's a wall of text you scroll past to reach what you came for. The only useful signal is *which* living specs were loaded; the full content already lives in the dedicated Living Specs viewer.

Now the Run log leads with the Phases timeline, then a compact **Living specs: viewer-ui · spec-viewer** line of chips. A chip that resolves to an on-disk spec is clickable and opens that capability in the Living Specs viewer; unresolved ones render as plain names.

Closes #488.

## Technical

- `enrichLivingSpecs` (`livingSpecsContent.ts`) now attaches a workspace-relative `specPath` per capability instead of reading, parsing, and shipping the full spec text. The now-dead `parseCapabilitySpec` / `stripInlineMarkdown` parser and its unit tests are removed.
- New `openLivingSpec` webview→extension message. `handleOpenLivingSpec` confines the path within the workspace root via the tree's existing `isPathWithinRoot` guard (rejects absolute paths and `..` traversal) before dispatching `speckit.viewSpecDocument` in living mode.
- `CapabilityContentView` drops `purpose`/`requirements`, gains `specPath`.
- `LivingSpecsCard` renders the chip row; `_activity.css` styles it (truncation with ellipsis on long names). Story + tests updated.

## Verify

Open `specs/_03_demo-living` in the viewer and look at Activity → Run log → Living specs: chips should sit on one line under Phases, a resolved chip should open the capability in the Living Specs viewer, a synced chip shows the folded-back marker, and long names truncate.

## Tests

- `LivingSpecsCard.test.tsx`: renders only capability names, never the full requirement bodies (even when the payload still carries them); a clickable chip posts `openLivingSpec` with `specPath`; an unresolved capability renders a plain non-clickable name.
- `livingSpecsContent.test.ts`: enrich resolves a clickable spec path per capability without attaching its content.

`npm run compile` + full suite (1693 tests) + `npm run package` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)