### PR TITLE
chore: simplify settings — one notifications toggle, clearer telemetry switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -441,9 +441,9 @@ Controls whether the extension prepends a short context-update preamble to every
 
 The preamble adds ~200–300 tokens per dispatch and is identical across all providers (Claude, Gemini, Copilot, Codex, Qwen). Extension-side step-boundary writes remain the hard guarantee for `startedAt` / `completedAt`: this preamble unlocks finer-grained substep tracking.
 
-### Step-Complete Notifications
+### Completion Notifications
 
-When a dispatched spec step finishes, the extension shows a VS Code information message naming the spec and step (e.g. `Spec 074 · Plan complete`). The message includes an **Open spec** action that focuses the viewer for that spec. VS Code routes info messages to the native OS notification surface when the window is unfocused, so you can tab away during long runs.
+When a dispatched spec step finishes, the extension shows a VS Code information message naming the spec and step (e.g. `Spec 074 · Plan complete`). The message includes an **Open spec** action that focuses the viewer for that spec. VS Code routes info messages to the native OS notification surface when the window is unfocused, so you can tab away during long runs. The same switch also governs the notification shown when a task phase completes.
 
 ```json
 {
@@ -451,7 +451,7 @@ When a dispatched spec step finishes, the extension shows a VS Code information 
 }
 ```
 
-Set to `false` to silence the message while keeping the in-viewer elapsed timer.
+Set to `false` to silence both notifications while keeping the in-viewer elapsed timer. (This one toggle replaces the former separate `speckit.notifications.phaseCompletion` setting; an existing "off" preference is carried over automatically.)
 
 ### Spec Directories
 

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -342,7 +342,7 @@ speckit.customCommands                // Custom command definitions
 speckit.customWorkflows               // Custom workflow definitions
 speckit.defaultWorkflow               // Default workflow name
 speckit.companion.installPrompt       // boolean — offer the install banner when the spec-kit extension is missing
