### PR TITLE
docs(living-specs): sync 9 drifted capability specs to match the code

### DIFF
--- a/capabilities/companion-commands/spec.md
+++ b/capabilities/companion-commands/spec.md
@@ -166,9 +166,9 @@ Read in full: the extension manifest, all part files, the node order and a sampl
 - Most individual node bodies under `nodes/` — read the order files, frontmatter shape, and three representative bodies.
 - `speckit-extension/workflows/speckit-companion.workflow.yml`.
 
-### Completion authors a delta block per changed capability before folding
+### Completion accounts for every loaded capability — a delta or an explicit skip, never silence
 
-The mark-complete step instructs the AI to read `livingSpecs.loaded` and, for each loaded capability whose behavior the feature changed, append a marked delta block to the feature spec capturing the real requirement, then fold. Capabilities merely read are skipped.
+The completion step (both the implement-time close and the terminal `mark-complete`) instructs the AI to read `livingSpecs.loaded` and account for **every** name in it before folding — each gets exactly one of two outcomes. A loaded capability whose *behavior* the feature changed gets a marked delta block appended to the feature spec capturing the real requirement. A loaded capability merely read for context gets an explicit recorded skip (`write-context.py --living-spec-skip "<name>: <reason>"`), so "correctly nothing" stays distinguishable from "silently nothing." A loaded capability that is neither is a hole the fold flags loudly. The delta verb is chosen by whether the requirement's heading already exists in that capability's living spec: a heading not already there goes under `## ADDED Requirements` even when it revises the same behavior area, and `## MODIFIED Requirements` is reserved for editing the body of a heading that already matches one in the living spec.
 
 #### Scenario: a feature changed a loaded capability
 
@@ -178,7 +178,12 @@ The mark-complete step instructs the AI to read `livingSpecs.loaded` and, for ea
 #### Scenario: a capability was read but not changed
 
 - **WHEN** the feature loaded a capability but did not change its behavior
-- **THEN** no delta block is authored for it and its spec is left untouched
+- **THEN** an explicit skip is recorded for it, not silence, and its spec is left untouched
+
+#### Scenario: a loaded capability is left unaccounted
+
+- **WHEN** a name in `livingSpecs.loaded` gets neither a delta block nor a recorded skip
+- **THEN** the fold flags it loudly as a hole
 
 ### Step boundaries are extension-stamped in order on every dispatch path
 
@@ -230,3 +235,31 @@ The commands under the never-halts contract — the four lifecycle hooks, the li
 
 - **WHEN** the clarify-type command body no longer contains an ask instruction
 - **THEN** the quality gate fails — asking is that command's purpose
+
+### The specify-time living-spec load is recorded deterministically, not by AI judgment
+
+Pre-briefing at specify no longer asks the AI to decide whether the project is configured or which capabilities apply — that hand-judgment is exactly what silently skipped the load on real runs. Given the files the change will touch, a deterministic recorder script re-reads the capability registry (`living-specs.yml`, or the legacy `livingSpecs` block), gates on `enabled`, runs the resolver, and writes the matched capabilities (leaf-first) onto `livingSpecs.loaded` **plus the one-line audit breadcrumb itself** — all on `.spec-context.json`, never touching the lifecycle log. The AI then only reads `livingSpecs.loaded` back to pull those specs into context; the reading is best-effort background, the recorder is the reliable write. The recorder is a silent no-op that exits 0 when the feature is off, nothing matches, or the registry/resolver can't be read, and is skipped without failing when the interpreter is unavailable — so it never fails or slows the command.
+
+#### Scenario: the project keeps living specs for a touched area
+
+- **WHEN** the recorder runs with the change's in-scope files against an enabled registry that matches
+- **THEN** it writes the matched capabilities leaf-first onto `livingSpecs.loaded` with the audit breadcrumb, and the AI reads those specs back from the record
+
+#### Scenario: nothing is configured or nothing matches
+
+- **WHEN** the recorder runs with the feature off or no capability owning the touched files
+- **THEN** it is a silent no-op that exits successfully, and the breadcrumb marks "correctly did nothing" apart from a broken capture
+
+### A simple-verdict run captures the same context a full run would, on the fast path
+
+When the classify step returns `simple`, specify writes the plan inline as the spec's `## Approach` section and never reaches `plan` or `tasks`. To keep the viewer honest, that fast path SHALL still capture what a full run would: the one-line approach is persisted onto `.spec-context.json` so the Overview APPROACH card reads it; the living-spec load is run **again post-draft** when the pre-draft load recorded nothing (the touched files are known by then, and the record is skipped if already populated); and the folded `plan` and `tasks` boundaries are stamped `by: extension` at step level — not as AI substeps — so the timing display counts specify, plan, and tasks as measured phases. All of it is best-effort and skipped silently when the interpreter is unavailable, and no `completed` status is written — the terminal gate stays its own step.
+
+#### Scenario: classify returns simple
+
+- **WHEN** the specify command finishes a simple-verdict draft
+- **THEN** the approach is captured, the folded plan and tasks boundaries are stamped as extension step-level events, and the spec lands at tasks with `status: ready-to-implement`
+
+#### Scenario: the pre-draft load recorded nothing
+
+- **WHEN** the simple run reaches the fold and `livingSpecs.loaded` is still empty
+- **THEN** the deterministic recorder runs once against the now-known touched files, and never re-resolves when the load already populated it

