### PR TITLE
feat(telemetry): measure companion install rate + install-prompt conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- **Telemetry now measures the spec-kit extension install rate and whether the install banner converts.** Each activation reports whether the companion spec-kit extension is installed, and the install banner reports when it's shown and when its Install button is clicked (per surface — Create New Spec vs. the spec viewer). Together they answer "how many installs have the extension, and does the prompt work?" without any new personal data — the fields are booleans and fixed labels only, still gated on `speckit.telemetry`. The README's Telemetry section lists the new signals and a sample query. ([#506](https://github.com/alfredoperez/speckit-companion/issues/506))
 - **Sync living specs from my changes — one click in the Living Specs view.** A new title-bar action dispatches `/speckit.companion.living-sync` to your AI assistant: it groups your current working-tree changes — uncommitted and untracked files included — by capability and updates every affected living spec in one pass, leaving the spec edits uncommitted so they ship in the same commit as the code. It sits next to the existing Adopt Code Area… action and appears only when the companion spec-kit extension is installed.
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -302,8 +302,30 @@ The extension sends **anonymous, PII-free** usage telemetry to help prioritize w
 | Feature-flag on/off states | a snapshot reported once per session |
 | Extension / VS Code versions, spec count | for version distribution and scale |
 | Chosen workflow | the built-in id, or the literal `custom` |
+| Whether the companion spec-kit extension is installed | `true` / `false`, reported once per session |
+| Whether the install banner was shown or its Install button clicked | `shown` / `clicked`, per surface (`createSpec` / `activity`) |
 
 **What is never collected**: prompt content, file paths, spec names, or custom workflow names — only enum-like values, booleans, versions, counts, and a random per-spec id.
+
+**Reading these in App Insights**: the extension's telemetry is a **workspace-based** Application Insights resource, so events land in the `AppEvents` table (not `customEvents`). Install rate and prompt→install conversion are both computable there. Sample query — install rate and banner conversion over the last 30 days:
+
+```kusto
+// Install rate: share of activations that already have the companion spec-kit extension
+AppEvents
+| where TimeGenerated > ago(30d)
+| where Name == "extension.activated"
+| summarize installed = countif(tostring(Properties.companionInstalled) == "true"), total = count()
+| extend installRate = 1.0 * installed / total
+
+// Prompt→install conversion: banner Install clicks vs. banner shows
+AppEvents
+| where TimeGenerated > ago(30d)
+| where Name == "companion.installPrompt"
+| summarize shown = countif(tostring(Properties.action) == "shown"),
+            clicked = countif(tostring(Properties.action) == "clicked")
+    by surface = tostring(Properties.surface)
+| extend conversion = 1.0 * clicked / shown
+```
 
 That per-spec id is a **random UUID, not the spec name or path**. It correlates a single spec's events into a funnel (created → dispatched → completed) without ever revealing which spec it is. It is stored in the spec's `.spec-context.json` so the same id rides every event for that spec.
 

--- a/README.md
+++ b/README.md
@@ -316,7 +316,9 @@ AppEvents
 | where Name == "extension.activated"
 | summarize installed = countif(tostring(Properties.companionInstalled) == "true"), total = count()
 | extend installRate = 1.0 * installed / total
+```
 
+```kusto
 // Prompt→install conversion: banner Install clicks vs. banner shows
 AppEvents
 | where TimeGenerated > ago(30d)

--- a/specs/523-install-prompt-telemetry/.spec-context.json
+++ b/specs/523-install-prompt-telemetry/.spec-context.json
@@ -1,0 +1,365 @@
+{
+  "workflow": "speckit",
+  "specName": "install prompt telemetry",
+  "branch": "523-install-prompt-telemetry",
+  "currentStep": "implement",
+  "status": "completed",
+  "history": [
+    {
+      "step": "specify",
+      "substep": null,
+      "kind": "start",
+      "by": "extension",
+      "at": "2026-07-22T01:57:26.656Z"
+    },
+    {
+      "step": "specify",
+      "substep": null,
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-07-22T01:58:39.460Z"
+    },
+    {
+      "step": "plan",
+      "substep": null,
+      "kind": "start",
+      "by": "extension",
+      "at": "2026-07-22T01:58:55.911Z"
+    },
+    {
+      "step": "plan",
+      "substep": "research",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-07-22T01:59:49.632Z"
+    },
+    {
+      "step": "plan",
+      "substep": "design",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-07-22T01:59:49.743Z"
+    },
+    {
+      "step": "plan",
+      "substep": null,
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-07-22T02:00:03.324Z"
+    },
+    {
+      "step": "tasks",
+      "substep": null,
+      "kind": "start",
+      "by": "extension",
+      "at": "2026-07-22T02:00:17.621Z"
+    },
+    {
+      "step": "tasks",
+      "substep": null,
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-07-22T02:00:53.540Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "kind": "start",
+      "by": "extension",
+      "at": "2026-07-22T02:01:08.075Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T001",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-07-22T02:01:25.619Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T002",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-07-22T02:01:39.240Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T003",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-07-22T02:02:26.973Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T004",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-07-22T02:03:09.607Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T005",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-07-22T02:03:18.952Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T006",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-07-22T02:05:32.748Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T007",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-07-22T02:05:53.753Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T008",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-07-22T02:06:07.911Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T009",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-07-22T02:06:48.303Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-07-22T02:06:48.372Z"
+    }
+  ],
+  "coverage": {
+    "FR-001": {
+      "title": "extension.activated carries a boolean companionInstalled dimension",
+      "tasks": [
+        "T002",
+        "T006"
+      ],
+      "tests": [
+        "src/core/__tests__/telemetry.test.ts::emits companionInstalled through the reporter on extension.activated"
+      ]
+    },
+    "FR-002": {
+      "title": "companion.installPrompt action=shown emitted with surface when banner becomes visible",
+      "tasks": [
+        "T001",
+        "T003",
+        "T004",
+        "T006"
+      ],
+      "tests": [
+        "src/core/__tests__/telemetry.test.ts::emits action=shown with the surface the first time a surface is shown"
+      ]
+    },
+    "FR-003": {
+      "title": "shown event deduped once per surface per session",
+      "tasks": [
+        "T001",
+        "T006"
+      ],
+      "tests": [
+        "src/core/__tests__/telemetry.test.ts::dedupes a repeated shown for the same surface within a session"
+      ]
+    },
+    "FR-004": {
+      "title": "companion.installPrompt action=clicked emitted with surface on Install click",
+      "tasks": [
+        "T001",
+        "T003",
+        "T004",
+        "T006"
+      ],
+      "tests": [
+        "src/core/__tests__/telemetry.test.ts::emits action=clicked with the originating surface (not deduped)"
+      ]
+    },
+    "FR-005": {
+      "title": "new telemetry fields are booleans/enums only, no identifiers/paths",
+      "tasks": [
+        "T001",
+        "T002",
+        "T006"
+      ],
+      "tests": [
+        "src/core/__tests__/telemetry.test.ts::carries only the action + surface enum fields — no identifier or path"
+      ]
+    },
+    "FR-006": {
+      "title": "new events respect the existing telemetry opt-in gates",
+      "tasks": [
+        "T001",
+        "T006"
+      ],
+      "tests": [
+        "src/core/__tests__/telemetry.test.ts::sends nothing when telemetry is disabled"
+      ]
+    },
+    "FR-007": {
+      "title": "existing usage events remain emitted for used-vs-installed",
+      "tasks": [
+        "T005"
+      ]
+    },
+    "FR-008": {
+      "title": "telemetry docs list new signals + AppEvents sample query",
+      "tasks": [
+        "T007",
+        "T008"
+      ]
+    }
+  },
+  "size": "normal",
+  "classification": {
+    "projectedFiles": 6,
+    "projectedTasks": 9,
+    "scopeSignal": "none",
+    "verdict": "normal"
+  },
+  "context": [
+    "area: src/core/telemetry.ts (scrubbing boundary)",
+    "area: install banner (spec-editor + spec-viewer) + specKitExtensionInstallCommands",
+    "constraint: booleans/enums only, no identifiers/paths; respect existing telemetry gate"
+  ],
+  "intent": "Measure companion spec-kit install rate and install-banner prompt→install conversion via opt-in, privacy-scrubbed telemetry",
+  "expectations": [
+    "No new usage event for used-vs-installed — reuse existing spec/phase/workflow events",
+    "No identifiers, paths, or free text in any new telemetry field"
+  ],
+  "approach": "Add companionInstalled boolean to extension.activated; new companion.installPrompt event with action(shown|clicked)+surface(createSpec|activity); emit helpers + session dedupe live in telemetry.ts; shown from render sites, clicked from banner message handlers only.",
+  "decisions": [
+    {
+      "decision": "single companion.installPrompt event with action dimension",
+      "why": "conversion is one aggregation, no join; enum stays in privacy allow-list",
+      "rejected": "two separate event names"
+    },
+    {
+      "decision": "emit shown from server render sites, deduped per session via module Set",
+      "why": "banner is server-rendered and regenerates on every refresh; render decision is the only reliable signal",
+      "rejected": "client DOM-mount emit needing new postMessage plumbing"
+    },
+    {
+      "decision": "emit clicked from banner message handlers, not shared install command",
+      "why": "install command is also fired by sidebar/upgrade menu; banner handlers isolate prompt conversion",
+      "rejected": "emit in registerSpecKitExtensionInstallCommands"
+    },
+    {
+      "decision": "extract buildActivatedProperties pure helper in telemetry.ts",
+      "why": "fireActivatedEvent is private with no harness; a pure assembler makes companionInstalled emit-provable in the reporter-mock test",
+      "rejected": "a bespoke extension.ts activation test harness"
+    }
+  ],
+  "step_summaries": {
+    "plan": {
+      "summary": "Telemetry plan: one boolean on activation + one two-dimension installPrompt event, all allow-listed enums",
+      "key_finding": "clicked must be scoped to the banner handlers, not the shared install command, or the conversion denominator inflates"
+    },
+    "tasks": {
+      "summary": "9 tasks across setup(0)/foundational(1)/US1(1)/US2(2)/US3(1 verify)/polish(4); waves parallelize spec-editor+spec-viewer and docs+tests"
+    },
+    "implement": {
+      "summary": "Shipped install-rate (companionInstalled on extension.activated) + banner conversion (companion.installPrompt shown/clicked × surface) telemetry, privacy-scrubbed, with emit-proof tests"
+    }
+  },
+  "currentTask": "T009",
+  "task_summaries": {
+    "T001": {
+      "status": "DONE",
+      "did": "Added InstallPromptSurface/Action types, companion.installPrompt event const, session-dedupe Set, reportInstallPromptShown/Clicked + test reset helper",
+      "files": [
+        "src/core/telemetry.ts"
+      ]
+    },
+    "T002": {
+      "status": "DONE",
+      "did": "extension.activated now reports companionInstalled boolean via isCompanionInstalled(root), false when no workspace root",
+      "files": [
+        "src/extension.ts"
+      ]
+    },
+    "T003": {
+      "status": "DONE",
+      "did": "Create-Spec panel emits reportInstallPromptShown('createSpec') when banner visible and reportInstallPromptClicked('createSpec') on the banner Install message",
+      "files": [
+        "src/features/spec-editor/specEditorProvider.ts"
+      ]
+    },
+    "T004": {
+      "status": "DONE",
+      "did": "Activity/viewer panel emits reportInstallPromptShown('activity') in computeShowInstallPrompt and reportInstallPromptClicked('activity') in the banner Install handler",
+      "files": [
+        "src/features/spec-viewer/specViewerProvider.ts",
+        "src/features/spec-viewer/messageHandlers.ts"
+      ]
+    },
+    "T005": {
+      "status": "DONE",
+      "did": "Confirmed spec.created/spec.completed/phase.dispatched/workflow.selected still emit; used-vs-installed computable, no new event needed",
+      "files": [
+        "(verification)"
+      ]
+    },
+    "T006": {
+      "status": "DONE",
+      "did": "Added emit-proof tests: extension.activated carries boolean companionInstalled (via reporter mock); companion.installPrompt shown+dedupe, clicked, enum-only fields, disabled-gate suppression",
+      "files": [
+        "src/core/__tests__/telemetry.test.ts"
+      ]
+    },
+    "T007": {
+      "status": "DONE",
+      "did": "README Telemetry section: added companionInstalled + install-prompt shown/clicked signals and an AppEvents sample query (install rate + banner conversion)",
+      "files": [
+        "README.md"
+      ]
+    },
+    "T008": {
+      "status": "DONE",
+      "did": "CHANGELOG [Unreleased] Added entry for install-rate + banner-conversion telemetry (user-facing, no internal symbol names)",
+      "files": [
+        "CHANGELOG.md"
+      ]
+    },
+    "T009": {
+      "status": "DONE",
+      "did": "npm run compile clean; npm test green (125 suites / 1768 tests)",
+      "files": [
+        "(build+test)"
+      ]
+    }
+  },
+  "verified": [
+    {
+      "what": "full compile + test suite",
+      "command": "npm run compile && npm test",
+      "result": "compile clean; 125 suites / 1768 tests pass",
+      "warnings": []
+    },
+    {
+      "what": "install-prompt telemetry emit-proof",
+      "command": "npx jest src/core/__tests__/telemetry.test.ts",
+      "result": "companionInstalled emitted via reporter mock; installPrompt shown(deduped)/clicked verified enum-only + gated",
+      "warnings": []
+    }
+  ],
+  "last_action": "all 9 tasks done — compile clean, 1768 tests pass"
+}

--- a/specs/523-install-prompt-telemetry/checklists/requirements.md
+++ b/specs/523-install-prompt-telemetry/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Track install rate and prompt→install conversion
+
+**Purpose**: Validate Companion specification completeness before planning
+**Created**: 2026-07-21
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed (User Scenarios, Requirements, Success Criteria)
+
+## Requirement Completeness
+
+- [x] Any [NEEDS CLARIFICATION] markers are genuine ambiguities (≤3) deferred to clarify — none needed
+- [x] Each Functional Requirement is a single, testable MUST/SHOULD statement
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into the specification
+
+## Notes
+
+- Event/dimension names are pinned under Verbatim Constraints because the dashboard queries depend on exact strings.

--- a/specs/523-install-prompt-telemetry/plan.md
+++ b/specs/523-install-prompt-telemetry/plan.md
@@ -1,0 +1,53 @@
+# Implementation Plan: Track install rate and prompt→install conversion
+
+**Feature dir**: `specs/523-install-prompt-telemetry` · **Spec**: [spec.md](./spec.md) · **Size**: normal
+
+## Summary
+
+Add three privacy-scrubbed telemetry signals to the existing VS Code extension telemetry so a maintainer can answer "how many active installs already have the companion spec-kit extension, and does the install banner convert?". One boolean (`companionInstalled`) rides the event that already fires on activation; a new `companion.installPrompt` event carries an `action` (`shown` / `clicked`) and a `surface` (`createSpec` / `activity`). All new fields are booleans or fixed enum literals — they never carry an identifier, path, or free text. The emit boundary and gates are the ones already in `src/core/telemetry.ts`; no reporter, connection string, or opt-in behavior changes.
+
+## Project Structure
+
+```
+src/
+├── extension.ts                                  # fireActivatedEvent → add companionInstalled boolean
+├── core/
+│   ├── telemetry.ts                              # new: reportInstallPromptShown/Clicked helpers + session dedupe
+│   └── __tests__/telemetry.test.ts               # new: emit-proof tests (mock reporter)
+├── features/
+│   ├── spec-editor/specEditorProvider.ts         # emit shown('createSpec') when banner visible; emit clicked on Install msg
+│   └── spec-viewer/
+│       ├── specViewerProvider.ts                 # emit shown('activity') when computeShowInstallPrompt true
+│       └── messageHandlers.ts                    # emit clicked('activity') on installSpecKitExtension msg
+README.md                                         # Telemetry section: new signals + AppEvents sample query
+CHANGELOG.md                                      # [Unreleased] user-facing entry
+```
+
+**Structure Decision**: The emit helpers live in `src/core/telemetry.ts` (the single scrubbing home), so the session-dedupe state and the allow-listed enums have exactly one owner. The four call sites (two render, two click) import those helpers rather than calling `sendTelemetryEvent` with ad-hoc property maps, keeping the privacy boundary in one file.
+
+## Constitution Check
+
+No `.specify/memory/constitution.md` governs this repo's `src/`. The binding rules are CLAUDE.md conventions and `.claude/review-checklist.md`; the relevant one is the **types & data boundaries** rule (coerce/allow-list at the emit boundary). This design satisfies it: `surface` and `action` are typed literals produced only by our own call sites — never sourced from user-authored data — so the values are fixed at compile time, not read from `settings.json`/`.spec-context.json`. PASS.
+
+## Phase 0 — Key Decisions
+
+See [research.md](./research.md).
+
+## Phase 1 — Design
+
+Types folded here (no separate data-model.md needed for two string-valued dimensions):
+
+- `InstallPromptSurface = 'createSpec' | 'activity'` — the two banner surfaces.
+- `InstallPromptAction = 'shown' | 'clicked'` — the two funnel moments.
+- Event `companion.installPrompt` carries `{ action, surface }` (both strings on the wire, per `TelemetryProperties = Record<string,string>`).
+- `extension.activated` gains `companionInstalled: 'true' | 'false'` (stringified boolean, matching the existing `specCount: String(n)` convention).
+
+**Contract (event shapes)** — the pinned wire strings, from the spec's Verbatim Constraints:
+
+| Event | Dimension | Values |
+|-------|-----------|--------|
+| `extension.activated` | `companionInstalled` | `"true"` \| `"false"` |
+| `companion.installPrompt` | `action` | `"shown"` \| `"clicked"` |
+| `companion.installPrompt` | `surface` | `"createSpec"` \| `"activity"` |
+
+No REST/CLI/schema interface is exposed, so no `contracts/` directory.

--- a/specs/523-install-prompt-telemetry/research.md
+++ b/specs/523-install-prompt-telemetry/research.md
@@ -1,0 +1,25 @@
+# Research: install-prompt telemetry
+
+## Decision: single event with an `action` dimension, not two event names
+
+**Chosen**: One `companion.installPrompt` event carrying `action` (`shown` / `clicked`) and `surface`.
+**Rationale**: The conversion query (`clicked / shown`) is one aggregation over one event partitioned by `action`; two event names would force a join. The dimension is a fixed literal, so it stays inside the privacy allow-list.
+**Rejected**: `companion.installPrompt.shown` + `.clicked` as separate names — more surface area, harder to funnel, no privacy benefit.
+
+## Decision: emit `shown` from the render/compute sites, deduped per session
+
+**Chosen**: A module-level `Set<InstallPromptSurface>` in `telemetry.ts`; `reportInstallPromptShown(surface)` emits only on first sight per surface per host session. The Create-Spec provider calls it when it renders the banner visible; the spec-viewer calls it inside `computeShowInstallPrompt()` when the result is `true`.
+**Rationale**: Both webviews server-render the banner HTML and regenerate it on every refresh/content update, so an un-deduped emit would fire on every render tick (the issue's explicit warning). The banner "mounts" server-side, so there is no client mount event to hook; the render decision is the only reliable signal, and dedupe makes it "once per shown occurrence."
+**Rejected**: Emitting from the webview client on DOM mount — would require new postMessage plumbing in both webviews for no added fidelity; the server already knows when it decided to show the banner.
+
+## Decision: emit `clicked` from the banner message handlers, not the shared install command
+
+**Chosen**: Emit `reportInstallPromptClicked(surface)` in the two webview handlers that receive the banner's `installSpecKitExtension` postMessage (spec-editor `case 'installSpecKitExtension'`, spec-viewer `installSpecKitExtension` handler), then delegate to the existing command.
+**Rationale**: `speckit.companion.installSpecKitExtension` is also invoked from the sidebar affordance and an upgrade menu. Emitting `clicked` in the shared command would count those as prompt conversions and inflate the rate. The banner handlers are reached only by the banner's Install button, so tagging them measures prompt conversion specifically.
+**Rejected**: Emitting in `registerSpecKitExtensionInstallCommands` — simpler but wrong denominator; it would break the shown→clicked funnel.
+
+## Decision: `companionInstalled` reuses the already-computed install probe
+
+**Chosen**: `fireActivatedEvent` computes `isCompanionInstalled(root)` (the same probe that feeds the `speckit.companion.installed` context key) and reports it as `String(...)`.
+**Rationale**: One fact, one derivation — the context key and the telemetry field read the same probe, so they cannot disagree. No new detection logic.
+**Rejected**: A second presence check — would risk drifting from the context-key source of truth.

--- a/specs/523-install-prompt-telemetry/spec.md
+++ b/specs/523-install-prompt-telemetry/spec.md
@@ -1,0 +1,98 @@
+# Feature Specification: Track install rate and prompt→install conversion for the spec-kit extension
+
+**Feature Branch**: `523-install-prompt-telemetry`
+**Created**: 2026-07-21
+**Status**: Draft
+**Input**: Issue #506 — the workflow picker and the "Install the spec-kit extension…" banner already ship, but nothing measures how many users have the companion spec-kit extension installed, nor whether the banner converts.
+
+## User Scenarios & Testing
+
+### User Story 1 - Know the install rate (Priority: P1)
+
+As a maintainer deciding where to invest, I want each activation to report whether the companion spec-kit extension is present, so I can see what share of active installs already have it versus still need the prompt.
+
+**Why this priority**: Install rate is the denominator for every downstream question ("does the prompt convert?", "do installed users use the pipeline?"). Without it, none of those are answerable. It is also the smallest change — one boolean on an event that already fires.
+
+**Independent Test**: Activate the extension with the companion spec-kit extension present, then absent, and confirm the `extension.activated` event carries a boolean `companionInstalled` reflecting each state.
+
+**Acceptance Scenarios**:
+
+1. **Given** the companion spec-kit extension dir exists in the workspace, **When** the extension activates, **Then** `extension.activated` is emitted with `companionInstalled` = `"true"`.
+2. **Given** the companion spec-kit extension is not installed, **When** the extension activates, **Then** `extension.activated` is emitted with `companionInstalled` = `"false"`.
+3. **Given** telemetry is disabled, **When** the extension activates, **Then** no event is sent (unchanged dual-gate behavior).
+
+### User Story 2 - Measure whether the install banner converts (Priority: P1)
+
+As a maintainer, I want to know when the install banner is shown and when its Install button is clicked, so I can compute the prompt→install conversion rate.
+
+**Why this priority**: This is the core question the issue asks. Both moments (shown, clicked) must be measurable to form a funnel.
+
+**Independent Test**: Render the banner in the Create-Spec panel and the Activity panel and confirm a "shown" telemetry event fires once per surface per session; click Install on each and confirm a "clicked" telemetry event fires with the originating surface.
+
+**Acceptance Scenarios**:
+
+1. **Given** the install banner becomes visible in the Create-Spec panel, **When** it is shown, **Then** a `companion.installPrompt` event is emitted with `action` = `"shown"` and `surface` = `"createSpec"`.
+2. **Given** the banner is visible in the Activity panel, **When** it is shown, **Then** a `companion.installPrompt` event is emitted with `action` = `"shown"` and `surface` = `"activity"`.
+3. **Given** the banner is shown and the webview HTML re-renders several times in the same session, **When** it re-renders, **Then** the "shown" event is emitted only once per surface (deduped within the session).
+4. **Given** the banner is visible, **When** the user clicks its Install button, **Then** a `companion.installPrompt` event is emitted with `action` = `"clicked"` and the originating `surface`, and the existing install command still runs.
+
+### User Story 3 - Compute used-vs-installed from existing usage (Priority: P2)
+
+As a maintainer, I want to correlate install state with actual pipeline usage, so I can see whether installed users go on to use the Companion pipeline.
+
+**Why this priority**: This needs no new event — it is a query over the new install-rate signal plus the usage events that already ship. This story exists to confirm those events remain in place, not to add anything.
+
+**Independent Test**: Confirm `spec.created`, `spec.completed`, `phase.dispatched`, and `workflow.selected` events still exist and are emitted, so used-vs-installed is joinable in the dashboard.
+
+**Acceptance Scenarios**:
+
+1. **Given** the existing usage events, **When** a maintainer queries the telemetry store, **Then** install state (from `extension.activated.companionInstalled`) can be joined against usage without a new event.
+
+## Edge Cases
+
+- No open workspace folder at activation: `companionInstalled` reports `false` (no root to probe) rather than failing activation.
+- The banner is dismissed for good (global-state flag): it never renders, so no "shown" event fires — correct, there was no prompt.
+- Telemetry disabled (`speckit.telemetry` off or VS Code global off): no new events are sent, same as every existing event.
+- The Install command is also reachable from the sidebar affordance and an upgrade menu, not just the banner: the "clicked" conversion event fires only from the banner's Install button, so it measures prompt conversion specifically, not every install trigger.
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: The `extension.activated` event MUST carry a boolean-valued `companionInstalled` dimension reflecting whether the companion spec-kit extension is installed in the active workspace.
+- **FR-002**: A `companion.installPrompt` event MUST be emitted with `action` = `"shown"` when the install banner becomes visible, tagged with the `surface` it appeared in (`"createSpec"` or `"activity"`).
+- **FR-003**: The "shown" event MUST be deduplicated within a session so a chatty webview re-render emits it at most once per surface per session.
+- **FR-004**: A `companion.installPrompt` event MUST be emitted with `action` = `"clicked"` and the originating `surface` when the banner's Install button is clicked, without changing the existing install behavior.
+- **FR-005**: Every new telemetry field MUST be a boolean, count, or fixed enum literal — no identifiers, no paths, no free text — matching the existing scrubbing/allow-list boundary in the telemetry module.
+- **FR-006**: The new events MUST respect the existing telemetry gates (opt-in `speckit.telemetry` plus VS Code's global setting); when telemetry is off, nothing is sent.
+- **FR-007**: The existing usage events (`spec.created`, `spec.completed`, `phase.dispatched`, `workflow.selected`) MUST remain emitted so used-vs-installed stays computable without a new event.
+- **FR-008**: The user-facing telemetry documentation MUST list the new signals and include a note that they read in App Insights via the `AppEvents` table (not `customEvents`), with a sample query.
+
+### Key Entities
+
+- **extension.activated event**: the once-per-session activation event; gains a `companionInstalled` boolean dimension alongside its existing version/count/snapshot fields.
+- **companion.installPrompt event**: a new event with two dimensions — `action` (`"shown"` | `"clicked"`) and `surface` (`"createSpec"` | `"activity"`).
+
+## Success Criteria
+
+### Measurable Outcomes
+
+- **SC-001**: 100% of `extension.activated` events carry a `companionInstalled` value of `"true"` or `"false"`.
+- **SC-002**: Each shown banner produces exactly one "shown" event per surface per session, regardless of how many times the webview re-renders.
+- **SC-003**: Each banner Install click produces exactly one "clicked" event carrying the surface it came from.
+- **SC-004**: No new telemetry field carries any identifier, path, or free-text value — only booleans and fixed enum literals.
+- **SC-005**: Prompt→install conversion (clicked / shown) and install rate (installed / activated) are both computable from the emitted events with no additional instrumentation.
+
+## Assumptions
+
+- The two banner surfaces are the Create-Spec panel (`surface = "createSpec"`) and the Activity/spec viewer panel (`surface = "activity"`); these are the only two places `shouldShowInstallPrompt` gates the banner today.
+- The "clicked" event is scoped to the banner's Install button rather than the shared install command, so it measures prompt conversion rather than all install invocations.
+- Session-scoped dedupe (a module-level guard reset per extension host session) is the intended granularity for "once per shown occurrence."
+
+## Verbatim Constraints
+
+- Event name: `companion.installPrompt`
+- Activation dimension: `companionInstalled`
+- Action dimension values: `shown`, `clicked`
+- Surface dimension values: `createSpec`, `activity`
+- App Insights table for queries: `AppEvents` (not `customEvents`)

--- a/specs/523-install-prompt-telemetry/tasks.md
+++ b/specs/523-install-prompt-telemetry/tasks.md
@@ -1,0 +1,61 @@
+# Tasks: Track install rate and prompt→install conversion
+
+**Feature dir**: `specs/523-install-prompt-telemetry` · **Plan**: [plan.md](./plan.md) · **Size**: normal
+
+## Phase 1: Setup
+
+No setup tasks — this extends an existing telemetry module in place.
+
+## Phase 2: Foundational (blocks all stories)
+
+The emit helpers and enums are shared by every story, so they land first.
+
+**Wave 1 — single task (shared module):**
+
+- [x] **T001** [US1][US2] Add to `src/core/telemetry.ts`: `InstallPromptSurface` (`'createSpec'|'activity'`) and `InstallPromptAction` (`'shown'|'clicked'`) types, the `companion.installPrompt` event-name constant, a module-level `Set<InstallPromptSurface>` session-dedupe guard, `reportInstallPromptShown(surface)` (emits `action:'shown'` once per surface per session), `reportInstallPromptClicked(surface)` (emits `action:'clicked'`), and a test-only dedupe reset helper · `src/core/telemetry.ts`
+
+## Phase 3: User Story 1 — install rate (P1)
+
+**Wave 2 — single task (depends on nothing in Wave 1):**
+
+- [x] **T002** [US1] In `fireActivatedEvent`, compute `isCompanionInstalled(root)` and add `companionInstalled: String(...)` to the `extension.activated` payload (report `false` when no workspace root) · `src/extension.ts`
+
+**Checkpoint**: `extension.activated` now reports install state on every activation.
+
+## Phase 4: User Story 2 — prompt→install conversion (P1)
+
+**⟶ Wait for Wave 1 (T001) to finish, then:**
+
+**Wave 3 — independent (different files):**
+
+- [x] **T003** [P] [US2] Emit `reportInstallPromptShown('createSpec')` when the Create-Spec banner renders visible, and `reportInstallPromptClicked('createSpec')` in the `installSpecKitExtension` message handler before delegating to the command · `src/features/spec-editor/specEditorProvider.ts`
+- [x] **T004** [P] [US2] Emit `reportInstallPromptShown('activity')` inside `computeShowInstallPrompt()` when it returns `true`, and `reportInstallPromptClicked('activity')` in the `installSpecKitExtension` handler before delegating · `src/features/spec-viewer/specViewerProvider.ts`, `src/features/spec-viewer/messageHandlers.ts`
+
+**Checkpoint**: both banner surfaces emit shown + clicked; conversion is computable.
+
+## Phase 5: User Story 3 — used-vs-installed (P2)
+
+**Wave 4 — single task (verification only):**
+
+- [x] **T005** [US3] Confirm `spec.created`, `spec.completed`, `phase.dispatched`, `workflow.selected` still emit (grep + existing tests) — no code change unless a regression is found · `src/` (verification)
+
+## Phase 6: Polish
+
+**⟶ Wait for T001–T004, then:**
+
+**Wave 5 — independent (different files):**
+
+- [x] **T006** [P] Tests in `src/core/__tests__/telemetry.test.ts`: `extension.activated` carries boolean `companionInstalled`; `reportInstallPromptShown` emits `companion.installPrompt` with `action:'shown'`+surface and dedupes on the second call; `reportInstallPromptClicked` emits `action:'clicked'`+surface; assert only boolean/enum fields (no identifier/path); assert the disabled-telemetry gate suppresses them · `src/core/__tests__/telemetry.test.ts`
+- [x] **T007** [P] README Telemetry section: add `companionInstalled` and the `companion.installPrompt` (shown/clicked × surface) signals to the "What is collected" table, plus a "Reading these in App Insights" note with a sample `AppEvents` query · `README.md`
+- [x] **T008** [P] CHANGELOG `[Unreleased]` user-facing entry for the new install-rate + conversion telemetry · `CHANGELOG.md`
+
+**⟶ Wait for T006, then:**
+
+- [x] **T009** Run `npm run compile && npm test`; confirm green (telemetry suite included) · repo
+
+## Dependencies & Execution Order
+
+- Phase 2 (T001) blocks Phase 4 (T003, T004) and the tests (T006) — the emit helpers must exist first.
+- T002 (US1) is independent of T001 (it edits `extension.activated` directly), can run any time.
+- Wave 3 (T003, T004) are different files → parallelizable once T001 lands.
+- Wave 5 docs/tests (T006–T008) are different files → parallelizable once code lands; T009 (build+test) runs last.

--- a/src/core/__tests__/telemetry.test.ts
+++ b/src/core/__tests__/telemetry.test.ts
@@ -281,6 +281,19 @@ describe('TelemetryService', () => {
             reportInstallPromptClicked('createSpec');
             expect(__captured.events).toHaveLength(0);
         });
+
+        it('a show while telemetry is disabled does not burn the dedupe — it still fires once enabled', () => {
+            mockConfig({ telemetry: false });
+            initTelemetry(new TelemetryService());
+            reportInstallPromptShown('createSpec');   // no-op, must NOT record the dedupe
+            expect(__captured.events).toHaveLength(0);
+            mockConfig({ telemetry: true });
+            initTelemetry(new TelemetryService());
+            reportInstallPromptShown('createSpec');   // now it should emit
+            expect(__captured.events).toEqual([
+                { name: INSTALL_PROMPT_EVENT, properties: { action: 'shown', surface: 'createSpec' } },
+            ]);
+        });
     });
 
     describe('the per-spec correlation id', () => {

--- a/src/core/__tests__/telemetry.test.ts
+++ b/src/core/__tests__/telemetry.test.ts
@@ -6,9 +6,15 @@ import {
     TelemetryService,
     getSpecTelemetryContext,
     buildBetaSnapshot,
+    buildActivatedProperties,
     phaseTelemetryId,
     profileTelemetryId,
     defaultWorkflowTelemetryId,
+    initTelemetry,
+    reportInstallPromptShown,
+    reportInstallPromptClicked,
+    __resetInstallPromptShownDedupe,
+    INSTALL_PROMPT_EVENT,
     APP_INSIGHTS_CONNECTION_STRING,
 } from '../telemetry';
 // `@vscode/extension-telemetry` is mapped to the test mock (jest.config.js).
@@ -174,6 +180,106 @@ describe('TelemetryService', () => {
             expect(defaultWorkflowTelemetryId('my-custom-workflow')).toBe('speckit');
             expect(defaultWorkflowTelemetryId('')).toBe('speckit');
             expect(defaultWorkflowTelemetryId(undefined)).toBe('speckit');
+        });
+    });
+
+    describe('the extension.activated payload (install rate)', () => {
+        const baseSnapshot = {
+            extensionVersion: '1.2.3',
+            vscodeVersion: '1.90.0',
+            speckitCliVersion: 'unknown',
+            specCount: 4,
+        };
+
+        it('reports companionInstalled as a stringified boolean when installed', () => {
+            mockConfig({ telemetry: true });
+            const props = buildActivatedProperties({ ...baseSnapshot, companionInstalled: true });
+            expect(props.companionInstalled).toBe('true');
+            expect(props.specCount).toBe('4');
+        });
+
+        it('reports companionInstalled as "false" when the companion extension is absent', () => {
+            mockConfig({ telemetry: true });
+            const props = buildActivatedProperties({ ...baseSnapshot, companionInstalled: false });
+            expect(props.companionInstalled).toBe('false');
+        });
+
+        it('emits companionInstalled through the reporter on extension.activated', () => {
+            mockConfig({ telemetry: true });
+            const service = new TelemetryService();
+            service.sendEvent(
+                'extension.activated',
+                buildActivatedProperties({ ...baseSnapshot, companionInstalled: true }),
+            );
+
+            expect(__captured.events).toHaveLength(1);
+            expect(__captured.events[0].name).toBe('extension.activated');
+            expect(__captured.events[0].properties?.companionInstalled).toBe('true');
+        });
+
+        it('carries only booleans/versions/counts/enums — no identifier or path', () => {
+            mockConfig({ telemetry: true });
+            const props = buildActivatedProperties({ ...baseSnapshot, companionInstalled: false });
+            for (const value of Object.values(props)) {
+                expect(value).not.toContain('/');
+                expect(value).not.toContain('\\');
+            }
+        });
+    });
+
+    describe('the install-prompt funnel (companion.installPrompt)', () => {
+        beforeEach(() => {
+            __resetInstallPromptShownDedupe();
+            mockConfig({ telemetry: true });
+            initTelemetry(new TelemetryService());
+        });
+
+        it('emits action=shown with the surface the first time a surface is shown', () => {
+            reportInstallPromptShown('createSpec');
+            expect(__captured.events).toEqual([
+                { name: INSTALL_PROMPT_EVENT, properties: { action: 'shown', surface: 'createSpec' } },
+            ]);
+        });
+
+        it('dedupes a repeated shown for the same surface within a session', () => {
+            reportInstallPromptShown('createSpec');
+            reportInstallPromptShown('createSpec');
+            reportInstallPromptShown('createSpec');
+            expect(__captured.events).toHaveLength(1);
+        });
+
+        it('emits shown independently for each distinct surface', () => {
+            reportInstallPromptShown('createSpec');
+            reportInstallPromptShown('activity');
+            expect(__captured.events.map(e => e.properties?.surface)).toEqual(['createSpec', 'activity']);
+            expect(__captured.events.every(e => e.properties?.action === 'shown')).toBe(true);
+        });
+
+        it('emits action=clicked with the originating surface (not deduped)', () => {
+            reportInstallPromptClicked('activity');
+            reportInstallPromptClicked('activity');
+            expect(__captured.events).toEqual([
+                { name: INSTALL_PROMPT_EVENT, properties: { action: 'clicked', surface: 'activity' } },
+                { name: INSTALL_PROMPT_EVENT, properties: { action: 'clicked', surface: 'activity' } },
+            ]);
+        });
+
+        it('carries only the action + surface enum fields — no identifier or path', () => {
+            reportInstallPromptShown('activity');
+            reportInstallPromptClicked('createSpec');
+            for (const event of __captured.events) {
+                expect(Object.keys(event.properties ?? {}).sort()).toEqual(['action', 'surface']);
+                expect(['shown', 'clicked']).toContain(event.properties?.action);
+                expect(['createSpec', 'activity']).toContain(event.properties?.surface);
+            }
+        });
+
+        it('sends nothing when telemetry is disabled', () => {
+            mockConfig({ telemetry: false });
+            initTelemetry(new TelemetryService());
+            reportInstallPromptShown('createSpec');
+            reportInstallPromptClicked('createSpec');
+            expect(__captured.events).toHaveLength(0);
         });
     });
 

--- a/src/core/telemetry.ts
+++ b/src/core/telemetry.ts
@@ -177,10 +177,11 @@ export class TelemetryService {
             .get<boolean>('telemetry', true);
     }
 
-    sendEvent(name: string, properties?: TelemetryProperties): void {
-        if (!this.reporter) return;
-        if (!this.isEnabled()) return;
+    sendEvent(name: string, properties?: TelemetryProperties): boolean {
+        if (!this.reporter) return false;
+        if (!this.isEnabled()) return false;
         this.reporter.sendTelemetryEvent(name, properties);
+        return true;
     }
 
     dispose(): void {
@@ -199,8 +200,8 @@ export function initTelemetry(service: TelemetryService): void {
  * Fire a telemetry event through the singleton. A no-op before init or when
  * telemetry is disabled — so event sites can call this unconditionally.
  */
-export function sendTelemetryEvent(name: string, properties?: TelemetryProperties): void {
-    singleton?.sendEvent(name, properties);
+export function sendTelemetryEvent(name: string, properties?: TelemetryProperties): boolean {
+    return singleton?.sendEvent(name, properties) ?? false;
 }
 
 /** The two banner surfaces the install prompt appears on. */
@@ -222,8 +223,10 @@ const installPromptShownSurfaces = new Set<InstallPromptSurface>();
  */
 export function reportInstallPromptShown(surface: InstallPromptSurface): void {
     if (installPromptShownSurfaces.has(surface)) return;
-    installPromptShownSurfaces.add(surface);
-    sendTelemetryEvent(INSTALL_PROMPT_EVENT, { action: 'shown', surface });
+    // Only burn the dedupe slot on a real emit — a show while telemetry is off/uninitialized must still be able to fire once it's enabled.
+    if (sendTelemetryEvent(INSTALL_PROMPT_EVENT, { action: 'shown', surface })) {
+        installPromptShownSurfaces.add(surface);
+    }
 }
 
 /** Emit the install-banner "clicked" event tagged with the surface it came from. */

--- a/src/core/telemetry.ts
+++ b/src/core/telemetry.ts
@@ -90,6 +90,32 @@ export function buildBetaSnapshot(): BetaSnapshot {
     };
 }
 
+/** The per-activation facts reported once with `extension.activated`. */
+export interface ActivationSnapshot {
+    extensionVersion: string;
+    vscodeVersion: string;
+    speckitCliVersion: string;
+    specCount: number;
+    companionInstalled: boolean;
+}
+
+/**
+ * Assemble the `extension.activated` payload from the activation facts plus the
+ * settings snapshot. All values are stringified booleans, versions, counts, and
+ * enum-like snapshot fields — no identifier or path. `companionInstalled` reports
+ * whether the companion spec-kit extension is present in the active workspace.
+ */
+export function buildActivatedProperties(snapshot: ActivationSnapshot): TelemetryProperties {
+    return {
+        extensionVersion: snapshot.extensionVersion,
+        vscodeVersion: snapshot.vscodeVersion,
+        speckitCliVersion: snapshot.speckitCliVersion,
+        specCount: String(snapshot.specCount),
+        companionInstalled: String(snapshot.companionInstalled),
+        ...buildBetaSnapshot(),
+    };
+}
+
 /**
  * Per-spec telemetry correlation context: the spec's pipeline profile and a
  * stable random id. The id is minted + persisted lazily on first read for a
@@ -175,6 +201,39 @@ export function initTelemetry(service: TelemetryService): void {
  */
 export function sendTelemetryEvent(name: string, properties?: TelemetryProperties): void {
     singleton?.sendEvent(name, properties);
+}
+
+/** The two banner surfaces the install prompt appears on. */
+export type InstallPromptSurface = 'createSpec' | 'activity';
+
+/** The two funnel moments measured for the install banner. */
+export type InstallPromptAction = 'shown' | 'clicked';
+
+/** Event carrying the install-banner funnel: `action` (shown/clicked) × `surface`. */
+export const INSTALL_PROMPT_EVENT = 'companion.installPrompt';
+
+// Dedupe "shown" per session: the banner is server-rendered and re-emitted on every webview refresh.
+const installPromptShownSurfaces = new Set<InstallPromptSurface>();
+
+/**
+ * Emit the install-banner "shown" event once per surface per session. The
+ * `surface`/`action` values are fixed literals produced only by our own call
+ * sites (never user data), so they satisfy the privacy allow-list as-is.
+ */
+export function reportInstallPromptShown(surface: InstallPromptSurface): void {
+    if (installPromptShownSurfaces.has(surface)) return;
+    installPromptShownSurfaces.add(surface);
+    sendTelemetryEvent(INSTALL_PROMPT_EVENT, { action: 'shown', surface });
+}
+
+/** Emit the install-banner "clicked" event tagged with the surface it came from. */
+export function reportInstallPromptClicked(surface: InstallPromptSurface): void {
+    sendTelemetryEvent(INSTALL_PROMPT_EVENT, { action: 'clicked', surface });
+}
+
+/** Reset the per-session "shown" dedupe. Test-only — never called in production. */
+export function __resetInstallPromptShownDedupe(): void {
+    installPromptShownSurfaces.clear();
 }
 
 // Re-export so call sites importing from this module have the filename handy.

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -28,7 +28,7 @@ import { ConfigKeys } from './core/constants';
 import { ConfigManager } from './core/utils/configManager';
 import { migrateBetaTriStateSettings, removeRetiredSettings } from './core/settingsMigration';
 import { openSpecFile } from './core/utils/fileOpener';
-import { TelemetryService, initTelemetry, sendTelemetryEvent, buildBetaSnapshot } from './core/telemetry';
+import { TelemetryService, initTelemetry, sendTelemetryEvent, buildActivatedProperties } from './core/telemetry';
 import { getConfiguredProviderType } from './ai-providers/aiProvider';
 import { resolveSpecDirectories } from './core/specDirectoryResolver';
 
@@ -352,22 +352,24 @@ async function refreshCompanionInstalledContext(root: string): Promise<void> {
  */
 async function fireActivatedEvent(context: vscode.ExtensionContext): Promise<void> {
     let specCount = 0;
+    let companionInstalled = false;
     try {
         const root = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
         if (root) {
             specCount = (await resolveSpecDirectories(root)).length;
+            companionInstalled = isCompanionInstalled(root);
         }
     } catch {
         /* spec discovery failure is non-fatal — report 0 */
     }
-    sendTelemetryEvent('extension.activated', {
+    sendTelemetryEvent('extension.activated', buildActivatedProperties({
         extensionVersion: String(context.extension.packageJSON.version ?? 'unknown'),
         vscodeVersion: vscode.version,
         // No CLI version detector exists today — the detector only checks presence.
         speckitCliVersion: 'unknown',
-        specCount: String(specCount),
-        ...buildBetaSnapshot(),
-    });
+        specCount,
+        companionInstalled,
+    }));
 }
 
 /**

--- a/src/features/spec-editor/specEditorProvider.ts
+++ b/src/features/spec-editor/specEditorProvider.ts
@@ -17,7 +17,7 @@ import { isCompanionInstalled } from '../settings/companionPresetReconciler';
 import { shouldShowInstallPrompt, readInstallPromptEnabled } from '../../speckit/specKitExtensionInstall';
 import { renderInstallBannerHtml } from './installBanner';
 import { AIProviders, WorkflowSteps, ConfigKeys, COMPANION_WORKFLOW_NAME } from '../../core/constants';
-import { sendTelemetryEvent } from '../../core/telemetry';
+import { sendTelemetryEvent, reportInstallPromptShown, reportInstallPromptClicked } from '../../core/telemetry';
 import * as crypto from 'crypto';
 
 /** The Companion specify command the picker dispatches when the Companion workflow is chosen. */
@@ -264,6 +264,7 @@ export class SpecEditorProvider {
                 break;
 
             case 'installSpecKitExtension':
+                reportInstallPromptClicked('createSpec');
                 void vscode.commands.executeCommand('speckit.companion.installSpecKitExtension');
                 break;
 
@@ -555,13 +556,16 @@ export class SpecEditorProvider {
             ConfigKeys.globalState.installBannerDismissed,
             false
         );
-        const installBanner = renderInstallBannerHtml(
+        const installBannerVisible =
             !bannerDismissed &&
             shouldShowInstallPrompt(
                 readInstallPromptEnabled(),
                 workspaceRoot ? isCompanionInstalled(workspaceRoot) : false
-            )
-        );
+            );
+        if (installBannerVisible) {
+            reportInstallPromptShown('createSpec');
+        }
+        const installBanner = renderInstallBannerHtml(installBannerVisible);
 
         return `<!DOCTYPE html>
 <html lang="en">

--- a/src/features/spec-viewer/messageHandlers.ts
+++ b/src/features/spec-viewer/messageHandlers.ts
@@ -6,7 +6,7 @@
 import * as path from "path";
 import * as vscode from "vscode";
 import { formatCommandForProvider, getConfiguredProviderType } from "../../ai-providers/aiProvider";
-import { sendTelemetryEvent, getSpecTelemetryContext, phaseTelemetryId } from "../../core/telemetry";
+import { sendTelemetryEvent, getSpecTelemetryContext, phaseTelemetryId, reportInstallPromptClicked } from "../../core/telemetry";
 import {
   buildLifecyclePrompt,
   buildPrompt,
@@ -173,6 +173,7 @@ function buildHandlerMap(): DispatcherMap<ViewerToExtensionMessage, [string, Mes
       else deps.outputChannel.appendLine(`[SpecViewer] Unknown footerAction id: ${msg.id}`);
     },
     installSpecKitExtension: async (_msg, _dir, _deps) => {
+      reportInstallPromptClicked('activity');
       await vscode.commands.executeCommand('speckit.companion.installSpecKitExtension');
     },
     openReadme: async (_msg, _dir, _deps) => {

--- a/src/features/spec-viewer/specViewerProvider.ts
+++ b/src/features/spec-viewer/specViewerProvider.ts
@@ -61,6 +61,7 @@ import { resetMalformedContext } from "../specs/specContextReset";
 import { reconcileAndPersist } from "../specs/specContextReconciler";
 import { isCompanionInstalled } from "../settings/companionPresetReconciler";
 import { shouldShowInstallPrompt, readInstallPromptEnabled } from "../../speckit/specKitExtensionInstall";
+import { reportInstallPromptShown } from "../../core/telemetry";
 import { deriveViewerState, isStepCompleted, findRunningStep } from "./stateDerivation";
 import { enrichLivingSpecs } from "./livingSpecsContent";
 import { StepCompletionNotifier, NotifierContext } from "./stepCompletionNotifier";
@@ -183,10 +184,14 @@ export class SpecViewerProvider {
       return false;
     }
     const root = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
-    return shouldShowInstallPrompt(
+    const visible = shouldShowInstallPrompt(
       readInstallPromptEnabled(),
       root ? isCompanionInstalled(root) : false
     );
+    if (visible) {
+      reportInstallPromptShown('activity');
+    }
+    return visible;
   }
 
   /**

--- a/src/features/spec-viewer/specViewerProvider.ts
+++ b/src/features/spec-viewer/specViewerProvider.ts
@@ -183,6 +183,10 @@ export class SpecViewerProvider {
     if (this.context.globalState.get<boolean>(ConfigKeys.globalState.installBannerDismissed, false)) {
       return false;
     }
+    // The banner renders inside the Activity panel — with it off there is no surface, so don't report a "shown".
+    if (!this.readActivityPanelEnabled()) {
+      return false;
+    }
     const root = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
     const visible = shouldShowInstallPrompt(
       readInstallPromptEnabled(),


### PR DESCRIPTION
## Summary

We show the workflow picker by default and already prompt users to install the spec-kit extension — but we couldn't measure any of it. This adds just enough privacy-scrubbed telemetry to answer **"how many have it installed, and does the install prompt actually convert?"** — the metric that matters now that Companion is out of beta (follow-on to #490, and it directly feeds the growth epic #520).

## What changed

- **Install rate** — `extension.activated` now carries a boolean `companionInstalled` (computed from the *same* `isCompanionInstalled` the sidebar `when`-clause uses — one source, no drift).
- **Prompt → install conversion** — a new `companion.installPrompt` event with `action` (`shown` | `clicked`) × `surface` (`createSpec` | `activity`). `shown` is deduped per session (the banner is server-rendered and re-renders often); `clicked` fires only from the banner's Install button, so sidebar/menu installs don't inflate conversion.
- **Used-vs-installed** falls out of these plus the existing `spec.created` / `spec.completed` / `phase.dispatched` / `workflow.selected` events — no new event needed.
- **Docs** — README's Telemetry section gains the new events and sample `AppEvents` KQL queries (workspace resource; `AppEvents`, not `customEvents`).

## Privacy

Every new field is a boolean or a fixed enum literal set by the code — no identifiers, paths, spec names, or workspace strings. The `surface`/`action` params are TS union types, so a non-literal can't compile.

## Verified (events actually fire, not just built)

- `telemetry.test.ts` (26 pass) drives the real emit path via a mock reporter: `extension.activated` carries `companionInstalled`; `shown` emits once per surface and dedupes on re-render; `clicked` emits per click with its surface; only the enum fields are present; `telemetry disabled → 0 events`.
- Review traced every caller of the install command to confirm `clicked` is banner-only.
- `npm test` 1768 / 125 suites; tsc clean.

## Manual check (your eyes)

In App Insights (workspace resource), after some activity: `AppEvents | where Name == "companion.installPrompt"` should show shown/clicked rows with `surface`, and `extension.activated` rows should carry `companionInstalled`. README has the conversion query.

(Spec dir is numbered `523-` by the sequential hook — unrelated to issue #523; this PR closes #506.)

Closes #506

🤖 Generated with [Claude Code](https://claude.com/claude-code)