### PR TITLE
fix(living-specs): a re-fold of an already-synced spec no longer false-alarms

### DIFF
--- a/speckit-extension/scripts/living_spec_fold.py
+++ b/speckit-extension/scripts/living_spec_fold.py
@@ -58,7 +58,7 @@ def _synced_capability_names(feature_dir: Path) -> set[str]:
     except Exception:  # noqa: BLE001 - best-effort
         return set()
     synced = (ctx.get("livingSpecs") or {}).get("synced") or []
-    return {c for c in synced if isinstance(c, str) and c.strip()}
+    return {c.strip() for c in synced if isinstance(c, str) and c.strip()}
 
 
 def _accountability_gap(feature_dir: Path, synced) -> list[str]:

--- a/speckit-extension/scripts/living_spec_fold.py
+++ b/speckit-extension/scripts/living_spec_fold.py
@@ -49,15 +49,30 @@ def _skipped_capability_names(feature_dir: Path) -> set[str]:
     }
 
 
+def _synced_capability_names(feature_dir: Path) -> set[str]:
+    """The capability names already folded on a prior run (livingSpecs.synced),
+    or empty. A re-fold writes nothing new (idempotent), so its in-run synced list
+    is empty — but the capability IS accounted for. Best-effort."""
+    try:
+        ctx = read_ctx(feature_dir / ".spec-context.json")
+    except Exception:  # noqa: BLE001 - best-effort
+        return set()
+    synced = (ctx.get("livingSpecs") or {}).get("synced") or []
+    return {c for c in synced if isinstance(c, str) and c.strip()}
+
+
 def _accountability_gap(feature_dir: Path, synced) -> list[str]:
-    """Loaded capabilities completion neither folded (synced) nor recorded a skip
-    for. The core accountability check — computed in BOTH fold branches so a partial
+    """Loaded capabilities completion neither folded nor recorded a skip for. The
+    core accountability check — computed in BOTH fold branches so a partial
     multi-capability fold (one delta authored, another capability forgotten)