--- a/capabilities/workflows/spec.md
+++ b/capabilities/workflows/spec.md
@@ -21,6 +21,7 @@ The extension SHALL provide the stock SpecKit pipeline and the SpecKit Companion
 - **WHEN** a spec selects it
 - **THEN** each step dispatches the Companion command family
 - **AND** the pipeline ends at a terminal step that marks the spec complete
+- **AND** that terminal step is marked untimed — it only flips status, so it is excluded from the pipeline's timing-coverage denominator rather than counted as a step that should record a duration
 
 ### Built-in names are reserved at every scope
 
@@ -33,7 +34,7 @@ A custom workflow SHALL NOT be able to claim a built-in workflow's name, includi
 
 ### Selection filters, resolution does not
 
-Surfaces that let a user *pick* a workflow SHALL hide workflows the active provider cannot run and built-ins whose prerequisites are absent. Resolving a workflow a spec has *already recorded* SHALL NOT filter. A spec that loses its real steps because the user switched providers would render the wrong pipeline and dispatch the wrong command.
+Surfaces that let a user *pick* a workflow SHALL hide workflows the active provider cannot run and built-ins whose prerequisites are absent. The Companion pipeline's only selection prerequisite is that the companion spec-kit extension is installed in the project — there is no separate enabling setting gating its offer. Resolving a workflow a spec has *already recorded* SHALL NOT filter. A spec that loses its real steps because the user switched providers would render the wrong pipeline and dispatch the wrong command.
 
 #### Scenario: an existing spec is opened under a provider that could not have selected its workflow
 - **WHEN** the spec's recorded workflow is resolved for display
@@ -41,7 +42,7 @@ Surfaces that let a user *pick* a workflow SHALL hide workflows the active provi
 - **AND** the same workflow is still absent from the picker
 
 #### Scenario: the Companion pipeline's prerequisites are not met
-- **WHEN** its enabling setting is off, or the companion spec-kit extension is not installed in the project
+- **WHEN** the companion spec-kit extension is not installed in the project
 - **THEN** it is not offered for selection
 - **AND** every surface that builds a picker uses the same predicate, so no picker can offer it while another hides it
 
@@ -117,7 +118,7 @@ The document panel SHALL derive its phase stepper, document tabs, and next-docum
 #### Scenario: a document is opened that matches a pipeline step's output file
 - **WHEN** the panel renders
 - **THEN** the phase, the completed phases, and the tab set derive from the recorded workflow's step order and the files present on disk
-- **AND** files that are not step outputs surface as related documents rather than as phases
+- **AND** files that are not step outputs surface as related documents rather than as phases, their display names capitalizing each word and turning both dashes and underscores into spaces
 
 #### Scenario: a spec is on a workflow whose pipeline ends in a terminal step
 - **WHEN** the panel renders that spec's document

--- a/speckit-extension/scripts/capture-runtime.spec.md
+++ b/speckit-extension/scripts/capture-runtime.spec.md
@@ -202,7 +202,7 @@ The drift script SHALL accept a working-tree mode that widens each capability's 
 
 ### Recording which living specs cover a change MUST be deterministic, not AI-judged
 
