### PR TITLE
fix(capture): serialize per-spec .spec-context.json writes to close the concurrent race

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- **A phase no longer flips to "untrusted timing" at random when a spec advances.** Advancing a step fired two context updates at once, and if they overlapped, the later one could overwrite the step's start marker — which is what made a phase's duration occasionally read as untrusted. Updates to a single spec's context now happen one at a time, so both always land and the start marker is never lost. Updates to different specs still run in parallel, so nothing gets slower. ([#527](https://github.com/alfredoperez/speckit-companion/issues/527))
+
 ## [0.30.0] - 2026-07-22
 
 ### Added

--- a/docs/capture-and-timing.md
+++ b/docs/capture-and-timing.md
@@ -63,6 +63,15 @@ Both gaps the financial-page E2E exposed were closed by moving capture off the A
 
 All remaining `by:ai` writes (the plan/tasks/clarify/analyze self-closes and substep boundaries) now go through `write-context.py --finish`, never a hand-edited JSON file — so the duplicate-`status`-key corruption can't recur. They are the plan/tasks/clarify/analyze self-closes and substep boundaries. History: `Projects/speckit companion/backlog/specify-duration-and-duplicate-start.md`.
 
+## Fixed — serialized context writes (2026-07-22, #527)
+
+The extension-side write path (`updateSpecContext`) does a read-modify-write of `.spec-context.json`. When a step advanced, two of those ran effectively at once and both read the same base `history` before either wrote — so whichever landed last silently dropped the other's entry. When the loser was the step's `start`, that phase read as untrusted timing. #519 removed the *sequential* double-write; this closes the remaining *simultaneous* one.
+
+- **Per-spec write serialization.** `updateSpecContext` now chains each read-modify-write onto a per-target promise (keyed by the resolved file path), so at most one runs for a given spec at a time and a later write sees the earlier write's state. Different specs keep independent chains and still run concurrently — there is no global write gate. The chain is self-cleaning and failure-safe: a throwing write releases the queue (the next write still runs) and still propagates its error.
+- **One start-write per advance.** The dispatch caller (`executeWorkflowStep`) used to fire a progress update and then a second start-write that raced it. The progress update is now awaited and already owns complete-on-advance + start, so the redundant second start-write is gone.
+
+This is ordering only — no schema change, and the finish-only / append-only timing model is unchanged.
+
 ## Finish-only journaling (2026-06-08, v2)
 
 The 2026-06-08 fix above made per-task capture *reliable* (the hook owns it) but at the cost of *cadence*: writing a `start` **and** a `complete` for each task at one end-of-step instant produces `0s` ticks (start == complete) and a burst (all tasks share a tight window). v2 moves to a **finish-only** model that recovers honest cadence without re-introducing hand-authored JSON:

--- a/specs/527-serialize-context-writes/.spec-context.json
+++ b/specs/527-serialize-context-writes/.spec-context.json
@@ -1,0 +1,271 @@
+{
+  "workflow": "companion",
+  "specName": "Serialize Context Writes",
+  "branch": "527-serialize-context-writes",
+  "selectedAt": "2026-07-22T13:41:21.321Z",
+  "currentStep": "implement",
+  "status": "completed",
+  "history": [
+    {
+      "step": "specify",
+      "substep": null,
+      "kind": "start",
+      "by": "extension",
+      "at": "2026-07-22T13:41:21.321Z"
+    },
+    {
+      "step": "specify",
+      "substep": null,
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-07-22T13:45:53.472Z"
+    },
+    {
+      "step": "plan",
+      "substep": null,
+      "kind": "start",
+      "by": "extension",
+      "at": "2026-07-22T13:45:53.633Z"
+    },
+    {
+      "step": "plan",
+      "substep": null,
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-07-22T13:45:53.716Z"
+    },
+    {
+      "step": "tasks",
+      "substep": null,
+      "kind": "start",
+      "by": "extension",
+      "at": "2026-07-22T13:45:53.798Z"
+    },
+    {
+      "step": "tasks",
+      "substep": null,
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-07-22T13:45:53.871Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "kind": "start",
+      "by": "extension",
+      "at": "2026-07-22T13:50:42.407Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T001",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-07-22T13:55:06.427Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T002",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-07-22T13:55:06.482Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T003",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-07-22T13:55:06.538Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T004",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-07-22T13:55:59.637Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T005",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-07-22T13:55:59.691Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T006",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-07-22T13:55:59.752Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T007",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-07-22T13:56:32.890Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-07-22T13:56:32.972Z"
+    }
+  ],
+  "last_action": "all 7 tasks done — 1790/1790 tests pass, compile clean",
+  "coverage": {
+    "FR-001": {
+      "title": "Writes to a single spec's context file are serialized (one read-modify-write in flight)",
+      "tests": [
+        "tests/unit/specs/specContextWriter.spec.ts::applies both overlapping same-spec writes"
+      ]
+    },
+    "FR-002": {
+      "title": "Serialization is per-spec so different specs never block one another",
+      "tests": [
+        "tests/unit/specs/specContextWriter.spec.ts::overlapping writes to two different specs both complete"
+      ]
+    },
+    "FR-003": {
+      "title": "Concurrent same-spec writes both apply; history stays append-only",
+      "tests": [
+        "tests/unit/specs/specContextWriter.spec.ts::applies both overlapping same-spec writes",
+        "tests/unit/specs/specContextWriter.spec.ts::stress of many overlapping same-spec writes loses no entry"
+      ]
+    },
+    "FR-004": {
+      "title": "A failed write releases the queue and still propagates its error",
+      "tests": [
+        "tests/unit/specs/specContextWriter.spec.ts::a throwing queued write releases the lock"
+      ]
+    },
+    "FR-005": {
+      "title": "Existing write guarantees preserved (non-JSON refusal, atomic, append-only, profile back-fill)",
+      "tests": [
+        "tests/unit/specs/specContextWriter.spec.ts::still refuses to overwrite an existing non-JSON file"
+      ]
+    },
+    "FR-006": {
+      "title": "The racing extension start-writes can no longer overwrite each other",
+      "tests": [
+        "tests/unit/specs/specContextWriter.spec.ts::applies both overlapping same-spec writes"
+      ]
+    }
+  },
+  "size": "simple",
+  "classification": {
+    "projectedFiles": 3,
+    "projectedTasks": 7,
+    "scopeSignal": "none",
+    "verdict": "simple"
+  },
+  "context": [
+    "area: src/features/specs/specContextWriter.ts (updateSpecContext read-modify-write)",
+    "area: src/features/specs/specCommands.ts (executeWorkflowStep progress/start race)",
+    "constraint: preserve append-only history + atomic write + non-JSON refusal",
+    "constraint: per-spec scope only — never a global write gate"
+  ],
+  "intent": "Serialize per-spec .spec-context.json writes so a concurrent read-modify-write can't drop a step-start and untrust timing",
+  "expectations": [
+    "No schema change to .spec-context.json",
+    "No cross-process / file-system lock — single extension host is the only writer",
+    "No change to what is written (finish-only, append-only) — ordering only"
+  ],
+  "approach": "Per-target write queue in updateSpecContext (keyed by target path) + remove the redundant unawaited startStep in executeWorkflowStep",
+  "livingSpecs": {
+    "loaded": [
+      "specs"
+    ],
+    "synced": [
+      "specs"
+    ]
+  },
+  "telemetryInstanceId": "35ed8164-4d0f-4b49-a0d3-cab66e1cc538",
+  "currentTask": "T007",
+  "task_summaries": {
+    "T001": {
+      "status": "DONE",
+      "did": "Added a per-target write chain (Map keyed by resolved path) in updateSpecContext so each spec's read-modify-write runs one at a time; self-cleaning, failure-safe tail",
+      "files": [
+        "src/features/specs/specContextWriter.ts"
+      ]
+    },
+    "T002": {
+      "status": "DONE",
+      "did": "Chain is keyed by target path so different specs get independent chains and run concurrently — no global gate",
+      "files": [
+        "src/features/specs/specContextWriter.ts"
+      ]
+    },
+    "T003": {
+      "status": "DONE",
+      "did": "Awaited updateStepProgress (was fire-and-forget) and removed the redundant complete-on-advance + startStep block so exactly one start-write occurs; dropped now-unused imports",
+      "files": [
+        "src/features/specs/specCommands.ts"
+      ]
+    },
+    "T004": {
+      "status": "DONE",
+      "did": "Test: overlapping same-spec writes both land, history append-only, start survives; plus 25-write stress loses nothing (FR-001/003/006, SC-001)",
+      "files": [
+        "tests/unit/specs/specContextWriter.spec.ts"
+      ]
+    },
+    "T005": {
+      "status": "DONE",
+      "did": "Test: overlapping writes to two different specs both complete and both mutations run (FR-002, SC-003)",
+      "files": [
+        "tests/unit/specs/specContextWriter.spec.ts"
+      ]
+    },
+    "T006": {
+      "status": "DONE",
+      "did": "Test: a throwing write propagates its error and releases the queue so the next same-spec write runs; non-JSON file still refused (FR-004/005, SC-004)",
+      "files": [
+        "tests/unit/specs/specContextWriter.spec.ts"
+      ]
+    },
+    "T007": {
+      "status": "DONE",
+      "did": "npm test (1790 pass) + npm run compile clean — no regressions in the context-write path"
+    }
+  },
+  "verified": [
+    {
+      "what": "Full unit + integration suite after the serialization change",
+      "command": "npm test",
+      "result": "126 suites / 1790 tests pass, incl. 5 new specContextWriter serialization tests",
+      "warnings": []
+    },
+    {
+      "what": "TypeScript build after dropping now-unused imports",
+      "command": "npm run compile",
+      "result": "clean, no errors",
+      "warnings": []
+    }
+  ],
+  "decisions": [
+    {
+      "decision": "Serialize per target path via a module-level Map of promise chains; store a never-rejecting tail as the next writers prior",
+      "why": "Keeps different specs concurrent (per-key chains) while a failed write releases the queue instead of poisoning it (FR-002, FR-004)",
+      "rejected": "A single global write mutex — would throttle unrelated specs and violate FR-002"
+    },
+    {
+      "decision": "Removed the redundant complete-on-advance + startStep block in executeWorkflowStep and awaited updateStepProgress instead",
+      "why": "updateStepProgress already completes the prior step and starts the new one; awaiting it leaves exactly one start-write and removes the racing second writer (FR-006)",
+      "rejected": "Keeping both writers and only awaiting — leaves dead duplicate code relying on start-dedup"
+    }
+  ],
+  "step_summaries": {
+    "implement": {
+      "summary": "Serialized per-spec .spec-context.json writes (per-target promise chain) and removed the racing second start-write in executeWorkflowStep; 5 new tests, full suite green"
+    }
+  }
+}

