### PR TITLE
fix(spec-viewer): footer stops offering the forward advance once a spec is done (#529)

### DIFF
--- a/docs/viewer-states.md
+++ b/docs/viewer-states.md
@@ -262,13 +262,15 @@ Zones: **Left** = `regenerate`. **Right** = `refine`, `approve`, `reactivate`,
 | `specified` | Regenerate | Approve → **Plan** | forward action present |
 | `planned` | Regenerate | Approve → **Tasks** | |
 | `ready-to-implement` | Regenerate | Approve → **Implement** | |
-| `implemented` | Regenerate | **Mark Completed**, **Archive** | Approve hidden; closure controls appear |
+| `implemented` | Regenerate | **Mark Completed**, **Archive** | Approve hidden; closure controls appear. A done spec (`status` ∈ {`implemented`, `completed`}) offers **only** its finish actions regardless of the recorded `currentStep` — see the done-state guard below. |
 | `completed` | — | **Reactivate**, **Archive** | terminal; Regenerate hidden |
 | `archived` | — | **Reactivate** | terminal; Archive hidden |
 
 The `Approve` label resolves to the next workflow step (`getApproveLabel`); it is hidden on the final `implement` step and whenever a past tab is viewed (the footer always reflects the true workflow stage, not the viewed tab). While a step is in flight the `CatalogFooter` suppresses its forward-motion button and keeps `Regenerate` (plus any closure/refine actions); the moment the step settles — its `status` settles **or** its completion is recorded in history (`FooterActions` reads the resilient `isStepInFlight`, not the status string alone, so a lagging status can't keep it locked, #491) — the forward button reappears; it never leaves the action bar empty.
 
 A status recovered via the sidebar gear maps to the **same row** as its normal pause stage: forcing `ready-to-implement` after an interrupted implement run restores Approve → **Implement**, and forcing `planned` restores Approve → **Tasks** — the stale start left by the interrupted run does not suppress the forward button (#414, "Rollback recovery" above). The oracle rows in `footerMatrix.fixtures.ts` pin these recovered states alongside the normal ones.
+
+**Done-state guard**: once a spec is done building (`status` ∈ {`implemented`, `completed`}), the footer offers **only** its finish actions (**Mark Completed** / **Archive**) — the forward **Approve** never appears, regardless of what `currentStep` records. During a fast-path finish, `status` can flip to `implemented` before the pipeline stamps the final step's boundary, so `currentStep` transiently trails (e.g. still `tasks`). Without the guard that skew would light **Approve → Implement** next to **Mark Completed** — advance-and-finish side by side. `shouldShowApprove` returns early on `isSpecDone(ctx)` so the footer stays correct through the skew; the oracle's `implemented (fast-path skew: currentStep still at tasks)` row pins it.
 
 The source-tab **Refine** button (`✨ Refine (N)`) still appears dynamically
 when pending inline comments are collected. Each comment is persisted to

--- a/specs/528-footer-done-guard/.spec-context.json
+++ b/specs/528-footer-done-guard/.spec-context.json
@@ -1,0 +1,213 @@
+{
+  "workflow": "companion",
+  "specName": "Footer Done Guard",
+  "branch": "528-footer-done-guard",
+  "selectedAt": "2026-07-22T20:45:44.521Z",
+  "currentStep": "implement",
+  "status": "completed",
+  "history": [
+    {
+      "step": "specify",
+      "substep": null,
+      "kind": "start",
+      "by": "extension",
+      "at": "2026-07-22T20:45:44.521Z"
+    },
+    {
+      "step": "specify",
+      "substep": null,
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-07-22T20:51:14.340Z"
+    },
+    {
+      "step": "plan",
+      "substep": null,
+      "kind": "start",
+      "by": "extension",
+      "at": "2026-07-22T20:51:14.423Z"
+    },
+    {
+      "step": "plan",
+      "substep": null,
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-07-22T20:51:14.505Z"
+    },
+    {
+      "step": "tasks",
+      "substep": null,
+      "kind": "start",
+      "by": "extension",
+      "at": "2026-07-22T20:51:14.584Z"
+    },
+    {
+      "step": "tasks",
+      "substep": null,
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-07-22T20:51:14.665Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "kind": "start",
+      "by": "extension",
+      "at": "2026-07-22T20:54:43.271Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T001",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-07-22T20:56:56.301Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T002",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-07-22T20:57:09.801Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T003",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-07-22T20:57:37.789Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T004",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-07-22T20:58:59.885Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-07-22T20:58:59.968Z"
+    }
+  ],
+  "livingSpecs": {
+    "loaded": [
+      "spec-viewer"
+    ],
+    "synced": [
+      "spec-viewer"
+    ]
+  },
+  "last_action": "spec completed; living spec-viewer folded (+1 ADDED req)",
+  "coverage": {
+    "FR-001": {
+      "title": "Footer MUST NOT surface the forward advance action once the spec is done-building, regardless of the recorded current step",
+      "tests": [
+        "src/features/spec-viewer/__tests__/footerMatrix.test.ts::implemented (fast-path skew: currentStep still at tasks)"
+      ]
+    },
+    "FR-002": {
+      "title": "While done, the footer MUST keep surfacing its finish actions (Mark Completed / Archive) as today",
+      "tests": [
+        "src/features/spec-viewer/__tests__/footerMatrix.test.ts::implemented",
+        "src/features/spec-viewer/__tests__/footerMatrix.test.ts::implemented (fast-path skew: currentStep still at tasks)"
+      ]
+    },
+    "FR-003": {
+      "title": "For a not-yet-done spec, the forward advance action MUST remain visible as before, including the recovered-after-interruption case",
+      "tests": [
+        "src/features/spec-viewer/__tests__/footerMatrix.test.ts::ready-to-implement (recovered after interrupted implement)"
+      ]
+    },
+    "FR-004": {
+      "title": "The footer matrix oracle MUST include the done-status / lagging-current-step skew case asserting no forward button",
+      "tests": [
+        "src/features/spec-viewer/__tests__/footerMatrix.fixtures.ts::implemented (fast-path skew: currentStep still at tasks)"
+      ]
+    },
+    "FR-005": {
+      "title": "The documented footer button matrix MUST state a done spec offers only its finish actions regardless of current step"
+    }
+  },
+  "size": "simple",
+  "classification": {
+    "projectedFiles": 3,
+    "projectedTasks": 4,
+    "scopeSignal": "smaller",
+    "verdict": "simple"
+  },
+  "context": [
+    "living spec: spec-viewer",
+    "area: src/features/spec-viewer/footerActions.ts (footer visibility rules)",
+    "constraint: guard-only fix, do not change status/currentStep capture ordering"
+  ],
+  "intent": "Stop the viewer footer from offering the forward advance action once a spec is done, so it never shows advance and finish at the same time",
+  "expectations": [
+    "Tightening the status/currentStep capture ordering so they never skew",
+    "Changing which lifecycle statuses count as done"
+  ],
+  "approach": "Add an isSpecDone early-return guard to shouldShowApprove, add a skew row to the footer matrix fixtures, and update the viewer-states footer matrix doc",
+  "telemetryInstanceId": "ad553b6a-d35a-4ddb-a24d-4b1f3fd81203",
+  "currentTask": "T004",
+  "task_summaries": {
+    "T001": {
+      "status": "DONE",
+      "did": "Added an early isSpecDone(ctx) guard to shouldShowApprove so a done spec never surfaces the forward advance action regardless of currentStep skew",
+      "files": [
+        "src/features/spec-viewer/footerActions.ts"
+      ]
+    },
+    "T002": {
+      "status": "DONE",
+      "did": "Added the fast-path skew oracle row (status implemented, currentStep tasks) asserting right zone archive+complete and no approve",
+      "files": [
+        "src/features/spec-viewer/__tests__/footerMatrix.fixtures.ts"
+      ]
+    },
+    "T003": {
+      "status": "DONE",
+      "did": "Documented the done-state guard in the footer button matrix: a done spec offers only finish actions regardless of currentStep, with the fast-path skew explained",
+      "files": [
+        "docs/viewer-states.md"
+      ]
+    },
+    "T004": {
+      "status": "DONE",
+      "did": "Ran the footer matrix suite (17 pass, +1 skew row) and the full test run (1791 pass, 126 suites); tsc clean",
+      "files": [
+        "npm test"
+      ]
+    }
+  },
+  "verified": [
+    {
+      "what": "footer matrix oracle incl. new fast-path skew row",
+      "command": "npx jest footerMatrix",
+      "result": "17 pass / 0 fail (was 16 — +1 skew row)",
+      "warnings": []
+    },
+    {
+      "what": "full test suite + type-check",
+      "command": "npm test; tsc --noEmit",
+      "result": "1791 pass / 126 suites, tsc clean",
+      "warnings": []
+    }
+  ],
+  "decisions": [
+    {
+      "decision": "Guard placed as the first line of shouldShowApprove (before the step===implement check)",
+      "why": "isSpecDone covers implemented+completed and makes the footer correct regardless of currentStep/history skew, in one place",
+      "rejected": "Tightening capture ordering so status/currentStep never skew (explicitly out of scope per spec)"
+    }
+  ],
+  "step_summaries": {
+    "implement": {
+      "summary": "Done-state guard in shouldShowApprove suppresses the forward Approve on a done spec regardless of currentStep skew; skew oracle row + doc added"
+    }
+  }
+}

--- a/specs/528-footer-done-guard/checklists/requirements.md
+++ b/specs/528-footer-done-guard/checklists/requirements.md
@@ -1,0 +1,35 @@
+# Specification Quality Checklist: Footer Done Guard
+
+**Purpose**: Validate Companion specification completeness before planning
+**Created**: 2026-07-22
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed (User Scenarios, Requirements, Success Criteria)
+
+## Requirement Completeness
+
+- [x] Any [NEEDS CLARIFICATION] markers are genuine ambiguities (≤3) deferred to clarify — not unresolved guesses
+- [x] Each Functional Requirement is a single, testable MUST/SHOULD statement
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into the specification
+
+## Notes
+
+- The Approach and Verbatim Constraints sections carry literal identifiers (`shouldShowApprove`, `isSpecDone`, file paths). These are the user-pinned requirements from Issue #529 recorded verbatim, which is the one sanctioned place for exact identifiers — they are not implementation-detail leakage into the requirement statements.
+- No open `[NEEDS CLARIFICATION]` markers: the request is a precisely-scoped state-machine fix.

--- a/specs/528-footer-done-guard/plan.md
+++ b/specs/528-footer-done-guard/plan.md
@@ -1,0 +1,3 @@
+# Plan: Footer Done Guard
+
+> Fast-path spec — the implementation approach lives inline in [`./spec.md#approach`](./spec.md#approach). Task checklist: [`./tasks.md`](./tasks.md).

--- a/specs/528-footer-done-guard/spec.md
+++ b/specs/528-footer-done-guard/spec.md
@@ -1,0 +1,80 @@
+# Feature Specification: Footer Done Guard
+
+**Source**: [Issue #529](https://github.com/alfredoperez/speckit-companion/issues/529)
+
+## User Scenarios & Testing
+
+### User Story 1 - A finished spec offers only finish actions, never "advance" too (Priority: P1)
+
+When a spec has finished building, the viewer footer should present only the actions that close it out — Mark Completed and Archive. A developer watching a fast-path spec complete should never see the forward "Implement" button lit at the same time as "Mark Completed". The lifecycle buttons are a state machine, and offering "advance to the next step" and "finish the run" side by side is contradictory and confusing.
+
+**Why this priority**: This is the whole feature — one contradictory footer state that a real user hit and reported. Removing it delivers all the value.
+
+**Independent Test**: Render the footer for a spec whose status says it is done building but whose recorded current step still lags behind, and confirm only the finish actions appear.
+
+**Acceptance Scenarios**:
+
+1. **Given** a spec that has finished building but whose recorded current step still trails behind the status (the transient fast-path skew), **When** the footer renders, **Then** the forward advance button is absent and only the finish actions (Mark Completed and Archive) are offered.
+2. **Given** a spec that has been marked completed while its recorded current step still lags, **When** the footer renders, **Then** no forward advance button appears.
+3. **Given** a spec still moving through the pipeline (not yet done building), **When** the footer renders, **Then** the forward advance button appears exactly as it does today — including the recovered-after-interruption case where the user rolled the status back to keep going.
+
+### Edge Cases
+
+- The status flips to "done building" before the pipeline records the final step's boundary — the exact window the report describes.
+- A run that was interrupted and then rolled back so the developer can continue: the forward button must still appear (the finish guard must not swallow it).
+- An already-archived spec: the forward button is already hidden; the guard must leave its finish actions untouched.
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: The footer MUST NOT surface the forward advance action once the spec has reached a done-building state, regardless of whether the recorded current step has caught up.
+- **FR-002**: While a spec is done, the footer MUST keep surfacing its finish actions (Mark Completed and/or Archive) exactly as it does today.
+- **FR-003**: For a spec still moving through the pipeline (not yet done building), the forward advance action MUST remain visible exactly as before, including the recovered-after-interruption case.
+- **FR-004**: The automated footer button matrix MUST include a case for the done-status / lagging-current-step skew, asserting the forward advance button is absent and only the finish actions render.
+- **FR-005**: The documented footer button matrix MUST state that a done spec offers only its finish actions regardless of the recorded current step.
+
+### Key Entities
+
+- **Spec context** — the per-spec lifecycle record. Two attributes matter here: the lifecycle **status** (how far the spec has progressed) and the recorded **current step** (the step the pipeline last marked active). During a fast-path finish these two can transiently disagree, and that disagreement is the trigger for the bug.
+- **Footer action** — a lifecycle button with a visibility rule. One action advances the pipeline forward; the finish actions (Mark Completed, Archive) close the spec out. They are meant to be mutually exclusive by state.
+
+## Success Criteria
+
+### Measurable Outcomes
+
+- **SC-001**: Across every done-building state, the forward advance button appears zero times; only finish actions render.
+- **SC-002**: Across every not-yet-done stage that previously showed the forward advance button (including the recovered-after-interruption rows), it still appears — no forward-flow regression.
+- **SC-003**: The footer matrix test suite passes with the new skew case included, and the full test run stays green.
+
+## Assumptions
+
+- "Done building" follows the existing lifecycle vocabulary — the `implemented` and `completed` stages the footer already treats as done. The `completed` and `archived` stages are already suppressed by the footer's existing terminal check, so the new guard's practical effect is closing the `implemented`-status skew window.
+- The fix is a visibility guard in the shared footer rules, not a change to how status and current step get captured. Tightening the capture ordering so the two never skew is explicitly out of scope — the guard makes the footer correct regardless.
+
+## Verbatim Constraints
+
+- `shouldShowApprove` — the footer rule that gains the done-state guard, in `src/features/spec-viewer/footerActions.ts`.
+- `isSpecDone` — the existing predicate that detects the done-building state (`implemented` / `completed`).
+- `src/features/spec-viewer/__tests__/footerMatrix.test.ts` — the data-driven oracle that must exercise the skew case.
+- `docs/viewer-states.md` — the footer button matrix reference to update.
+
+## Approach
+
+- Add an early `if (isSpecDone(ctx)) return false;` guard at the top of `shouldShowApprove` in `src/features/spec-viewer/footerActions.ts`, so a done spec never yields a forward advance action regardless of the current-step / history skew. (`completed` and `archived` are already suppressed by the existing `isTerminal` check on the `APPROVE` action; this closes the remaining `implemented`-status gap.)
+- Add a fixture row to `src/features/spec-viewer/__tests__/footerMatrix.fixtures.ts` (consumed by the data-driven `footerMatrix.test.ts`): `status: implemented`, `currentStep: tasks`, expecting the right zone `['archive', 'complete']` and no `approve`.
+- Update the footer button matrix in `docs/viewer-states.md` to note that a done spec offers only its finish actions regardless of the recorded current step.
+
+Files to touch: `src/features/spec-viewer/footerActions.ts`, `src/features/spec-viewer/__tests__/footerMatrix.fixtures.ts`, `docs/viewer-states.md`.
+
+## ADDED Requirements
+<!-- capability: spec-viewer -->
+
+### A done spec offers only its finish actions, never the forward advance
+
+Once a spec has reached a done-building state, the footer MUST offer only its finish actions (Mark Completed / Archive) and MUST NOT surface the forward advance action, regardless of what the recorded current step says. A fast-path finish can flip the status to done before the pipeline records the final step's boundary, leaving the recorded current step transiently behind; the done status alone SHALL suppress the forward action so advance and finish are never offered together.
+
+#### Scenario: the status is done but the recorded current step still trails
+- **WHEN** a spec's status reports it is done building while its recorded current step lags at an earlier step
+- **THEN** the footer offers only the finish actions
+- **AND** the forward advance action is absent

--- a/specs/528-footer-done-guard/tasks.md
+++ b/specs/528-footer-done-guard/tasks.md
@@ -1,0 +1,6 @@
+# Tasks: Footer Done Guard
+
+- [x] **T001** Add an early `if (isSpecDone(ctx)) return false;` guard at the top of `shouldShowApprove` so a done spec never surfaces the forward advance action + src/features/spec-viewer/footerActions.ts
+- [x] **T002** [P] Add the skew oracle row (`status: implemented`, `currentStep: tasks` → right zone `['archive','complete']`, no `approve`) so the matrix test covers the done/lagging-step case + src/features/spec-viewer/__tests__/footerMatrix.fixtures.ts
+- [x] **T003** [P] Update the footer button matrix so a done spec is documented as offering only its finish actions regardless of the recorded current step + docs/viewer-states.md
+- [x] **T004** Run the footer matrix suite and the full test run; confirm the new case passes and nothing regresses + npm test

--- a/src/features/spec-viewer/__tests__/footerMatrix.fixtures.ts
+++ b/src/features/spec-viewer/__tests__/footerMatrix.fixtures.ts
@@ -149,6 +149,16 @@ export const FOOTER_MATRIX: FooterMatrixRow[] = [
         right: ['archive', 'complete'],
     },
     {
+        // Fast-path skew: `status` is done while `currentStep` still trails at
+        // `tasks`; the done-state guard must drop Approve, leaving only finish.
+        name: 'implemented (fast-path skew: currentStep still at tasks)',
+        status: 'implemented',
+        currentStep: 'tasks',
+        history: historyThrough('tasks'),
+        left: ['regenerate'],
+        right: ['archive', 'complete'],
+    },
+    {
         name: 'completed',
         status: 'completed',
         currentStep: 'implement',

--- a/src/features/spec-viewer/footerActions.ts
+++ b/src/features/spec-viewer/footerActions.ts
@@ -97,8 +97,7 @@ function shouldShowApprove(
     stepHistory: DerivedHistory,
     workflowSteps?: WorkflowStepConfig[]
 ): boolean {
-    // A done spec never advances: guards the fast-path skew where `status` flips
-    // to done before `currentStep` catches up (else advance + finish show together).
+    // A done spec never advances — guards the fast-path status/currentStep skew.
     if (isSpecDone(ctx)) return false;
     // Implement step closure is owned by `Mark Completed` (gated on
     // `isSpecDone(ctx)`). Approve here would surface a duplicate

--- a/src/features/spec-viewer/footerActions.ts
+++ b/src/features/spec-viewer/footerActions.ts
@@ -97,6 +97,9 @@ function shouldShowApprove(
     stepHistory: DerivedHistory,
     workflowSteps?: WorkflowStepConfig[]
 ): boolean {
+    // A done spec never advances: guards the fast-path skew where `status` flips
+    // to done before `currentStep` catches up (else advance + finish show together).
+    if (isSpecDone(ctx)) return false;
     // Implement step closure is owned by `Mark Completed` (gated on
     // `isSpecDone(ctx)`). Approve here would surface a duplicate
     // "Complete" button the moment every task box gets ticked, before

--- a/src/features/spec-viewer/spec-viewer.spec.md
+++ b/src/features/spec-viewer/spec-viewer.spec.md
@@ -199,3 +199,12 @@ Each render MUST emit its own content-security policy with a freshly generated p
 ## Uncovered
 
 _None — every file in the area was read, though the test files under `__tests__/` were read only for the contracts they pin, not line by line._
+
+### A done spec offers only its finish actions, never the forward advance
+
+Once a spec has reached a done-building state, the footer MUST offer only its finish actions (Mark Completed / Archive) and MUST NOT surface the forward advance action, regardless of what the recorded current step says. A fast-path finish can flip the status to done before the pipeline records the final step's boundary, leaving the recorded current step transiently behind; the done status alone SHALL suppress the forward action so advance and finish are never offered together.
+
+#### Scenario: the status is done but the recorded current step still trails
+- **WHEN** a spec's status reports it is done building while its recorded current step lags at an earlier step
+- **THEN** the footer offers only the finish actions
+- **AND** the forward advance action is absent


### PR DESCRIPTION
## What

During a fast-path implement, the viewer footer briefly showed **Implement** (forward advance) *and* **Mark Completed** as two green buttons at once — because `status` flips to `implemented` before `currentStep` advances. The lifecycle buttons are a state machine; a done spec should never offer "advance" and "finish" together.

## Fix

`shouldShowApprove` now returns `false` when `isSpecDone(ctx)` (status `implemented`/`completed`/`archived`) — a done spec has no forward dispatch; **Mark Completed** / **Archive** own the terminal actions. This makes the footer robust to a `status`/`currentStep` skew instead of relying on both advancing in lock-step.

## Verify

`footerMatrix.test.ts` gains the skew case — `status: implemented` + `currentStep: tasks` must not surface the forward button (17/17 pass). `docs/viewer-states.md` footer matrix updated. The new requirement is folded into the `spec-viewer` living spec.

Closes #529

🤖 Generated with [Claude Code](https://claude.com/claude-code)