-The capture runtime SHALL provide a script that, given a feature directory and the changed files, reads the living-specs registry, gates on `enabled: true`, runs the shipped resolver to find the capabilities that own those files, and records their names (most-specific first) onto `livingSpecs.loaded`. The specify command bodies call this script instead of asking the model to gate-and-decide, so the record cannot be lost to a misjudged "not configured." Like every capture script it is best-effort, opt-in, and read-only: any miss is a silent no-op that exits successfully.
+The capture runtime SHALL provide a script that, given a feature directory and the changed files, reads the living-specs registry, gates on `enabled: true`, runs the shipped resolver to find the capabilities that own those files, and records their names (most-specific first) onto `livingSpecs.loaded`. The specify command bodies call this script instead of asking the model to gate-and-decide, so the record cannot be lost to a misjudged "not configured." Like every capture script it is best-effort, opt-in, and read-only: any miss is a silent no-op that exits successfully. The recorder also returns its own outcome — `loaded`, `no-match`, or `not-configured` — and writes a deterministic `last_action` breadcrumb from that outcome, so the one-line audit trail the specify command used to ask the AI to author is now derived from what the script actually did rather than the model's reading of it. This is what stops "correctly did nothing" from being misjudged as "not configured."
 
 #### Scenario: an enabled registry with a matching change
 - **WHEN** the recorder runs with changed files a configured capability owns
@@ -212,3 +212,40 @@ The capture runtime SHALL provide a script that, given a feature directory and t
 #### Scenario: the feature is off or nothing matches
 - **WHEN** the registry is absent or disabled, or no capability owns the changed files
 - **THEN** the recorder writes nothing and exits successfully
+
+#### Scenario: the recorder writes its own audit breadcrumb
+- **WHEN** the recorder finishes — whether it matched, found no match, or found the feature not configured
+- **THEN** it writes a `last_action` breadcrumb naming that outcome itself, rather than the specify command asking the model to author the line
+
+### Completion accounts for every loaded capability — fold it, or record a reasoned skip
+
+A capability recorded on `livingSpecs.loaded` is a promise the run will settle it. Completion MUST close that loop for each loaded capability: either fold a requirement delta into its spec, or record an explicit skip note saying why it was left untouched. The runtime SHALL provide a skip writer (`--living-spec-skip "<name>: <reason>"`) that appends `{name, reason}` to `livingSpecs.skipped`, de-duped on the name with the first reason winning. A skip MUST both name a capability and justify it — an entry with a blank reason is dropped and warned about on stderr, so an unexplained skip never counts as accountability and the capability stays unaccounted. The fold's backstop then computes, in BOTH its no-delta branch and its partial-fold branch, the loaded capabilities that are neither folded (this run or on a prior run) nor skipped, and reports that gap loudly and actionably; when every loaded capability is accounted for it says so out loud — "correctly nothing," visibly distinct from the silently-nothing gap.
+
+#### Scenario: a loaded capability the change didn't alter
+- **WHEN** completion records a reasoned skip for a loaded capability
+- **THEN** the note lands on `livingSpecs.skipped` and the fold treats that capability as accounted
+
+#### Scenario: a skip with no reason
+- **WHEN** a skip note carries a name but a blank reason
+- **THEN** it is not recorded, the omission is warned on stderr, and the capability stays unaccounted
+
+#### Scenario: a loaded capability is neither folded nor skipped
+- **WHEN** the fold runs with a loaded capability that has no delta block and no skip note
+- **THEN** the fold names it as unaccounted and points at the two ways to close the loop
+- **AND** a partial fold that authored a delta for one capability does not silence the gap for the others
+
+#### Scenario: an already-synced spec is folded again
+- **WHEN** a spec whose capabilities were folded on a prior run is re-folded, writing nothing new
+- **THEN** the persisted `livingSpecs.synced` names keep those capabilities accounted and the backstop does not false-alarm
+
+### An unmatched MODIFIED requirement is promoted to ADDED, not dropped
+
+A requirement authored under `## MODIFIED Requirements` that matches no existing heading in the living spec is a genuinely-new requirement, not a mistake. The fold SHALL append it as if it were ADDED — resolving its heading through the delta set's renames first — and count it separately from applied modifications, rather than silently discarding it as an unmatched target. This promotion stays idempotent: a re-fold that finds the promoted requirement already present appends nothing.
+
+#### Scenario: a MODIFIED heading matches nothing
+- **WHEN** the fold applies a MODIFIED delta whose heading is absent from the living spec
+- **THEN** the requirement is appended and reported as promoted, not skipped
+
+#### Scenario: the promoted requirement is folded again
+- **WHEN** the same delta set is folded a second time
+- **THEN** the already-present requirement is left in place and nothing is duplicated

