### PR TITLE
fix(capture): dedup redundant step-level starts in the TS writer to protect fast-path timing

### DIFF
--- a/speckit-extension/tests/test_context.py
+++ b/speckit-extension/tests/test_context.py
@@ -447,12 +447,7 @@ class LifecycleCaptureTests(unittest.TestCase):
         self.assertEqual(len(completes), 1, "must not add a complete over a legacy self-loop complete")
 
     def test_fold_then_separate_dispatch_keeps_one_start_per_step(self) -> None:
-        # #519 path 1: the specify body folds plan+tasks (simple mode), then the
-        # workflow-engine `small` route separately dispatches plan/tasks whose
-        # bodies stamp their own extension start+complete. Two guards keep each
-        # step at exactly one start (the trust rule needs `explicitStarts == 1`):
-        # the more-advanced guard blocks the earlier-step (plan) re-dispatch, and
-        # `_has_step_start`/`_has_complete` dedup the same-step (tasks) re-dispatch.
+        # A fold then a separate plan/tasks re-dispatch must still leave exactly one start per step: the more-advanced guard blocks the plan re-dispatch and the start/complete dedup handles tasks.
         wc.update_context(self.fd, "specify", "specifying", "extension", "start")
         wc.update_context(self.fd, "specify", "specified", "extension", "complete")
         wc.update_context(self.fd, "plan", "planning", "extension", "start")

--- a/speckit-extension/tests/test_context.py
+++ b/speckit-extension/tests/test_context.py
@@ -446,6 +446,34 @@ class LifecycleCaptureTests(unittest.TestCase):
         self.assertEqual(len(starts), 1, "must not add a start over a legacy start")
         self.assertEqual(len(completes), 1, "must not add a complete over a legacy self-loop complete")
 
+    def test_fold_then_separate_dispatch_keeps_one_start_per_step(self) -> None:
+        # #519 path 1: the specify body folds plan+tasks (simple mode), then the
+        # workflow-engine `small` route separately dispatches plan/tasks whose
+        # bodies stamp their own extension start+complete. Two guards keep each
+        # step at exactly one start (the trust rule needs `explicitStarts == 1`):
+        # the more-advanced guard blocks the earlier-step (plan) re-dispatch, and
+        # `_has_step_start`/`_has_complete` dedup the same-step (tasks) re-dispatch.
+        wc.update_context(self.fd, "specify", "specifying", "extension", "start")
+        wc.update_context(self.fd, "specify", "specified", "extension", "complete")
+        wc.update_context(self.fd, "plan", "planning", "extension", "start")
+        wc.update_context(self.fd, "plan", "planned", "extension", "complete")
+        wc.update_context(self.fd, "tasks", "tasking", "extension", "start")
+        wc.update_context(self.fd, "tasks", "ready-to-implement", "extension", "complete")
+        # The workflow engine now dispatches small-plan / small-tasks again.
+        wc.update_context(self.fd, "plan", "planning", "extension", "start")
+        wc.update_context(self.fd, "plan", "planned", "extension", "complete")
+        wc.update_context(self.fd, "tasks", "tasking", "extension", "start")
+        wc.update_context(self.fd, "tasks", "ready-to-implement", "extension", "complete")
+
+        history = _ctx(self.fd)["history"]
+        for step in ("plan", "tasks"):
+            starts = [e for e in history
+                      if e["step"] == step and e["substep"] is None and wc._entry_kind(e) == "start"]
+            completes = [e for e in history
+                         if e["step"] == step and e["substep"] is None and wc._entry_kind(e) == "complete"]
+            self.assertEqual(len(starts), 1, f"{step} must keep exactly one step-level start")
+            self.assertEqual(len(completes), 1, f"{step} must keep exactly one step-level complete")
+
     def test_kind_complete_respects_no_backward_clobber(self) -> None:
         # A late specify complete must never drag a shipped (implemented) spec back.
         wc.update_context(self.fd, "implement", "implemented", "extension", "complete")

