### PR TITLE
test(spec-viewer): guard completed fast-path timing with same-instant folded steps (#544)

### DIFF
--- a/src/features/spec-viewer/__tests__/stateDerivation.test.ts
+++ b/src/features/spec-viewer/__tests__/stateDerivation.test.ts
@@ -217,6 +217,25 @@ describe('deriveViewerState', () => {
             expect(timing.elapsedMs).toBeGreaterThan(0);
         });
 
+        it('a completed fast-path spec with same-instant folded plan/tasks still reaches 4 of 4', () => {
+            // 528-footer-done-guard shape: specify real, plan+tasks folded at the same instant
+            // as specify-complete (by:extension, sub-second), implement real. Must not read "0 of 4".
+            const folded = makeContext({
+                currentStep: 'implement',
+                status: 'completed',
+                history: [
+                    ...extPair('specify', '2026-07-22T20:45:44.000Z', '2026-07-22T20:51:14.000Z'),
+                    ...extPair('plan', '2026-07-22T20:51:14.000Z', '2026-07-22T20:51:14.082Z'),
+                    ...extPair('tasks', '2026-07-22T20:51:14.082Z', '2026-07-22T20:51:14.164Z'),
+                    ...extPair('implement', '2026-07-22T20:54:43.000Z', '2026-07-22T20:58:59.000Z'),
+                ],
+            });
+            const timing = deriveViewerState(folded, 'implement', companionSteps).timing;
+            expect(timing.measuredPhases).toBe(4);   // folded phases still count as measured
+            expect(timing.complete).toBe(true);
+            expect(timing.elapsedMs).toBeGreaterThan(0);
+        });
+
         it('a fast-path spec parked at ready-to-implement shows 3 of 4, not complete', () => {
             const parked = makeContext({
                 currentStep: 'tasks',


### PR DESCRIPTION
## What

#544 reported a completed fast-path spec showing "Timing coverage: 0 of 4 phases". **The bug was already fixed** before the issue was filed:
- **#517** (`990ca1ba`) — folded fast-path spans are trusted.
- **#518** (`07640d54`) — the untimed `mark-complete` step is excluded from the denominator.

Both landed 2026-07-21, before spec 528 ran (2026-07-22) and before #544 was filed. The "0 of 4" seen was a mid-run transient (correct during the long specify phase) or a not-yet-reinstalled build. The re-post-on-settle path is fully wired: `fileWatchers.ts` → `refreshContextIfDisplaying` re-derives the full viewer state (timing recomputed fresh, uncached) on **every** `.spec-context.json` write, and the webview fully replaces `viewerState` (no stale merge).

## The gap this closes

No test pinned the exact intersection the issue's Verify asks for — a **completed** fast-path spec with **same-instant folded** plan/tasks (`by: extension`, sub-second) surfacing **4/4 complete** through `deriveViewerState`. The existing `completedRun()` fixture uses multi-minute plan/tasks spans, so a future folded-span-trust regression could silently return "0/4" or "2/4" uncaught. This adds that guard (46 tests pass).

## Verify

`npm test` → the new case `a completed fast-path spec with same-instant folded plan/tasks still reaches 4 of 4` passes on current code.

Closes #544

🤖 Generated with [Claude Code](https://claude.com/claude-code)