--- a/src/core/core.spec.md
+++ b/src/core/core.spec.md
@@ -74,6 +74,11 @@ A span SHALL be reported as trustworthy only when both of its boundaries were st
 - **WHEN** a step's start or end was written by something other than the extension
 - **THEN** the span is marked untrusted and no elapsed time is rendered for it
 
+#### Scenario: the whole run's elapsed time is requested
+- **WHEN** a run-level timing summary is derived from the history log
+- **THEN** a start, end, and elapsed span appear only if every expected phase has a trustworthy closed span; otherwise the summary reports how many phases were measured and stays incomplete
+- **AND** the summary is derived in memory, never persisted, so the history log stays the only timing source on disk
+
 ### The extension notices spec changes wherever specs live
 
 File watchers SHALL be registered from the configured spec patterns, not from a single hardcoded directory, so a workspace using any supported layout still gets live updates. Watching only one layout is a known regression shape: a context write goes unobserved, the open viewer never refreshes, and a newly created spec never clears the empty state.
@@ -131,6 +136,22 @@ Every telemetry payload SHALL contain only enum-like values, booleans, versions,
 - **THEN** a random identifier is minted and persisted so later events for the same spec correlate
 - **AND** a failure to persist it does not block the event
 
+#### Scenario: the extension activates
+- **WHEN** the activation event fires
+- **THEN** it carries only versions, a spec count, a companion-installed boolean, and enum-like feature-flag states — never a spec name, path, or user-authored workflow name
+
+### Engagement is counted without naming what was engaged
+
+The extension SHALL emit a bare event when a spec, a living spec, or a steering document is opened, and when a living-spec drift or sync runs — carrying no property at all, so a count can never be tied to a name or path. The install-banner funnel is likewise reported as fixed `shown`/`clicked` × surface literals produced only by our own call sites. Opened-in-viewer events MUST be de-duplicated per session so a re-rendering panel cannot inflate the count, and the de-dupe key used for that MUST be an internal identity that is never sent. A de-dupe slot MUST be claimed only after an event actually emits, so an open that happened while telemetry was off or uninitialized still fires once telemetry becomes available.
+
+#### Scenario: the same spec is re-revealed in the viewer
+- **WHEN** the panel re-renders and would re-emit the open event
+- **THEN** only the first open of that spec this session is sent, keyed by an identity that never leaves the process
+
+#### Scenario: a spec is opened while telemetry is disabled
+- **WHEN** the event cannot be sent yet
+- **THEN** no de-dupe slot is consumed, so the first successful send still happens once telemetry turns on
+
 ### Context keys have one writer and one catalogue
 
 VS Code context keys SHALL be written through a single wrapper that accepts only catalogued key names and logs failures. Activation MUST reset every catalogued key, so a value from a previous session cannot leak into the new one and leave a menu affordance stuck.
@@ -142,6 +163,14 @@ VS Code context keys SHALL be written through a single wrapper that accepts only
 #### Scenario: the extension activates
 - **WHEN** startup runs
 - **THEN** every catalogued key is reset to its default
+
+### A spec's display name resolves by preference without changing its identity
+
+A readable display name SHALL be resolved by preference — a recorded name first, then a document heading, then a humanized form of the directory slug — while the directory slug remains the stable identifier. A blank or whitespace-only candidate MUST be treated as absent so it can never win over the humanized-slug fallback.
+
+#### Scenario: a spec has no recorded name
+- **WHEN** a display name is needed and the recorded name is empty or whitespace
+- **THEN** a document heading is used when present, otherwise the humanized slug — and the slug still identifies the spec
 
 ### Shared primitives absorb host and shell differences
 

--- a/src/features/spec-editor/spec-editor.spec.md
+++ b/src/features/spec-editor/spec-editor.spec.md
@@ -45,7 +45,7 @@ The workflow list SHALL be built from what the active AI provider supports and w
 
 ### A missing dependency degrades or refuses, but never dispatches something unresolvable
 
-When a chosen action needs the companion piece and it is absent, the host SHALL either downgrade to the equivalent stock action or, when there is no equivalent, refuse to start at all. Either way the user gets a non-blocking explanation and a one-click way to install. Dispatching a command the AI cannot resolve is never acceptable.
+When a chosen action needs the companion piece and it is absent, the host SHALL either downgrade to the equivalent stock action or, when there is no equivalent, refuse to start at all. Either way the user gets a non-blocking explanation and a one-click way to install. Dispatching a command the AI cannot resolve is never acceptable. When the panel surfaces its install prompt, and when the user takes it, the host SHALL record the exposure and the click so install-prompt adoption can be measured.
 
 #### Scenario: the Companion entry point is chosen without the companion piece
 - **WHEN** the user submits