-    can't silence the gap the way the no-delta-only check did."""
+    can't silence the gap the way the no-delta-only check did. A capability counts
+    as accounted if it was folded THIS run (`synced` arg), folded on a PRIOR run
+    (persisted livingSpecs.synced — so an idempotent re-fold doesn't false-alarm),
+    or explicitly skipped."""
     loaded = _loaded_capabilities(feature_dir)
     if not loaded:
         return []
-    accounted = set(synced) | _skipped_capability_names(feature_dir)
+    accounted = set(synced) | _synced_capability_names(feature_dir) | _skipped_capability_names(feature_dir)
     return [c for c in loaded if c not in accounted]
 
 
@@ -388,7 +403,9 @@ def fold_living_spec(feature_dir: Path, by: str) -> Path | None:
         loaded = _loaded_capabilities(feature_dir)
         if loaded:
             skipped = _skipped_capability_names(feature_dir)
-            unaccounted = [c for c in loaded if c not in skipped]
+            # Accounted = folded on a prior run (persisted synced) OR skipped, so a
+            # re-fold of an already-synced spec doesn't false-alarm.
+            unaccounted = _accountability_gap(feature_dir, [])
             if unaccounted:
                 # The loud, actionable backstop: a capability was loaded, no delta
                 # was authored, and no skip note explains why. This is the exact
@@ -404,14 +421,15 @@ def fold_living_spec(feature_dir: Path, by: str) -> Path | None:
                     file=sys.stderr,
                 )
             else:
-                # Every loaded capability carries an explicit skip note: this change
-                # genuinely touched none of their behavior. "Correctly nothing,"
+                # Every loaded capability is accounted for — folded on an earlier
+                # run and/or carrying an explicit skip note. "Correctly nothing,"
                 # visibly distinct from the unaccounted case above.
                 print(
                     f"[companion] Living-spec fold: all {len(loaded)} loaded "
                     f"capabilit{'y' if len(loaded) == 1 else 'ies'} "
-                    f"({', '.join(loaded)}) have explicit skip notes; nothing to "
-                    "fold — correctly nothing.",
+                    f"({', '.join(loaded)}) {'is' if len(loaded) == 1 else 'are'} "
+                    "accounted for (folded earlier or skipped); nothing to fold — "
+                    "correctly nothing.",
                     file=sys.stderr,
                 )
         else:

--- a/speckit-extension/tests/test_living_specs.py
+++ b/speckit-extension/tests/test_living_specs.py
@@ -1244,8 +1244,26 @@ class FoldLivingSpecTests(unittest.TestCase):
         self.assertIsNone(wc.fold_living_spec(fdir, "ai"))
         self.assertEqual(self._living(root), before)  # byte-identical
         self.assertIn("correctly nothing", log)
-        self.assertIn("explicit skip notes", log)
+        self.assertIn("accounted for", log)
         self.assertNotIn("The loop did not close", log)
+
+    def test_refold_of_a_synced_spec_does_not_false_alarm(self) -> None:
+        # A capability folded on the first run is accounted for by the persisted
+        # livingSpecs.synced; an idempotent re-fold (which writes nothing new, so
+        # its in-run synced list is empty) must NOT print "the loop did not close".
+        root = _git_repo(ENABLED_TODOS_YAML, {"capabilities/todos/spec.md": TODOS_LIVING},
+                         code_files=["src/todos/list.ts"])
+        fdir = _write_feature(root, "001-feat",
+            "# Feat\n\n## ADDED Requirements\n\n### Due dates\n\n#### Scenario: s\n- a\n")
+        wc.set_living_specs_loaded(fdir, ["todos"])
+        wc.fold_living_spec(fdir, "ai")                       # first fold — writes + records synced
+        self.assertEqual(self._ctx(fdir)["livingSpecs"]["synced"], ["todos"])
+        after_first = self._living(root)
+        log = self._fold_log(fdir)                            # re-fold
+        wc.fold_living_spec(fdir, "ai")
+        self.assertEqual(self._living(root), after_first)     # byte-identical
+        self.assertNotIn("The loop did not close", log)
+        self.assertNotIn("unaccounted", log)
 
     def test_partial_skip_still_flags_the_unaccounted_one(self) -> None:
         root = _git_repo(ENABLED_TODOS_YAML, {"capabilities/todos/spec.md": TODOS_LIVING},

--- a/speckit-extension/tests/test_living_specs.py
+++ b/speckit-extension/tests/test_living_specs.py
@@ -1259,9 +1259,8 @@ class FoldLivingSpecTests(unittest.TestCase):
         wc.fold_living_spec(fdir, "ai")                       # first fold — writes + records synced
         self.assertEqual(self._ctx(fdir)["livingSpecs"]["synced"], ["todos"])
         after_first = self._living(root)
-        log = self._fold_log(fdir)                            # re-fold
-        wc.fold_living_spec(fdir, "ai")
-        self.assertEqual(self._living(root), after_first)     # byte-identical
+        log = self._fold_log(fdir)                            # the re-fold (captures its stderr)
+        self.assertEqual(self._living(root), after_first)     # byte-identical, same run as `log`
         self.assertNotIn("The loop did not close", log)
         self.assertNotIn("unaccounted", log)
 


### PR DESCRIPTION
## What's wrong

Finishing a feature folds its changes into the living spec and records which capabilities it synced. The fold is idempotent — running it again is a supported no-op. But the "did the loop close?" backstop only looked at what *this* run folded, so a second, harmless fold of an already-synced spec wrongly announced **"the loop did not close"** for a capability it had already handled.

## The fix

The accountability check now counts a capability as handled if it was folded on *any* run (the persisted `livingSpecs.synced`), not just the current one. A re-fold stays quiet.

## What I need from you

Nothing — review at your pace. Python suite 545 pass (+1 regression test).

## Dev details

- `living_spec_fold.py`: new `_synced_capability_names` (reads persisted `livingSpecs.synced`); `_accountability_gap` unions it; both fold branches route through the shared helper.
- Regression test `test_refold_of_a_synced_spec_does_not_false_alarm`.
- **Found by the LS-R3 matrix (S8), the standing regression harness added in #540** — the matrix caught a real bug in the #536 backstop from #539.

Closes nothing (follow-up to #539).

🤖 Generated with [Claude Code](https://claude.com/claude-code)