--- a/specs/519-fast-path-untrust-dedup/.spec-context.json
+++ b/specs/519-fast-path-untrust-dedup/.spec-context.json
@@ -1,0 +1,39 @@
+{
+  "workflow": "speckit-companion",
+  "specName": "Fast Path Untrust Dedup",
+  "branch": "519-fast-path-untrust-dedup",
+  "currentStep": "implement",
+  "status": "completed",
+  "size": "simple",
+  "classification": {
+    "projectedFiles": 4,
+    "projectedTasks": 3,
+    "scopeSignal": "none",
+    "verdict": "simple"
+  },
+  "intent": "A second extension start on plan or tasks must not flip the fast-path timing to untrusted; the TypeScript writer dedups redundant starts like the Python one.",
+  "approach": "Add a hasStepStart helper mirroring write-context.py's _has_step_start and guard setStepStarted with it, so a re-click or re-dispatch is a no-op; forceStatus opts out to keep recording honest recovery boundaries.",
+  "context": [
+    "living spec: companion-commands",
+    "area: src/features/specs/specContextWriter.ts (setStepStarted dedup)",
+    "area: src/features/specs/historyHelpers.ts (hasStepStart twin of _has_step_start)",
+    "constraint: cross-language derivation parity — TS dedup must match the Python writer"
+  ],
+  "expectations": [
+    "no change to the fast-path fold bodies or the workflow definition",
+    "forceStatus recovery boundary behavior unchanged (#347)"
+  ],
+  "history": [
+    { "step": "specify", "substep": null, "kind": "start", "by": "extension", "at": "2026-07-21T14:00:00.110Z" },
+    { "step": "specify", "substep": null, "kind": "complete", "by": "extension", "at": "2026-07-21T14:04:30.220Z" },
+    { "step": "plan", "substep": null, "kind": "start", "by": "extension", "at": "2026-07-21T14:04:30.300Z" },
+    { "step": "plan", "substep": null, "kind": "complete", "by": "extension", "at": "2026-07-21T14:04:30.380Z" },
+    { "step": "tasks", "substep": null, "kind": "start", "by": "extension", "at": "2026-07-21T14:04:30.460Z" },
+    { "step": "tasks", "substep": null, "kind": "complete", "by": "extension", "at": "2026-07-21T14:04:30.540Z" },
+    { "step": "implement", "substep": null, "kind": "start", "by": "extension", "at": "2026-07-21T14:04:40.000Z" },
+    { "step": "implement", "task": "T001", "kind": "complete", "by": "ai", "at": "2026-07-21T14:12:10.000Z" },
+    { "step": "implement", "task": "T002", "kind": "complete", "by": "ai", "at": "2026-07-21T14:18:05.000Z" },
+    { "step": "implement", "task": "T003", "kind": "complete", "by": "ai", "at": "2026-07-21T14:24:40.000Z" },
+    { "step": "implement", "substep": null, "kind": "complete", "by": "extension", "at": "2026-07-21T14:25:00.000Z" }
+  ]
+}

--- a/specs/519-fast-path-untrust-dedup/plan.md
+++ b/specs/519-fast-path-untrust-dedup/plan.md
@@ -1,0 +1,5 @@
+# Implementation Plan: Fast-path timing stays trusted when plan/tasks get a second start
+
+**Size**: simple — this plan is a pointer. On the fast path the real design lives in the spec's **Approach** section; a full plan is not written.
+
+See [`spec.md`](./spec.md) → Approach.

