### PR TITLE
fix: viewer step-tab strip no longer overlaps nested sub-docs at narrow width

### DIFF
--- a/webview/src/spec-viewer/FullViewer.stories.tsx
+++ b/webview/src/spec-viewer/FullViewer.stories.tsx
@@ -473,3 +473,23 @@ export const Implementing172: Story = {
         />
     ),
 };
+
+// ── 172 · narrow pane · the rail folds to a horizontal strip ──
+// Below a container width of 900px the doc-rail becomes a horizontal scrolling
+// strip. Each step keeps its nested artifact chips (#504); the pane is pinned
+// narrow so those sub-docs stay inside their own step column instead of bleeding
+// into the neighbouring tab (#560).
+export const NarrowPaneFold172: Story = {
+    name: '172 · Narrow pane (rail folds horizontal, nested sub-docs)',
+    render: () => (
+        <div style="width: 760px; max-width: 100%; height: 100vh; overflow: hidden;">
+            <InteractiveViewer
+                ctx={ctx172}
+                docs={docs172}
+                initialDoc="plan"
+                view="document"
+                vs={vsFromContext(ctx172, completedFooter)}
+            />
+        </div>
+    ),
+};

--- a/webview/styles/spec-viewer/_base.css
+++ b/webview/styles/spec-viewer/_base.css
@@ -220,6 +220,23 @@ body {
         background: var(--bg-secondary);
     }
 
+    /* #504 nests each step's artifacts in a `.step-tab-group` (the tab plus a
+       `.step-substeps` column). In the horizontal fold that wrapper must own a
+       column sized to its WIDEST child — left as a plain block it collapses to
+       the tab button's width and the wider sub-doc chips overflow into the next
+       tab's column (#560). */
+    .doc-rail .rail-group .step-tabs > .step-tab-group {
+        display: flex;
+        flex-direction: column;
+        align-items: stretch;
+        flex: none;
+    }
+
+    .doc-rail .step-tab-group .step-substeps {
+        padding-left: 0;
+        width: auto;
+    }
+
     .main-column {
         flex: 1;
     }


### PR DESCRIPTION
Closes #560

## What was broken
When the viewer pane is narrow (`@container viewer max-width:900px`), the left rail folds into a horizontal step-tab strip. PR #504 wrapped each step's tab + nested sub-doc chips in a `.step-tab-group` > `.step-substeps` column, but the fold CSS only ever styled `.step-tabs`/`.step-tab`/`.step-child` — never the new wrapper. So each `.step-tab-group` stayed a plain block collapsed to the tab button's width, and the wider `white-space:nowrap` sub-doc chips overflowed into the neighboring tab's column.

## Fix
Inside the fold block, make each `.step-tab-group` a flex column (`align-items:stretch; flex:none`) so it sizes to its widest child, and zero the vertical-rail `padding-left` on `.step-substeps`. #504's nesting is untouched; the wide vertical rail is unaffected (rules are scoped inside the `max-width:900px` container query).

## Verify
Open a spec with plan artifacts (e.g. 172), narrow the pane below ~900px so the rail folds → nested chips stay in their own tab column, strip scrolls horizontally, no overlap. Storybook: Viewer/Full Viewer → "172 · Narrow pane". CSS-only + story; 1829 tests pass, `.vsix` builds.