--- a/src/features/spec-viewer/spec-viewer.spec.md
+++ b/src/features/spec-viewer/spec-viewer.spec.md
@@ -36,6 +36,20 @@ Everything the reader sees about *where the spec stands* — the status badge, w
 - **THEN** those earlier steps are treated as completed by their position in the ordering
 - **AND** no step is left falsely pulsing
 
+### Timing is reported by real wall-clock spans, and only timed steps count toward coverage
+
+The viewer MUST derive a timing summary from the spec's recorded step history and surface a step's wall-clock duration only when both of that step's boundaries were stamped by the extension and fall in order; a span that fails that trust test is withheld rather than shown as a guessed or capped figure. When the run is not fully trusted the viewer reports a plain "X of Y phases" coverage statement instead. The coverage denominator MUST count only steps that are expected to be timed — a step declared untimed (one that merely flips the spec's status without ever writing a start/complete boundary, such as the terminal completion step) SHALL be excluded from Y, so a fully-captured completed run reaches its full coverage and shows its elapsed span rather than stalling one short.
+
+#### Scenario: a completed run includes a status-only terminal step
+- **WHEN** a completed spec's workflow ends with an untimed step that only records completion
+- **THEN** that step is left out of the timing denominator
+- **AND** the run reads as fully covered and its started/elapsed/ended span is shown
+
+#### Scenario: a step's boundaries are not both trustworthy
+- **WHEN** one of a step's start/complete stamps is missing, out of order, or overlaps an adjacent phase
+- **THEN** no duration is claimed for that step
+- **AND** the viewer falls back to the coverage statement rather than a fabricated time
+
 ### One fact has exactly one derivation
 
 Any fact this feature shares with another surface — the sidebar tree, the Living Specs panel, task counting, in-flight detection — MUST be read from that fact's single owning module rather than recomputed here. Two independent derivations of the same fact will drift, and every time this repo has shipped one, the two surfaces eventually contradicted each other in front of the user.
@@ -49,6 +63,11 @@ Any fact this feature shares with another surface — the sidebar tree, the Livi
 - **WHEN** the header shows both a requirement count and a covered-of-total ratio
 - **THEN** both are counted off the same requirement identifiers
 - **AND** the count and the denominator always match
+
+#### Scenario: the header and the sidebar both name a spec
+- **WHEN** the header renders a spec's display name and the sidebar tree renders the same spec's row
+- **THEN** both resolve the name through one shared resolver — recorded name first, then the document heading, then a humanized slug — so a raw directory slug is never shown when a readable title exists
+- **AND** the two surfaces cannot show different names for the same spec, while the slug stays the stable identifier behind filtering, sorting, and open
 
 ### Every refresh ships a complete state snapshot from one builder
 
@@ -175,17 +194,36 @@ When a step's recorded completion appears, the viewer SHOULD tell the reader, wi
 
 ### A living spec is presented as a capability, not a run
 
-A living-spec panel MUST drop the workflow machinery entirely — no run state, no phases, no forward actions — and present the capability's tiers as the only navigation. Its title comes from the capability's own spec document whichever tier is displayed, so the title belongs to the capability rather than to the tab on screen. A document that declares itself a draft SHALL be badged as one rather than presented as settled.
+A living-spec panel MUST drop the workflow machinery entirely — no run state, no phases, no workflow forward action — and present the capability's tiers as the only navigation. Its title comes from the capability's own spec document whichever tier is displayed, so the title belongs to the capability rather than to the tab on screen. A document that declares itself a draft SHALL be badged as one rather than presented as settled. The one action the panel MAY offer is a capability-maintenance affordance — an Update control that folds code changes back into the spec — which resolves the capability's spec tier from the panel's own source anchor and hands off to the shared living-specs update command so it builds the same prompt the sidebar's Update-drifted action does.
 
 #### Scenario: the architecture tier is selected
 - **WHEN** a non-spec tier is displayed
 - **THEN** the header still shows the capability's title as authored in its spec tier
 - **AND** no workflow status or forward action appears
 
+#### Scenario: the reader asks to update a drifted living spec
+- **WHEN** the reader triggers Update from a living-spec panel
+- **THEN** the capability's spec-tier path is resolved from the panel's source anchor, not from the tab on screen
+- **AND** the request is routed through the same living-specs update command the sidebar uses, so both entry points fold back identically
+
 #### Scenario: the document carries a draft banner near its top
 - **WHEN** the spec declares itself a draft
 - **THEN** the header badges it as a draft
 - **AND** the in-document banner is left intact
