### PR TITLE
fix(spec-viewer): single divider under the coverage header, not a doubled rule (#545)

### DIFF
--- a/webview/styles/spec-viewer/_overview-dossier.css
+++ b/webview/styles/spec-viewer/_overview-dossier.css
@@ -410,9 +410,7 @@
     grid-template-columns: minmax(0, 1.55fr) minmax(120px, 0.55fr) minmax(130px, 0.5fr);
     gap: var(--space-4);
     padding: 0 12px 8px;
-    /* Own the single divider under the column labels; the coverage container no
-       longer adds a second border-top (which stacked with these labels as a
-       doubled rule). */
+    /* The one divider under the labels — .dossier-coverage adds none in wide mode. */
     border-bottom: 1px solid var(--border);
     color: var(--text-label);
     font-family: var(--font-mono);
@@ -420,11 +418,6 @@
     font-weight: 700;
     text-transform: uppercase;
     letter-spacing: 0.08em;
-}
-
-.dossier-coverage {
-    /* No border-top: the label row above owns the divider. In narrow mode the
-       label row is hidden (below), so the border-top is restored there. */
 }
 
 .dossier-coverage__row {

--- a/webview/styles/spec-viewer/_overview-dossier.css
+++ b/webview/styles/spec-viewer/_overview-dossier.css
@@ -410,6 +410,10 @@
     grid-template-columns: minmax(0, 1.55fr) minmax(120px, 0.55fr) minmax(130px, 0.5fr);
     gap: var(--space-4);
     padding: 0 12px 8px;
+    /* Own the single divider under the column labels; the coverage container no
+       longer adds a second border-top (which stacked with these labels as a
+       doubled rule). */
+    border-bottom: 1px solid var(--border);
     color: var(--text-label);
     font-family: var(--font-mono);
     font-size: 10px;
@@ -419,7 +423,8 @@
 }
 
 .dossier-coverage {
-    border-top: 1px solid var(--border);
+    /* No border-top: the label row above owns the divider. In narrow mode the
+       label row is hidden (below), so the border-top is restored there. */
 }
 
 .dossier-coverage__row {
@@ -563,6 +568,11 @@
 
     .dossier-coverage__head {
         display: none;
+    }
+
+    .dossier-coverage {
+        /* Labels are hidden here, so the container owns the single top divider. */
+        border-top: 1px solid var(--border);
     }
 
     .dossier-coverage__row {


### PR DESCRIPTION
## What

The Overview **Coverage** section rendered a doubled horizontal rule between its header (`N/N traced`) and the first requirement.

## Cause

The column-label row (`.dossier-coverage__head`) sat flush under the section head with no top padding, and `.dossier-coverage` added its own `border-top` just below the labels — the faint uppercase labels plus that border read as two stacked lines.

## Fix

The label row now owns the single divider (`border-bottom`), and the container drops its `border-top`. In narrow mode the label row is `display: none`, so the container's `border-top` is restored inside the media query — exactly **one** divider in both wide and narrow layouts.

CSS-only; the existing coverage stories (`ActivityPanel`/`PageChrome`) are the visual baseline.

Closes #545

🤖 Generated with [Claude Code](https://claude.com/claude-code)