### PR TITLE
feat(viewer): honest wall-clock timing + phases/overview redesign

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -109,13 +109,27 @@ const beardedVividLight: Record<string, string> = {
 };
 
 interface StoryTheme {
-    bodyClass: 'vscode-dark' | 'vscode-light';
+    bodyClass: 'vscode-dark' | 'vscode-light' | 'vscode-high-contrast';
     vars: Record<string, string>;
 }
 
 const themes: Record<string, StoryTheme> = {
     'monokai-black': { bodyClass: 'vscode-dark', vars: beardedMonokaiBlack },
     'vivid-light': { bodyClass: 'vscode-light', vars: beardedVividLight },
+    'high-contrast': {
+        bodyClass: 'vscode-high-contrast',
+        vars: {
+            ...beardedMonokaiBlack,
+            '--vscode-editor-background': '#000000',
+            '--vscode-editor-foreground': '#ffffff',
+            '--vscode-foreground': '#ffffff',
+            '--vscode-sideBar-background': '#000000',
+            '--vscode-editorWidget-background': '#000000',
+            '--vscode-contrastBorder': '#ffffff',
+            '--vscode-focusBorder': '#ffff00',
+            '--vscode-panel-border': '#ffffff',
+        },
+    },
 };
 
 // Mock vscode API
@@ -135,6 +149,7 @@ const preview: Preview = {
                 items: [
                     { value: 'monokai-black', title: 'Bearded Monokai Black (dark)' },
                     { value: 'vivid-light', title: 'Bearded Vivid Light (light)' },
+                    { value: 'high-contrast', title: 'VS Code High Contrast' },
                 ],
                 dynamicTitle: true,
             },