+
+### Living specs surfaced in the run log are compact chips that hand off to their own viewer
+
+When a run loaded living specs, the viewer MUST surface them in the run log as compact, clickable chips rather than dumping each capability's purpose and requirements inline — the full content belongs in the Living Specs viewer, not the run strip. A capability earns a clickable chip only when its spec resolves to a file that exists within the workspace root; a capability that cannot be resolved or falls outside the root stays present but unavailable, and any unexpected failure leaves the names-only list untouched. Clicking a chip MUST open that capability in the viewer's living mode, confining the supplied path within the root before it reaches the filesystem.
+
+#### Scenario: a loaded capability resolves within the workspace
+- **WHEN** the run log lists a living spec whose document exists inside the workspace
+- **THEN** it renders as a chip carrying that capability's workspace-relative path
+- **AND** clicking it opens the capability in the living-spec viewer rather than expanding content in place
+
+#### Scenario: a capability cannot be resolved
+- **WHEN** a loaded living spec has no resolvable in-root document
+- **THEN** it is still listed but is not made clickable
+- **AND** the run log never renders the capability's purpose or requirement rows inline
 
 ### The webview shell is generated under a locked-down policy
 

--- a/src/features/steering/steering.spec.md
+++ b/src/features/steering/steering.spec.md
@@ -108,6 +108,19 @@ Creating, initializing, refining, and cleaning up after deleting a steering docu
 - **THEN** a follow-up prompt asks the assistant to drop references to it from the project rules file
 - **AND** a failure of that follow-up is surfaced without leaving the deletion half-reported
 
+### Opening a steering document is counted as a usage signal
+
+Clicking a generated steering document or a workflow reference row SHALL route through the extension's own open command, which records a `steering.opened` telemetry event before handing the file to the editor. The count is what tells us whether the view is actually consulted; a raw editor-open would open the file but leave that use invisible. Only these extension-authored and reference rows are counted — provider-owned, SpecKit-owned, and Companion command and template rows open directly and emit nothing.
+
+#### Scenario: the user opens a generated steering document from the tree
+- **WHEN** the row is clicked
+- **THEN** a `steering.opened` event is recorded, counted once per open
+- **AND** the document then opens in the editor
+
+#### Scenario: the user opens a provider-owned or SpecKit-owned file
+- **WHEN** that row is clicked
+- **THEN** the file opens directly with no `steering.opened` event
+
 ### Unreadable or malformed configuration degrades to an empty section
 
 Any parse or read failure while assembling a section SHALL yield an empty result for that section rather than an error dialog or a failed render. The steering view is ambient context, so one broken YAML file must not take the tree down.

--- a/webview/src/spec-editor/editor-ui.spec.md
+++ b/webview/src/spec-editor/editor-ui.spec.md
@@ -101,9 +101,17 @@ While the extension is working, the editor MUST prevent a second submission from
 
 ### The Storybook mock stays a faithful stand-in for the real form
 
-Because the shipped editor is imperative DOM rather than a component tree, a separate Preact mock exists purely as the visual baseline. That mock MUST reflect the real form's states — empty, over-limit, submitting, and hands-off-available-or-not — so a reviewer reading Storybook is not shown an arrangement the product never produces. When the real form gains or loses a state, updating the mock is part of that change, not a follow-up. [inferred]
+Because the shipped editor is imperative DOM rather than a component tree, a separate Preact mock exists purely as the visual baseline. That mock MUST reflect the real form's states — empty, over-limit, submitting, hands-off-available-or-not, attachments-present, and a narrow (split-pane) layout — so a reviewer reading Storybook is not shown an arrangement the product never produces. To keep the visuals honest, the mock MUST render through the shipped `spec-editor.css` using the real form's class names and native controls (`textarea`, workflow `select`) rather than bespoke inline styles, so it inherits the product's styling instead of re-declaring it. When the real form gains or loses a state, updating the mock is part of that change, not a follow-up. [inferred]
 