--- a/specs/519-fast-path-untrust-dedup/spec.md
+++ b/specs/519-fast-path-untrust-dedup/spec.md
@@ -1,0 +1,29 @@
+# Feature Specification: Fast-path timing stays trusted when plan/tasks get a second start
+
+**Feature Branch**: `519-fast-path-untrust-dedup`
+**Status**: Completed
+**Size**: simple (fast path)
+
+The fast-path fold stamps exactly one extension step-level `start` per folded step, which is what the timing trust rule needs. But off-happy-path a second extension `start` could land on `plan`/`tasks` and flip those phases to untrusted (the viewer stops showing real durations). This closes those paths on the TypeScript writer, which — unlike the Python writer — did not dedup redundant starts.
+
+## User Scenarios
+
+### A re-clicked or re-dispatched phase keeps its trusted timing (Priority: P1)
+
+A developer runs a small change through the fast path. Later they re-click the Plan phase button, or the workflow engine re-dispatches plan/tasks. Before this change, that second start made the timing panel drop plan/tasks from the measured phases. After this change, the second start is a no-op and the timing stays trusted, exactly like the Python capture script already behaved.
+
+## Approach
+
+Give the TypeScript lifecycle writer the same idempotent start-dedup the Python writer has. `setStepStarted` now skips appending a step-level `start` when the log already holds a step-level start for that `(step, substep=null)`, mirroring `write-context.py`'s `_has_step_start` (including the legacy kind-less inference). The redundant append becomes a no-op while `currentStep`/`status` still realign. The manual recovery path (`forceStatus`) opts out so it can still re-stamp an honest override boundary on a stranded step (#347).
+
+## Requirements
+
+- **FR-001**: `setStepStarted` does not append a second step-level start when one already exists for the same step; it still realigns `currentStep`/`status`.
+- **FR-002**: The dedup mirrors `write-context.py`'s `_has_step_start` semantics, including legacy kind-less (`from`-based) entries, and is pinned by parity tests.
+- **FR-003**: A re-started folded step keeps `durationTrusted === true` through `deriveStepHistory`.
+- **FR-004**: The `forceStatus` recovery escape hatch is unchanged (still records an honest override boundary).
+
+## Non-goals
+
+- No change to the fast-path fold command bodies, the workflow definition, or the Python writer's start/complete logic (both already dedup).
+- No change to the timing trust rule in `deriveStepHistory` — the fix is upstream at the writer.