--- a/specs/527-serialize-context-writes/checklists/requirements.md
+++ b/specs/527-serialize-context-writes/checklists/requirements.md
@@ -1,0 +1,35 @@
+# Specification Quality Checklist: Serialize `.spec-context.json` writes
+
+**Purpose**: Validate Companion specification completeness before planning
+**Created**: 2026-07-22
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed (User Scenarios, Requirements, Success Criteria)
+
+## Requirement Completeness
+
+- [x] Any [NEEDS CLARIFICATION] markers are genuine ambiguities (≤3) deferred to clarify — not unresolved guesses
+- [x] Each Functional Requirement is a single, testable MUST/SHOULD statement
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into the specification
+
+## Notes
+
+- This is an internal correctness fix, so the "user" in the scenarios is the developer whose spec timing must stay trustworthy. Implementation specifics (file paths, function names) are confined to the Approach and Verbatim Constraints sections, where the request pinned exact identifiers.
+- Classified **simple** (fast-path): touches 2 files, ≤10 tasks, no scope-up wording. `plan.md` and `tasks.md` were written in this pass.

--- a/specs/527-serialize-context-writes/plan.md
+++ b/specs/527-serialize-context-writes/plan.md
@@ -1,0 +1,3 @@
+# Plan: Serialize `.spec-context.json` writes
+
+> Fast-path spec. The implementation approach lives inline in the spec — see [spec.md → Approach](./spec.md#approach). Task checklist: [tasks.md](./tasks.md).

--- a/specs/527-serialize-context-writes/spec.md
+++ b/specs/527-serialize-context-writes/spec.md
@@ -1,0 +1,116 @@
+# Feature Specification: Serialize `.spec-context.json` writes
+
+**Feature Branch**: `527-serialize-context-writes`
+**Created**: 2026-07-22
+**Status**: Specified
+**Source**: [#527](https://github.com/alfredoperez/speckit-companion/issues/527) (follow-up from #519)
+
+## Overview
+
+When a spec advances a step, the extension records the change into that spec's `.spec-context.json`. Today two of those recordings can run at the same time and each reads the file, changes its own copy, and writes it back. Whichever finishes last wins, so the other one's change is silently lost. When the loser was the step's real "start" marker, the timing for that phase becomes untrusted. The earlier fix (#519) stopped the *sequential* double-writes but left this rarer *simultaneous* one open. This feature closes it by making writes to a single spec's context file happen one at a time.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - A step's timing stays trustworthy when it advances (Priority: P1)
+
+A developer advances a spec to the next step (for example, from spec to plan). Behind the scenes the extension writes a couple of context updates for that transition. No matter how those writes are timed relative to each other, both land, and the step's start marker is never overwritten — so the viewer shows a real, trusted duration for the phase instead of an "untrusted timing" flag.
+
+**Why this priority**: This is the whole point of the change. The observed symptom — a phase intermittently flipping to untrusted timing — comes directly from a lost start-write, and this story fixes it.
+
+**Independent Test**: Drive two context updates for the same spec so they overlap in time, then read the resulting `.spec-context.json`. Both updates are present in `history`, and no earlier entry was dropped. This can be exercised on its own without any UI.
+
+**Acceptance Scenarios**:
+
+1. **Given** a spec whose step is being advanced, **When** the progress update and the step-start update are both issued for that spec at effectively the same moment, **Then** the final `.spec-context.json` contains both changes and the step-start entry survives.
+2. **Given** the same overlapping writes, **When** the file is read afterward, **Then** `history` is still append-only (nothing earlier was shrunk or modified) and the phase reads as trusted timing.
+
+### User Story 2 - Concurrent writes to different specs stay independent (Priority: P2)
+
+A developer has more than one spec being touched around the same time. Serializing writes for one spec must not make writes for a *different* spec wait on it. Each spec's context file is guarded on its own, so unrelated specs keep updating without added delay.
+
+**Why this priority**: Correctness for the racing case must not come at the cost of throttling everything through one global gate. It protects performance and keeps the fix scoped to the actual hazard (same-file writes).
+
+**Independent Test**: Issue overlapping writes to two different spec directories and confirm both complete correctly and neither is blocked waiting on the other's file.
+
+**Acceptance Scenarios**:
+
+1. **Given** two different specs each receiving an update at the same time, **When** both writes run, **Then** each spec's `.spec-context.json` reflects its own update and neither result is lost.
+2. **Given** a slow write in progress for spec A, **When** a write for spec B is issued, **Then** spec B's write proceeds without waiting for spec A to finish.
+
+### User Story 3 - Existing failure and safety behavior is preserved (Priority: P3)
+
+The write path already refuses to clobber a corrupt file and enforces append-only history. Serializing writes must keep those guarantees intact: a failed write still surfaces its error, still frees the lock so later writes are not stuck, and never turns a lost-update bug into a deadlock.
+
+**Why this priority**: The fix touches a hot, shared code path. It has value only if it doesn't regress the protections already relied on.
+
+**Independent Test**: Force one queued write to throw, then confirm a subsequent write for the same spec still runs (the queue advanced) and the error from the failed write was not swallowed.
+
+**Acceptance Scenarios**:
+
+1. **Given** a queued write that throws, **When** the next write for the same spec is issued, **Then** that next write still executes (the serialization released after the failure).
+2. **Given** an existing on-disk file that is not valid JSON, **When** a write is attempted, **Then** it still refuses rather than overwriting, exactly as before.
+
+## Edge Cases
+
+- Two writes for the **same** spec issued in the same tick — both must land, in a defined order, with append-only history preserved.
+- A write that **throws** while holding the per-spec turn — the turn must be released so following writes for that spec are not permanently blocked.
+- Writes for **different** specs at the same time — must not serialize against each other.
+- The **first-ever** write for a spec (file does not exist yet) — serialization must handle the "no prior lock for this spec" case without a race on creating the lock itself.
+- A large backlog of queued writes for one spec — must drain in order without unbounded growth beyond the work actually issued.
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: Writes to a single spec's `.spec-context.json` MUST be serialized so that at most one read-modify-write for that file is in flight at a time, and a later write reads the state left by the previous write.
+- **FR-002**: Serialization MUST be scoped per spec (keyed by the spec directory / target file), so writes to different specs run concurrently and never block one another.
+- **FR-003**: When two writes for the same spec are issued concurrently, both MUST be applied and the resulting `history` MUST remain append-only with no earlier entry dropped or modified.
+- **FR-004**: A write that fails MUST release its place in the per-spec queue so subsequent writes for that spec still run, and MUST still propagate its error to the caller rather than swallowing it.
+- **FR-005**: The change MUST preserve existing write-path guarantees: refusal to overwrite a non-JSON existing file, atomic replacement of the file, append-only enforcement, and the profile back-fill behavior.
+- **FR-006**: The redundant/racing extension start-writes that motivate this fix (the fire-and-forget progress update and the awaited step-start during a step advance) MUST no longer be able to overwrite each other's result.
+
+## Success Criteria
+
+### Measurable Outcomes
+
+- **SC-001**: In a stress test issuing many overlapping writes to the same spec, 100% of issued updates are present in the final `history` and 0 earlier entries are lost or mutated.
+- **SC-002**: A phase advanced under concurrent writes reports trusted timing in 100% of repeated runs (no intermittent untrusted-timing flips attributable to a lost start-write).
+- **SC-003**: Overlapping writes to two different specs both complete, and the second spec's write does not wait on the first spec's write to finish.
+- **SC-004**: A forced write failure never blocks the next write for the same spec (no deadlock) and the error is observable to the caller.
+
+## Assumptions
+
+- The race is confined to writes going through the shared context-write path; direct file edits by other tools are out of scope (and already discouraged by the "never hand-edit" rule).
+- Per-spec serialization within a single extension host process is sufficient; cross-process file locking is not required, since the extension host is the single writer for its workspace.
+- The two constants of the timing model (finish-only recording, append-only history) are unchanged — this feature is purely about *ordering* writes, not changing what is written.
+
+## Approach
+
+The fix is a per-target write queue on the shared write path, plus removing the redundant unawaited start-write that creates the race.
+
+- Add per-spec-file serialization inside the shared write helper `updateSpecContext` in `src/features/specs/specContextWriter.ts`, keyed by the resolved target path. Chain each write onto a promise stored per key so the read-modify-write for one file runs strictly one at a time; make the chain self-clean and failure-safe so a throwing write still releases the next one. Different keys (different specs) keep independent chains and run concurrently.
+- Close the specific caller-side race in `executeWorkflowStep` in `src/features/specs/specCommands.ts`: today `updateStepProgress` is fire-and-forget (~line 695) while `startStep` is awaited (~line 776), and both read `history` before either writes. Either `await updateStepProgress` before `startStep`, or drop the now-redundant `startStep` (progress-update already starts the step). Prefer the change that keeps a single start-write for the step.
+- Keep `writeSpecContext`, `atomicWrite`, `assertAppendOnly`, and the profile back-fill untouched in behavior — the queue wraps them, it does not replace them.
+
+Dependencies: none beyond the two files above; no schema change, no new setting.
+
+## Verbatim Constraints
+
+- Target file name: `.spec-context.json`
+- Race site (caller): `executeWorkflowStep` in `src/features/specs/specCommands.ts`
+- Serialization site (write path): `updateSpecContext` in `src/features/specs/specContextWriter.ts`
+
+## ADDED Requirements
+<!-- capability: specs -->
+
+### Concurrent writes to a spec's state record are serialized, never lost
+
+Two updates to the same spec's state record that arrive at the same time both land: writes to a single spec's `.spec-context.json` run one at a time, so a concurrent read-modify-write can never overwrite another writer's entry. Writes to different specs stay independent and never wait on each other, and a failed write releases the queue for the next one instead of wedging it.
+
+#### Scenario: two updates race on the same spec
+- **WHEN** a step-progress update and another write to the same spec overlap
+- **THEN** both entries land in the lifecycle log and neither writer's change is lost
+
+#### Scenario: a queued write fails
+- **WHEN** a serialized write throws
+- **THEN** its error reaches its caller and the next queued write for that spec still runs

--- a/specs/527-serialize-context-writes/tasks.md
+++ b/specs/527-serialize-context-writes/tasks.md
@@ -5,7 +5,7 @@ Dependency-ordered. `[P]` marks tasks that can run in parallel.
 - [x] **T001** Add a per-target write queue (mutex keyed by resolved target path) inside `updateSpecContext` so each spec's read-modify-write runs one at a time; the chain must be self-cleaning and release on failure + `src/features/specs/specContextWriter.ts`
 - [x] **T002** Verify different spec keys keep independent chains (writes to different specs run concurrently, never block each other) + `src/features/specs/specContextWriter.ts`
 - [x] **T003** Close the caller-side race in `executeWorkflowStep`: await `updateStepProgress` before `startStep`, or drop the redundant `startStep` so only one start-write occurs + `src/features/specs/specCommands.ts`
-- [x] **T004** [P] Test: overlapping same-spec writes both land, history stays append-only, start entry survives (FR-001, FR-003, FR-006) + `tests/features/specs/specContextWriter.test.ts`
-- [x] **T005** [P] Test: overlapping writes to two different specs both complete and do not serialize against each other (FR-002) + `tests/features/specs/specContextWriter.test.ts`
-- [x] **T006** [P] Test: a throwing queued write releases the lock (next same-spec write still runs) and its error still propagates; non-JSON existing file still refused (FR-004, FR-005) + `tests/features/specs/specContextWriter.test.ts`
+- [x] **T004** [P] Test: overlapping same-spec writes both land, history stays append-only, start entry survives (FR-001, FR-003, FR-006) + `tests/unit/specs/specContextWriter.spec.ts`
+- [x] **T005** [P] Test: overlapping writes to two different specs both complete and do not serialize against each other (FR-002) + `tests/unit/specs/specContextWriter.spec.ts`
+- [x] **T006** [P] Test: a throwing queued write releases the lock (next same-spec write still runs) and its error still propagates; non-JSON existing file still refused (FR-004, FR-005) + `tests/unit/specs/specContextWriter.spec.ts`
 - [x] **T007** Run `npm test` and `npm run compile`; confirm no regressions in the context-write path

--- a/specs/527-serialize-context-writes/tasks.md
+++ b/specs/527-serialize-context-writes/tasks.md
@@ -1,0 +1,11 @@
+# Tasks: Serialize `.spec-context.json` writes
+
+Dependency-ordered. `[P]` marks tasks that can run in parallel.
+
+- [x] **T001** Add a per-target write queue (mutex keyed by resolved target path) inside `updateSpecContext` so each spec's read-modify-write runs one at a time; the chain must be self-cleaning and release on failure + `src/features/specs/specContextWriter.ts`
+- [x] **T002** Verify different spec keys keep independent chains (writes to different specs run concurrently, never block each other) + `src/features/specs/specContextWriter.ts`
+- [x] **T003** Close the caller-side race in `executeWorkflowStep`: await `updateStepProgress` before `startStep`, or drop the redundant `startStep` so only one start-write occurs + `src/features/specs/specCommands.ts`
+- [x] **T004** [P] Test: overlapping same-spec writes both land, history stays append-only, start entry survives (FR-001, FR-003, FR-006) + `tests/features/specs/specContextWriter.test.ts`
+- [x] **T005** [P] Test: overlapping writes to two different specs both complete and do not serialize against each other (FR-002) + `tests/features/specs/specContextWriter.test.ts`
+- [x] **T006** [P] Test: a throwing queued write releases the lock (next same-spec write still runs) and its error still propagates; non-JSON existing file still refused (FR-004, FR-005) + `tests/features/specs/specContextWriter.test.ts`
+- [x] **T007** Run `npm test` and `npm run compile`; confirm no regressions in the context-write path

--- a/src/features/specs/specCommands.ts
+++ b/src/features/specs/specCommands.ts
@@ -18,11 +18,10 @@ import {
 } from '../workflows';
 import { updateStepProgress, readSpecContextSync } from './specContextManager';
 import { resolveDispatchWithFallback, resolveDispatchForRoot } from './profileDispatch';
-import { startStep, completeStep, setStatus, forceStatus, reactivate } from './stepLifecycle';
-import { lastEntryIsCompletionFor } from './historyHelpers';
+import { startStep, setStatus, forceStatus, reactivate } from './stepLifecycle';
 import { updateSelectionContextKeys } from './selectionContextKeys';
 import { track as trackTerminal } from './terminalStepTracker';
-import type { HistoryEntry, StepName, Status } from '../../core/types/specContext';
+import type { StepName, Status } from '../../core/types/specContext';
 import { SpecsFilterState } from './specsFilterState';
 import { SpecsSortState } from './specsSortState';
 import { ALL_SORT_MODES, SortMode } from './specsSortMode';
@@ -58,9 +57,6 @@ const FORCE_STATUS_CHOICES: Status[] = [
     'implemented',
     'completed',
 ];
-
-// `lastEntryIsCompletionFor` is shared with messageHandlers (Approve button
-// path) — lifted into a stdlib-only helper module to avoid the duplicate.
 
 /**
  * Register SpecKit workflow commands (create, specify, plan, tasks, etc.)
@@ -689,12 +685,18 @@ async function executeWorkflowStep(
 
     outputChannel.appendLine(`[SpecKit] Using workflow: ${workflow.displayName || workflow.name}`);
 
-    // Update step progress in .spec-context.json
+    // Update step progress in .spec-context.json. Awaited (not fire-and-forget)
+    // so it fully settles before any later lifecycle write for this spec —
+    // `updateSpecContext` also serializes per file, but awaiting here keeps the
+    // single start-write ordered ahead of dispatch. A write failure must not
+    // block dispatch (R002), so the error is logged, not thrown.
     const normalized = normalizeWorkflowConfig(workflow);
     const workflowStepNames = (normalized.steps || []).map(s => s.name);
-    updateStepProgress(targetDir, step, workflowStepNames).catch(err => {
+    try {
+        await updateStepProgress(targetDir, step, workflowStepNames);
+    } catch (err) {
         outputChannel.appendLine(`[SpecKit] Failed to update step progress: ${err}`);
-    });
+    }
 
     // Resolve the command for this step from the spec's workflow (a `companion`
     // spec resolves the /speckit.companion.* command family).
@@ -746,35 +748,11 @@ async function executeWorkflowStep(
         prompt += refinementContext;
     }
 
-    if (LIFECYCLE_STEPS.has(step)) {
-        // Complete-on-advance: terminal-close completion only fires when the
-        // step is run via an actual terminal. IDE Chat (Copilot/Cursor)
-        // returns no terminal handle, so `trackTerminal` no-ops and the
-        // prior step's `completedAt` stays null forever. Emit completion
-        // here whenever the user advances to a different lifecycle step.
-        try {
-            const prevCtx = readSpecContextSync(targetDir);
-            const prev = prevCtx?.currentStep;
-            // Derive per-step timing from history[] (the canonical log) — the
-            // on-disk `stepHistory` is no longer populated by the new writer,
-            // so reading it would make this guard fail-open and emit redundant
-            // completion entries on every advance.
-            const prevHistory = (prevCtx?.history ?? []) as HistoryEntry[];
-            const prevStepDone =
-                prev != null && lastEntryIsCompletionFor(prevHistory, prev as StepName);
-            if (
-                prev &&
-                prev !== step &&
-                LIFECYCLE_STEPS.has(prev) &&
-                !prevStepDone
-            ) {
-                await completeStep(targetDir, prev as StepName, 'extension');
-            }
-        } catch (err) {
-            outputChannel.appendLine(`[SpecKit] Complete-on-advance check failed: ${err}`);
-        }
-        await startStep(targetDir, step as StepName, 'extension');
-    }
+    // The step's complete-on-advance + start-write is owned entirely by the
+    // awaited `updateStepProgress` above (its lifecycle path completes the prior
+    // step and starts this one). A second start-write here is what raced with
+    // that one and could drop the start marker — so there is exactly one
+    // start-write per step now.
     const wrapped = buildPrompt({
         command: prompt,
         step,

--- a/src/features/specs/specContextWriter.ts
+++ b/src/features/specs/specContextWriter.ts
@@ -244,8 +244,21 @@ function deriveCompletedStatus(step: StepName): SpecContext['status'] {
 }
 
 /**
+ * Per-target write chains. Each `.spec-context.json` gets its own promise so
+ * its read-modify-write runs strictly one at a time (FR-001). Keyed by the
+ * resolved target path, so different specs keep independent chains and run
+ * concurrently (FR-002). The stored tail never rejects, so a failed write
+ * releases the queue instead of poisoning it (FR-004).
+ */
+const writeChains = new Map<string, Promise<unknown>>();
+
+/**
  * Convenience wrapper: take an existing raw file (or missing), apply a
  * draft-mutation callback, and persist atomically.
+ *
+ * Serialized per target path: two concurrent updates to the same spec run one
+ * after the other, so the later one reads the state the earlier one wrote and
+ * can't drop its `history` entry.
  */
 export async function updateSpecContext(
     specDir: string,
@@ -253,6 +266,36 @@ export async function updateSpecContext(
     fallback: SpecContext
 ): Promise<SpecContext> {
     const target = path.join(specDir, SPEC_CONTEXT_FILENAME);
+    // The get+set below runs synchronously before any await, so two concurrent
+    // callers can't interleave here: the second reads the first's tail as its
+    // prior and chains behind it. `prior` never rejects (see `tail`), so a
+    // failed predecessor still lets us run.
+    const prior = writeChains.get(target) ?? Promise.resolve();
+    const result = prior.then(() =>
+        runSpecContextUpdate(specDir, target, mutate, fallback)
+    );
+    const tail = result.then(
+        () => undefined,
+        () => undefined
+    );
+    writeChains.set(target, tail);
+    // Self-clean once this is the last write to settle, so the map doesn't grow
+    // unbounded across specs. A newer write for the same target replaces `tail`,
+    // in which case we leave its entry alone.
+    void tail.then(() => {
+        if (writeChains.get(target) === tail) {
+            writeChains.delete(target);
+        }
+    });
+    return result;
+}
+
+async function runSpecContextUpdate(
+    specDir: string,
+    target: string,
+    mutate: (ctx: SpecContext) => SpecContext,
+    fallback: SpecContext
+): Promise<SpecContext> {
     let current: SpecContext;
     try {
         const raw = await fs.promises.readFile(target, 'utf-8');

--- a/src/features/specs/specContextWriter.ts
+++ b/src/features/specs/specContextWriter.ts
@@ -266,11 +266,14 @@ export async function updateSpecContext(
     fallback: SpecContext
 ): Promise<SpecContext> {
     const target = path.join(specDir, SPEC_CONTEXT_FILENAME);
+    // Chain key is the RESOLVED absolute path, so two specDir strings that reach
+    // the same file (relative vs absolute, `..` segments) share one queue.
+    const key = path.resolve(target);
     // The get+set below runs synchronously before any await, so two concurrent
     // callers can't interleave here: the second reads the first's tail as its
     // prior and chains behind it. `prior` never rejects (see `tail`), so a
     // failed predecessor still lets us run.
-    const prior = writeChains.get(target) ?? Promise.resolve();
+    const prior = writeChains.get(key) ?? Promise.resolve();
     const result = prior.then(() =>
         runSpecContextUpdate(specDir, target, mutate, fallback)
     );
@@ -278,13 +281,13 @@ export async function updateSpecContext(
         () => undefined,
         () => undefined
     );
-    writeChains.set(target, tail);
+    writeChains.set(key, tail);
     // Self-clean once this is the last write to settle, so the map doesn't grow
     // unbounded across specs. A newer write for the same target replaces `tail`,
     // in which case we leave its entry alone.
     void tail.then(() => {
-        if (writeChains.get(target) === tail) {
-            writeChains.delete(target);
+        if (writeChains.get(key) === tail) {
+            writeChains.delete(key);
         }
     });
     return result;

--- a/src/features/specs/specs.spec.md
+++ b/src/features/specs/specs.spec.md
@@ -207,3 +207,15 @@ The Living Specs view's title bar SHALL carry a sync action that dispatches the 
 #### Scenario: the action is triggered
 - **WHEN** the user triggers the sync title action with the companion extension installed
 - **THEN** the sync slash command is dispatched to the AI provider and nothing is edited by the extension itself
+
+### Concurrent writes to a spec's state record are serialized, never lost
+
+Two updates to the same spec's state record that arrive at the same time both land: writes to a single spec's `.spec-context.json` run one at a time, so a concurrent read-modify-write can never overwrite another writer's entry. Writes to different specs stay independent and never wait on each other, and a failed write releases the queue for the next one instead of wedging it.
+
+#### Scenario: two updates race on the same spec
+- **WHEN** a step-progress update and another write to the same spec overlap
+- **THEN** both entries land in the lifecycle log and neither writer's change is lost
+
+#### Scenario: a queued write fails
+- **WHEN** a serialized write throws
+- **THEN** its error reaches its caller and the next queued write for that spec still runs

--- a/tests/unit/specs/specContextWriter.spec.ts
+++ b/tests/unit/specs/specContextWriter.spec.ts
@@ -1,0 +1,163 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+    updateSpecContext,
+    setStepStarted,
+    appendHistory,
+    writeSpecContext,
+} from '../../../src/features/specs/specContextWriter';
+import { readSpecContext } from '../../../src/features/specs/specContextReader';
+import { backfillMinimalContext } from '../../../src/features/specs/specContextBackfill';
+import { HistoryEntry, SpecContext } from '../../../src/core/types/specContext';
+
+function mkTmp(): string {
+    return fs.mkdtempSync(path.join(os.tmpdir(), 'spec-writer-'));
+}
+
+function fresh(): SpecContext {
+    return backfillMinimalContext({
+        workflow: 'speckit-companion',
+        specName: 'x',
+        branch: 'main',
+    });
+}
+
+function ctxPath(dir: string): string {
+    return path.join(dir, '.spec-context.json');
+}
+
+describe('updateSpecContext — per-spec write serialization', () => {
+    it('applies both overlapping same-spec writes, keeps history append-only, and the start entry survives (FR-001, FR-003, FR-006)', async () => {
+        const dir = mkTmp();
+        await writeSpecContext(dir, fresh());
+
+        // Two updates issued in the same tick: a step-start and a second entry.
+        // Before serialization these both read the same base `history` and the
+        // loser's change was lost. Both must now land.
+        const p1 = updateSpecContext(
+            dir,
+            ctx => setStepStarted(ctx, 'plan', 'extension'),
+            fresh()
+        );
+        const p2 = updateSpecContext(
+            dir,
+            ctx =>
+                appendHistory(ctx, {
+                    step: 'plan',
+                    substep: 'research',
+                    kind: 'complete',
+                    by: 'ai',
+                    at: new Date().toISOString(),
+                }),
+            fresh()
+        );
+        await Promise.all([p1, p2]);
+
+        const loaded = await readSpecContext(dir);
+        expect(loaded).not.toBeNull();
+        const kinds = loaded!.history.map(h => `${h.step}/${h.substep ?? ''}/${h.kind}`);
+        // The step-start write was not overwritten.
+        expect(kinds).toContain('plan//start');
+        // The second write also landed.
+        expect(kinds).toContain('plan/research/complete');
+        // Append-only: the original entry from the seed write is still first.
+        expect(loaded!.history.length).toBeGreaterThanOrEqual(2);
+    });
+
+    it('a stress of many overlapping same-spec writes loses no entry (SC-001)', async () => {
+        const dir = mkTmp();
+        await writeSpecContext(dir, fresh());
+        const N = 25;
+        const writes = Array.from({ length: N }, (_, i) =>
+            updateSpecContext(
+                dir,
+                ctx =>
+                    appendHistory(ctx, {
+                        step: 'implement',
+                        substep: `t${i}`,
+                        kind: 'complete',
+                        by: 'ai',
+                        at: new Date().toISOString(),
+                    }),
+                fresh()
+            )
+        );
+        await Promise.all(writes);
+
+        const loaded = await readSpecContext(dir);
+        const subs = new Set(
+            loaded!.history.filter(h => h.substep?.startsWith('t')).map(h => h.substep)
+        );
+        expect(subs.size).toBe(N);
+    });
+
+    it('overlapping writes to two different specs both complete and do not serialize against each other (FR-002, SC-003)', async () => {
+        const dirA = mkTmp();
+        const dirB = mkTmp();
+        await writeSpecContext(dirA, fresh());
+        await writeSpecContext(dirB, fresh());
+
+        const order: string[] = [];
+        // Spec A's mutation blocks briefly; spec B must not wait on it.
+        const slowA = updateSpecContext(
+            dirA,
+            ctx => {
+                order.push('A');
+                return setStepStarted(ctx, 'plan', 'extension');
+            },
+            fresh()
+        );
+        const fastB = updateSpecContext(
+            dirB,
+            ctx => {
+                order.push('B');
+                return setStepStarted(ctx, 'plan', 'extension');
+            },
+            fresh()
+        );
+        await Promise.all([slowA, fastB]);
+
+        const a = await readSpecContext(dirA);
+        const b = await readSpecContext(dirB);
+        expect(a!.history.some(h => h.step === 'plan' && h.kind === 'start')).toBe(true);
+        expect(b!.history.some(h => h.step === 'plan' && h.kind === 'start')).toBe(true);
+        // Both mutations ran (neither was blocked out).
+        expect(order).toContain('A');
+        expect(order).toContain('B');
+    });
+
+    it('a throwing queued write releases the lock so the next same-spec write still runs, and its error propagates (FR-004, SC-004)', async () => {
+        const dir = mkTmp();
+        await writeSpecContext(dir, fresh());
+
+        const boom = updateSpecContext(
+            dir,
+            () => {
+                throw new Error('mutate failed');
+            },
+            fresh()
+        );
+        const next = updateSpecContext(
+            dir,
+            ctx => setStepStarted(ctx, 'plan', 'extension'),
+            fresh()
+        );
+
+        // The failed write surfaces its error to the caller (not swallowed).
+        await expect(boom).rejects.toThrow('mutate failed');
+        // The queue advanced: the following write still completed.
+        await expect(next).resolves.toBeDefined();
+
+        const loaded = await readSpecContext(dir);
+        expect(loaded!.history.some(h => h.step === 'plan' && h.kind === 'start')).toBe(true);
+    });
+
+    it('still refuses to overwrite an existing non-JSON file (FR-005)', async () => {
+        const dir = mkTmp();
+        fs.writeFileSync(ctxPath(dir), 'not json {{{', 'utf-8');
+        await expect(
+            updateSpecContext(dir, ctx => ctx, fresh())
+        ).rejects.toThrow(/not valid JSON/);
+    });
+});

--- a/tests/unit/specs/specContextWriter.spec.ts
+++ b/tests/unit/specs/specContextWriter.spec.ts
@@ -9,7 +9,7 @@ import {
 } from '../../../src/features/specs/specContextWriter';
 import { readSpecContext } from '../../../src/features/specs/specContextReader';
 import { backfillMinimalContext } from '../../../src/features/specs/specContextBackfill';
-import { HistoryEntry, SpecContext } from '../../../src/core/types/specContext';
+import { SpecContext } from '../../../src/core/types/specContext';
 
 function mkTmp(): string {
     return fs.mkdtempSync(path.join(os.tmpdir(), 'spec-writer-'));
@@ -92,39 +92,38 @@ describe('updateSpecContext — per-spec write serialization', () => {
         expect(subs.size).toBe(N);
     });
 
-    it('overlapping writes to two different specs both complete and do not serialize against each other (FR-002, SC-003)', async () => {
+    it('writes to two different specs run on independent queues — spec B completes while spec A is gated (FR-002, SC-003)', async () => {
         const dirA = mkTmp();
         const dirB = mkTmp();
         await writeSpecContext(dirA, fresh());
         await writeSpecContext(dirB, fresh());
 
-        const order: string[] = [];
-        // Spec A's mutation blocks briefly; spec B must not wait on it.
-        const slowA = updateSpecContext(
-            dirA,
-            ctx => {
-                order.push('A');
-                return setStepStarted(ctx, 'plan', 'extension');
-            },
-            fresh()
+        // Hold spec A's write open by gating its file read; spec B must still
+        // finish. Under a single global queue, B would chain behind the gated A
+        // and this test would deadlock (time out) — that's the point.
+        let releaseA: () => void = () => {};
+        const aGate = new Promise<void>(r => { releaseA = r; });
+        const realRead = fs.promises.readFile;
+        const spy = jest.spyOn(fs.promises, 'readFile').mockImplementation(
+            async (p: any, ...args: any[]) => {
+                if (String(p) === ctxPath(dirA)) await aGate;
+                return (realRead as any)(p, ...args);
+            }
         );
-        const fastB = updateSpecContext(
-            dirB,
-            ctx => {
-                order.push('B');
-                return setStepStarted(ctx, 'plan', 'extension');
-            },
-            fresh()
-        );
-        await Promise.all([slowA, fastB]);
 
-        const a = await readSpecContext(dirA);
+        const slowA = updateSpecContext(dirA, ctx => setStepStarted(ctx, 'plan', 'extension'), fresh());
+        const fastB = updateSpecContext(dirB, ctx => setStepStarted(ctx, 'plan', 'extension'), fresh());
+
+        // B resolves while A is still gated → the queues are independent.
+        await fastB;
         const b = await readSpecContext(dirB);
-        expect(a!.history.some(h => h.step === 'plan' && h.kind === 'start')).toBe(true);
         expect(b!.history.some(h => h.step === 'plan' && h.kind === 'start')).toBe(true);
-        // Both mutations ran (neither was blocked out).
-        expect(order).toContain('A');
-        expect(order).toContain('B');
+
+        releaseA();
+        await slowA;
+        spy.mockRestore();
+        const a = await readSpecContext(dirA);
+        expect(a!.history.some(h => h.step === 'plan' && h.kind === 'start')).toBe(true);
     });
 
     it('a throwing queued write releases the lock so the next same-spec write still runs, and its error propagates (FR-004, SC-004)', async () => {


### PR DESCRIPTION
## Summary

A phase could flip to "untrusted timing" at random when a spec advanced a step. Advancing fired two context writes at once — `updateStepProgress` (fire-and-forget) and a second `startStep` — each an unserialized read-modify-write on `.spec-context.json`. Last writer won, and when the lost write was the step's start marker, that phase's duration read as untrusted. #519 closed the *sequential* double-starts; this closes the *simultaneous* one.

## What changed

- **`updateSpecContext` serializes per target path** — a module-level chain per `.spec-context.json`, so two concurrent updates to the same spec run one after the other (the second reads the first's committed state). Different specs keep independent chains and run in parallel. The stored tail never rejects, so a failed write releases the queue instead of wedging it; the map self-cleans.
- **`executeWorkflowStep` now awaits `updateStepProgress` and deletes the redundant `startStep` block.** `updateStepProgress` already does complete-on-advance + the start-write **atomically** — the second start-write was pure redundancy and the source of the race. Exactly one start-write per step now. (Complete-on-advance for IDE Chat is preserved — it lives in `updateStepProgress`, unconditionally.)

## Verified

- Full suite green (1790 jest). 5 new tests in `tests/unit/specs/specContextWriter.spec.ts`: two overlapping same-spec writes both land (real `Promise.all` overlap), a 25-write stress loses nothing, cross-spec writes don't serialize against each other, a throwing write releases the lock and propagates its error, non-JSON files still refused.
- Reviewed the highest-risk deletion end-to-end: `updateStepProgress` → `canonicalUpdateSpecContext` (= the serialized `updateSpecContext`) completes the prior lifecycle step and starts the new one in one atomic write, idempotent on re-advance — so nothing about complete-on-advance is lost.

## Living specs

This spec's own completion folds a new requirement into the `specs` living spec (`src/features/specs/specs.spec.md`) — "concurrent writes to a spec's state record are serialized, never lost." The loop closes on its own fix.

Closes #527

🤖 Generated with [Claude Code](https://claude.com/claude-code)