-This duplication is accepted for now and its cost is recorded plainly: the mock is hand-maintained, nothing enforces that it matches, and a stale mock misrepresents the product to every reviewer who trusts it.
+This duplication is accepted for now and its cost is recorded plainly: the mock is still hand-maintained and nothing enforces that its structure matches the real DOM, so a stale mock misrepresents the product to every reviewer who trusts it — though sharing the shipped stylesheet narrows the drift to structure rather than appearance.
+
+#### Scenario: attachments are present
+- **WHEN** the form is shown with images attached
+- **THEN** the mock renders each as a thumbnail carrying its name and a remove control, matching the real preview list
+
+#### Scenario: the panel is narrow
+- **WHEN** the editor is shown in a constrained (split-pane) width
+- **THEN** the mock exercises that layout so the responsive arrangement is reviewable
 
 #### Scenario: a submission state is added or changed
 - **WHEN** the real form gains a new visual state

--- a/webview/src/spec-viewer/viewer-ui.spec.md
+++ b/webview/src/spec-viewer/viewer-ui.spec.md
@@ -71,6 +71,13 @@ Any value that originated in the spec's record or in user configuration — a st
 
 The rendering pipeline MUST emit each source line as an addressable, hoverable unit carrying its own line number and an affordance to attach a comment, so annotation works anywhere in the document without a separate mode. Authoring scaffolding that belongs to the generator rather than the reader — front matter, notation legends, metadata already shown in the header — SHALL be stripped rather than rendered. Structured passages the specs use repeatedly (user stories, phased task lists, requirement blocks, acceptance scenarios, callouts) SHOULD be recognised and rendered as their own components rather than as generic prose, and those components stay commentable too.
 
+The attach-a-comment affordance MUST name the specific line it targets in its accessible label rather than carrying a generic one, so that identical controls repeated down the document are distinguishable to assistive technology; the glyph inside it is decorative and MUST be hidden from that tree.
+
+#### Scenario: a line's comment affordance is reached without a pointer
+- **WHEN** the reader tabs to a line's add-comment control
+- **THEN** it announces the particular line it will annotate, not a generic "add comment"
+- **AND** the glyph inside it is hidden from assistive technology
+
 #### Scenario: a document written with foreign line endings
 - **WHEN** the source uses carriage returns
 - **THEN** line endings are normalised before any block-level parsing
@@ -124,10 +131,17 @@ Anything that marks an element on open — an editor, a comment container — MU
 
 Adding, editing, or removing a comment MUST post the change to the extension rather than write anything itself; the local card is a rendering of the record, not the record. An edit that changes nothing, or that resolves to no target, SHALL be a no-op rather than a posted mutation. Dispatching refinement for a document MUST clear the local cards and let the refreshed record re-render them, so what is shown after the round trip is what was actually persisted.
 
+The line-level structural actions (remove a story, scenario, task, section, or line) are likewise requests the webview posts, not edits it performs. They MUST be labelled as suggestions rather than as direct removals, so the reader is never told a click deletes content the webview does not itself remove.
+
 #### Scenario: a comment is deleted
 - **WHEN** the reader deletes a card
 - **THEN** the removal is posted, the card unmounts, and focus returns to the line's own control
 - **AND** the pending count updates
+
+#### Scenario: a reader picks a structural line action
+- **WHEN** the reader chooses to remove a story, scenario, task, section, or line from its menu
+- **THEN** the control reads as a suggestion, not a direct removal
+- **AND** the request is posted for the AI to act on rather than editing the document in place
 
 ### A settled spec is readable but not annotatable
 
@@ -199,6 +213,40 @@ Readable content MUST use the body and primary text tokens; the secondary and mu
 - **WHEN** a step is in flight
 - **THEN** the in-flight indicator renders without animation
 