--- a/specs/519-fast-path-untrust-dedup/tasks.md
+++ b/specs/519-fast-path-untrust-dedup/tasks.md
@@ -1,0 +1,5 @@
+# Tasks: Fast-path timing stays trusted when plan/tasks get a second start
+
+- [x] **T001** Add a `hasStepStart` helper (TS twin of `_has_step_start`, legacy kind-less aware) in `historyHelpers.ts`
+- [x] **T002** Dedup step-level starts in `setStepStarted`; keep `forceStatus` opted out (#347)
+- [x] **T003** Cover the writer dedup + the derivation-stays-trusted end-to-end, plus a Python fold-then-re-dispatch parity test

--- a/src/features/specs/__tests__/specContextWriter.test.ts
+++ b/src/features/specs/__tests__/specContextWriter.test.ts
@@ -2,6 +2,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import { appendHistory, setStepStarted, setStepCompleted, setSubstepStarted, setSubstepCompleted, updateSpecContext } from '../specContextWriter';
+import { deriveStepHistory } from '../stepHistoryDerivation';
 import type { HistoryEntry, SpecContext } from '../../../core/types/specContext';
 
 function makeContext(overrides: Partial<SpecContext> = {}): SpecContext {
@@ -83,6 +84,72 @@ describe('setStepStarted', () => {
         const e = result.history[0];
         expect(e.kind).toBe('start');
         expect(e.from).toBeUndefined();
+    });
+
+    // #519: a step is started once. A re-click / GUI start-append race / engine
+    // double-dispatch must not stamp a second step-level start (the trust rule
+    // needs exactly one extension start). Mirrors write-context.py `_has_step_start`.
+    it('does not append a second step-level start when one already exists (dedup)', () => {
+        const existing = entry({ step: 'plan', substep: null, kind: 'start', by: 'extension', at: '2026-04-29T01:00:00Z' });
+        const ctx = makeContext({ currentStep: 'plan', status: 'planning', history: [existing] });
+
+        const result = setStepStarted(ctx, 'plan', 'extension', '2026-04-29T01:05:00Z');
+
+        const planStarts = result.history.filter(
+            e => e.step === 'plan' && e.kind === 'start' && e.substep == null
+        );
+        expect(planStarts).toHaveLength(1);
+        expect(planStarts[0].at).toBe('2026-04-29T01:00:00Z'); // the original, not the re-click
+    });
+
+    it('still realigns currentStep/status when it dedups the redundant start', () => {
+        const existing = entry({ step: 'plan', substep: null, kind: 'start', by: 'extension' });
+        const ctx = makeContext({ currentStep: 'specify', status: 'specifying', history: [existing] });
+
+        const result = setStepStarted(ctx, 'plan', 'extension', '2026-04-29T01:05:00Z');
+
+        expect(result.currentStep).toBe('plan');
+        expect(result.status).toBe('planning');
+        expect(result.history).toHaveLength(1); // no new entry
+    });
+
+    it('dedups a legacy kind-less start entry (self-loop = complete, else start)', () => {
+        const legacyStart = entry({ step: 'plan', substep: null, kind: undefined, from: { step: 'specify', substep: null } });
+        const ctx = makeContext({ currentStep: 'plan', status: 'planning', history: [legacyStart] });
+
+        const result = setStepStarted(ctx, 'plan', 'extension', '2026-04-29T01:05:00Z');
+
+        expect(result.history).toHaveLength(1); // legacy row already counts as a start
+    });
+
+    it('appends the first start when none exists yet', () => {
+        const ctx = makeContext({ currentStep: 'specify', status: 'specified', history: [] });
+        const result = setStepStarted(ctx, 'plan', 'extension', '2026-04-29T01:05:00Z');
+        expect(result.history).toHaveLength(1);
+        expect(result.history[0]).toMatchObject({ step: 'plan', kind: 'start' });
+    });
+
+    // #519 end-to-end: a re-click on an already-folded plan step goes through
+    // setStepStarted again. The dedup keeps ONE extension step-level start, so
+    // deriveStepHistory's trust rule (explicitStarts.length === 1) still trusts it.
+    it('a re-started folded step stays duration-trusted through deriveStepHistory', () => {
+        let ctx = makeContext({ currentStep: 'tasks', status: 'ready-to-implement', history: [
+            entry({ step: 'specify', kind: 'start', at: '2026-04-29T00:00:00Z' }),
+            entry({ step: 'specify', kind: 'complete', at: '2026-04-29T00:01:00Z' }),
+            entry({ step: 'plan', kind: 'start', at: '2026-04-29T00:01:00Z' }),
+            entry({ step: 'plan', kind: 'complete', at: '2026-04-29T00:02:00Z' }),
+            entry({ step: 'tasks', kind: 'start', at: '2026-04-29T00:02:00Z' }),
+            entry({ step: 'tasks', kind: 'complete', at: '2026-04-29T00:03:00Z' }),
+        ] });
+
+        // The user re-clicks the Plan phase button on the folded spec.
+        ctx = setStepStarted(ctx, 'plan', 'extension', '2026-04-29T00:04:00Z');
+
+        const planStarts = ctx.history.filter(e => e.step === 'plan' && e.kind === 'start' && e.substep == null);
+        expect(planStarts).toHaveLength(1);
+
+        const sh = deriveStepHistory(ctx.history, ctx.currentStep, ctx.status);
+        expect(sh.plan.durationTrusted).toBe(true);
     });
 });
 

--- a/src/features/specs/__tests__/specContextWriter.test.ts
+++ b/src/features/specs/__tests__/specContextWriter.test.ts
@@ -86,9 +86,7 @@ describe('setStepStarted', () => {
         expect(e.from).toBeUndefined();
     });
 
