### PR TITLE
fix(providers): Antigravity dispatches the real `agy` CLI, not a non-existent binary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - **The path to SpecKit Companion is now visible where you actually look.** When the Companion spec-kit extension isn't installed, the sidebar surfaces a one-click upgrade instead of hiding it: a dot on the SpecKit activity-bar icon, a pinned **Get Companion** row atop the Specs tree, a dismissable **Install SpecKit Companion** button in the empty Specs view, and **SpecKit Companion** always offered in Create New Spec — picking it shows the benefits and installs in one click first, then falls back to standard SpecKit if you decline. Every nudge disappears the moment the extension is installed, with no reload, and the old buried "Not installed" badge in the Steering view is retired. ([#543](https://github.com/alfredoperez/speckit-companion/issues/543))
-- **Antigravity joins the provider list.** You can now pick **Antigravity** — Google's agentic coding assistant — under **Settings > speckit.aiProvider**, and SpecKit commands dispatch to the `antigravity` CLI in an integrated terminal, the same way Codex, Gemini, and Qwen do. ([#546](https://github.com/alfredoperez/speckit-companion/issues/546))
+- **Antigravity joins the provider list.** You can now pick **Antigravity** — Google's agentic coding agent — under **Settings > speckit.aiProvider**, and SpecKit commands run in its `agy` command-line tool inside an integrated terminal, opened interactively so you can approve edits as they happen. If `agy` isn't installed yet, the extension offers its one-line install command. ([#546](https://github.com/alfredoperez/speckit-companion/issues/546))
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ Compare the file lists side by side to see the contrast between the full and min
 | **Agents** | .claude/agents/*.md | .github/agents/*.agent.md | Limited support | Hierarchical AGENTS.md | Not supported | .opencode/agent/*.md | Not supported | .claude/agents/*.md | .wibey/agents/*.md | .wibey/agents/*.md | Not supported |
 | **Hooks** | .claude/settings.json | Not supported | Not supported | Not supported | Not supported | Not supported | Not supported | .claude/settings.json | .wibey/hooks/hooks.json | .wibey/hooks/hooks.json | Not supported |
 | **MCP Servers** | .claude/settings.json | ~/.copilot/mcp-config.json | ~/.gemini/settings.json | ~/.codex/config.toml | ~/.qwen/settings.json | ~/.opencode/opencode.jsonc | Not supported | .claude/settings.json | .wibey/.mcp.json | .wibey/.mcp.json | Not supported |
-| **CLI Command** | `claude` | `ghcs` / `gh copilot` | `gemini` | `codex` | `qwen` | `opencode` | Built-in editor chat (Copilot / Composer / Cascade) | Claude Code GUI panel (no terminal) | `wibey` | Wibey chat panel (no terminal) | `antigravity` |
+| **CLI Command** | `claude` | `ghcs` / `gh copilot` | `gemini` | `codex` | `qwen` | `opencode` | Built-in editor chat (Copilot / Composer / Cascade) | Claude Code GUI panel (no terminal) | `wibey` | Wibey chat panel (no terminal) | `agy` |
 
 Configure your preferred provider: **Settings > speckit.aiProvider**
 

--- a/package.json
+++ b/package.json
@@ -1025,7 +1025,7 @@
               "IDE Chat - Routes prompts to the host editor's built-in AI chat (Copilot / Cursor / Windsurf)",
               "Wibey CLI - Walmart's built-in AI coding assistant (dispatches SpecKit commands to the wibey CLI in a VS Code terminal)",
               "Wibey (VS Code) - Opens the Wibey chat panel and pre-fills the command (uses wibey.sendPrompt when available, clipboard fallback otherwise)",
-              "Antigravity - Google's agentic coding assistant (dispatches SpecKit commands to the antigravity CLI in a VS Code terminal)"
+              "Antigravity - Google's agentic coding agent (runs the `agy` CLI interactively in a VS Code terminal)"
             ],
             "scope": "machine",
             "order": 2,

--- a/src/ai-providers/__tests__/antigravityProvider.test.ts
+++ b/src/ai-providers/__tests__/antigravityProvider.test.ts
@@ -8,7 +8,15 @@ describe('Antigravity provider', () => {
         const entry = PROVIDER_PATHS[AIProviders.ANTIGRAVITY];
         expect(entry).toBeDefined();
         expect(entry.displayName).toBe('Antigravity');
-        expect(entry.commandFormat).toBe('dot');
+        expect(entry.commandFormat).toBe('dash');
+    });
+
+    it('dispatches the `agy` binary interactively (-i), not the non-existent `antigravity` CLI', () => {
+        const outputChannel = { appendLine: jest.fn() } as any;
+        const provider = new AntigravityCliProvider({} as any, outputChannel) as any;
+        expect(provider.cliBinary).toBe('agy');
+        expect(provider.cliPromptFlag()).toBe('-i ');
+        expect(provider.installHint.installCommand).toContain('antigravity.google/cli/install.sh');
     });
 
     it('resolves the antigravity setting value to AntigravityCliProvider', () => {

--- a/src/ai-providers/aiProvider.ts
+++ b/src/ai-providers/aiProvider.ts
@@ -433,11 +433,12 @@ const _PROVIDER_PATHS_RAW: Record<AIProviderType, ProviderPaths> = {
         supportsInteractivePermissions: true,
         autoApproveFlag: '',
     },
-    // Antigravity — Google's agentic coding CLI. Dispatched as a terminal-CLI
-    // provider (same family as Codex/Gemini/Qwen). Config paths beyond dispatch
-    // are conservative: project-root AGENTS.md steering, nothing claimed for
-    // agents/skills/hooks/MCP that isn't confirmed. These can be tightened once
-    // the tool's layout is verified; they never affect the core dispatch.
+    // Antigravity — Google's terminal agent, the `agy` CLI (successor to Gemini
+    // CLI), dispatched interactively (`agy -i`). Its spec-kit commands install as
+    // dash-named skills for the `agy` agent, so commandFormat is 'dash' (matching
+    // the ide-chat Antigravity host). Config paths beyond dispatch are
+    // conservative: project-root AGENTS.md steering, nothing claimed for
+    // agents/skills/hooks/MCP that isn't confirmed.
     [AIProviders.ANTIGRAVITY]: {
         steeringFile: 'AGENTS.md',
         globalSteeringFile: null,
@@ -451,9 +452,9 @@ const _PROVIDER_PATHS_RAW: Record<AIProviderType, ProviderPaths> = {
         configDir: '.antigravity',
         supportsHooks: false,
         displayName: 'Antigravity',
-        commandFormat: 'dot',
+        commandFormat: 'dash',
         quickPickIcon: '$(rocket)',
-        quickPickDescription: "Google's agentic coding assistant — terminal mode",
+        quickPickDescription: "Google's agentic coding agent — runs the `agy` CLI in an interactive terminal",
         supportsInteractivePermissions: true,
         autoApproveFlag: '',
     },

--- a/src/ai-providers/antigravityCliProvider.ts
+++ b/src/ai-providers/antigravityCliProvider.ts
@@ -2,27 +2,29 @@ import { AIProviders } from '../core/constants';
 import { CliTerminalProvider } from './cliTerminalProvider';
 
 /**
- * Antigravity CLI provider — `antigravity -p "$(cat <tmp>)"`.
+ * Antigravity CLI provider — `agy -i "$(cat <tmp>)"`.
  *
- * Google's agentic coding tool. Shape is the default `CliTerminalProvider`
- * pattern (same as Qwen): write the prompt to a temp file, invoke the CLI
- * with `-p`, clean up. The slash-command entry passes the slash through.
- *
- * The exact binary name and prompt flag are the one detail that can't be
- * verified from inside this repo; they're isolated here so a maintainer can
- * correct them in one place if the real invocation differs.
+ * Google's Antigravity ships a terminal agent, the `agy` binary (the successor
+ * to Gemini CLI). It is agentic and interactive: `-p` runs a single prompt
+ * non-interactively and hangs waiting for tool-approval prompts, so we dispatch
+ * with `-i` / `--prompt-interactive` — "run an initial prompt interactively and
+ * continue the session" — which lets the user approve edits/commands live in the
+ * terminal, the same shape as the other CLI agents.
  */
 export class AntigravityCliProvider extends CliTerminalProvider {
     public readonly name = 'Antigravity';
     public readonly type = AIProviders.ANTIGRAVITY;
 
-    protected readonly cliBinary = 'antigravity';
-    // Antigravity is a download — surface the install page as an openable URL, not a copyable command.
+    protected readonly cliBinary = 'agy';
     protected readonly installHint = {
-        displayName: 'Antigravity CLI',
-        installUrl: 'https://antigravity.google',
+        displayName: 'Antigravity CLI (agy)',
+        installCommand: 'curl -fsSL https://antigravity.google/cli/install.sh | bash',
     };
     protected readonly defaultTerminalTitle = 'SpecKit - Antigravity';
     protected readonly headlessTerminalName = 'Antigravity Background';
     protected readonly logPrefix = 'Antigravity';
+
+    protected cliPromptFlag(): string {
+        return '-i ';
+    }
 }

--- a/src/ai-providers/ideChatProvider.ts
+++ b/src/ai-providers/ideChatProvider.ts
@@ -223,8 +223,13 @@ export class IdeChatProvider implements IAIProvider {
                 this.outputChannel.appendLine(
                     `[IdeChatProvider] No chat command available for ${profile.label} — cannot dispatch`
                 );
+                // Antigravity has no chat command we can drive — but it ships the `agy`
+                // CLI, which the dedicated Antigravity provider runs. Name it directly.
+                const hint = host === 'antigravity'
+                    ? 'Switch `speckit.aiProvider` to **Antigravity** to run this command in its `agy` CLI.'
+                    : SWITCH_TO_CLI_HINT;
                 vscode.window.showWarningMessage(
-                    `SpecKit Companion couldn't find a built-in AI chat to open in this editor. ${SWITCH_TO_CLI_HINT}`
+                    `SpecKit Companion couldn't find a built-in AI chat to open in this editor. ${hint}`
                 );
                 return false;
             }


### PR DESCRIPTION
## What was broken

The Antigravity provider added in #546 (still under `[Unreleased]`, never shipped) guessed the wrong command-line tool. It assumed a binary named `antigravity` invoked with `-p`. Neither is right:

- Antigravity's terminal agent is **`agy`** (a Go binary, the successor to Gemini CLI), installed to `~/.local/bin/` via `curl -fsSL https://antigravity.google/cli/install.sh | bash`.
- `-p` runs a single prompt **non-interactively** and hangs waiting for tool-approval prompts — useless for an agentic coding tool that writes files.

So selecting **Antigravity** could never dispatch, and routing it through **IDE Chat** silently no-op'd (Antigravity's Agent isn't Copilot's `workbench.action.chat.open`).

## The fix

Antigravity stays a first-class terminal-CLI provider — just wired to the real tool:

- **`cliBinary = 'agy'`**, dispatched with **`-i` / `--prompt-interactive`** ("run the initial prompt interactively and continue the session") so edits/commands are approved live in the terminal, exactly like the other CLI agents.
- Install detection via `agy --version`; the install hint is the real one-line installer.
- `commandFormat: 'dash'` to match the `agy` agent's dash-named spec-kit skills (and the existing ide-chat Antigravity host).
- IDE Chat, selected inside Antigravity, now points the user at the **Antigravity** provider by name instead of a generic "Claude, Gemini" hint.

## How to verify

1. Settings → `speckit.aiProvider` → **Antigravity**.
2. Open a spec → **Plan** → a `SpecKit - Antigravity` terminal opens and runs `agy -i "…"` interactively.

Manually verified on macOS in both VS Code and the Antigravity IDE (v0.30.11 local build): selecting **Antigravity** opens the `agy` CLI and dispatches. `agy` 1.1.6 confirmed installed and responding.

## Notes

- No `Closes` — #546 is already merged; this corrects it before it ever releases. The `[Unreleased]` changelog entry for #546 is rewritten in place rather than adding a contradicting line.
- One detail only a live agy run can confirm: whether its spec-kit skills resolve as `/speckit-plan` (dash, chosen here) or `/speckit.plan` (dot). Isolated to `commandFormat`, trivially flipped if the run shows otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)