+### Run timing is a summary the extension provides, not a duration the webview sums
+
+Elapsed time and per-phase coverage MUST be read from the timing summary the extension sends, never recomputed in the webview from per-step activity timestamps. The webview SHALL NOT sum step spans, cap idle gaps, or otherwise derive a working-time figure of its own; it renders the summary's completion flag, its elapsed figure, and its measured-of-expected phase count as given. A run that has not settled surfaces phase coverage — "N of M phases" — not a fabricated wall-clock total; only a summary that reports itself complete surfaces a start, an elapsed figure, and an end.
+
+Recorded substep events are journal moments, not measured work. Each event carries the timestamp at which it was recorded, is ordered by it, and is shown as "recorded at" that moment. The webview SHALL NOT present the gap between a substep's start and finish as a duration, because an AI or CLI finish is a cadence record rather than a measured piece of work.
+
+#### Scenario: a run is still in flight
+- **WHEN** the timing summary reports itself not yet complete
+- **THEN** the run surfaces measured-of-expected phase coverage
+- **AND** no start, elapsed, or end figure is shown as if the run had settled
+
+#### Scenario: a recorded substep event is displayed
+- **WHEN** a tracked substep is rendered in the phase history
+- **THEN** it reads as "recorded at" its journal timestamp
+- **AND** the span between its start and finish is not presented as a work duration
+
+### The pipeline rail lists document-producing steps only
+
+The rail MUST render only steps that produce a document of their own; steps that merely act — Implement, Mark Complete, any custom step with no document — never appear as rail entries. Every index the rail computes — its root phase, the host of the live implement percent, the in-flight step that locks later tabs — MUST be computed against the rendered list, so a hidden acting step can neither shift a tab nor lock one. An acting step that is running therefore contributes no lock, because it holds no rail position to lock from.
+
+#### Scenario: an acting step is the running step
+- **WHEN** a step with no document of its own is in flight
+- **THEN** it does not appear in the rail
+- **AND** it locks none of the document tabs
+
+### Durable context leads the panel; the granular run history stays collapsed
+
+The activity panel MUST lead with the run's lifecycle signal and durable context — intent, the run's timing overview, the living specs it touched, verified proof, decisions, coverage — and demote the granular run history (phase events, tasks, concerns, files, comments) into a collapsed log below. The living specs a feature touched and its run-timing overview belong to that durable context and render inline in the overview's intent, not as separate run-log cards. A living-spec chip is always a link that opens its capability by name; a stored spec path, when present, rides along but is not required for the chip to be clickable.
+
+#### Scenario: a spec touched living specs
+- **WHEN** the overview renders
+- **THEN** the touched capabilities appear as links inside the intent, not as a separate card
+- **AND** selecting one opens that capability by name
+
 ## Uncovered
 
 The following files were not read in full — their exported surface and role were established, but their bodies were not reviewed line by line:
@@ -206,19 +254,14 @@ The following files were not read in full — their exported surface and role we
 - `webview/src/spec-viewer/markdown/preprocessors.ts` (read partially; only the first ~60 lines and the export inventory)
 - `webview/src/spec-viewer/toc.ts`
 - `webview/src/spec-viewer/highlighting.ts`
-- `webview/src/spec-viewer/timelineEvents.ts`
 - `webview/src/spec-viewer/relativeTime.ts`
 - `webview/src/spec-viewer/activityHeroModel.ts`
 - `webview/src/spec-viewer/elapsedFormat.ts`
-- `webview/src/spec-viewer/types.ts`
 - `webview/src/spec-viewer/components/InlineEditor.tsx`
-- `webview/src/spec-viewer/components/TimelineEvent.tsx`
 - `webview/src/spec-viewer/components/cards/TasksCard.tsx`
 - `webview/src/spec-viewer/components/cards/FilesCard.tsx`
 - `webview/src/spec-viewer/components/cards/ConcernsCard.tsx`
 - `webview/src/spec-viewer/components/cards/CommentsCard.tsx`
-- `webview/src/spec-viewer/components/cards/LivingSpecsCard.tsx`
-- `webview/src/spec-viewer/components/cards/PhasesCard.tsx`
 - `webview/src/spec-viewer/components/cards/toStringArray.ts`
 - `webview/src/spec-viewer/components/index.ts`
 - All `*.stories.tsx` files and all files under `__tests__/`


### PR DESCRIPTION
## What

The living specs had drifted — recent merged work changed code across 10 capabilities (52 files, all `unspeced`) without re-folding the specs. This syncs each spec to the real current behavior, in its existing requirement+scenario format, preserving every still-valid requirement.

Authored per-capability from each spec's actual drift diff (`git diff <spec's last commit>..HEAD`), one focused update each. `speckit-cli` was a pure doc-comment refactor and is intentionally unchanged.

## Coverage

| Capability | What was folded back |
|---|---|
| capture-runtime | deterministic gate outcome + breadcrumb, skip notes/accountability, promoted MODIFIED→ADDED |
| companion-commands | completion accountability + skip notes, deterministic specify-time load, fast-path capture parity |
| core | engagement telemetry (names never sent), TimingSummary, display-name resolver |
| spec-viewer / viewer-ui | wall-clock timing + untimed steps, compact chips + Update control, doc-only rail, comment a11y |
| steering | steering.opened usage signal |
| workflows | companion selectability (installed-only), untimed step attr, formatDocName |
| editor-ui / spec-editor | install-prompt telemetry, mock-fidelity states |

## Notes

Docs-only (living specs are markdown). Drift badges clear once this lands. No runtime code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)