-    // #519: a step is started once. A re-click / GUI start-append race / engine
-    // double-dispatch must not stamp a second step-level start (the trust rule
-    // needs exactly one extension start). Mirrors write-context.py `_has_step_start`.
+    // A re-click / race / double-dispatch must not stamp a second step-level start (the trust rule needs exactly one extension start).
     it('does not append a second step-level start when one already exists (dedup)', () => {
         const existing = entry({ step: 'plan', substep: null, kind: 'start', by: 'extension', at: '2026-04-29T01:00:00Z' });
         const ctx = makeContext({ currentStep: 'plan', status: 'planning', history: [existing] });
@@ -129,9 +127,7 @@ describe('setStepStarted', () => {
         expect(result.history[0]).toMatchObject({ step: 'plan', kind: 'start' });
     });
 
-    // #519 end-to-end: a re-click on an already-folded plan step goes through
-    // setStepStarted again. The dedup keeps ONE extension step-level start, so
-    // deriveStepHistory's trust rule (explicitStarts.length === 1) still trusts it.
+    // A re-click on a folded plan step re-runs setStepStarted; the dedup keeps ONE extension start, so deriveStepHistory still trusts it.
     it('a re-started folded step stays duration-trusted through deriveStepHistory', () => {
         let ctx = makeContext({ currentStep: 'tasks', status: 'ready-to-implement', history: [
             entry({ step: 'specify', kind: 'start', at: '2026-04-29T00:00:00Z' }),

--- a/src/features/specs/__tests__/specContextWriter.test.ts
+++ b/src/features/specs/__tests__/specContextWriter.test.ts
@@ -151,6 +151,24 @@ describe('setStepStarted', () => {
         const sh = deriveStepHistory(ctx.history, ctx.currentStep, ctx.status);
         expect(sh.plan.durationTrusted).toBe(true);
     });
+
+    // The forceStatus recovery path opts out of the dedup (dedupe=false) so it can
+    // re-stamp an honest override boundary on an already-started stranded step.
+    // Without this, a manual recovery could not record a fresh start.
+    it('appends a second start when dedupe is disabled, even though one exists', () => {
+        const existing = entry({ step: 'plan', substep: null, kind: 'start', by: 'extension', at: '2026-04-29T01:00:00Z' });
+        const ctx = makeContext({ currentStep: 'plan', status: 'planning', history: [existing] });
+
+        const result = setStepStarted(ctx, 'plan', 'user', '2026-04-29T01:05:00Z', false);
+
+        const planStarts = result.history.filter(
+            e => e.step === 'plan' && e.kind === 'start' && e.substep == null
+        );
+        expect(planStarts).toHaveLength(2);
+        expect(planStarts[1].at).toBe('2026-04-29T01:05:00Z');
+        expect(result.currentStep).toBe('plan');
+        expect(result.status).toBe('planning');
+    });
 });
 
 describe('setStepCompleted', () => {

--- a/src/features/specs/__tests__/stepLifecycle.test.ts
+++ b/src/features/specs/__tests__/stepLifecycle.test.ts
@@ -3,6 +3,7 @@ import {
     completeStep,
     startSubstep,
     completeSubstep,
+    forceStatus,
 } from '../stepLifecycle';
 
 const SPEC_DIR = '/workspace/specs/061-extension-lifecycle-writes';
@@ -68,6 +69,21 @@ describe('stepLifecycle', () => {
                 expect.any(Object),
                 'tasks',
                 'extension'
+            );
+        });
+    });
+
+    describe('forceStatus', () => {
+        it('re-stamps a start with the dedup disabled for an in-flight status', async () => {
+            await forceStatus(SPEC_DIR, 'planning', 'user');
+            const [, mutate] = mockUpdateSpecContext.mock.calls[0];
+            mutate({ currentStep: 'implement', status: 'implementing', history: [] });
+            expect(mockSetStepStarted).toHaveBeenCalledWith(
+                expect.any(Object),
+                'plan',
+                'user',
+                undefined,
+                false
             );
         });
     });

--- a/src/features/specs/historyHelpers.ts
+++ b/src/features/specs/historyHelpers.ts
@@ -29,6 +29,39 @@ export function isPerTaskEntry(e: DiscriminatorEntry): boolean {
 }
 
 /**
+ * The entry's kind, inferring it for legacy kind-less rows exactly as the Python
+ * `_entry_kind` does: a self-loop (`from.step === step` with the matching
+ * substep) is a completion, anything else is a start. The TS twin of that rule.
+ */
+function entryKind(e: HistoryEntry): 'start' | 'complete' {
+    if (e.kind === 'start' || e.kind === 'complete') return e.kind;
+    const from = e.from;
+    if (from?.step === e.step && (from?.substep ?? null) === (e.substep ?? null)) {
+        return 'complete';
+    }
+    return 'start';
+}
+
+/**
+ * True iff a step-level `start` for `(step, substep)` already exists anywhere in
+ * the log. The TypeScript twin of `write-context.py`'s `_has_step_start`: a step
+ * is started once, so a redundant start append is a no-op. Per-task finishes
+ * never count; `substep` defaults to `null` (the step-level start).
+ */
+export function hasStepStart(
+    history: HistoryEntry[],
+    step: StepName | string,
+    substep: string | null = null,
+): boolean {
+    return history.some(e =>
+        e.step === step
+        && (e.substep ?? null) === (substep ?? null)
+        && !isPerTaskEntry(e)
+        && entryKind(e) === 'start'
+    );
+}
+
+/**
  * Walk `history` from newest to oldest and report whether the most recent
  * entry for `step` is a completion.
  *

--- a/src/features/specs/specContextWriter.ts
+++ b/src/features/specs/specContextWriter.ts
@@ -20,6 +20,7 @@ import {
     StepName,
 } from '../../core/types/specContext';
 import { SPEC_CONTEXT_FILENAME, normalizeSpecContext } from './specContextReader';
+import { hasStepStart } from './historyHelpers';
 
 export async function writeSpecContext(
     specDir: string,
@@ -147,17 +148,27 @@ export function setStepStarted(
     ctx: SpecContext,
     step: StepName,
     by: HistoryEntryBy,
-    at: string = new Date().toISOString()
+    at: string = new Date().toISOString(),
+    dedupe = true
 ): SpecContext {
+    const advanced: SpecContext = {
+        ...ctx,
+        currentStep: step,
+        status: deriveInProgressStatus(step),
+    };
+    // Idempotent per (step, substep=null), mirroring write-context.py's
+    // `_has_step_start`: a step is started once. A re-click, a GUI
+    // start-append race, or an engine double-dispatch would otherwise stamp a
+    // second extension start and flip the phase untrusted (deriveStepHistory
+    // requires exactly one). Still realign currentStep/status — only the
+    // redundant history append is skipped (matches the Python writer). The
+    // `forceStatus` recovery path opts out (`dedupe=false`) so it can re-stamp
+    // an honest override boundary on an already-started stranded step (#347).
+    if (dedupe && hasStepStart(ctx.history, step, null)) {
+        return advanced;
+    }
     const entry: HistoryEntry = { step, substep: null, kind: 'start', by, at };
-    return appendHistory(
-        {
-            ...ctx,
-            currentStep: step,
-            status: deriveInProgressStatus(step),
-        },
-        entry
-    );
+    return appendHistory(advanced, entry);
 }
 
 export function setStepCompleted(

--- a/src/features/specs/specContextWriter.ts
+++ b/src/features/specs/specContextWriter.ts
@@ -156,14 +156,7 @@ export function setStepStarted(
         currentStep: step,
         status: deriveInProgressStatus(step),
     };
-    // Idempotent per (step, substep=null), mirroring write-context.py's
-    // `_has_step_start`: a step is started once. A re-click, a GUI
-    // start-append race, or an engine double-dispatch would otherwise stamp a
-    // second extension start and flip the phase untrusted (deriveStepHistory
-    // requires exactly one). Still realign currentStep/status — only the
-    // redundant history append is skipped (matches the Python writer). The
-    // `forceStatus` recovery path opts out (`dedupe=false`) so it can re-stamp
-    // an honest override boundary on an already-started stranded step (#347).
+    // Idempotent per (step, substep=null) like the Python writer: skip a redundant start but still realign currentStep/status; forceStatus opts out via dedupe=false to re-stamp a recovery boundary.
     if (dedupe && hasStepStart(ctx.history, step, null)) {
         return advanced;
     }

--- a/src/features/specs/stepLifecycle.ts
+++ b/src/features/specs/stepLifecycle.ts
@@ -132,7 +132,7 @@ export async function setStatus(
 
 
 /**
- * Force-override a spec's status as a manual recovery escape hatch (#347).
+ * Force-override a spec's status as a manual recovery escape hatch.
  *
  * Unlike `setStatus` (which only writes a terminal status and a `complete`
  * boundary for the spec's *existing* `currentStep`), this realigns
@@ -164,9 +164,7 @@ export async function forceStatus(
                 const aligned: SpecContext = { ...ctx, currentStep: owning.step };
                 return owning.settled
                     ? setStepCompleted(aligned, owning.step, by)
-                    // Manual recovery re-stamps an honest boundary even when the
-                    // stranded step already has a start (#347) — opt out of the
-                    // idempotent start-dedup the automatic advance path uses.
+                    // Recovery re-stamps a boundary even on an already-started step — opt out of the start-dedup the automatic path uses.
                     : setStepStarted(aligned, owning.step, by, undefined, false);
             },
             buildFallback(specDir, owning.step)

--- a/src/features/specs/stepLifecycle.ts
+++ b/src/features/specs/stepLifecycle.ts
@@ -164,7 +164,10 @@ export async function forceStatus(
                 const aligned: SpecContext = { ...ctx, currentStep: owning.step };
                 return owning.settled
                     ? setStepCompleted(aligned, owning.step, by)
-                    : setStepStarted(aligned, owning.step, by);
+                    // Manual recovery re-stamps an honest boundary even when the
+                    // stranded step already has a start (#347) — opt out of the
+                    // idempotent start-dedup the automatic advance path uses.
+                    : setStepStarted(aligned, owning.step, by, undefined, false);
             },
             buildFallback(specDir, owning.step)
         );


### PR DESCRIPTION
## Summary

A completed fast-path spec could intermittently lose its trusted Plan/Tasks timing if those steps got a **second** extension-stamped start — from re-clicking a phase button, a GUI start-append race, or (latently) the workflow engine's `small` route. The timing trust rule needs exactly one extension start per step, and the TypeScript lifecycle writer — unlike the Python one — appended starts unconditionally.

This gives the TS writer the same idempotent start-dedup the Python writer (`write-context.py` `_has_step_start`) already has: a redundant step-level start is now a no-op, while `currentStep`/`status` still realign. So a re-click can't drop a phase from measured timing.

## What changed

- New `hasStepStart()` in `historyHelpers.ts` — the exact TS twin of Python `_has_step_start` (same `(step, substep)` key, same legacy kind-less inference, per-task entries excluded).
- `setStepStarted` skips a redundant step-level start (still realigns currentStep/status) — matching the Python writer's ordering. Both GUI append sites (`updateStepProgress` + `startStep`) route through it.
- `forceStatus` (the manual-recovery escape hatch) opts out via `dedupe=false` so it can re-stamp an honest override boundary on a stranded step.

## Verified

- Repro confirmed first: a history with two extension plan starts → `deriveStepHistory` marks plan untrusted; the old TS `setStepStarted` appended a second start where Python wouldn't.
- Parity checked line-for-line against `_has_step_start`/`_entry_kind`.
- Path 1 (workflow-engine double-dispatch) is already prevented on the Python write path (more-advanced guard + start/complete dedup) — added a parity test proving the full fold-then-re-dispatch yields one start + one complete per step. No workflow/command-body changes.
- Suites green: 1758 jest / 125 suites, 516 python; tsc clean.

## Known follow-up (not this PR)

`.spec-context.json` writes are an unserialized read-modify-write, so the rare *single-dispatch concurrent* case (`updateStepProgress` fire-and-forget + awaited `startStep` reading before either writes) can still slip a double-start through. The dedup closes every deterministic/sequential case; the concurrent one is a pre-existing write-serialization gap (fix: `await updateStepProgress`, or drop the redundant `startStep`). Worth a follow-up if benches still show intermittent flips.

## Manual check (your eyes)

Open a completed fast-path spec, re-click the **Plan** phase button — the timing panel should still show trusted per-phase durations (before this, that re-click dropped Plan from measured).

Closes #519

🤖 Generated with [Claude Code](https://claude.com/claude-code)