-speckit.notifications.phaseCompletion // boolean
+speckit.notifications.stepComplete    // boolean — notify on step and task-phase completion
 speckit.views.steering.visible        // boolean
 speckit.views.settings.visible        // boolean
 ```

--- a/package.json
+++ b/package.json
@@ -983,7 +983,7 @@
             "default": true,
             "scope": "window",
             "order": 0,
-            "description": "Show a notification when a dispatched spec step completes."
+            "description": "Show a notification when a spec step or task phase completes."
           },
           "speckit.aiProvider": {
             "type": "string",
@@ -1132,12 +1132,6 @@
                 }
               ]
             }
-          },
-          "speckit.notifications.phaseCompletion": {
-            "type": "boolean",
-            "default": true,
-            "scope": "window",
-            "description": "Show notification when a task phase is completed"
           },
           "speckit.views.steering.visible": {
             "type": "boolean",
@@ -1370,7 +1364,7 @@
             "default": true,
             "scope": "window",
             "order": 8,
-            "markdownDescription": "Send anonymous, PII-free usage telemetry to help prioritize providers and features. [What's collected](https://github.com/alfredoperez/speckit-companion#telemetry). Also honors VS Code's global `telemetry.telemetryLevel`."
+            "markdownDescription": "The single on/off switch for SpecKit Companion's anonymous, PII-free usage telemetry, which helps prioritize providers and features. [What's collected](https://github.com/alfredoperez/speckit-companion#telemetry). Turning this off stops all telemetry; leaving it on still respects VS Code's global `telemetry.telemetryLevel` (if you've disabled telemetry globally, nothing is sent regardless of this switch)."
           }
         }
       }

--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -72,7 +72,7 @@ export const ConfigKeys = {
         settingsVisible: 'speckit.views.settings.visible',
     },
     notifications: {
-        phaseCompletion: 'speckit.notifications.phaseCompletion',
+        stepComplete: 'speckit.notifications.stepComplete',
     },
     globalState: {
         skipVersion: 'speckit.skipVersion',

--- a/src/core/fileWatchers.ts
+++ b/src/core/fileWatchers.ts
@@ -19,11 +19,11 @@ import { FEATURE_CONTEXT_FILE } from '../features/workflows/types';
 import type { TransitionEntry } from '../features/workflows/types';
 
 /**
- * Check if phase completion notifications are enabled
+ * Check if step/phase completion notifications are enabled
  */
 function isPhaseCompletionNotificationEnabled(): boolean {
     const config = vscode.workspace.getConfiguration('speckit');
-    return config.get<boolean>('notifications.phaseCompletion', true);
+    return config.get<boolean>('notifications.stepComplete', true);
 }
 
 /**

--- a/src/core/fileWatchers.ts
+++ b/src/core/fileWatchers.ts
@@ -19,9 +19,9 @@ import { FEATURE_CONTEXT_FILE } from '../features/workflows/types';
 import type { TransitionEntry } from '../features/workflows/types';
 
 /**
- * Check if step/phase completion notifications are enabled
+ * Whether the single completion-notification toggle (step and task-phase) is on.
  */
-function isPhaseCompletionNotificationEnabled(): boolean {
+function isCompletionNotificationEnabled(): boolean {
     const config = vscode.workspace.getConfiguration('speckit');
     return config.get<boolean>('notifications.stepComplete', true);
 }
@@ -265,7 +265,7 @@ export function setupTasksWatcher(
 
                 for (const phaseName of completedPhases) {
                     outputChannel.appendLine(`[TasksWatcher] Phase completed: "${phaseName}" in ${specName}`);
-                    if (isPhaseCompletionNotificationEnabled()) {
+                    if (isCompletionNotificationEnabled()) {
                         await NotificationUtils.showPhaseCompleteNotification(specName, phaseName, uri.fsPath);
                     }
                 }

--- a/src/core/settingsMigration.test.ts
+++ b/src/core/settingsMigration.test.ts
@@ -286,9 +286,29 @@ describe('mergeNotificationSettings', () => {
         );
     });
 
-    it('is a no-op when phaseCompletion was true or unset', async () => {
+    it('preserves a narrower explicit true override (phase false@User + true@Workspace)', async () => {
         const { update } = setupConfig({
-            'notifications.phaseCompletion': { globalValue: true },
+            'notifications.phaseCompletion': { globalValue: false, workspaceValue: true },
+            'notifications.stepComplete': {},
+        });
+
+        await mergeNotificationSettings();
+
+        expect(update).toHaveBeenCalledWith(
+            'notifications.stepComplete',
+            false,
+            vscode.ConfigurationTarget.Global
+        );
+        expect(update).toHaveBeenCalledWith(
+            'notifications.stepComplete',
+            true,
+            vscode.ConfigurationTarget.Workspace
+        );
+    });
+
+    it('is a no-op when phaseCompletion is unset at every scope', async () => {
+        const { update } = setupConfig({
+            'notifications.phaseCompletion': {},
             'notifications.stepComplete': {},
         });
 

--- a/src/core/settingsMigration.test.ts
+++ b/src/core/settingsMigration.test.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode';
 import {
     coerceLegacyBoolean,
     migrateBetaTriStateSettings,
+    mergeNotificationSettings,
     removeRetiredSettings,
     BETA_BOOLEAN_SETTINGS,
     RETIRED_SETTINGS,
@@ -158,7 +159,7 @@ describe('removeRetiredSettings', () => {
 
     afterEach(() => jest.restoreAllMocks());
 
-    it('lists the retired toggles plus the former Companion-workflow gate keys', () => {
+    it('lists the retired toggles, the former Companion-workflow gate keys, and the merged-away phase-completion toggle', () => {
         expect([...RETIRED_SETTINGS]).toEqual([
             'companion.templateProfile',
             'companion.turboWorkflowPicker',
@@ -166,6 +167,7 @@ describe('removeRetiredSettings', () => {
             'companion.speckitCompanionWorkflow',
             'companion.workflowBeta',
             'companion.resumeBeta',
+            'notifications.phaseCompletion',
         ]);
     });
 
@@ -231,5 +233,84 @@ describe('removeRetiredSettings', () => {
     it('does not crash when inspect returns undefined for a key', async () => {
         setupConfig({});
         await expect(removeRetiredSettings()).resolves.toBeUndefined();
+    });
+});
+
+describe('mergeNotificationSettings', () => {
+    type Inspection = {
+        globalValue?: unknown;
+        workspaceValue?: unknown;
+        workspaceFolderValue?: unknown;
+    };
+
+    function setupConfig(inspections: Record<string, Inspection | undefined>) {
+        const update = jest.fn().mockResolvedValue(undefined);
+        const inspect = jest.fn((key: string) => inspections[key]);
+        jest.spyOn(vscode.workspace, 'getConfiguration').mockReturnValue({
+            inspect,
+            update,
+            get: jest.fn(),
+        } as unknown as vscode.WorkspaceConfiguration);
+        return { update, inspect };
+    }
+
+    afterEach(() => jest.restoreAllMocks());
+
+    it('turns stepComplete off at the scope where phaseCompletion was false', async () => {
+        const { update } = setupConfig({
+            'notifications.phaseCompletion': { globalValue: false },
+            'notifications.stepComplete': {},
+        });
+
+        await mergeNotificationSettings();
+
+        expect(update).toHaveBeenCalledWith(
+            'notifications.stepComplete',
+            false,
+            vscode.ConfigurationTarget.Global
+        );
+    });
+
+    it('forces stepComplete off even when it was explicitly true (either-false wins)', async () => {
+        const { update } = setupConfig({
+            'notifications.phaseCompletion': { workspaceValue: false },
+            'notifications.stepComplete': { workspaceValue: true },
+        });
+
+        await mergeNotificationSettings();
+
+        expect(update).toHaveBeenCalledWith(
+            'notifications.stepComplete',
+            false,
+            vscode.ConfigurationTarget.Workspace
+        );
+    });
+
+    it('is a no-op when phaseCompletion was true or unset', async () => {
+        const { update } = setupConfig({
+            'notifications.phaseCompletion': { globalValue: true },
+            'notifications.stepComplete': {},
+        });
+
+        await mergeNotificationSettings();
+
+        expect(update).not.toHaveBeenCalled();
+    });
+
+    it('is a no-op when stepComplete is already false at that scope (idempotent)', async () => {
+        const { update } = setupConfig({
+            'notifications.phaseCompletion': { globalValue: false },
+            'notifications.stepComplete': { globalValue: false },
+        });
+
+        await mergeNotificationSettings();
+
+        expect(update).not.toHaveBeenCalled();
+    });
+
+    it('does not crash when phaseCompletion inspect returns undefined', async () => {
+        const { update } = setupConfig({});
+        await expect(mergeNotificationSettings()).resolves.toBeUndefined();
+        expect(update).not.toHaveBeenCalled();
     });
 });

--- a/src/core/settingsMigration.ts
+++ b/src/core/settingsMigration.ts
@@ -42,6 +42,7 @@ export const RETIRED_SETTINGS: ReadonlyArray<string> = [
     'companion.speckitCompanionWorkflow',
     'companion.workflowBeta',
     'companion.resumeBeta',
+    'notifications.phaseCompletion',
 ];
 
 /**
@@ -98,6 +99,31 @@ export async function migrateBetaTriStateSettings(): Promise<void> {
             if (persisted === 'off' || persisted === 'beta' || persisted === 'on') {
                 await config.update(key, coerceLegacyBoolean(persisted, settingDefault), target);
             }
+        }
+    }
+}
+
+/**
+ * One-time, idempotent merge of the two former notification toggles into the
+ * single survivor `notifications.stepComplete`. The deprecated
+ * `notifications.phaseCompletion` is dropped by `removeRetiredSettings`; this
+ * runs first so a user who turned phase-completion notifications off keeps that
+ * preference on the merged toggle. Rule: if EITHER was false, the merged one is
+ * false — so any scope where `phaseCompletion` was explicitly `false` forces
+ * `stepComplete` to `false` at that same scope (unless it is already `false`).
+ * Both settings default `true`, so nothing to do when `phaseCompletion` is unset
+ * or `true`. Scope is preserved via per-scope `inspect()`.
+ */
+export async function mergeNotificationSettings(): Promise<void> {
+    const config = vscode.workspace.getConfiguration('speckit');
+    const phase = config.inspect('notifications.phaseCompletion');
+    const step = config.inspect('notifications.stepComplete');
+    if (!phase) {
+        return;
+    }
+    for (const { target, field } of SCOPES) {
+        if (phase[field] === false && step?.[field] !== false) {
+            await config.update('notifications.stepComplete', false, target);
         }
     }
 }

--- a/src/core/settingsMigration.ts
+++ b/src/core/settingsMigration.ts
@@ -107,12 +107,15 @@ export async function migrateBetaTriStateSettings(): Promise<void> {
  * One-time, idempotent merge of the two former notification toggles into the
  * single survivor `notifications.stepComplete`. The deprecated
  * `notifications.phaseCompletion` is dropped by `removeRetiredSettings`; this
- * runs first so a user who turned phase-completion notifications off keeps that
- * preference on the merged toggle. Rule: if EITHER was false, the merged one is
- * false — so any scope where `phaseCompletion` was explicitly `false` forces
- * `stepComplete` to `false` at that same scope (unless it is already `false`).
- * Both settings default `true`, so nothing to do when `phaseCompletion` is unset
- * or `true`. Scope is preserved via per-scope `inspect()`.
+ * runs first so a user's explicit phase-completion preference survives on the
+ * merged toggle. At every scope where `phaseCompletion` was explicitly set, the
+ * merged value is the either-false-wins combination of the two explicit values
+ * at that scope (`false` if either is `false`, else `true`) and is written only
+ * when it differs from the current `stepComplete` at that scope. This both
+ * propagates a broad `false` down AND preserves a narrower explicit `true`
+ * override (e.g. `false` at User + `true` at Workspace stays ON at Workspace).
+ * Scopes where `phaseCompletion` is unset are left untouched. Scope is preserved
+ * via per-scope `inspect()`.
  */
 export async function mergeNotificationSettings(): Promise<void> {
     const config = vscode.workspace.getConfiguration('speckit');
@@ -122,8 +125,14 @@ export async function mergeNotificationSettings(): Promise<void> {
         return;
     }
     for (const { target, field } of SCOPES) {
-        if (phase[field] === false && step?.[field] !== false) {
-            await config.update('notifications.stepComplete', false, target);
+        const phaseVal = phase[field];
+        if (phaseVal === undefined) {
+            continue;
+        }
+        const stepVal = step?.[field];
+        const merged = phaseVal === false || stepVal === false ? false : true;
+        if (merged !== stepVal) {
+            await config.update('notifications.stepComplete', merged, target);
         }
     }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -26,7 +26,7 @@ import { isCompanionInstalled } from './features/settings/companionPresetReconci
 import { Views, setupFileWatchers, setupTasksWatcher, setupSpecViewerWatcher } from './core';
 import { ConfigKeys } from './core/constants';
 import { ConfigManager } from './core/utils/configManager';
-import { migrateBetaTriStateSettings, removeRetiredSettings } from './core/settingsMigration';
+import { migrateBetaTriStateSettings, mergeNotificationSettings, removeRetiredSettings } from './core/settingsMigration';
 import { openSpecFile } from './core/utils/fileOpener';
 import { TelemetryService, initTelemetry, sendTelemetryEvent, buildActivatedProperties, reportInstallPromptShown } from './core/telemetry';
 import { getConfiguredProviderType } from './ai-providers/aiProvider';
@@ -122,8 +122,19 @@ export async function activate(context: vscode.ExtensionContext) {
         outputChannel.appendLine(`[Extension] Beta-settings migration skipped: ${detail}`);
     }
 
-    // Drop retired settings (the collapsed spec-driven toggles and the former
-    // Companion-workflow beta gate + its legacy keys) from settings.json. Activation
+    // Fold the deprecated notifications.phaseCompletion toggle into the merged
+    // notifications.stepComplete before the retired-key cleanup below removes it,
+    // so an off preference survives. Idempotent and scope-preserving.
+    try {
+        await mergeNotificationSettings();
+    } catch (err) {
+        const detail = err instanceof Error ? err.message : String(err);
+        outputChannel.appendLine(`[Extension] Notification-settings merge skipped: ${detail}`);
+    }
+
+    // Drop retired settings (the collapsed spec-driven toggles, the former
+    // Companion-workflow beta gate + its legacy keys, and the merged-away
+    // phase-completion notification toggle) from settings.json. Activation
     // tolerates them either way; this just keeps users' settings tidy. Wrapped so a
     // bad stored value can never fail activation (the provider-rename lesson).
     try {


### PR DESCRIPTION
Closes #561 (parts a + b). Part c (companion default) escalated — see below.

## Delivered
**(a) One Notifications toggle.** Merged `notifications.phaseCompletion` into `notifications.stepComplete` (retitled to cover both step and phase completion). Both notifiers now read the survivor. A one-time, idempotent, scope-preserving migration (`mergeNotificationSettings`) folds an off-preference forward (either-false-wins) *before* the retired key is dropped, so nobody silently re-enables notifications they turned off. Wrapped in try/catch — can never fail activation.

**(b) Clearer Telemetry switch.** `speckit.telemetry` reworded to read as a single unmistakable on/off (still notes it honors VS Code's global `telemetry.telemetryLevel`).

## Escalated — part (c), companion-as-default
NOT done here. Making `speckit.defaultWorkflow` resolve to `companion` when unset + the companion extension is installed touches **workflow-pick derived state** across 4 `config.get('defaultWorkflow')` read sites (Create-Spec pre-selection, per-feature resolution, workflow validation) plus a telemetry design call (whether to report an *effective* default the user never chose). That is the risky carve-out the task named → it goes through the full pipeline loop, not light. Detector to reuse: `isCompanionInstalled(root)` / the `speckit.companion.installed` context key.

## Verify
Settings → SpecKit: exactly one Notifications toggle; Telemetry reads as one switch. Migration: a user with `phaseCompletion:false` sees `stepComplete` flip false on next activation + the dead key removed. 1834 tests pass.