@@ -166,7 +181,7 @@ const preview: Preview = {
 
             // tokens.css and highlighting.ts key off body.vscode-dark/-light,
             // so the class must live on <body>, not just the wrapper div.
-            document.body.classList.remove('vscode-dark', 'vscode-light');
+            document.body.classList.remove('vscode-dark', 'vscode-light', 'vscode-high-contrast');
             document.body.classList.add(theme.bodyClass);
 
             // tokens.css declares its tokens on :root, and a custom property's

--- a/src/core/types/specContext.ts
+++ b/src/core/types/specContext.ts
@@ -95,6 +95,22 @@ export interface StepHistoryEntry {
     durationTrusted?: boolean;
 }
 
+/**
+ * Honest, derived timing coverage for one feature run. This is never persisted;
+ * `history[]` remains the only timing source on disk.
+ */
+export interface TimingSummary {
+    measuredPhases: number;
+    expectedPhases: number;
+    complete: boolean;
+    /** Present only when every expected phase has a trustworthy closed span. */
+    startedAt?: string;
+    /** Present only when every expected phase has a trustworthy closed span. */
+    endedAt?: string;
+    /** Wall-clock elapsed time, including pauses; present only for a complete run. */
+    elapsedMs?: number;
+}
+
 export interface HistoryEntryFrom {
     step: StepName | null;
     substep: string | null;
@@ -389,6 +405,7 @@ export interface ViewerState {
     footer: FooterAction[];
     history: HistoryEntry[];
     stepHistory: Record<string, StepHistoryEntry>;
+    timing: TimingSummary;
     /** Activity panel — passthroughs from `.spec-context.json`. */
     approach?: string;
     lastAction?: string;

--- a/src/features/spec-editor/specEditorProvider.ts
+++ b/src/features/spec-editor/specEditorProvider.ts
@@ -601,9 +601,10 @@ export class SpecEditorProvider {
 
                 <div class="editor-container">
                     <label class="editor-label" for="specContent">Feature Brief</label>
+                    <p id="helperText" class="sr-only">Include the problem, who it affects, key requirements, and constraints. A Jira or GitHub link also works on its own.</p>
                     <details class="writing-tips" id="writingTips">
                         <summary>Writing tips</summary>
-                        <p id="helperText">Include the problem, who it affects, key requirements, and constraints. A Jira or GitHub link also works on its own.</p>
+                        <p>Include the problem, who it affects, key requirements, and constraints. A Jira or GitHub link also works on its own.</p>
                     </details>
                     <textarea
                         class="spec-editor-textarea"

--- a/src/features/spec-editor/specEditorProvider.ts
+++ b/src/features/spec-editor/specEditorProvider.ts
@@ -600,13 +600,16 @@ export class SpecEditorProvider {
                 </div>
 
                 <div class="editor-container">
-                    <label class="editor-label sr-only" for="specContent">Specification</label>
-                    <p class="helper-text sr-only" id="helperText">Write as much or as little as you like — even just a Jira or GitHub link on its own works, and the AI will pull the details from it.</p>
+                    <label class="editor-label" for="specContent">Feature Brief</label>
+                    <details class="writing-tips" id="writingTips">
+                        <summary>Writing tips</summary>
+                        <p id="helperText">Include the problem, who it affects, key requirements, and constraints. A Jira or GitHub link also works on its own.</p>
+                    </details>
                     <textarea
                         class="spec-editor-textarea"
                         id="specContent"
                         aria-describedby="helperText charCount"
-                        placeholder="Describe your feature or task in detail — or just paste a link below and skip the description entirely.&#10;&#10;What helps:&#10;- What is the feature about?&#10;- What problem does it solve?&#10;- Who is it for?&#10;- Key requirements, constraints, or dependencies?&#10;&#10;Or paste a reference link on its own:&#10;- Jira:  https://your-org.atlassian.net/browse/PROJ-1234&#10;- GitHub:  https://github.com/your-org/your-repo/issues/42"
+                        placeholder="Describe the problem, audience, and desired outcome — or paste a Jira/GitHub link."
                     ></textarea>
                     <div class="editor-footer-row">
                         <button class="attach-image-btn" id="attachImageBtn" aria-label="Attach image (or paste an image to attach)">

--- a/src/features/spec-viewer/__tests__/messageHandlers.test.ts
+++ b/src/features/spec-viewer/__tests__/messageHandlers.test.ts
@@ -76,6 +76,53 @@ function createMockDeps(overrides?: Partial<MessageHandlerDependencies>): Messag
     };
 }
 
+describe('messageHandlers - living spec navigation', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        (vscode.workspace as any).workspaceFolders = [{ uri: vscode.Uri.file('/workspace') }];
+    });
+
+    afterEach(() => {
+        (vscode.workspace as any).workspaceFolders = undefined;
+    });
+
+    it('opens the exact enriched capability path in Living mode', async () => {
+        const handler = createMessageHandlers(SPEC_DIR, createMockDeps());
+
+        await handler({
+            type: 'openLivingSpec',
+            capabilityName: 'todos',
+            specPath: 'capabilities/todos/spec.md',
+        });
+
+        expect(vscode.commands.executeCommand).toHaveBeenCalledWith(
+            'speckit.viewSpecDocument',
+            '/workspace/capabilities/todos/spec.md',
+            { living: true },
+        );
+    });
+
+    it('resolves a historical names-only capability to its colocated spec', async () => {
+        (vscode.workspace.findFiles as jest.Mock).mockResolvedValueOnce([
+            vscode.Uri.file('/workspace/webview/src/spec-viewer/viewer-ui.spec.md'),
+        ]);
+        const handler = createMessageHandlers(SPEC_DIR, createMockDeps());
+
+        await handler({ type: 'openLivingSpec', capabilityName: 'viewer-ui' });
+
+        expect(vscode.workspace.findFiles).toHaveBeenCalledWith(
+            '**/viewer-ui.spec.md',
+            '**/{.git,node_modules,dist,storybook-static}/**',
+            1,
+        );
+        expect(vscode.commands.executeCommand).toHaveBeenCalledWith(
+            'speckit.viewSpecDocument',
+            '/workspace/webview/src/spec-viewer/viewer-ui.spec.md',
+            { living: true },
+        );
+    });
+});
+
 describe('messageHandlers - lifecycle actions', () => {
     beforeEach(() => {
         jest.clearAllMocks();

--- a/src/features/spec-viewer/messageHandlers.ts
+++ b/src/features/spec-viewer/messageHandlers.ts
@@ -159,7 +159,8 @@ function buildHandlerMap(): DispatcherMap<ViewerToExtensionMessage, [string, Mes
     },
     livingUpdate: (_msg, dir, deps) => handleLivingUpdate(dir, deps),
     openFile: (msg, _dir, deps) => handleOpenFile(msg.filename, deps),
-    openLivingSpec: (msg, _dir, deps) => handleOpenLivingSpec(msg.specPath, deps),
+    openLivingSpec: (msg, _dir, deps) =>
+      handleOpenLivingSpec(msg.specPath, msg.capabilityName, deps),
     webviewError: async (msg, _dir, deps) => {
       deps.outputChannel.appendLine(
         `[SpecViewer] Webview error (${msg.source}): ${msg.message}` +
@@ -766,14 +767,38 @@ async function handleLivingUpdate(
  * before it reaches the filesystem — the same guard the tree's open command uses.
  */
 async function handleOpenLivingSpec(
-  specPath: string,
+  suppliedPath: string | undefined,
+  capabilityName: string,
   deps: MessageHandlerDependencies,
 ): Promise<void> {
   const root = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
-  if (!root || !isPathWithinRoot(root, specPath)) {
+  if (!root) return;
+
+  let specPath = suppliedPath;
+  if (!specPath) {
+    const safeName = /^[a-zA-Z0-9._-]+$/.test(capabilityName) ? capabilityName : null;
+    if (safeName) {
+      const patterns = [`**/${safeName}.spec.md`, `**/${safeName}/spec.md`];
+      for (const pattern of patterns) {
+        const matches = await vscode.workspace.findFiles(
+          pattern,
+          '**/{.git,node_modules,dist,storybook-static}/**',
+          1,
+        );
+        const match = matches[0];
+        if (match) {
+          specPath = path.relative(root, match.fsPath);
+          break;
+        }
+      }
+    }
+  }
+
+  if (!specPath || !isPathWithinRoot(root, specPath)) {
     deps.outputChannel.appendLine(
-      `[SpecViewer] Refusing to open living spec outside workspace: ${specPath}`,
+      `[SpecViewer] Unable to resolve living spec for capability: ${capabilityName}`,
     );
+    vscode.window.showWarningMessage(`Living spec not found: ${capabilityName}`);
     return;
   }
   const absPath = path.join(root, specPath);

--- a/src/features/spec-viewer/stateDerivation.ts
+++ b/src/features/spec-viewer/stateDerivation.ts
@@ -30,7 +30,7 @@ import {
     LivingSpecsView,
 } from '../../core/types/specContext';
 import { getFooterActions } from './footerActions';
-import { deriveStepHistory } from '../specs/stepHistoryDerivation';
+import { deriveStepHistory, deriveTimingSummary } from '../specs/stepHistoryDerivation';
 import type { WorkflowStepConfig } from '../workflows/types';
 
 type DerivedHistory = Record<string, StepHistoryEntry>;
@@ -313,6 +313,9 @@ export function deriveViewerState(
     // Derive stepHistory once from the canonical history[] sequence and reuse
     // it across all the per-step derivations below.
     const stepHistory = deriveStepHistory(ctx.history ?? [], ctx.currentStep, ctx.status);
+    const expectedTimingPhases = workflowSteps?.length
+        ? workflowSteps.map(step => step.name)
+        : ['specify', 'plan', 'tasks', 'implement'];
     return {
         status: ctx.status,
         activeStep,
@@ -323,6 +326,7 @@ export function deriveViewerState(
         footer: getFooterActions(ctx, activeStep, workflowSteps),
         history: ctx.history ?? [],
         stepHistory,
+        timing: deriveTimingSummary(stepHistory, expectedTimingPhases),
         approach: pickString(ctx, 'approach'),
         lastAction: pickString(ctx, 'last_action'),
         taskSummaries: pickRecord<TaskSummary>(ctx, 'task_summaries'),

--- a/src/features/spec-viewer/types.ts
+++ b/src/features/spec-viewer/types.ts
@@ -472,7 +472,8 @@ export type ViewerToExtensionMessage =
     // Living-specs chip click — open the capability in the Living Specs viewer
     | {
           type: 'openLivingSpec';
-          specPath: string;
+          capabilityName: string;
+          specPath?: string;
       }
     // Webview render-time error (reported by error boundaries)
     | {

--- a/src/features/specs/__tests__/stepHistoryDerivation.test.ts
+++ b/src/features/specs/__tests__/stepHistoryDerivation.test.ts
@@ -1,4 +1,4 @@
-import { deriveStepHistory, deriveDocumentState } from '../stepHistoryDerivation';
+import { deriveStepHistory, deriveDocumentState, deriveTimingSummary } from '../stepHistoryDerivation';
 import { findRunningStep } from '../../spec-viewer/stateDerivation';
 import type { Transition } from '../../../core/types/specContext';
 
@@ -175,7 +175,7 @@ describe('deriveStepHistory', () => {
     });
 
     describe('collapses consecutive identical (step, substep) transitions', () => {
-        it('produces the same result feeding a duplicate adjacent transition as feeding one', () => {
+        it('collapses duplicate rows for display but preserves the repeated-start trust anomaly', () => {
             const single = [
                 tx({ step: 'specify', at: '2026-04-29T00:00:00Z' }),
                 tx({ step: 'plan',    at: '2026-04-29T00:01:00Z' }),
@@ -187,7 +187,9 @@ describe('deriveStepHistory', () => {
             ];
             const a = deriveStepHistory(single, 'plan');
             const b = deriveStepHistory(withDuplicate, 'plan');
-            expect(b).toEqual(a);
+            expect(b.specify.startedAt).toBe(a.specify.startedAt);
+            expect(b.specify.completedAt).toBe(a.specify.completedAt);
+            expect(b.specify.durationTrusted).toBe(false);
             // The dropped duplicate's `at` must not become startedAt.
             expect(b.specify.startedAt).toBe('2026-04-29T00:00:00Z');
         });
@@ -423,14 +425,106 @@ describe('deriveStepHistory', () => {
             expect(sh.specify.durationTrusted).toBe(true);
         });
 
-        it('an in-flight extension-started step stays trusted until an untrusted close arrives', () => {
+        it('does not call an in-flight start a measured duration', () => {
             const history: Transition[] = [
                 tx({ step: 'implement', kind: 'start', by: 'extension', at: '2026-07-01T10:00:00Z' }),
             ];
             const sh = deriveStepHistory(history, 'implement', 'implementing');
             expect(sh.implement.completedAt).toBeNull();
-            expect(sh.implement.durationTrusted).toBe(true);
+            expect(sh.implement.durationTrusted).toBe(false);
         });
+
+        it('rejects completion-before-start and repeated starts', () => {
+            const completionBeforeStart = deriveStepHistory([
+                tx({ step: 'plan', kind: 'complete', by: 'extension', at: '2026-07-01T09:59:00Z' }),
+                tx({ step: 'plan', kind: 'start', by: 'extension', at: '2026-07-01T10:00:00Z' }),
+            ], 'plan', 'planned');
+            expect(completionBeforeStart.plan.durationTrusted).toBe(false);
+
+            const repeated = deriveStepHistory([
+                tx({ step: 'plan', kind: 'start', by: 'extension', at: '2026-07-01T10:00:00Z' }),
+                tx({ step: 'plan', kind: 'start', by: 'extension', at: '2026-07-01T10:01:00Z' }),
+                tx({ step: 'plan', kind: 'complete', by: 'extension', at: '2026-07-01T10:03:00Z' }),
+            ], 'plan', 'planned');
+            expect(repeated.plan.durationTrusted).toBe(false);
+        });
+    });
+});
+
+describe('deriveTimingSummary', () => {
+    const measured = (startedAt: string, completedAt: string) => ({
+        startedAt,
+        completedAt,
+        durationTrusted: true,
+    });
+
+    it('returns wall-clock elapsed only when every expected phase is measured', () => {
+        const timing = deriveTimingSummary({
+            specify: measured('2026-07-01T10:00:00Z', '2026-07-01T10:05:00Z'),
+            plan: measured('2026-07-01T10:05:00Z', '2026-07-01T10:12:00Z'),
+            tasks: measured('2026-07-01T10:12:00Z', '2026-07-01T10:15:00Z'),
+            implement: measured('2026-07-01T10:15:00Z', '2026-07-01T10:24:00Z'),
+        });
+        expect(timing).toEqual({
+            measuredPhases: 4,
+            expectedPhases: 4,
+            complete: true,
+            startedAt: '2026-07-01T10:00:00Z',
+            endedAt: '2026-07-01T10:24:00Z',
+            elapsedMs: 24 * 60 * 1000,
+        });
+    });
+
+    it('keeps partial timing as coverage and never a total', () => {
+        const timing = deriveTimingSummary({
+            implement: measured('2026-07-01T10:15:00Z', '2026-07-01T10:21:30Z'),
+        });
+        expect(timing).toEqual({ measuredPhases: 1, expectedPhases: 4, complete: false });
+        expect(timing.elapsedMs).toBeUndefined();
+    });
+
+    it('models feature 484 as Implement-only timing (~6m 30s), never a run total', () => {
+        const history: Transition[] = [
+            tx({ step: 'specify', kind: 'start', by: 'extension', at: '2026-07-21T04:54:47.394Z' }),
+            tx({ step: 'specify', kind: 'complete', by: 'extension', at: '2026-07-21T04:56:53.041Z' }),
+            tx({ step: 'plan', substep: 'research', kind: 'complete', by: 'ai', at: '2026-07-21T04:58:08.019Z' }),
+            tx({ step: 'plan', kind: 'complete', by: 'ai', at: '2026-07-21T04:58:08.222Z' }),
+            tx({ step: 'plan', kind: 'start', by: 'extension', at: '2026-07-21T04:58:18.300Z' }),
+            tx({ step: 'tasks', substep: 'generate', kind: 'complete', by: 'ai', at: '2026-07-21T04:58:58.186Z' }),
+            tx({ step: 'tasks', kind: 'complete', by: 'ai', at: '2026-07-21T04:58:58.320Z' }),
+            tx({ step: 'tasks', kind: 'start', by: 'extension', at: '2026-07-21T04:59:18.547Z' }),
+            tx({ step: 'implement', kind: 'start', by: 'extension', at: '2026-07-21T04:59:32.305Z' }),
+            tx({ step: 'implement', kind: 'complete', by: 'extension', at: '2026-07-21T05:06:01.863Z' }),
+        ];
+        const steps = deriveStepHistory(history, 'implement', 'completed');
+        expect(steps.implement.durationTrusted).toBe(true);
+        expect(Date.parse(steps.implement.completedAt!) - Date.parse(steps.implement.startedAt))
+            .toBe(389_558);
+        expect(deriveTimingSummary(steps)).toEqual({
+            measuredPhases: 1,
+            expectedPhases: 4,
+            complete: false,
+        });
+    });
+
+    it('models feature 406 repeated/reversed boundaries without four trusted phases', () => {
+        const history: Transition[] = [
+            tx({ step: 'specify', kind: 'start', by: 'extension', at: '2026-07-21T00:25:21.186Z' }),
+            tx({ step: 'specify', kind: 'complete', by: 'extension', at: '2026-07-21T00:28:53.117Z' }),
+            tx({ step: 'specify', kind: 'complete', by: 'user', at: '2026-07-21T00:40:36.886Z' }),
+            tx({ step: 'plan', kind: 'complete', by: 'extension', at: '2026-07-21T00:40:44.310Z' }),
+            tx({ step: 'tasks', kind: 'start', by: 'extension', at: '2026-07-21T00:40:44.312Z' }),
+            tx({ step: 'plan', kind: 'start', by: 'user', at: '2026-07-21T00:41:37.194Z' }),
+            tx({ step: 'plan', kind: 'complete', by: 'user', at: '2026-07-21T00:49:34.719Z' }),
+            tx({ step: 'tasks', kind: 'start', by: 'extension', at: '2026-07-21T00:52:29.049Z' }),
+            tx({ step: 'tasks', kind: 'complete', by: 'user', at: '2026-07-21T01:02:03.685Z' }),
+            tx({ step: 'implement', kind: 'start', by: 'extension', at: '2026-07-21T01:02:05.953Z' }),
+            tx({ step: 'implement', kind: 'complete', by: 'extension', at: '2026-07-21T01:15:18.570Z' }),
+        ];
+        const timing = deriveTimingSummary(deriveStepHistory(history, 'implement', 'completed'));
+        expect(timing.complete).toBe(false);
+        expect(timing.measuredPhases).toBeLessThan(4);
+        expect(timing.elapsedMs).toBeUndefined();
     });
 });
 

--- a/src/features/specs/stepHistoryDerivation.ts
+++ b/src/features/specs/stepHistoryDerivation.ts
@@ -40,6 +40,7 @@ import {
     StepName,
     Status,
     SubstepEntry,
+    TimingSummary,
 } from '../../core/types/specContext';
 import { SpecStatuses } from '../../core/constants';
 import { isStepLevelEntry } from './historyHelpers';
@@ -358,19 +359,120 @@ export function deriveStepHistory(
 
         const substeps = buildSubsteps(g.transitions, completedAt, startedAt);
 
-        // Duration honesty: a span is a measured duration only when BOTH
-        // boundaries were stamped by the extension's own clock. AI/cli-journaled
-        // timestamps record when the write ran, not when the work happened —
-        // ordering-true, duration-false. Renderers must not show elapsed time
-        // for an untrusted span.
-        const startTrusted = g.transitions[0].by === 'extension';
-        const endTrusted = closeEntry?.by === 'extension';
+        // Duration honesty is deliberately stricter than lifecycle derivation.
+        // A measured phase needs exactly one explicit extension-stamped,
+        // step-level start and an extension-stamped close after it. The close
+        // may be this step's own completion or the next lifecycle step's start.
+        // AI/CLI rows remain useful cadence events, never duration boundaries.
+        // Trust checks use the raw append-only log, not the UI de-duplicated
+        // sequence: a repeated start is precisely one of the anomalies that
+        // must remain visible to the timing validator.
+        const rawStepTransitions = transitions.filter(t => t.step === g.step);
+        const explicitStarts = rawStepTransitions.filter(t =>
+            isStepLevelEntry(t) && t.kind === 'start' && t.by === 'extension'
+        );
+        const trustedStart = explicitStarts.length === 1 ? explicitStarts[0] : null;
+        const startMs = trustedStart ? Date.parse(trustedStart.at) : NaN;
+        const closeMs = completedAt ? Date.parse(completedAt) : NaN;
+        const closeIsOwnCompletion = closeEntry !== null
+            && closeEntry.step === g.step
+            && isStepLevelEntry(closeEntry)
+            && closeEntry.kind === 'complete'
+            && closeEntry.by === 'extension';
+        const closeIsNextStart = closeEntry !== null
+            && closeEntry.step !== g.step
+            && isStepLevelEntry(closeEntry)
+            && closeEntry.kind === 'start'
+            && closeEntry.by === 'extension';
+        const completionBeforeStart = trustedStart !== null && rawStepTransitions.some(t =>
+            isStepLevelEntry(t)
+            && t.kind === 'complete'
+            && Number.isFinite(Date.parse(t.at))
+            && Date.parse(t.at) < startMs
+        );
+        const competingLaterStart = trustedStart !== null && completedAt !== null && rawStepTransitions.some(t =>
+            t !== trustedStart
+            && isStepLevelEntry(t)
+            && t.kind === 'start'
+            && Number.isFinite(Date.parse(t.at))
+            && Date.parse(t.at) > startMs
+            && Date.parse(t.at) <= closeMs
+        );
+        const spanTrusted = trustedStart !== null
+            && completedAt !== null
+            && (closeIsOwnCompletion || closeIsNextStart)
+            && Number.isFinite(startMs)
+            && Number.isFinite(closeMs)
+            && closeMs > startMs
+            && !completionBeforeStart
+            && !competingLaterStart;
 
-        const entry: StepHistoryEntry = { startedAt, completedAt };
-        entry.durationTrusted = startTrusted && (completedAt === null || endTrusted);
+        const entry: StepHistoryEntry = {
+            startedAt: spanTrusted ? trustedStart!.at : startedAt,
+            completedAt,
+        };
+        entry.durationTrusted = spanTrusted;
         if (substeps.length > 0) entry.substeps = substeps;
         out[g.step] = entry;
     }
 
+    // A trustworthy phase cannot overlap or run backwards relative to another
+    // trustworthy lifecycle phase. Mark both sides untrusted conservatively;
+    // this prevents one malformed boundary from becoming a whole-run total.
+    let previous: { name: string; start: number; end: number } | null = null;
+    for (const step of STEP_NAMES) {
+        const entry = out[step];
+        if (!entry?.durationTrusted || !entry.completedAt) continue;
+        const current = {
+            name: step,
+            start: Date.parse(entry.startedAt),
+            end: Date.parse(entry.completedAt),
+        };
+        if (previous && current.start < previous.end) {
+            out[previous.name].durationTrusted = false;
+            entry.durationTrusted = false;
+        }
+        previous = current;
+    }
+
     return out;
+}
+
+const DEFAULT_TIMING_PHASES = ['specify', 'plan', 'tasks', 'implement'] as const;
+
+/** Derive timing coverage and, only for a complete sequence, wall-clock elapsed time. */
+export function deriveTimingSummary(
+    stepHistory: Record<string, StepHistoryEntry>,
+    expectedPhases: readonly string[] = DEFAULT_TIMING_PHASES,
+): TimingSummary {
+    const expected = [...new Set(expectedPhases.filter(Boolean))];
+    const measured = expected.filter(name => {
+        const entry = stepHistory[name];
+        return entry?.durationTrusted === true && !!entry.completedAt;
+    });
+    const base: TimingSummary = {
+        measuredPhases: measured.length,
+        expectedPhases: expected.length,
+        complete: expected.length > 0 && measured.length === expected.length,
+    };
+    if (!base.complete) return base;
+
+    const entries = expected.map(name => stepHistory[name]);
+    const spans = entries.map(entry => ({
+        start: Date.parse(entry.startedAt),
+        end: Date.parse(entry.completedAt as string),
+    }));
+    const sequenceValid = spans.every((span, index) =>
+        Number.isFinite(span.start)
+        && Number.isFinite(span.end)
+        && span.end > span.start
+        && (index === 0 || span.start >= spans[index - 1].end)
+    );
+    if (!sequenceValid) return { ...base, complete: false };
+
+    const startedAt = entries[0].startedAt;
+    const endedAt = entries[entries.length - 1].completedAt as string;
+    const elapsedMs = Date.parse(endedAt) - Date.parse(startedAt);
+    if (!Number.isFinite(elapsedMs) || elapsedMs <= 0) return { ...base, complete: false };
+    return { ...base, startedAt, endedAt, elapsedMs };
 }

--- a/src/features/specs/stepHistoryDerivation.ts
+++ b/src/features/specs/stepHistoryDerivation.ts
@@ -431,8 +431,11 @@ export function deriveStepHistory(
         if (previous && current.start < previous.end) {
             out[previous.name].durationTrusted = false;
             entry.durationTrusted = false;
+            // Both spans are now untrusted — neither may anchor the next comparison.
+            previous = null;
+        } else {
+            previous = current;
         }
-        previous = current;
     }
 
     return out;

--- a/webview/src/spec-editor/CreateSpecMock.tsx
+++ b/webview/src/spec-editor/CreateSpecMock.tsx
@@ -1,208 +1,102 @@
-/**
- * Static Preact mock of the Create New Spec form.
- *
- * The real spec editor at `src/features/spec-editor/specEditorProvider.ts`
- * is a vanilla-DOM webview, so this mock exists only to give Storybook a
- * faithful visual reference of the layout. Used by:
- *   - SpecEditor/CreateSpec stories (standalone view).
- *   - Viewer/Transitions/CreateSpec (the lifecycle "phase zero" entry).
- *
- * The Auto button (hands-off auto pipeline) lives here, next to Create Spec —
- * by design it is the canonical first-time entry point for the spec pipeline,
- * NOT a viewer-footer button. It is shown only when a workflow with a hands-off
- * orchestrator (SpecKit Companion) is selected; `showAuto` mirrors that gating.
- */
+/** Production-class Storybook fixture for the vanilla-DOM Create Spec webview. */
 
 export interface CreateSpecMockProps {
     initialContent?: string;
     submitting?: boolean;
     overLimit?: boolean;
-    /** Whether the selected workflow exposes the hands-off Auto button (Companion). */
     showAuto?: boolean;
+    attachments?: string[];
+    narrow?: boolean;
 }
 
 const MAX_CHARS = 50_000;
-
-const PLACEHOLDER_TEXT =
-    'Describe your feature or task in detail — or just paste a link below and skip the description entirely.\n\n' +
-    'What helps:\n' +
-    '- What is the feature about?\n' +
-    '- What problem does it solve?\n' +
-    '- Who is it for?\n' +
-    '- Key requirements, constraints, or dependencies?\n\n' +
-    'Or paste a reference link on its own:\n' +
-    '- Jira:  https://your-org.atlassian.net/browse/PROJ-1234\n' +
-    '- GitHub:  https://github.com/your-org/your-repo/issues/42';
+const PLACEHOLDER = 'Describe the problem, audience, and desired outcome — or paste a Jira/GitHub link.';
 
 export function CreateSpecMock({
     initialContent = '',
     submitting = false,
     overLimit = false,
     showAuto = true,
+    attachments = [],
+    narrow = false,
 }: CreateSpecMockProps) {
-    const charCount = overLimit ? MAX_CHARS + 1200 : initialContent.length;
-    const isEmpty = initialContent.trim().length === 0;
-    const canSubmit = !isEmpty && !overLimit && !submitting;
-    // Counter is hidden until ~90% of the limit, then shows in warning/over-limit color.
-    const showCount = charCount >= MAX_CHARS * 0.9;
+    const count = overLimit ? MAX_CHARS + 1200 : initialContent.length;
+    const canSubmit = initialContent.trim().length > 0 && !overLimit && !submitting;
+    const showCount = count >= MAX_CHARS * 0.9;
 
     return (
-        <div
-            style={`
-                background: var(--vscode-editor-background, #0a0512);
-                color: var(--vscode-foreground, #c8c8c8);
-                font-family: var(--vscode-font-family, system-ui, -apple-system, sans-serif);
-                padding: 32px;
-                min-height: 100vh;
-                box-sizing: border-box;
-            `}
-        >
-            <main style="max-width: 800px; margin: 0 auto;">
-                <header style="margin-bottom: 24px;">
-                    <h1 style="font-size: 28px; font-weight: 700; margin: 0 0 6px; color: var(--vscode-foreground, #fff);">
-                        Create New Spec
-                    </h1>
-                    <p style="font-size: 15px; margin: 0; color: var(--vscode-foreground, #c8c8c8);">
-                        Describe your feature — or just paste a link — and the AI will generate the spec, plan, and tasks for it.
-                    </p>
+        <div class="spec-editor" id="app" aria-busy={submitting ? 'true' : 'false'}>
+            <main class="spec-editor-column" style={narrow ? 'max-width: 440px' : undefined}>
+                <header class="spec-editor-header">
+                    <h1>Create New Spec</h1>
+                    <p>Describe your feature — or just paste a link — and the AI will generate the spec, plan, and tasks for it.</p>
                 </header>
 
-                <div style="display: flex; justify-content: flex-end; align-items: center; gap: 12px; font-size: 15px; margin-bottom: 8px;">
-                    <span>Workflow</span>
-                    <button
-                        type="button"
-                        style="
-                            background: var(--vscode-button-secondaryBackground, #1f1828);
-                            color: var(--vscode-button-secondaryForeground, #ddd);
-                            border: 1px solid var(--vscode-widget-border, #303030);
-                            padding: 6px 12px;
-                            border-radius: 4px;
-                            font-size: 15px;
-                            cursor: pointer;
-                            display: inline-flex;
-                            align-items: center;
-                            gap: 8px;
-                            min-width: 120px;
-                            justify-content: space-between;
-                        "
-                    >
-                        SpecKit
-                        <span style="opacity: 0.5;">▾</span>
-                    </button>
+                <div class="spec-editor-content">
+                    <div class="workflow-row">
+                        <div class="workflow-selector">
+                            <label for="story-workflow">Workflow</label>
+                            <select id="story-workflow" aria-label="Workflow">
+                                <option>SpecKit</option>
+                            </select>
+                        </div>
+                    </div>
+
+                    <div class="editor-container">
+                        <label class="editor-label" for="story-brief">Feature Brief</label>
+                        <details class="writing-tips">
+                            <summary>Writing tips</summary>
+                            <p>Include the problem, who it affects, key requirements, and constraints. A Jira or GitHub link also works on its own.</p>
+                        </details>
+                        <textarea
+                            id="story-brief"
+                            class="spec-editor-textarea"
+                            placeholder={PLACEHOLDER}
+                            value={initialContent}
+                            readOnly
+                        />
+                        <div class="editor-footer-row">
+                            <button class="attach-image-btn" type="button">
+                                <span class="codicon codicon-file-media" aria-hidden="true" />
+                                Attach image
+                            </button>
+                            {showCount && (
+                                <div class={`char-count ${overLimit ? 'error' : 'warning'}`}>
+                                    {overLimit
+                                        ? `Over limit — ${count.toLocaleString()} / ${MAX_CHARS.toLocaleString()} (remove ${(count - MAX_CHARS).toLocaleString()} characters)`
+                                        : `${count.toLocaleString()} / ${MAX_CHARS.toLocaleString()}`}
+                                </div>
+                            )}
+                        </div>
+                        <div class="image-thumbnails">
+                            {attachments.map((name, index) => (
+                                <div class="image-thumbnail" key={name}>
+                                    <div class="create-spec-fixture-image" aria-hidden="true">{index + 1}</div>
+                                    <span class="image-name">{name}</span>
+                                    <button class="remove-btn" type="button" aria-label={`Remove image ${name}`}>×</button>
+                                </div>
+                            ))}
+                        </div>
+                    </div>
                 </div>
 
-                <section style="margin-bottom: 20px;">
-                    <div
-                        style={`
-                            background: var(--vscode-input-background, #0c0814);
-                            border: 1px solid var(--vscode-widget-border, #2a2a2a);
-                            border-radius: 6px;
-                            padding: 16px;
-                            font-family: var(--vscode-font-family, system-ui, sans-serif);
-                            font-size: 15px;
-                            line-height: 1.6;
-                            min-height: 280px;
-                            white-space: pre-wrap;
-                            color: ${isEmpty ? 'rgba(200, 200, 200, 0.85)' : 'var(--vscode-input-foreground, #ddd)'};
-                        `}
-                    >
-                        {initialContent || PLACEHOLDER_TEXT}
-                    </div>
-                    <div style="display: flex; align-items: center; justify-content: space-between; gap: 8px; margin-top: 6px;">
-                        <button
-                            type="button"
-                            aria-label="Attach image (or paste an image to attach)"
-                            style="
-                                background: transparent;
-                                color: var(--vscode-button-secondaryForeground, #ddd);
-                                border: 1px solid var(--vscode-widget-border, #303030);
-                                padding: 4px 10px;
-                                font-size: 12px;
-                                border-radius: 4px;
-                                cursor: pointer;
-                                display: inline-flex;
-                                align-items: center;
-                                gap: 6px;
-                            "
-                        >
-                            <span aria-hidden="true">🖼</span>
-                            Attach image
-                        </button>
-                        {showCount && (
-                            <span
-                                style={`font-size: 12px; color: ${overLimit ? 'var(--vscode-editorError-foreground, #f14c4c)' : 'var(--vscode-editorWarning-foreground, #cca700)'};`}
-                            >
-                                {overLimit
-                                    ? `Over limit — ${charCount.toLocaleString()} / ${MAX_CHARS.toLocaleString()} (remove ${(charCount - MAX_CHARS).toLocaleString()} characters)`
-                                    : `${charCount.toLocaleString()} / ${MAX_CHARS.toLocaleString()}`}
-                            </span>
-                        )}
-                    </div>
-                </section>
-
-                <footer style="padding-top: 16px; display: flex; align-items: center; gap: 12px;">
-                    <p style="margin: 0; font-size: 11px; color: var(--vscode-foreground, #c8c8c8);">
-                        <kbd style="background: var(--vscode-keybindingLabel-background, #2a2a2a); padding: 1px 6px; border-radius: 3px; border: 1px solid var(--vscode-widget-border, #303030);">Ctrl/Cmd</kbd>
-                        {' + '}
-                        <kbd style="background: var(--vscode-keybindingLabel-background, #2a2a2a); padding: 1px 6px; border-radius: 3px; border: 1px solid var(--vscode-widget-border, #303030);">Enter</kbd>
-                        {' to submit · '}
-                        <kbd style="background: var(--vscode-keybindingLabel-background, #2a2a2a); padding: 1px 6px; border-radius: 3px; border: 1px solid var(--vscode-widget-border, #303030);">Esc</kbd>
-                        {' to cancel'}
-                    </p>
-                    <div style="flex: 1;" />
-                    <button
-                        type="button"
-                        style="
-                            background: transparent;
-                            color: var(--vscode-foreground, #ddd);
-                            border: 1px solid var(--vscode-widget-border, #303030);
-                            padding: 8px 18px;
-                            border-radius: 4px;
-                            font-size: 13px;
-                            cursor: pointer;
-                        "
-                    >
-                        Cancel
-                    </button>
-                    {showAuto && (
-                    <button
-                        type="button"
-                        disabled={!canSubmit}
-                        title="Build the whole spec hands-off — specify → plan → tasks → implement → completed, no pauses"
-                        style={`
-                            background: var(--vscode-button-secondaryBackground, #1f1828);
-                            color: var(--vscode-button-secondaryForeground, #ddd);
-                            border: 1px solid var(--vscode-widget-border, #303030);
-                            padding: 8px 18px;
-                            border-radius: 4px;
-                            font-size: 13px;
-                            cursor: ${canSubmit ? 'pointer' : 'not-allowed'};
-                            font-weight: 500;
-                            opacity: ${canSubmit ? 1 : 0.5};
-                        `}
-                    >
-                        Auto
-                    </button>
-                    )}
-                    <button
-                        type="button"
-                        disabled={!canSubmit}
-                        style={`
-                            background: ${canSubmit ? 'var(--vscode-button-background, #3c3c3c)' : 'var(--vscode-button-secondaryBackground, #2a2a2a)'};
-                            color: var(--vscode-button-foreground, #fff);
-                            border: 1px solid var(--vscode-widget-border, #303030);
-                            padding: 8px 22px;
-                            border-radius: 4px;
-                            font-size: 13px;
-                            font-weight: 600;
-                            cursor: ${canSubmit ? 'pointer' : 'not-allowed'};
-                            opacity: ${canSubmit ? 1 : 0.5};
-                        `}
-                    >
+                <footer class="spec-editor-actions">
+                    <div class="keyboard-hints"><kbd>Ctrl/Cmd</kbd>+<kbd>Enter</kbd> to submit • <kbd>Esc</kbd> to cancel</div>
+                    <div class="action-spacer" />
+                    <button class="btn-cancel" type="button">Cancel</button>
+                    {showAuto && <button class="btn-secondary" type="button" disabled={!canSubmit}>Auto</button>}
+                    <button class="btn-primary" type="button" disabled={!canSubmit}>
                         {submitting ? 'Creating…' : 'Create Spec'}
                     </button>
                 </footer>
             </main>
+
+            {submitting && (
+                <div class="loading-overlay" role="status">
+                    <div class="loading-spinner" aria-hidden="true" />
+                    <p class="loading-text">Creating your spec…</p>
+                </div>
+            )}
         </div>
     );
 }

--- a/webview/src/spec-editor/__stories__/CreateSpec.stories.tsx
+++ b/webview/src/spec-editor/__stories__/CreateSpec.stories.tsx
@@ -7,6 +7,7 @@
 
 import type { Meta, StoryObj } from '@storybook/preact';
 import { CreateSpecMock } from '../CreateSpecMock';
+import '../../../styles/spec-editor.css';
 
 const meta: Meta = {
     title: 'SpecEditor/CreateSpec',
@@ -80,4 +81,19 @@ export const StockWorkflow: Story = {
             showAuto={false}
         />
     ),
+};
+
+export const WithAttachments: Story = {
+    name: 'Attachments',
+    render: () => (
+        <CreateSpecMock
+            initialContent="Use the attached reference states for the refreshed viewer."
+            attachments={['viewer-wide.png', 'viewer-narrow.png']}
+        />
+    ),
+};
+
+export const Narrow: Story = {
+    name: 'Narrow',
+    render: () => <CreateSpecMock initialContent="Make the viewer usable in a narrow split pane." narrow />,
 };

--- a/webview/src/spec-viewer/FullViewer.stories.tsx
+++ b/webview/src/spec-viewer/FullViewer.stories.tsx
@@ -25,6 +25,7 @@ import { renderMarkdown, setCurrentTask, setHasSpecContext, setTaskSummaries } f
 import { applyHighlighting } from './highlighting';
 import { buildToc } from './toc';
 import { mockDoc, mockRelatedDoc, mockNavState } from './components/__stories__/mockData';
+import { deriveStepHistory, deriveTimingSummary } from '../../../src/features/specs/stepHistoryDerivation';
 
 import spec392 from '../../../specs/392-living-specs-viewer/spec.md?raw';
 import plan392 from '../../../specs/392-living-specs-viewer/plan.md?raw';
@@ -51,6 +52,16 @@ import dataModel394 from '../../../specs/394-adopt-codex-design/data-model.md?ra
 import checklist394 from '../../../specs/394-adopt-codex-design/checklists/requirements.md?raw';
 import contract394 from '../../../specs/394-adopt-codex-design/contracts/ui-contract.md?raw';
 import ctx394Raw from '../../../specs/394-adopt-codex-design/.spec-context.json?raw';
+import spec406 from '../../../specs/406-living-spec-components/spec.md?raw';
+import plan406 from '../../../specs/406-living-spec-components/plan.md?raw';
+import tasks406 from '../../../specs/406-living-spec-components/tasks.md?raw';
+import ctx406Raw from '../../../specs/406-living-spec-components/.spec-context.json?raw';
+import viewerUiLiving from './viewer-ui.spec.md?raw';
+import specViewerLiving from '../../../src/features/spec-viewer/spec-viewer.spec.md?raw';
+import spec393 from '../../../specs/393-implement-button-lost/spec.md?raw';
+import plan393 from '../../../specs/393-implement-button-lost/plan.md?raw';
+import tasks393 from '../../../specs/393-implement-button-lost/tasks.md?raw';
+import ctx393Raw from '../../../specs/393-implement-button-lost/.spec-context.json?raw';
 
 /** The slice of an on-disk .spec-context.json these stories consume. */
 interface SpecContextData {
@@ -68,11 +79,19 @@ interface SpecContextData {
     expectations?: string[];
     context?: string[];
     verified?: ViewerState['verified'];
+    coverage?: Record<string, { title?: string; tasks?: string[]; tests?: string[] }>;
+    classification?: ViewerState['classification'];
+    livingSpecs?: {
+        loaded?: string[];
+        synced?: string[];
+    };
 }
 
 const ctx392 = JSON.parse(ctx392Raw) as SpecContextData;
 const ctx172 = JSON.parse(ctx172Raw) as SpecContextData;
 const ctx394 = JSON.parse(ctx394Raw) as SpecContextData;
+const ctx406 = JSON.parse(ctx406Raw) as SpecContextData;
+const ctx393 = JSON.parse(ctx393Raw) as SpecContextData;
 
 /** Every openable document of a spec, keyed by the `documentType` the nav emits. */
 interface DocEntry {
@@ -114,6 +133,18 @@ const docs394: DocSet = {
     research: { md: research394, label: 'Research', parentStep: 'plan' },
     'data-model': { md: dataModel394, label: 'Data Model', parentStep: 'plan' },
     contract: { md: contract394, label: 'UI Contract', parentStep: 'plan' },
+};
+
+const docs406: DocSet = {
+    spec: { md: spec406, label: 'Specification' },
+    plan: { md: plan406, label: 'Plan' },
+    tasks: { md: tasks406, label: 'Tasks' },
+};
+
+const docs393: DocSet = {
+    spec: { md: spec393, label: 'Specification' },
+    plan: { md: plan393, label: 'Plan' },
+    tasks: { md: tasks393, label: 'Tasks' },
 };
 
 function relatedDocsFor(docs: DocSet) {
@@ -170,6 +201,21 @@ function vsFromContext(
     footer: SerializedFooterAction[],
     overrides: Partial<ViewerState> = {},
 ): ViewerState {
+    // Use the same production timing derivation as the extension provider so
+    // integrated stories never manufacture durations from raw journal events.
+    const derivedStepHistory = deriveStepHistory(
+        ctx.history as Parameters<typeof deriveStepHistory>[0],
+        ctx.currentStep as Parameters<typeof deriveStepHistory>[1],
+        ctx.status as Parameters<typeof deriveStepHistory>[2],
+    );
+    const coverage = ctx.coverage
+        ? Object.entries(ctx.coverage).map(([req, row]) => ({
+            req,
+            title: row.title,
+            tasks: row.tasks ?? [],
+            tests: row.tests ?? [],
+        }))
+        : undefined;
     return {
         status: ctx.status,
         activeStep: ctx.currentStep,
@@ -179,7 +225,8 @@ function vsFromContext(
         activeSubstep: null,
         footer,
         history: ctx.history,
-        stepHistory: stepHistoryFrom(ctx.history),
+        stepHistory: derivedStepHistory as ViewerState['stepHistory'],
+        timing: deriveTimingSummary(derivedStepHistory),
         approach: ctx.approach,
         lastAction: ctx.last_action,
         taskSummaries: ctx.task_summaries,
@@ -188,6 +235,11 @@ function vsFromContext(
         expectations: ctx.expectations,
         context: ctx.context,
         verified: ctx.verified,
+        coverage,
+        classification: ctx.classification,
+        livingSpecs: ctx.livingSpecs
+            ? { loaded: ctx.livingSpecs.loaded ?? [], synced: ctx.livingSpecs.synced ?? [] }
+            : undefined,
         ...overrides,
     } as ViewerState;
 }
@@ -244,22 +296,25 @@ interface InteractiveViewerProps {
     vs: ViewerState;
     extraNav?: Partial<NavState>;
     view?: 'overview' | 'document';
+    livingDocs?: Record<string, DocEntry>;
 }
 
 /** FullViewer + working navigation: answers the nav's `stepperClick` /
  *  `switchDocument` messages in-story, standing in for messageHandlers.ts. */
-function InteractiveViewer({ ctx, docs, initialDoc, vs, extraNav, view }: InteractiveViewerProps) {
+function InteractiveViewer({ ctx, docs, initialDoc, vs, extraNav, view, livingDocs }: InteractiveViewerProps) {
     const [doc, setDoc] = useState(initialDoc);
 
     useEffect(() => {
         const host = window as unknown as { vscode: { postMessage: (msg: unknown) => void } };
         const original = host.vscode.postMessage;
         host.vscode.postMessage = (msg: unknown) => {
-            const m = msg as { type?: string; phase?: string; documentType?: string };
+            const m = msg as { type?: string; phase?: string; documentType?: string; capabilityName?: string };
             if (m?.type === 'stepperClick' && m.phase && docs[m.phase]) {
                 setDoc(m.phase);
             } else if (m?.type === 'switchDocument' && m.documentType && docs[m.documentType]) {
                 setDoc(m.documentType);
+            } else if (m?.type === 'openLivingSpec' && m.capabilityName && livingDocs?.[m.capabilityName]) {
+                setDoc(`living:${m.capabilityName}`);
             } else {
                 original(msg);
             }
@@ -267,17 +322,22 @@ function InteractiveViewer({ ctx, docs, initialDoc, vs, extraNav, view }: Intera
         return () => {
             host.vscode.postMessage = original;
         };
-    }, [docs]);
+    }, [docs, livingDocs]);
+
+    const livingName = doc.startsWith('living:') ? doc.slice('living:'.length) : null;
+    const activeDoc = livingName ? livingDocs?.[livingName] : docs[doc];
 
     const nav = navFromContext(ctx, {
-        currentDoc: doc as DocumentType,
+        currentDoc: (livingName ? 'spec' : doc) as DocumentType,
         relatedDocs: relatedDocsFor(docs),
-        isViewingRelatedDoc: !CORE_DOCS.includes(doc),
-        docTypeLabel: docs[doc].label,
+        isViewingRelatedDoc: livingName ? false : !CORE_DOCS.includes(doc),
+        docTypeLabel: activeDoc?.label,
+        livingMode: livingName !== null,
+        specContextName: livingName ?? ctx.specName,
         ...extraNav,
     });
 
-    return <FullViewer md={docs[doc].md} nav={nav} vs={vs} view={view} />;
+    return <FullViewer md={activeDoc?.md ?? docs[initialDoc].md} nav={nav} vs={vs} view={livingName ? 'document' : view} />;
 }
 
 const meta: Meta = {
@@ -310,6 +370,36 @@ export const ComposableCommandNodes172: Story = {
     name: '172 · Composable Command Nodes',
     render: () => (
         <InteractiveViewer ctx={ctx172} docs={docs172} initialDoc="spec" vs={vsFromContext(ctx172, completedFooter)} />
+    ),
+};
+
+export const LivingComponents406: Story = {
+    name: '406 · Living Components (Overview + real artifacts)',
+    render: () => (
+        <InteractiveViewer
+            ctx={ctx406}
+            docs={docs406}
+            initialDoc="spec"
+            view="overview"
+            vs={vsFromContext(ctx406, completedFooter)}
+            livingDocs={{
+                'viewer-ui': { md: viewerUiLiving, label: 'viewer-ui' },
+                'spec-viewer': { md: specViewerLiving, label: 'spec-viewer' },
+            }}
+        />
+    ),
+};
+
+export const IncompleteMetadata393: Story = {
+    name: '393 · Incomplete metadata (no Approach)',
+    render: () => (
+        <InteractiveViewer
+            ctx={ctx393}
+            docs={docs393}
+            initialDoc="spec"
+            view="overview"
+            vs={vsFromContext(ctx393, completedFooter)}
+        />
     ),
 };
 

--- a/webview/src/spec-viewer/__tests__/timelineEvents.test.ts
+++ b/webview/src/spec-viewer/__tests__/timelineEvents.test.ts
@@ -62,6 +62,15 @@ describe('mergeStepEvents', () => {
         expect(events[1].by).toBe('cli');
     });
 
+    it('uses the journal finish as recordedAt without treating it as a task duration', () => {
+        const transitions = [
+            tx({ step: 'plan', substep: 'research', kind: 'complete', by: 'ai', at: '2026-04-29T00:04:00Z' }),
+        ];
+        const events = mergeStepEvents('plan', history, transitions);
+        expect(events[0].recordedAt).toBe('2026-04-29T00:04:00Z');
+        expect(events[0].startedAt).toBe('2026-04-29T00:01:00Z');
+    });
+
     it('emits logged-only events for transitions not present in substeps[]', () => {
         const transitions = [
             tx({ step: 'specify', substep: 'parsing',   by: 'cli', at: '2026-04-29T00:00:00Z' }),
@@ -83,14 +92,13 @@ describe('mergeStepEvents', () => {
         expect(events[0].name).toBe('parsing');
     });
 
-    it('returns events sorted by startedAt', () => {
+    it('returns events sorted by their recorded timestamp', () => {
         const transitions = [
             tx({ step: 'plan', substep: 'late',  by: 'ai', at: '2026-04-29T00:08:00Z' }),
             tx({ step: 'plan', substep: 'early', by: 'ai', at: '2026-04-29T00:00:30Z' }),
         ];
         const events = mergeStepEvents('plan', history, transitions);
-        // research (T+1m) → early (T+30s)? No — T+30s comes first.
-        expect(events.map(e => e.name)).toEqual(['early', 'research', 'design', 'late']);
+        expect(events.map(e => e.name)).toEqual(['early', 'research', 'late', 'design']);
     });
 
     it('prefers tracked source when name overlaps with a transition', () => {

--- a/webview/src/spec-viewer/components/ActivityPanel.stories.tsx
+++ b/webview/src/spec-viewer/components/ActivityPanel.stories.tsx
@@ -246,11 +246,20 @@ const richReasoningState: ViewerState = {
         tasks: { startedAt: '2026-07-02T10:18:00Z', completedAt: '2026-07-02T10:21:00Z', durationTrusted: true },
         implement: { startedAt: '2026-07-02T10:21:00Z', completedAt: '2026-07-02T10:52:00Z', durationTrusted: true },
     },
+    timing: {
+        measuredPhases: 4,
+        expectedPhases: 4,
+        complete: true,
+        startedAt: '2026-07-02T10:00:00Z',
+        endedAt: '2026-07-02T10:52:00Z',
+        elapsedMs: 52 * 60_000,
+    },
     intent: 'Turn the Activity panel from an 11-card scroll into a brief: hero summary, always-visible ICE plan, tabbed detail, and signature data visuals.',
     context: ['area: webview/src/spec-viewer/components', 'constraint: approved A-hybrid mock', 'living spec: none configured'],
     expectations: ['existing cards reused inside tabs', 'tab state in-memory only', 'color encodes state only'],
     approach: 'Three new components recomposing existing cards; signature elements as token-driven CSS and SVG.',
     classification: { projectedFiles: 12, projectedTasks: 11, scopeSignal: 'none', verdict: 'normal' },
+    livingSpecs: { loaded: ['viewer-ui', 'spec-viewer'], synced: ['viewer-ui'] },
     decisions: [
         { decision: 'inline SVG stroke-dasharray donut', why: 'zero dependencies, token-colored', rejected: 'a chart library' },
         { decision: 'tab state as an in-memory signal', why: 'matches the webview reactive idiom', rejected: 'persisting the active tab' },
@@ -322,6 +331,7 @@ export const DossierMidPipeline: Story = {
                 plan: { startedAt: '2026-07-02T10:06:00Z', completedAt: '2026-07-02T10:18:00Z', durationTrusted: false },
                 implement: { startedAt: '2026-07-02T10:21:00Z', completedAt: null, durationTrusted: true },
             },
+            timing: { measuredPhases: 1, expectedPhases: 4, complete: false },
         };
         navState.value = { showInstallPrompt: false } as NavState;
         return <div style="max-width: 900px;"><ActivityPanel /></div>;

--- a/webview/src/spec-viewer/components/ActivityPanel.tsx
+++ b/webview/src/spec-viewer/components/ActivityPanel.tsx
@@ -13,7 +13,6 @@ import { TasksCard } from './cards/TasksCard';
 import { ConcernsCard } from './cards/ConcernsCard';
 import { FilesCard } from './cards/FilesCard';
 import { CommentsCard } from './cards/CommentsCard';
-import { LivingSpecsCard } from './cards/LivingSpecsCard';
 
 /**
  * The viewer install banner, rendered INSIDE the Activity panel (#255 — it used
@@ -73,9 +72,9 @@ function hasRunLogData(state: ViewerState): boolean {
         (state.history?.length ?? 0) > 0 ||
         Object.keys(state.stepHistory ?? {}).length > 0 ||
         Object.keys(state.taskSummaries ?? {}).length > 0 ||
+        (state.concerns?.length ?? 0) > 0 ||
         (state.filesModified?.length ?? 0) > 0 ||
         (state.reviewComments?.length ?? 0) > 0 ||
-        !!state.livingSpecs ||
         !!state.lastAction
     );
 }
@@ -94,8 +93,8 @@ export function ActivityPanel() {
 
     const taskCount = Object.keys(state.taskSummaries ?? {}).length;
 
-    // Durable context leads (why → fence → proof → choices → traceability);
-    // how-the-run-happened demotes to the collapsed log at the bottom.
+    // Lifecycle signal first, then durable context (why → fence → proof →
+    // choices → traceability); granular run history stays collapsed below.
     return (
         <div class="activity-panel dossier">
             <InstallBanner />
@@ -104,7 +103,6 @@ export function ActivityPanel() {
             <VerifiedSection state={state} />
             <DecisionsSection state={state} />
             <CoverageSection state={state} />
-            <ConcernsCard state={state} />
             {hasRunLogData(state) && (
                 <details class="dossier-log">
                     <summary>
@@ -114,8 +112,8 @@ export function ActivityPanel() {
                         {state.lastAction && <p class="dossier-log__last-action">{state.lastAction}</p>}
                         <LatestFeed />
                         <PhasesCard state={state} />
-                        <LivingSpecsCard state={state} />
                         <TasksCard state={state} />
+                        <ConcernsCard state={state} />
                         <FilesCard state={state} />
                         <CommentsCard state={state} />
                     </div>

--- a/webview/src/spec-viewer/components/OverviewDossier.tsx
+++ b/webview/src/spec-viewer/components/OverviewDossier.tsx
@@ -1,4 +1,6 @@
 import type { ViewerState } from '../types';
+import { formatElapsed } from '../relativeTime';
+import { LivingSpecLinks, livingSpecChips } from './cards/LivingSpecsCard';
 
 /**
  * The Overview's sections, ordered by what a future session needs:
@@ -8,6 +10,59 @@ import type { ViewerState } from '../types';
 
 const CONSTRAINT_PREFIX = 'constraint: ';
 const AREA_PREFIX = 'area: ';
+const PHASE_ORDER = ['specify', 'clarify', 'plan', 'tasks', 'analyze', 'implement'];
+
+function phaseNames(state: ViewerState): string[] {
+    const keys = Object.keys(state.stepHistory ?? {});
+    const known = PHASE_ORDER.filter(step => keys.includes(step));
+    return [...known, ...keys.filter(step => !PHASE_ORDER.includes(step))];
+}
+
+/** Compact lifecycle signal for the top of Overview; task events stay in Run Log. */
+export function OverviewTiming({ state }: { state: ViewerState }) {
+    const phases = phaseNames(state);
+    if (phases.length === 0) return null;
+
+    const timing = state.timing;
+    const complete = timing?.complete === true && timing.elapsedMs !== undefined;
+    const summary = complete
+        ? `${formatElapsed(timing.elapsedMs!)} elapsed`
+        : timing
+            ? `Timing coverage: ${timing.measuredPhases} of ${timing.expectedPhases} phases`
+            : 'Timing not recorded';
+
+    return (
+        <section class="dossier-timing" aria-label="Run timing overview">
+            <div class="dossier-timing__head">
+                <span class="dossier-kicker">Run overview</span>
+                {summary && <strong>{summary}</strong>}
+            </div>
+            <div class="dossier-timing__phases" role="list">
+                {phases.map((phase, index) => {
+                    const entry = state.stepHistory[phase];
+                    const inFlight = entry.completedAt === null;
+                    const duration = entry.durationTrusted && entry.completedAt
+                        ? formatElapsed(Date.parse(entry.completedAt) - Date.parse(entry.startedAt))
+                        : null;
+                    return (
+                        <div
+                            key={phase}
+                            role="listitem"
+                            class={`dossier-timing__phase${inFlight ? ' is-in-flight' : ''}`}
+                        >
+                            {index > 0 && <span class="dossier-timing__connector" aria-hidden="true" />}
+                            <span class="dossier-timing__dot" aria-hidden="true" />
+                            <span class="dossier-timing__name">
+                                {phase.charAt(0).toUpperCase() + phase.slice(1)}
+                            </span>
+                            {duration && <span class="dossier-timing__duration">{duration}</span>}
+                        </div>
+                    );
+                })}
+            </div>
+        </section>
+    );
+}
 
 function sizingLine(c: NonNullable<ViewerState['classification']>): string {
     const parts: string[] = [];
@@ -39,22 +94,36 @@ function SectionHead({ kicker, title, count, tone }: {
 export function IntentSection({ state }: { state: ViewerState }) {
     const { intent, approach, context, classification } = state;
     const area = context?.find(item => item.startsWith(AREA_PREFIX))?.slice(AREA_PREFIX.length);
-    if (!intent && !approach && !area) return null;
+    const livingSpecs = state.livingSpecs;
+    const livingSpecsCount = livingSpecs ? livingSpecChips(livingSpecs).length : 0;
+    const hasTiming = phaseNames(state).length > 0;
+    if (!intent && !approach && !area && !classification && livingSpecsCount === 0 && !hasTiming) return null;
 
     return (
         <section class="dossier-intent" aria-label="Intent">
             <p class="dossier-kicker">Intent</p>
             {intent && <p class="dossier-intent__statement">{intent}</p>}
-            {(approach || area || classification) && (
+            <OverviewTiming state={state} />
+            {(approach || area || classification || livingSpecsCount > 0) && (
                 <div class="dossier-intent__meta">
-                    {approach && (
-                        <div>
-                            <span class="dossier-meta-label">Approach</span>
-                            <p>{approach}</p>
+                    {(approach || (livingSpecs && livingSpecsCount > 0)) && (
+                        <div class="dossier-intent__approach">
+                            {approach && (
+                                <>
+                                    <span class="dossier-meta-label">Approach</span>
+                                    <p>{approach}</p>
+                                </>
+                            )}
+                            {livingSpecs && livingSpecsCount > 0 && (
+                                <div class="dossier-intent__living-specs">
+                                    <span class="dossier-meta-label">Living specs</span>
+                                    <LivingSpecLinks livingSpecs={livingSpecs} />
+                                </div>
+                            )}
                         </div>
                     )}
                     {(area || classification) && (
-                        <div>
+                        <div class="dossier-intent__context">
                             {area && (
                                 <>
                                     <span class="dossier-meta-label">Working area</span>

--- a/webview/src/spec-viewer/components/RunStrip.stories.tsx
+++ b/webview/src/spec-viewer/components/RunStrip.stories.tsx
@@ -59,8 +59,28 @@ export const CompletedWithPr: Story = {
             stepHistory: {
                 implement: { startedAt: '2026-07-02T10:00:00Z', completedAt: '2026-07-02T13:11:00Z', durationTrusted: true },
             },
+            timing: {
+                measuredPhases: 4,
+                expectedPhases: 4,
+                complete: true,
+                startedAt: '2026-07-02T09:36:00Z',
+                endedAt: '2026-07-02T13:11:00Z',
+                elapsedMs: 12_780_000,
+            },
             prUrl: 'https://github.com/alfredoperez/speckit-companion/pull/431',
             prNumber: 431,
+        });
+        return <RunStrip />;
+    },
+};
+
+export const PartialTiming: Story = {
+    name: 'Partial timing (coverage, never total)',
+    render: () => {
+        navState.value = mockNavState({});
+        viewerState.value = baseState({
+            status: 'completed',
+            timing: { measuredPhases: 1, expectedPhases: 4, complete: false },
         });
         return <RunStrip />;
     },

--- a/webview/src/spec-viewer/components/RunStrip.tsx
+++ b/webview/src/spec-viewer/components/RunStrip.tsx
@@ -7,7 +7,7 @@ import { heroStats, formatActiveTime } from '../activityHeroModel';
  */
 
 /** Least → most important; the CSS hides by this key as width runs out. */
-type FactKey = 'active' | 'checks' | 'traced' | 'concerns' | 'tasks';
+type FactKey = 'timing' | 'checks' | 'traced' | 'concerns' | 'tasks';
 
 export function RunStrip() {
     const vs = viewerState.value;
@@ -36,8 +36,13 @@ export function RunStrip() {
         });
     }
     if (stats.checks !== undefined) facts.push({ key: 'checks', value: `${stats.checks} checks` });
-    if (stats.trustedActiveMs !== undefined) {
-        facts.push({ key: 'active', value: `${formatActiveTime(stats.trustedActiveMs)} active` });
+    if (vs.timing?.complete && vs.timing.elapsedMs !== undefined) {
+        facts.push({ key: 'timing', value: `${formatActiveTime(vs.timing.elapsedMs)} elapsed` });
+    } else if (vs.timing && vs.timing.measuredPhases > 0) {
+        facts.push({
+            key: 'timing',
+            value: `Timing ${vs.timing.measuredPhases}/${vs.timing.expectedPhases} phases`,
+        });
     }
 
     if (facts.length === 0 && !vs.prUrl) return null;

--- a/webview/src/spec-viewer/components/TaskLine.stories.tsx
+++ b/webview/src/spec-viewer/components/TaskLine.stories.tsx
@@ -87,7 +87,7 @@ const CommentIconSVG = () => (
   <svg width="14" height="14" viewBox="0 0 24 24">
     <path
       fill="none"
-      stroke="#ffffff"
+      stroke="currentColor"
       stroke-linecap="round"
       stroke-linejoin="round"
       stroke-width="1.5"

--- a/webview/src/spec-viewer/components/TimelineEvent.tsx
+++ b/webview/src/spec-viewer/components/TimelineEvent.tsx
@@ -1,5 +1,5 @@
 import type { TimelineEventModel } from '../timelineEvents';
-import { formatDuration, formatStepOffset } from '../relativeTime';
+import { formatStepOffset } from '../relativeTime';
 
 const KNOWN_ACTORS = new Set(['extension', 'cli', 'ai', 'user']);
 
@@ -10,31 +10,17 @@ export interface TimelineEventProps {
 
 export function TimelineEvent({ event, stepStartedAt }: TimelineEventProps) {
     const actor = event.by && KNOWN_ACTORS.has(event.by) ? event.by : null;
-    const offset = formatStepOffset(stepStartedAt, event.startedAt);
-    const isInFlight = event.source === 'tracked' && event.completedAt === null;
-    const duration = event.source === 'tracked'
-        ? (event.completedAt
-            ? formatDuration(event.startedAt, event.completedAt)
-            : formatDuration(event.startedAt, null))
-        : null;
+    const offset = formatStepOffset(stepStartedAt, event.recordedAt);
 
     return (
-        <div class={`timeline-entry${isInFlight ? ' is-in-flight' : ''}`}>
+        <div class="timeline-entry">
             <span class="timeline-substep">{event.name}</span>
             {actor && (
                 <span class={`timeline-actor-badge is-${actor}`}>{event.by}</span>
             )}
-            <time class="timeline-offset" dateTime={event.startedAt} title={event.startedAt}>
-                {offset}
+            <time class="timeline-offset" dateTime={event.recordedAt} title={event.recordedAt}>
+                recorded at {offset}
             </time>
-            {duration && (
-                <span
-                    class="timeline-event-duration"
-                    title={event.completedAt ?? `live since ${event.startedAt}`}
-                >
-                    {isInFlight ? `${duration} so far` : duration}
-                </span>
-            )}
         </div>
     );
 }

--- a/webview/src/spec-viewer/components/__tests__/OverviewDossier.test.tsx
+++ b/webview/src/spec-viewer/components/__tests__/OverviewDossier.test.tsx
@@ -1,0 +1,137 @@
+/** @jest-environment jsdom */
+import { h, render } from 'preact';
+import { IntentSection, OverviewTiming } from '../OverviewDossier';
+import type { ViewerState } from '../../types';
+
+const base = (overrides: Partial<ViewerState>): ViewerState => ({
+    status: 'specified',
+    activeStep: 'specify',
+    steps: {},
+    pulse: null,
+    highlights: [],
+    activeSubstep: null,
+    footer: [],
+    history: [],
+    stepHistory: {},
+    ...overrides,
+});
+
+describe('IntentSection', () => {
+    afterEach(() => {
+        delete (globalThis as { vscode?: unknown }).vscode;
+    });
+
+    it('renders an approach-only state as one metadata block with no empty sibling', () => {
+        const host = document.createElement('div');
+        render(h(IntentSection, { state: base({ intent: 'Make timing honest.', approach: 'Trust explicit boundaries only.' }) }), host);
+        const meta = host.querySelector('.dossier-intent__meta');
+        expect(meta).not.toBeNull();
+        expect(meta?.children).toHaveLength(1);
+        expect(meta?.textContent).toContain('Trust explicit boundaries only.');
+    });
+
+    it('places selected living specs below Approach, before the Working Area column', () => {
+        const host = document.createElement('div');
+        render(h(IntentSection, {
+            state: base({
+                intent: 'Keep the implementation aligned with its capabilities.',
+                approach: 'Keep capability context beside the implementation strategy.',
+                context: ['area: spec-viewer footer'],
+                livingSpecs: { loaded: ['viewer-ui', 'spec-viewer'], synced: [] },
+                classification: { verdict: 'normal', projectedFiles: 2, projectedTasks: 4, scopeSignal: 'none' },
+                stepHistory: {
+                    specify: { startedAt: '2026-07-21T10:00:00Z', completedAt: '2026-07-21T10:04:00Z', durationTrusted: false },
+                },
+                timing: { measuredPhases: 0, expectedPhases: 4, complete: false },
+            }),
+        }), host);
+
+        const approach = host.querySelector('.dossier-intent__approach');
+        const context = host.querySelector('.dossier-intent__context');
+        expect(approach?.textContent).toContain('Approach');
+        expect(approach?.textContent).toContain('Living specs');
+        expect(context?.textContent).toContain('Working area');
+        expect(context?.textContent).toContain('Size');
+        expect(context?.textContent).not.toContain('Living specs');
+        expect(Array.from(approach?.querySelectorAll('.living-specs-chip') ?? []).map(node => node.textContent))
+            .toEqual(['viewer-ui', 'spec-viewer']);
+        expect(host.querySelector('.dossier-intent__statement')?.nextElementSibling)
+            .toBe(host.querySelector('.dossier-timing'));
+    });
+
+    it('renders living specs even when other intent fields are absent', () => {
+        const host = document.createElement('div');
+        render(h(IntentSection, {
+            state: base({ livingSpecs: { loaded: ['viewer-ui'], synced: [] } }),
+        }), host);
+        expect(host.querySelector('.dossier-intent')).not.toBeNull();
+        expect(host.textContent).toContain('viewer-ui');
+    });
+
+    it('omits the whole region when no intent context exists', () => {
+        const host = document.createElement('div');
+        render(h(IntentSection, { state: base({}) }), host);
+        expect(host.querySelector('.dossier-intent')).toBeNull();
+    });
+});
+
+describe('OverviewTiming', () => {
+    it('shows a trustworthy whole-run elapsed total and lifecycle phases', () => {
+        const host = document.createElement('div');
+        render(h(OverviewTiming, {
+            state: base({
+                stepHistory: {
+                    specify: { startedAt: '2026-07-21T10:00:00Z', completedAt: '2026-07-21T10:04:00Z', durationTrusted: true },
+                    plan: { startedAt: '2026-07-21T10:04:00Z', completedAt: '2026-07-21T10:12:00Z', durationTrusted: true },
+                    tasks: { startedAt: '2026-07-21T10:12:00Z', completedAt: '2026-07-21T10:15:00Z', durationTrusted: true },
+                    implement: { startedAt: '2026-07-21T10:15:00Z', completedAt: '2026-07-21T10:24:00Z', durationTrusted: true },
+                },
+                timing: { measuredPhases: 4, expectedPhases: 4, complete: true, elapsedMs: 24 * 60_000 },
+            }),
+        }), host);
+
+        expect(host.textContent).toContain('24m elapsed');
+        expect(host.textContent).toContain('Specify');
+        expect(host.textContent).toContain('Implement');
+        expect(host.textContent).not.toContain('Timing coverage');
+    });
+
+    it('shows partial coverage and only trusted individual phase durations', () => {
+        const host = document.createElement('div');
+        render(h(OverviewTiming, {
+            state: base({
+                stepHistory: {
+                    specify: { startedAt: '2026-07-21T10:00:00Z', completedAt: '2026-07-21T10:04:00Z', durationTrusted: false },
+                    plan: { startedAt: '2026-07-21T10:04:00Z', completedAt: '2026-07-21T10:12:00Z', durationTrusted: false },
+                    tasks: { startedAt: '2026-07-21T10:12:00Z', completedAt: '2026-07-21T10:15:00Z', durationTrusted: false },
+                    implement: { startedAt: '2026-07-21T10:15:00Z', completedAt: '2026-07-21T10:21:29Z', durationTrusted: true },
+                },
+                timing: { measuredPhases: 1, expectedPhases: 4, complete: false },
+            }),
+        }), host);
+
+        expect(host.textContent).toContain('Timing coverage: 1 of 4 phases');
+        expect(host.textContent).toContain('6m 29s');
+        expect(host.textContent).not.toContain('elapsed');
+    });
+
+    it('makes zero trusted timing explicit without inventing an elapsed total', () => {
+        const host = document.createElement('div');
+        render(h(OverviewTiming, {
+            state: base({
+                stepHistory: {
+                    specify: { startedAt: '2026-07-21T10:00:00Z', completedAt: '2026-07-21T10:04:00Z', durationTrusted: false },
+                },
+                timing: { measuredPhases: 0, expectedPhases: 4, complete: false },
+            }),
+        }), host);
+        expect(host.textContent).toContain('Timing coverage: 0 of 4 phases');
+        expect(host.textContent).not.toContain('elapsed');
+    });
+
+    it('omits itself when no lifecycle history exists', () => {
+        const host = document.createElement('div');
+        render(h(OverviewTiming, { state: base({}) }), host);
+        expect(host.querySelector('.dossier-timing')).toBeNull();
+    });
+});

--- a/webview/src/spec-viewer/components/cards/LivingSpecsCard.tsx
+++ b/webview/src/spec-viewer/components/cards/LivingSpecsCard.tsx
@@ -6,7 +6,7 @@ export interface LivingSpecsCardProps {
     state: ViewerState;
 }
 
-interface Chip {
+export interface LivingSpecChip {
     name: string;
     synced: boolean;
     specPath?: string;
@@ -17,7 +17,7 @@ interface Chip {
  * `capabilities` (which carry the clickable spec path); falls back to the
  * names-only `loaded`/`synced` arrays for legacy payloads.
  */
-function toChips(ls: LivingSpecsView): Chip[] {
+export function livingSpecChips(ls: LivingSpecsView): LivingSpecChip[] {
     if (ls.capabilities && ls.capabilities.length > 0) {
         return ls.capabilities.map((cap: CapabilityContentView) => ({
             name: cap.name,
@@ -27,13 +27,50 @@ function toChips(ls: LivingSpecsView): Chip[] {
     }
     const synced = new Set(ls.synced);
     const seen = new Set<string>();
-    const chips: Chip[] = [];
+    const chips: LivingSpecChip[] = [];
     for (const name of [...ls.loaded, ...ls.synced]) {
         if (seen.has(name)) continue;
         seen.add(name);
         chips.push({ name, synced: synced.has(name) });
     }
     return chips;
+}
+
+/** Shared compact links used by both the Overview context and legacy card story. */
+export function LivingSpecLinks({ livingSpecs }: { livingSpecs: LivingSpecsView }) {
+    const chips = livingSpecChips(livingSpecs);
+    if (chips.length === 0) return null;
+
+    const openSpec = (chip: LivingSpecChip) => {
+        vscode.postMessage({
+            type: 'openLivingSpec',
+            capabilityName: chip.name,
+            ...(chip.specPath ? { specPath: chip.specPath } : {}),
+        });
+    };
+
+    return (
+        <ul class="living-specs-chips">
+            {chips.map(chip => (
+                <li key={chip.name} class="living-specs-chips__item">
+                    <button
+                        type="button"
+                        class="living-specs-chip living-specs-chip--link"
+                        title={`Open ${chip.name} in the Living Specs viewer`}
+                        aria-label={`Open ${chip.name} in the Living Specs viewer`}
+                        onClick={() => openSpec(chip)}
+                    >
+                        {chip.name}
+                    </button>
+                    {chip.synced && (
+                        <span class="living-specs-chip__synced" title="Folded back into the living spec">
+                            folded back
+                        </span>
+                    )}
+                </li>
+            ))}
+        </ul>
+    );
 }
 
 /**
@@ -47,40 +84,14 @@ export function LivingSpecsCard({ state }: LivingSpecsCardProps) {
     const ls = state.livingSpecs;
     if (!ls) return null;
 
-    const chips = toChips(ls);
+    const chips = livingSpecChips(ls);
     if (chips.length === 0) return null;
-
-    const openSpec = (specPath: string) => {
-        vscode.postMessage({ type: 'openLivingSpec', specPath });
-    };
 
     return (
         <section class="activity-card activity-card--living-specs">
             <h3 class="activity-card__title">Living specs</h3>
             <div class="activity-card__body">
-                <ul class="living-specs-chips">
-                    {chips.map(chip => (
-                        <li key={chip.name} class="living-specs-chips__item">
-                            {chip.specPath ? (
-                                <button
-                                    type="button"
-                                    class="living-specs-chip living-specs-chip--link"
-                                    title={`Open ${chip.name} in the Living Specs viewer`}
-                                    onClick={() => openSpec(chip.specPath!)}
-                                >
-                                    {chip.name}
-                                </button>
-                            ) : (
-                                <span class="living-specs-chip">{chip.name}</span>
-                            )}
-                            {chip.synced && (
-                                <span class="living-specs-chip__synced" title="Folded back into the living spec">
-                                    folded back
-                                </span>
-                            )}
-                        </li>
-                    ))}
-                </ul>
+                <LivingSpecLinks livingSpecs={ls} />
             </div>
         </section>
     );

--- a/webview/src/spec-viewer/components/cards/PhasesCard.stories.tsx
+++ b/webview/src/spec-viewer/components/cards/PhasesCard.stories.tsx
@@ -30,8 +30,100 @@ const baseState = (overrides: Partial<ViewerState>): ViewerState => ({
     footer: [],
     transitions: [],
     stepHistory: {},
+    timing: { measuredPhases: 0, expectedPhases: 4, complete: false },
     ...overrides,
 });
+
+const trusted = (start: string, end: string) => ({
+    startedAt: start,
+    completedAt: end,
+    durationTrusted: true,
+});
+
+export const CompleteTrustworthyTiming: Story = {
+    name: 'Timing · complete trustworthy run',
+    render: () => (
+        <PhasesCard state={baseState({
+            status: 'completed',
+            stepHistory: {
+                specify: trusted('2026-07-02T10:00:00Z', '2026-07-02T10:05:00Z'),
+                plan: trusted('2026-07-02T10:05:00Z', '2026-07-02T10:12:00Z'),
+                tasks: trusted('2026-07-02T10:12:00Z', '2026-07-02T10:15:00Z'),
+                implement: trusted('2026-07-02T10:15:00Z', '2026-07-02T10:24:00Z'),
+            },
+            timing: {
+                measuredPhases: 4,
+                expectedPhases: 4,
+                complete: true,
+                startedAt: '2026-07-02T10:00:00Z',
+                endedAt: '2026-07-02T10:24:00Z',
+                elapsedMs: 1_440_000,
+            },
+        })} />
+    ),
+};
+
+export const Feature484PartialTiming: Story = {
+    name: 'Timing · 484 partial (Implement 6m 30s)',
+    render: () => (
+        <PhasesCard state={baseState({
+            status: 'completed',
+            stepHistory: {
+                specify: { startedAt: '2026-07-02T09:00:00Z', completedAt: '2026-07-02T09:04:00Z', durationTrusted: false },
+                plan: { startedAt: '2026-07-02T09:04:00Z', completedAt: '2026-07-02T09:15:00Z', durationTrusted: false },
+                tasks: { startedAt: '2026-07-02T09:15:00Z', completedAt: '2026-07-02T09:18:00Z', durationTrusted: false },
+                implement: trusted('2026-07-02T09:18:00Z', '2026-07-02T09:24:30Z'),
+            },
+            timing: { measuredPhases: 1, expectedPhases: 4, complete: false },
+        })} />
+    ),
+};
+
+export const AnomalousSequence: Story = {
+    name: 'Timing · anomalous overlap',
+    render: () => (
+        <PhasesCard state={baseState({
+            stepHistory: {
+                specify: { startedAt: '2026-07-02T10:00:00Z', completedAt: '2026-07-02T10:10:00Z', durationTrusted: false },
+                plan: { startedAt: '2026-07-02T10:05:00Z', completedAt: '2026-07-02T10:15:00Z', durationTrusted: false },
+            },
+        })} />
+    ),
+};
+
+export const InFlightUnmeasured: Story = {
+    name: 'Timing · in flight (not measured)',
+    render: () => (
+        <PhasesCard state={baseState({
+            status: 'implementing',
+            stepHistory: {
+                implement: { startedAt: '2026-07-02T10:00:00Z', completedAt: null, durationTrusted: false },
+            },
+        })} />
+    ),
+};
+
+export const RepeatedStartUntrusted: Story = {
+    name: 'Timing · repeated start',
+    render: () => (
+        <PhasesCard state={baseState({
+            stepHistory: {
+                plan: { startedAt: '2026-07-02T10:00:00Z', completedAt: '2026-07-02T10:08:00Z', durationTrusted: false },
+            },
+        })} />
+    ),
+};
+
+export const CompletionBeforeStartUntrusted: Story = {
+    name: 'Timing · completion before start',
+    render: () => (
+        <PhasesCard state={baseState({
+            stepHistory: {
+                plan: { startedAt: '2026-07-02T10:08:00Z', completedAt: '2026-07-02T10:00:00Z', durationTrusted: false },
+            },
+        })} />
+    ),
+};
 
 // ── Specify just started, in flight ──────────────────────────
 // Mirrors the ngx-dev-toolbar screenshot moment: the specify step

--- a/webview/src/spec-viewer/components/cards/PhasesCard.tsx
+++ b/webview/src/spec-viewer/components/cards/PhasesCard.tsx
@@ -1,12 +1,10 @@
 import type { ViewerState, HistoryEntry, StepHistoryEntry } from '../../types';
 import { mergeStepEvents, buildHistoryIndex, TimelineEventModel } from '../../timelineEvents';
 import { Badge } from '../../../shared/components/Badge';
+import { TimelineEvent } from '../TimelineEvent';
 import {
     formatElapsed,
-    formatStepOffset,
     formatAbsolute,
-    activeDurationMs,
-    IDLE_GAP_CAP_MS,
 } from '../../relativeTime';
 
 const STEP_ORDER = ['specify', 'clarify', 'plan', 'tasks', 'analyze', 'implement'];
@@ -57,50 +55,20 @@ function buildGroups(stepHistory: ViewerState['stepHistory'], history: HistoryEn
     return groups;
 }
 
-/**
- * All recorded activity timestamps for a step, in no particular order:
- * the step start, every event boundary, and the completion (when present).
- * Feeds `activeDurationMs`, which sorts them and sums the gaps with long idle
- * pauses capped — so "elapsed" reflects working time, not wall-clock.
- */
-function activityPoints(group: StepGroup): string[] {
-    const pts = [group.startedAt];
-    for (const e of group.events) {
-        pts.push(e.startedAt);
-        if (e.completedAt) pts.push(e.completedAt);
-    }
-    if (group.completedAt) pts.push(group.completedAt);
-    return pts;
-}
-
 export function PhasesCard({ state }: PhasesCardProps) {
     const groups = buildGroups(state.stepHistory ?? {}, state.history ?? []);
     if (groups.length === 0) return null;
 
-    // Overall: the whole-spec start (absolute), end (absolute or in-flight), and
-    // total *active* time. Only extension-stamped (trusted) steps carry real
-    // clock times — a custom workflow's synthesized progression has derived
-    // placeholder timestamps (epoch), which must never surface as a wall-clock
-    // summary. So the overall row is built from trusted groups only, and hides
-    // entirely when none exist (the per-step strip below still renders names).
-    const trustedGroups = groups.filter(
-        g => state.stepHistory?.[g.step]?.durationTrusted === true
-    );
-    const hasTrustedTiming = trustedGroups.length > 0;
-    const overallStart = hasTrustedTiming ? trustedGroups[0].startedAt : null;
-    const lastTrusted = hasTrustedTiming ? trustedGroups[trustedGroups.length - 1] : null;
-    const overallEnd = lastTrusted?.completedAt ?? null;
-    const TERMINAL_STATUSES = new Set(['completed', 'archived']);
-    const overallInFlight = overallEnd === null || !TERMINAL_STATUSES.has(state.status ?? '');
-    const overallActiveMs = trustedGroups.reduce(
-        (sum, g) => sum + activeDurationMs(activityPoints(g)),
-        0
-    );
+    const timing = state.timing;
+    const completeTiming = timing?.complete === true
+        && timing.startedAt !== undefined
+        && timing.endedAt !== undefined
+        && timing.elapsedMs !== undefined;
 
     // Per-step start dates are noise on a single-day spec; show a step's start
     // date only when it began on a different calendar day than the spec start
     // (i.e. a multi-day spec). With no trusted start, there's no reference day.
-    const specStartDay = overallStart ? new Date(overallStart).toDateString() : null;
+    const specStartDay = timing?.startedAt ? new Date(timing.startedAt).toDateString() : null;
 
     // Author only at spec start: the first history entry's actor.
     const firstEntry = (state.history ?? [])[0];
@@ -120,25 +88,28 @@ export function PhasesCard({ state }: PhasesCardProps) {
                 )}
             </h3>
             <div class="activity-card__body">
-                {hasTrustedTiming && (
+                {completeTiming && (
                     <div class="phases-overall">
                         <div class="phases-overall__stat">
                             <span class="phases-overall__label">Started</span>
-                            <span class="phases-overall__value">{formatAbsolute(overallStart as string)}</span>
+                            <span class="phases-overall__value">{formatAbsolute(timing.startedAt!)}</span>
                         </div>
                         <div class="phases-overall__stat">
-                            <span class="phases-overall__label">Total</span>
-                            <span class="phases-overall__value">
-                                {formatElapsed(overallActiveMs)} active
-                            </span>
+                            <span class="phases-overall__label">Elapsed</span>
+                            <span class="phases-overall__value">{formatElapsed(timing.elapsedMs!)}</span>
                         </div>
                         <div class="phases-overall__stat">
                             <span class="phases-overall__label">Ended</span>
                             <span class="phases-overall__value">
-                                {overallInFlight ? 'in progress' : formatAbsolute(overallEnd as string)}
+                                {formatAbsolute(timing.endedAt!)}
                             </span>
                         </div>
                     </div>
+                )}
+                {!completeTiming && timing && timing.measuredPhases > 0 && (
+                    <p class="phases-coverage">
+                        Timing coverage: {timing.measuredPhases} of {timing.expectedPhases} phases
+                    </p>
                 )}
                 <div class="phases-strip" role="list">
                     {groups.map((group, idx) => {
@@ -146,9 +117,8 @@ export function PhasesCard({ state }: PhasesCardProps) {
                         // Timing honesty: a step shows elapsed time only when its span
                         // was extension-stamped; journaled steps render name-only.
                         const trusted = state.stepHistory?.[group.step]?.durationTrusted === true;
-                        // Elapsed = active time (idle gaps capped), not wall-clock.
-                        const duration = trusted || inFlight
-                            ? formatElapsed(activeDurationMs(activityPoints(group)))
+                        const duration = trusted && group.completedAt
+                            ? formatElapsed(Date.parse(group.completedAt) - Date.parse(group.startedAt))
                             : null;
                         const showStepDate = specStartDay !== null &&
                             new Date(group.startedAt).toDateString() !== specStartDay;
@@ -168,6 +138,22 @@ export function PhasesCard({ state }: PhasesCardProps) {
                         );
                     })}
                 </div>
+                {groups.some(group => group.events.length > 0) && (
+                    <div class="phases-events" aria-label="Recorded phase events">
+                        {groups.filter(group => group.events.length > 0).map(group => (
+                            <div class="phases-events__group" key={`${group.step}-events`}>
+                                <h4>{group.step}</h4>
+                                {group.events.map((event, index) => (
+                                    <TimelineEvent
+                                        key={`${event.name}-${event.recordedAt}-${index}`}
+                                        event={event}
+                                        stepStartedAt={group.startedAt}
+                                    />
+                                ))}
+                            </div>
+                        ))}
+                    </div>
+                )}
             </div>
         </section>
     );

--- a/webview/src/spec-viewer/components/cards/__tests__/LivingSpecsCard.test.tsx
+++ b/webview/src/spec-viewer/components/cards/__tests__/LivingSpecsCard.test.tsx
@@ -91,11 +91,14 @@ describe('LivingSpecsCard', () => {
         btn!.click();
         expect(postMessage).toHaveBeenCalledWith({
             type: 'openLivingSpec',
+            capabilityName: 'todos',
             specPath: 'capabilities/todos/spec.md',
         });
     });
 
-    it('renders an unresolved capability as a plain, non-clickable name', () => {
+    it('keeps an unresolved historical capability actionable by name', () => {
+        const postMessage = jest.fn();
+        (globalThis as { vscode?: unknown }).vscode = { postMessage };
         const c = renderCard(
             baseState({
                 livingSpecs: {
@@ -105,8 +108,13 @@ describe('LivingSpecsCard', () => {
                 },
             }),
         );
-        expect(c.querySelector('button.living-specs-chip--link')).toBeNull();
-        expect(c.querySelector('.living-specs-chip')?.textContent).toBe('ghost');
+        const button = c.querySelector<HTMLButtonElement>('button.living-specs-chip--link');
+        expect(button?.textContent).toBe('ghost');
+        button!.click();
+        expect(postMessage).toHaveBeenCalledWith({
+            type: 'openLivingSpec',
+            capabilityName: 'ghost',
+        });
     });
 
     it('shows only the capability names — never the full requirement bodies', () => {

--- a/webview/src/spec-viewer/editor/lineActions.ts
+++ b/webview/src/spec-viewer/editor/lineActions.ts
@@ -48,11 +48,11 @@ export interface ContextAction {
  */
 export function getContextActions(lineType: LineType): ContextAction[] {
     const actions: Record<LineType, ContextAction[]> = {
-        'user-story': [{ action: 'remove-story', label: 'Remove Story' }],
-        'acceptance': [{ action: 'remove-scenario', label: 'Remove Scenario' }],
-        'task': [{ action: 'toggle-task', label: 'Toggle' }, { action: 'remove-task', label: 'Remove Task' }],
-        'section': [{ action: 'remove-section', label: 'Remove Section' }],
-        'paragraph': [{ action: 'remove-line', label: 'Remove Line' }],
+        'user-story': [{ action: 'remove-story', label: 'Suggest removing story' }],
+        'acceptance': [{ action: 'remove-scenario', label: 'Suggest removing scenario' }],
+        'task': [{ action: 'toggle-task', label: 'Toggle' }, { action: 'remove-task', label: 'Suggest removing task' }],
+        'section': [{ action: 'remove-section', label: 'Suggest removing section' }],
+        'paragraph': [{ action: 'remove-line', label: 'Suggest removing line' }],
     };
     return actions[lineType];
 }

--- a/webview/src/spec-viewer/markdown/LivingComponents.stories.tsx
+++ b/webview/src/spec-viewer/markdown/LivingComponents.stories.tsx
@@ -8,6 +8,7 @@ import {
     setTaskSummaries,
 } from './index';
 import { applyHighlighting } from '../highlighting';
+import webviewSharedCapability from '../../../../capabilities/webview-shared/spec.md?raw';
 
 /**
  * Shared living-mode host: renders a markdown fixture through the real
@@ -54,6 +55,11 @@ export default meta;
 type Story = StoryObj<typeof LivingDoc>;
 
 const DRAFT_BANNER = '> [DRAFT] Surface-first draft from existing code — review before trusting.';
+
+export const CompleteCapability: Story = {
+    name: 'Complete capability · Webview Shared',
+    args: { md: webviewSharedCapability },
+};
 
 // ── User Story 1 — draft notice + purpose callout ──────────────────────
 

--- a/webview/src/spec-viewer/markdown/livingComponents.ts
+++ b/webview/src/spec-viewer/markdown/livingComponents.ts
@@ -12,7 +12,7 @@
 
 import { parseInline, escapeHtml } from './inline';
 
-const COMMENT_ICON_SVG = `<svg width="14" height="14" viewBox="0 0 24 24"><path fill="none" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M14 6h8m-4-4v8M6.099 19.5q-1.949-.192-2.927-1.172C2 17.157 2 15.271 2 11.5V11c0-3.771 0-5.657 1.172-6.828S6.229 3 10 3h1.5m-5 15c-.205 1.002-1.122 3.166-.184 3.865c.49.357 1.271-.024 2.834-.786c1.096-.535 2.206-1.148 3.405-1.424c.438-.1.885-.143 1.445-.155c3.771 0 5.657 0 6.828-1.172C21.947 17.21 21.998 15.44 22 12M8 14h6M8 9h3" color="currentColor"/></svg>`;
+const COMMENT_ICON_SVG = `<svg width="14" height="14" viewBox="0 0 24 24" aria-hidden="true"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M14 6h8m-4-4v8M6.099 19.5q-1.949-.192-2.927-1.172C2 17.157 2 15.271 2 11.5V11c0-3.771 0-5.657 1.172-6.828S6.229 3 10 3h1.5m-5 15c-.205 1.002-1.122 3.166-.184 3.865c.49.357 1.271-.024 2.834-.786c1.096-.535 2.206-1.148 3.405-1.424c.438-.1.885-.143 1.445-.155c3.771 0 5.657 0 6.828-1.172C21.947 17.21 21.998 15.44 22 12M8 14h6M8 9h3"/></svg>`;
 
 /**
  * Per-region fallback wrapper: run `fn` over `region`; if it
@@ -117,7 +117,7 @@ function buildScenario(title: string, steps: { kw: string; rest: string }[]): st
             const rest = parseInline(s.rest.trim());
             return (
                 `<li class="living-scenario-step line ${STEP_CLASS[s.kw]}" data-line="${lineNum}" data-list-id="${listId}">` +
-                `<button class="line-add-btn" data-line="${lineNum}" data-list-id="${listId}" title="Add comment">${COMMENT_ICON_SVG}</button>` +
+                `<button class="line-add-btn" data-line="${lineNum}" data-list-id="${listId}" title="Add comment to scenario line ${lineNum}" aria-label="Add comment to scenario line ${lineNum}">${COMMENT_ICON_SVG}</button>` +
                 `<div class="line-content"><span class="living-scenario-kw">${s.kw}</span> ${rest}</div>` +
                 `<div class="line-comment-slot"></div>` +
                 `</li>`
@@ -128,7 +128,7 @@ function buildScenario(title: string, steps: { kw: string; rest: string }[]): st
     // data-line 0 (steps are 1-based) under the scenario's list id.
     const titleHtml = title
         ? `<div class="living-scenario-title line" data-line="0" data-list-id="${listId}">` +
-          `<button class="line-add-btn" data-line="0" data-list-id="${listId}" title="Add comment">${COMMENT_ICON_SVG}</button>` +
+          `<button class="line-add-btn" data-line="0" data-list-id="${listId}" title="Add comment to scenario title" aria-label="Add comment to scenario title">${COMMENT_ICON_SVG}</button>` +
           `<div class="line-content">${parseInline(title)}</div>` +
           `<div class="line-comment-slot"></div>` +
           `</div>`
@@ -313,7 +313,7 @@ function buildUncovered(scope: string, groups: UncoveredGroup[]): string {
     // (its own stable list id) rather than baking it into the summary blob.
     const scopeHtml = scope
         ? `<div class="living-uncovered-scope line" data-line="1" data-list-id="living-uncovered-scope">` +
-          `<button class="line-add-btn" data-line="1" data-list-id="living-uncovered-scope" title="Add comment">${COMMENT_ICON_SVG}</button>` +
+          `<button class="line-add-btn" data-line="1" data-list-id="living-uncovered-scope" title="Add comment to uncovered scope" aria-label="Add comment to uncovered scope">${COMMENT_ICON_SVG}</button>` +
           `<div class="line-content">${parseInline(scope)}</div>` +
           `<div class="line-comment-slot"></div>` +
           `</div>`
@@ -326,7 +326,7 @@ function buildUncovered(scope: string, groups: UncoveredGroup[]): string {
                     const lineNum = idx + 1;
                     return (
                         `<li class="living-uncovered-file line" data-line="${lineNum}" data-list-id="${listId}">` +
-                        `<button class="line-add-btn" data-line="${lineNum}" data-list-id="${listId}" title="Add comment">${COMMENT_ICON_SVG}</button>` +
+                        `<button class="line-add-btn" data-line="${lineNum}" data-list-id="${listId}" title="Add comment to uncovered file ${lineNum}" aria-label="Add comment to uncovered file ${lineNum}">${COMMENT_ICON_SVG}</button>` +
                         `<div class="line-content">${parseInline(f)}</div>` +
                         `<div class="line-comment-slot"></div>` +
                         `</li>`
@@ -386,7 +386,7 @@ export function preprocessLivingUncovered(markdown: string): string {
             // Keep the authored sentinel line commentable, like the scope line.
             component =
                 `<div class="living-uncovered-none line" data-line="1" data-list-id="living-uncovered-none">` +
-                `<button class="line-add-btn" data-line="1" data-list-id="living-uncovered-none" title="Add comment">${COMMENT_ICON_SVG}</button>` +
+                `<button class="line-add-btn" data-line="1" data-list-id="living-uncovered-none" title="Add comment to uncovered summary" aria-label="Add comment to uncovered summary">${COMMENT_ICON_SVG}</button>` +
                 `<div class="line-content">${parseInline(text)}</div>` +
                 `<div class="line-comment-slot"></div>` +
                 `</div>`;

--- a/webview/src/spec-viewer/markdown/renderer.test.ts
+++ b/webview/src/spec-viewer/markdown/renderer.test.ts
@@ -197,4 +197,11 @@ describe('task lines — id and markers render as metadata chips', () => {
         expect(html).toContain('Create the shared-parts directory');
         expect(html).not.toContain('task-item__marker');
     });
+
+    it('gives every comment affordance a line-specific accessible name', () => {
+        const html = renderMarkdown('- [ ] **T001** Add accessible comments\n');
+        expect(html).toContain('aria-label="Add comment to task line 1"');
+        expect(html).toContain('stroke="currentColor"');
+        expect(html).not.toContain('stroke="#ffffff"');
+    });
 });

--- a/webview/src/spec-viewer/markdown/renderer.ts
+++ b/webview/src/spec-viewer/markdown/renderer.ts
@@ -134,11 +134,11 @@ function highlightTree(text: string): string {
  * Uses single "+" button for GitHub-style inline review
  */
 // Comment icon SVG for line action buttons
-const COMMENT_ICON_SVG = `<svg width="14" height="14" viewBox="0 0 24 24"><path fill="none" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M14 6h8m-4-4v8M6.099 19.5q-1.949-.192-2.927-1.172C2 17.157 2 15.271 2 11.5V11c0-3.771 0-5.657 1.172-6.828S6.229 3 10 3h1.5m-5 15c-.205 1.002-1.122 3.166-.184 3.865c.49.357 1.271-.024 2.834-.786c1.096-.535 2.206-1.148 3.405-1.424c.438-.1.885-.143 1.445-.155c3.771 0 5.657 0 6.828-1.172C21.947 17.21 21.998 15.44 22 12M8 14h6M8 9h3" color="currentColor"/></svg>`;
+const COMMENT_ICON_SVG = `<svg width="14" height="14" viewBox="0 0 24 24" aria-hidden="true"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M14 6h8m-4-4v8M6.099 19.5q-1.949-.192-2.927-1.172C2 17.157 2 15.271 2 11.5V11c0-3.771 0-5.657 1.172-6.828S6.229 3 10 3h1.5m-5 15c-.205 1.002-1.122 3.166-.184 3.865c.49.357 1.271-.024 2.834-.786c1.096-.535 2.206-1.148 3.405-1.424c.438-.1.885-.143 1.445-.155c3.771 0 5.657 0 6.828-1.172C21.947 17.21 21.998 15.44 22 12M8 14h6M8 9h3"/></svg>`;
 
 function wrapWithLineActions(content: string, lineNum: number): string {
     return `<div class="line" data-line="${lineNum}">
-        <button class="line-add-btn" data-line="${lineNum}" title="Add comment">
+        <button class="line-add-btn" data-line="${lineNum}" title="Add comment to line ${lineNum}" aria-label="Add comment to line ${lineNum}">
             ${COMMENT_ICON_SVG}
         </button>
         <div class="line-content">${content}</div>
@@ -152,7 +152,7 @@ function wrapWithLineActions(content: string, lineNum: number): string {
  * inline "+" comment affordance still appears on hover.
  */
 function wrapComponentLine(componentHtml: string, lineNum: number): string {
-    return `<div class="line component-line" data-line="${lineNum}"><button class="line-add-btn" data-line="${lineNum}" title="Add comment">${COMMENT_ICON_SVG}</button>${componentHtml}<div class="line-comment-slot"></div></div>`;
+    return `<div class="line component-line" data-line="${lineNum}"><button class="line-add-btn" data-line="${lineNum}" title="Add comment to line ${lineNum}" aria-label="Add comment to line ${lineNum}">${COMMENT_ICON_SVG}</button>${componentHtml}<div class="line-comment-slot"></div></div>`;
 }
 
 /**
@@ -481,7 +481,7 @@ export function renderMarkdown(markdown: string): string {
                     captureHtml = `<div class="task-item__capture">${didHtml}${filesHtml}</div>`;
                 }
                 html += `<li ${classAttr} data-line="${sourceLineNum}"${dataTaskAttr}>` +
-                    `<button class="line-add-btn" data-line="${sourceLineNum}" title="Add comment">${COMMENT_ICON_SVG}</button>` +
+                    `<button class="line-add-btn" data-line="${sourceLineNum}" title="Add comment to task line ${sourceLineNum}" aria-label="Add comment to task line ${sourceLineNum}">${COMMENT_ICON_SVG}</button>` +
                     `<input type="checkbox" ${checked} data-line="${sourceLineNum}">` +
                     `<span class="task-text line-content">${innerText}</span>` +
                     captureHtml +
@@ -490,7 +490,7 @@ export function renderMarkdown(markdown: string): string {
             } else {
                 // Wrap regular list items with line actions for commenting
                 html += `<li class="line" data-line="${sourceLineNum}">
-                    <button class="line-add-btn" data-line="${sourceLineNum}" title="Add comment">
+                    <button class="line-add-btn" data-line="${sourceLineNum}" title="Add comment to list line ${sourceLineNum}" aria-label="Add comment to list line ${sourceLineNum}">
                         ${COMMENT_ICON_SVG}
                     </button>
                     <span class="line-content">${content}</span>
@@ -524,7 +524,7 @@ export function renderMarkdown(markdown: string): string {
             const content = parseInline(olMatch[2]);
             // Wrap ordered list items with line actions for commenting
             html += `<li class="line" data-line="${sourceLineNum}">
-                <button class="line-add-btn" data-line="${sourceLineNum}" title="Add comment">
+                <button class="line-add-btn" data-line="${sourceLineNum}" title="Add comment to list line ${sourceLineNum}" aria-label="Add comment to list line ${sourceLineNum}">
                     ${COMMENT_ICON_SVG}
                 </button>
                 <span class="line-content">${content}</span>

--- a/webview/src/spec-viewer/markdown/scenarios.ts
+++ b/webview/src/spec-viewer/markdown/scenarios.ts
@@ -52,7 +52,7 @@ export function parseAcceptanceScenarios(markdown: string): string {
         }
 
         // Comment icon SVG
-        const commentIcon = `<svg width="14" height="14" viewBox="0 0 24 24"><path fill="none" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M14 6h8m-4-4v8M6.099 19.5q-1.949-.192-2.927-1.172C2 17.157 2 15.271 2 11.5V11c0-3.771 0-5.657 1.172-6.828S6.229 3 10 3h1.5m-5 15c-.205 1.002-1.122 3.166-.184 3.865c.49.357 1.271-.024 2.834-.786c1.096-.535 2.206-1.148 3.405-1.424c.438-.1.885-.143 1.445-.155c3.771 0 5.657 0 6.828-1.172C21.947 17.21 21.998 15.44 22 12M8 14h6M8 9h3" color="currentColor"/></svg>`;
+        const commentIcon = `<svg width="14" height="14" viewBox="0 0 24 24" aria-hidden="true"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M14 6h8m-4-4v8M6.099 19.5q-1.949-.192-2.927-1.172C2 17.157 2 15.271 2 11.5V11c0-3.771 0-5.657 1.172-6.828S6.229 3 10 3h1.5m-5 15c-.205 1.002-1.122 3.166-.184 3.865c.49.357 1.271-.024 2.834-.786c1.096-.535 2.206-1.148 3.405-1.424c.438-.1.885-.143 1.445-.155c3.771 0 5.657 0 6.828-1.172C21.947 17.21 21.998 15.44 22 12M8 14h6M8 9h3"/></svg>`;
 
         // Build list items with emphasized keywords
         const listItems = joinedLines.map((line, idx) => {
@@ -67,7 +67,7 @@ export function parseAcceptanceScenarios(markdown: string): string {
                 .replace(/\*?\*?(When)\*?\*?/gi, '<strong class="keyword-when">$1</strong>')
                 .replace(/\*?\*?(Then)\*?\*?/gi, '<strong class="keyword-then">$1</strong>');
 
-            return `<li class="scenario-item line" data-line="${lineNum}" data-list-id="${listId}"><button class="line-add-btn" data-line="${lineNum}" data-list-id="${listId}" title="Add comment">${commentIcon}</button><div class="line-content">${emphasized}</div><div class="line-comment-slot"></div></li>`;
+            return `<li class="scenario-item line" data-line="${lineNum}" data-list-id="${listId}"><button class="line-add-btn" data-line="${lineNum}" data-list-id="${listId}" title="Add comment to scenario line ${lineNum}" aria-label="Add comment to scenario line ${lineNum}">${commentIcon}</button><div class="line-content">${emphasized}</div><div class="line-comment-slot"></div></li>`;
         }).join('');
 
         // Output as HTML (not markdown) so label doesn't get wrapped in .line

--- a/webview/src/spec-viewer/timelineEvents.ts
+++ b/webview/src/spec-viewer/timelineEvents.ts
@@ -1,15 +1,15 @@
 /**
- * Merge `stepHistory.substeps` (carries duration) with non-null history
- * substeps (carries actor) into a single chronological event list per step.
+ * Merge derived substep rows with append-only history into one chronological
+ * event list per step.
  *
- * - Tracked events come from `stepHistory[step].substeps[]`. They have a
- *   `startedAt` and `completedAt` so we can render a duration.
+ * - Tracked events come from `stepHistory[step].substeps[]`, but their spans
+ *   are not presented as work durations; AI/CLI finishes are cadence records.
  * - Logged-only events come from history entries whose `substep` is non-null
  *   and whose name isn't already in the tracked set. They only carry an `at`
  *   timestamp; render as a single moment.
  *
- * Every event also gets an optional `by` actor, looked up from the matching
- * history entry by `(step, substep-name)`.
+ * Every event gets an optional actor and a `recordedAt` journal timestamp,
+ * looked up from the matching history entry by `(step, substep-name)`.
  */
 
 import type { HistoryEntry, StepHistoryEntry, SubstepEntry } from './types';
@@ -49,6 +49,8 @@ export interface TimelineEventModel {
     name: string;
     startedAt: string;
     completedAt: string | null;
+    /** The journal timestamp shown to readers; never interpreted as a duration boundary. */
+    recordedAt: string;
     source: TimelineEventSource;
     by?: string;
     /** Task id when this event is a per-task entry (T001…), else null. */
@@ -93,6 +95,7 @@ export function mergeStepEvents(
             name: sub.name,
             startedAt: sub.startedAt,
             completedAt: sub.completedAt ?? null,
+            recordedAt: tx?.at ?? sub.completedAt ?? sub.startedAt,
             source: 'tracked',
             by: tx?.by,
             task: tx && isPerTaskEntry(tx) ? tx.task : null,
@@ -113,11 +116,12 @@ export function mergeStepEvents(
             name: tx.substep,
             startedAt: tx.at,
             completedAt: null,
+            recordedAt: tx.at,
             source: 'logged',
             by: tx.by,
         });
     }
 
-    out.sort((a, b) => new Date(a.startedAt).getTime() - new Date(b.startedAt).getTime());
+    out.sort((a, b) => new Date(a.recordedAt).getTime() - new Date(b.recordedAt).getTime());
     return out;
 }

--- a/webview/src/spec-viewer/types.ts
+++ b/webview/src/spec-viewer/types.ts
@@ -184,6 +184,15 @@ export interface StepHistoryEntry {
     durationTrusted?: boolean;
 }
 
+export interface TimingSummary {
+    measuredPhases: number;
+    expectedPhases: number;
+    complete: boolean;
+    startedAt?: string;
+    endedAt?: string;
+    elapsedMs?: number;
+}
+
 export interface TaskSummary {
     status: string;
     did?: string;
@@ -261,6 +270,7 @@ export interface ViewerState {
     footer: SerializedFooterAction[];
     history: HistoryEntry[];
     stepHistory: Record<string, StepHistoryEntry>;
+    timing?: TimingSummary;
     approach?: string;
     lastAction?: string;
     taskSummaries?: Record<string, TaskSummary>;
@@ -351,7 +361,7 @@ export type ViewerToExtensionMessage =
     // File reference click
     | { type: 'openFile'; filename: string }
     // Living-specs chip click — open the capability in the Living Specs viewer
-    | { type: 'openLivingSpec'; specPath: string }
+    | { type: 'openLivingSpec'; capabilityName: string; specPath?: string }
     // Webview render-time error (reported by error boundaries)
     | { type: 'webviewError'; source: string; message: string; stack?: string };
 

--- a/webview/styles/spec-editor.css
+++ b/webview/styles/spec-editor.css
@@ -109,6 +109,24 @@
     color: var(--text-primary);
 }
 
+.writing-tips {
+    margin: 0 0 8px;
+    color: var(--text-body);
+    font-size: 0.85em;
+}
+
+.writing-tips summary {
+    width: fit-content;
+    color: var(--text-secondary);
+    cursor: pointer;
+}
+
+.writing-tips p {
+    max-width: 68ch;
+    margin: 6px 0 0;
+    line-height: 1.5;
+}
+
 .spec-editor-textarea {
     flex: 1;
     width: 100%;
@@ -225,6 +243,17 @@
     width: 100%;
     height: 100%;
     object-fit: cover;
+}
+
+.create-spec-fixture-image {
+    display: grid;
+    width: 100%;
+    height: 100%;
+    place-items: center;
+    background: var(--bg-elevated);
+    color: var(--text-muted);
+    font-family: var(--font-mono);
+    font-size: 1.4rem;
 }
 
 .image-thumbnail .image-name {

--- a/webview/styles/spec-viewer/_activity.css
+++ b/webview/styles/spec-viewer/_activity.css
@@ -1,11 +1,7 @@
 /**
  * SpecKit Companion - Activity Panel Styles
- * Card-stack layout: Approach, Phases, Tasks, Decisions, Concerns, Files.
- * Each card is hidden by its component when its data is absent.
- *
- * Substep timing inside Phases is intentionally NOT rendered — the on-disk
- * substep timestamps are AI-typed and unreliable. Only step-level durations
- * (extension-stamped) are shown.
+ * Run-log sections and their compact facts. AI/CLI substep timestamps render
+ * only as recorded-at events; only trustworthy step boundaries become spans.
  */
 
 .activity-panel {
@@ -70,7 +66,7 @@
    Phases card
    ============================================ */
 
-/* Overall span header: started · total · ended */
+/* Complete-run header: started · elapsed · ended */
 .phases-overall {
     display: flex;
     flex-wrap: wrap;
@@ -99,6 +95,12 @@
     font-weight: 600;
     color: var(--text-primary);
     font-variant-numeric: tabular-nums;
+}
+
+.phases-coverage {
+    margin: 0 0 var(--space-3);
+    color: var(--text-body);
+    font-size: 0.8rem;
 }
 
 /* Vertical timeline: phases stacked top-to-bottom on a left spine, one node each */
@@ -332,6 +334,7 @@
 }
 
 .living-specs-chip {
+    appearance: none;
     display: inline-block;
     max-width: 22em;
     overflow: hidden;
@@ -454,6 +457,34 @@
     font-size: 0.78rem;
     color: var(--text-body);
     font-variant-numeric: tabular-nums;
+}
+
+.phases-events {
+    margin-top: var(--space-4);
+    border-top: 1px solid var(--border);
+}
+
+.phases-events__group {
+    display: grid;
+    grid-template-columns: minmax(72px, 0.25fr) 1fr;
+    gap: var(--space-2) var(--space-3);
+    padding: var(--space-3) 0;
+    border-bottom: 1px solid var(--border);
+}
+
+.phases-events__group:last-child { border-bottom: 0; }
+
+.phases-events__group h4 {
+    margin: 2px 0 0;
+    color: var(--text-muted);
+    font-size: 0.72rem;
+    font-weight: 650;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+}
+
+.phases-events__group .timeline-entry {
+    grid-column: 2;
 }
 
 /* ============================================

--- a/webview/styles/spec-viewer/_base.css
+++ b/webview/styles/spec-viewer/_base.css
@@ -110,7 +110,7 @@ body {
 /* The facts yield from the least important end as the pane narrows: first the
    time and the checks, then everything but the way back to the Overview. */
 @container viewer (max-width: 1100px) {
-    .run-strip__fact[data-fact="active"],
+    .run-strip__fact[data-fact="timing"],
     .run-strip__fact[data-fact="checks"],
     .run-strip__pr {
         display: none;

--- a/webview/styles/spec-viewer/_content.css
+++ b/webview/styles/spec-viewer/_content.css
@@ -12,7 +12,7 @@
     /* Floor at 16px (matches VS Code's native markdown preview) so the panel
        stays readable regardless of a small editor font; scales up beyond that. */
     font-size: max(16px, calc(var(--font-size) + 1px));
-    line-height: var(--leading-loose);
+    line-height: 1.6;
     color: var(--text-body);
     max-width: 72ch;
     margin: 0 auto;

--- a/webview/styles/spec-viewer/_editor.css
+++ b/webview/styles/spec-viewer/_editor.css
@@ -15,6 +15,7 @@
     border-radius: var(--radius-md);
     box-shadow: none;
     overflow: hidden;
+    width: min(100%, 640px);
     animation: slideDown var(--transition-fast) ease-out;
 }
 
@@ -78,6 +79,17 @@
     justify-content: space-between;
     gap: 8px;
     padding: 0 var(--space-3) var(--space-2);
+}
+
+@media (max-width: 560px) {
+    .editor-footer {
+        align-items: stretch;
+        flex-direction: column;
+    }
+
+    .editor-buttons {
+        align-self: flex-end;
+    }
 }
 
 .editor-footer-actions {

--- a/webview/styles/spec-viewer/_line-actions.css
+++ b/webview/styles/spec-viewer/_line-actions.css
@@ -14,6 +14,7 @@
   border-radius: var(--radius-sm);
   transition: all var(--transition-fast);
   min-height: 24px;
+  padding-right: 32px;
 }
 
 .line.empty {
@@ -74,14 +75,14 @@
 .line-add-btn {
   position: absolute;
   left: auto; /* Unset left positioning */
-  right: 0; /* Position on right side */
-  top: 2px; /* Align to top */
-  width: 18px;
-  height: 18px;
+  right: 4px; /* Neutral control inside the reserved 32px annotation gutter. */
+  top: 2px;
+  width: 24px;
+  height: 24px;
   border-radius: var(--radius-sm);
-  border: 1px solid var(--info);
-  background: var(--info);
-  color: white;
+  border: 1px solid var(--border);
+  background: var(--bg-secondary);
+  color: var(--text-secondary);
   opacity: 0;
   transition: all var(--transition-fast);
   cursor: pointer;
@@ -92,8 +93,8 @@
 }
 
 .line-add-btn svg {
-  width: 12px;
-  height: 12px;
+  width: 14px;
+  height: 14px;
   flex-shrink: 0;
 }
 
@@ -116,9 +117,9 @@
 }
 
 .line-add-btn:hover {
-  background: color-mix(in srgb, var(--info) 85%, white);
-  border-color: color-mix(in srgb, var(--info) 85%, white);
-  transform: scale(1.1);
+  background: var(--bg-hover);
+  border-color: var(--border-hover);
+  color: var(--text-primary);
 }
 
 .line-add-btn:active {
@@ -138,7 +139,7 @@ li.line {
   position: relative;
   padding-top: 0;
   padding-bottom: 0;
-  padding-right: 0; /* No extra padding */
+  padding-right: 32px;
   margin: 0;
   min-height: unset;
   list-style-position: outside;
@@ -155,7 +156,7 @@ li.line .line-content {
 
 li.line .line-add-btn {
   left: auto; /* Unset left positioning */
-  right: 0; /* Position on right side */
+  right: 4px;
   top: 4px;
 }
 

--- a/webview/styles/spec-viewer/_living.css
+++ b/webview/styles/spec-viewer/_living.css
@@ -1,7 +1,7 @@
 /**
  * SpecKit Companion - Living Spec Components
  * Styles the living-spec composition layer (draft notice, purpose callout,
- * requirement cards, scenario steps, uncovered evidence) via the existing
+ * requirement groups, scenario steps, uncovered evidence) via the existing
  * viewer tokens so every component tracks dark, light, high-contrast, narrow,
  * and reduced-motion modes without owning any raw color.
  */
@@ -39,24 +39,25 @@
  * Wraps the authored `## Purpose` heading + body, which stay commentable. */
 #markdown-content .living-purpose {
   margin: 0 0 var(--space-5);
-  padding: var(--space-4) var(--space-5);
-  background: var(--accent-subtle);
-  border-radius: var(--radius-md);
+  padding: 0 0 var(--space-4);
+  border-bottom: 1px solid var(--border);
 }
 
 #markdown-content .living-purpose h2 {
   margin-top: 0;
 }
 
-/* ── Requirement card ───────────────────────────────────────────────── */
-/* Each `###` requirement becomes a scannable card. The heading and body stay
- * as their own commentable lines inside the wrapper. */
+/* ── Requirement group ──────────────────────────────────────────────── */
+/* Header-led editorial groups: a quiet boundary, then heading/meta/prose on
+ * the page canvas. The wrapper preserves the component contract without
+ * turning a long capability into nested card soup. */
 #markdown-content .living-req-card {
   margin: 0 0 var(--space-4);
-  padding: var(--space-3) var(--space-4);
-  background: var(--bg-secondary);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-md);
+  padding: var(--space-3) 0 0;
+  background: transparent;
+  border: 0;
+  border-top: 1px solid var(--border);
+  border-radius: 0;
 }
 
 #markdown-content .living-req-card > h3 {

--- a/webview/styles/spec-viewer/_overview-dossier.css
+++ b/webview/styles/spec-viewer/_overview-dossier.css
@@ -1,6 +1,6 @@
 /**
  * SpecKit Companion - Overview Dossier
- * The Context-First Overview: one typographic Intent statement, then
+ * The Context-First Overview: compact lifecycle signal, one typographic Intent statement, then
  * editorial sections divided by rules (Expectations fence, Verified ledger,
  * Decisions, Coverage traceability), with the run log collapsed at the end.
  */
@@ -20,6 +20,90 @@
     text-transform: uppercase;
 }
 
+/* ── Run overview — lifecycle only; granular events remain in Run Log ── */
+
+.dossier-timing {
+    margin: 0 0 var(--space-5);
+    padding: var(--space-3) 0;
+    border-top: 1px solid var(--border);
+    border-bottom: 1px solid var(--border);
+}
+
+.dossier-timing__head {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: var(--space-3);
+}
+
+.dossier-timing__head .dossier-kicker {
+    color: var(--accent);
+}
+
+.dossier-timing__head strong {
+    color: var(--text-body);
+    font-family: var(--font-mono);
+    font-size: 11px;
+    font-weight: 650;
+    font-variant-numeric: tabular-nums;
+}
+
+.dossier-timing__phases {
+    display: flex;
+    align-items: baseline;
+    flex-wrap: wrap;
+    row-gap: var(--space-2);
+    margin-top: var(--space-3);
+}
+
+.dossier-timing__phase {
+    display: inline-flex;
+    align-items: baseline;
+    gap: 6px;
+    min-width: 0;
+}
+
+.dossier-timing__connector {
+    width: clamp(12px, 2.5vw, 32px);
+    height: 1px;
+    margin: 0 var(--space-2);
+    background: var(--border);
+    align-self: center;
+}
+
+.dossier-timing__dot {
+    width: 8px;
+    height: 8px;
+    flex: none;
+    align-self: center;
+    border-radius: 50%;
+    background: var(--success);
+}
+
+.dossier-timing__phase.is-in-flight .dossier-timing__dot {
+    background: var(--accent);
+    animation: activity-dot-pulse 2s ease-in-out infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .dossier-timing__phase.is-in-flight .dossier-timing__dot {
+        animation: none;
+    }
+}
+
+.dossier-timing__name {
+    color: var(--text-primary);
+    font-size: 13px;
+    font-weight: 650;
+}
+
+.dossier-timing__duration {
+    color: var(--text-body);
+    font-size: 12px;
+    font-variant-numeric: tabular-nums;
+    white-space: nowrap;
+}
+
 /* ── Intent — the reason the spec exists, set as the page's thesis ── */
 
 .dossier-intent {
@@ -27,9 +111,13 @@
     border-bottom: 1px solid var(--border);
 }
 
+.dossier-intent > .dossier-kicker {
+    color: var(--purple);
+}
+
 .dossier-intent__statement {
     max-width: 72ch;
-    margin: var(--space-3) 0 var(--space-5);
+    margin: var(--space-3) 0 var(--space-4);
     font-size: clamp(16px, 1.5cqi, 19px);
     font-weight: 500;
     line-height: 1.45;
@@ -52,6 +140,20 @@
     background: var(--bg-secondary);
 }
 
+.dossier-intent__approach .dossier-meta-label {
+    color: var(--accent);
+}
+
+.dossier-intent__context .dossier-meta-label {
+    color: var(--accent);
+}
+
+/* Approach-only / area-only metadata is one editorial block, not half a grid
+   with a phantom empty pane. */
+.dossier-intent__meta > div:only-child {
+    grid-column: 1 / -1;
+}
+
 .dossier-meta-label {
     display: block;
     color: var(--text-label);
@@ -72,11 +174,32 @@
     margin-top: var(--space-3);
 }
 
+.dossier-intent__living-specs {
+    margin-top: var(--space-4);
+}
+
+.dossier-intent__living-specs:first-child {
+    margin-top: 0;
+}
+
+.dossier-intent__living-specs .dossier-meta-label {
+    margin-bottom: 7px;
+    color: var(--purple);
+}
+
+.dossier-intent__living-specs .living-specs-chip {
+    background: var(--bg-inset);
+}
+
 /* ── Section frame: editorial dividers, not stacked cards ── */
 
 .dossier-section {
     padding: var(--space-6) 0;
     border-bottom: 1px solid var(--border);
+}
+
+.dossier-section .dossier-kicker {
+    color: var(--accent);
 }
 
 .dossier-section__head {
@@ -393,6 +516,25 @@
     margin-top: var(--space-4);
 }
 
+/* The expanded log is one divided record, not a stack of cards inside a card. */
+.dossier-log .activity-card {
+    overflow: visible;
+    background: transparent;
+    border: 0;
+    border-top: 1px solid var(--border);
+    border-radius: 0;
+}
+
+.dossier-log .activity-card__title {
+    padding: var(--space-4) 0 var(--space-2);
+    background: transparent;
+    border: 0;
+}
+
+.dossier-log .activity-card__body {
+    padding: 0 0 var(--space-3);
+}
+
 .dossier-log__last-action {
     margin: 0;
     color: var(--text-body);
@@ -433,6 +575,17 @@
 }
 
 @container viewer (max-width: 560px) {
+    .dossier-timing__head {
+        align-items: flex-start;
+        flex-direction: column;
+        gap: 4px;
+    }
+
+    .dossier-timing__connector {
+        width: 10px;
+        margin-inline: 5px;
+    }
+
     .dossier-section__head {
         align-items: flex-start;
     }

--- a/webview/styles/spec-viewer/_task-phases.css
+++ b/webview/styles/spec-viewer/_task-phases.css
@@ -4,13 +4,14 @@
  * preprocessTaskPhases (phase number chip + MVP / priority chips).
  */
 
-/* Compact tinted card instead of an underlined heading. */
+/* Quiet phase boundary: structure without a competing filled panel. */
 #markdown-content .phase-header {
   margin: var(--space-6) 0 var(--space-3);
-  padding: 14px 16px;
+  padding: 14px 0 0;
   border: none;
-  border-radius: var(--radius-md);
-  background: var(--bg-elevated);
+  border-top: 1px solid var(--border);
+  border-radius: 0;
+  background: transparent;
 }
 
 #markdown-content .phase-header:first-child {

--- a/webview/styles/spec-viewer/_typography.css
+++ b/webview/styles/spec-viewer/_typography.css
@@ -9,7 +9,7 @@
 
 /* Document scale: a strong page title, quiet bounded sections. */
 #markdown-content h1 {
-    font-size: clamp(30px, 5vw, 46px);
+    font-size: clamp(30px, 5vw, 40px);
     font-weight: 700;
     line-height: 1.05;
     letter-spacing: -0.04em;
@@ -22,7 +22,7 @@
     font-weight: 650;
     line-height: var(--leading-snug);
     letter-spacing: -0.025em;
-    margin: 52px 0 18px 0;
+    margin: 40px 0 16px 0;
     color: var(--header-section);
 }
 
@@ -34,7 +34,7 @@
     font-size: 16px;
     font-weight: 600;
     line-height: 1.4;
-    margin: 32px 0 10px 0;
+    margin: 24px 0 8px 0;
     color: var(--header-subsection);
 }
 
@@ -54,7 +54,7 @@
 
 #markdown-content p {
     margin: 0 0 var(--space-5) 0;
-    line-height: var(--leading-loose);
+    line-height: 1.6;
     color: var(--text-body);
 }
 


### PR DESCRIPTION
## Summary

Reworks the spec viewer's timing display to be **honest** instead of a fudge. The old Phases card showed a capped "active-time" heuristic; this replaces it with real wall-clock step durations that appear **only when a phase's timing is actually trustworthy** (both boundaries extension-stamped and correctly ordered). When it isn't, the card states **"Timing coverage: X of Y phases"** rather than inventing a number.

- **New `TimingSummary`** (derived in-memory, never persisted) — measured-phase count, and a whole-run elapsed only when every phase is trustworthy.
- **Stricter `durationTrusted`** in `stepHistoryDerivation.ts` — requires exactly one extension-stamped step start, an ordered extension close, no completion-before-start and no competing later start, plus a cross-phase overlap guard. Trust checks read the raw append-only log so anomalies stay visible.
- **Reworked components** — `PhasesCard` (trusted wall-clock per step + coverage line), `TimelineEvent` (substeps as recorded-cadence markers, not fake spans), `RunStrip` (an `active` → `timing` fact), and a new `OverviewTiming` strip + living-specs surfacing in the Overview.
- **Also in this branch:** an accessibility pass (aria-labels on comment buttons, `aria-hidden`/`currentColor` SVGs, relabels) and a `CreateSpecMock` Storybook refactor (inline styles → CSS classes). Tangential to timing — see notes.

## Technical

- `src/features/specs/stepHistoryDerivation.ts` — new `spanTrusted` rules + overlap guard + exported `deriveTimingSummary`; `startedAt` snaps to the trusted start.
- `src/core/types/specContext.ts` / `webview/.../types.ts` — `TimingSummary` + `timing` on `ViewerState` (in-memory only; `history[]` stays the sole on-disk timing source).
- `stateDerivation.ts` wires `deriveTimingSummary` with `expectedTimingPhases` from the workflow.
- Webview: `PhasesCard.tsx`, `TimelineEvent.tsx`, `timelineEvents.ts`, `RunStrip.tsx`, `OverviewDossier.tsx` + stories/tests + CSS.

## Verify

`npm run compile` + `npm test` (1723 tests, incl. the new `OverviewDossier.test.tsx`) pass. Open a spec's Overview/Phases: a fully-instrumented run shows real per-step durations and a whole-run elapsed; a partially-instrumented one shows "Timing coverage: N of 4 phases" and no invented times.

## Review notes (from a pre-PR review — surfacing, not blocking)

- **Dead code from the removed active-time path.** `activeDurationMs` / `formatDuration` / `IDLE_GAP_CAP_MS` (`relativeTime.ts`) now have no non-test importers; `activityHeroModel.ts` still computes `trustedActiveMs` with no reader; `TimelineEventModel.source` is now write-only. Harmless (nothing breaks), but candidates to delete along with their orphaned tests.
- **Overlap guard is untested — and appears unreachable.** The cross-phase overlap guard in `deriveStepHistory` is defensive, but since a non-last step's `completedAt` is always the next step's start, consecutive trusted phases butt up exactly (equal, not overlapping), so no input to `deriveStepHistory` seems to trigger it. It reads correctly; if we want it covered, extract it to a pure helper and unit-test it directly.
- **Scope:** the accessibility pass (`renderer.ts`/`scenarios.ts`/`livingComponents.ts`/`lineActions.ts`) and the `CreateSpecMock` refactor are unrelated to timing and could be split into their own PR.

The rest of the review was clean — trust rules well-covered, webview invariants hold (no user data into HTML attributes; the `openLivingSpec` `capabilityName` path is regex-guarded + within-root), and no injection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
