### PR TITLE
fix: viewer polish — inline step strip, hide empty coverage, acronym-aware spec names

### DIFF
--- a/docs/viewer-states.md
+++ b/docs/viewer-states.md
@@ -388,14 +388,14 @@ When `.spec-context.json` data is available, a structured header renders above t
 | Row | Content | Source |
 |-----|---------|--------|
 | Row 1 | Badge pill + created date | `computeBadgeText()`, `computeCreatedDate()` |
-| Row 2 | `{DocType}: {specName}` | `getDocTypeLabel(step)`, `specName` or `deriveSpecName(specDir)` |
+| Row 2 | `{DocType}: {specName}` | `getDocTypeLabel(step)`, `resolveSpecDisplayName(specName, specDir)` (acronym-aware `toDisplayCase`) |
 | Row 3 | Branch badge with git icon | `branch` field from context |
 | Separator | Horizontal rule | Always shown |
 
 - **Badge color**: Uses `--header-title` (same as h1 headings) for primary color
 - **H1 hiding**: When header is present (`data-has-context="true"`), the first H1 in markdown is hidden via CSS to avoid duplicate title
 - **Metadata stripping**: When context data is available, `preprocessSpecMetadata` strips raw metadata (Status, Feature Branch, etc.) from rendered markdown
-- **Fallback**: When `specName` is missing from context, it is derived from the directory slug (e.g., `046-spec-viewer-header-redesign` → `Spec Viewer Header Redesign`)
+- **Fallback**: When `specName` is missing from context, it is derived from the directory slug (e.g., `046-spec-viewer-header-redesign` → `Spec Viewer Header Redesign`). Both the recorded name and the slug fallback pass through `toDisplayCase`, so the viewer header and the specs tree (which both call `resolveSpecDisplayName`) show one consistent, acronym-aware casing.
 - **No context**: When no `.spec-context.json` exists, no header renders; markdown displays as before
 
 ### Badge hover text
@@ -415,7 +415,7 @@ A living spec has no branch, created date, phases or task completion, so the hea
 
 Notes:
 
-- **The title is authored, so it is not re-cased.** `.spec-header-title` carries `text-transform: capitalize` for feature specs, whose names really are directory slugs. A heading-derived title adds `.spec-header-title--authored`, which turns that off — without it, `SpecKit` renders as `Speckit` and the fix looks like it never landed.
+- **The title is authored, so it is not re-cased.** Feature-spec names are cased in data by `toDisplayCase()` (`src/core/utils/specDisplayName.ts`) — acronym-aware, so `cli install nudge` becomes `CLI Install Nudge`, not `Cli Install Nudge` — and `.spec-header-title` no longer applies any CSS `text-transform`, so the data value is authoritative. A heading-derived title is never fed to the caser (it takes the heading branch of `resolveSpecDisplayName`), so `SpecKit` stays `SpecKit`.
 - **The title belongs to the capability, not the tier on screen.** It is read from the spec tier's document whichever of Spec / Architecture / Coverage is selected.
 - **Coverage and drift are the sidebar's own numbers.** They come from `readCapabilityHealth()` in `src/features/specs/livingSpecsModel.ts` — the exact call the Living Specs tree makes — so the two surfaces cannot disagree. See [`docs/sidebar.md`](./sidebar.md).
 - **The requirement count and the coverage denominator are one derivation.** Both call `requirementIds()` in `src/features/specs/livingSpecsModel.ts`, which ignores fenced code blocks, so `N requirements` and the `M` in `N/M covered` are counted off the same identifiers and cannot drift apart.
@@ -487,6 +487,8 @@ stateDiagram-v2
 | `reviewing` | Viewing completed step, not active workflow | White bold label |
 | `disabled` | Step not available (no file, not first) | Dimmed (opacity 0.35) |
 | `stale` | Document stale relative to upstream | `!` badge |
+
+**Narrow-pane fold.** The doc rail is a vertical list at full width; below a viewer-container width of 900px it folds to a single horizontally-scrolling strip. In that fold each step and its own file chips form one inline unit — the step tab followed by a horizontal row of its `.step-substeps` — with a divider between units, so the strip reads `Overview │ Specification Requirements │ Plan Nudge-Gate Research │ Tasks` rather than stacking sub-docs under each tab. The nesting (which file belongs to which step) is preserved; only the wide-vs-folded layout differs. Scoped entirely to the `@container viewer (max-width: 900px)` block in `webview/styles/spec-viewer/_base.css`.
 
 ### In-flight derivation (one fact, one path)
 

--- a/src/core/utils/__tests__/specDisplayName.test.ts
+++ b/src/core/utils/__tests__/specDisplayName.test.ts
@@ -1,6 +1,45 @@
-import { resolveSpecDisplayName } from '../specDisplayName';
+import { resolveSpecDisplayName, toDisplayCase } from '../specDisplayName';
+
+describe('toDisplayCase', () => {
+    it('title-cases ordinary words', () => {
+        expect(toDisplayCase('install nudge feature')).toBe('Install Nudge Feature');
+    });
+
+    it('preserves known acronyms in canonical upper form', () => {
+        expect(toDisplayCase('cli install nudge')).toBe('CLI Install Nudge');
+        expect(toDisplayCase('api url resolver')).toBe('API URL Resolver');
+    });
+
+    it('matches acronyms case-insensitively', () => {
+        expect(toDisplayCase('CLI Install')).toBe('CLI Install');
+        expect(toDisplayCase('Cli Install')).toBe('CLI Install');
+    });
+
+    it('special-cases VS Code from a two-word phrase or a single token', () => {
+        expect(toDisplayCase('vs code panel')).toBe('VS Code Panel');
+        expect(toDisplayCase('vscode panel')).toBe('VS Code Panel');
+    });
+
+    it('normalizes dashes and underscores to spaces', () => {
+        expect(toDisplayCase('cli-install_nudge')).toBe('CLI Install Nudge');
+    });
+
+    it('is idempotent on an already-cased name', () => {
+        expect(toDisplayCase('CLI Install Nudge')).toBe('CLI Install Nudge');
+    });
+});
 
 describe('resolveSpecDisplayName', () => {
+    it('acronym-cases a recorded lowercase feature name at the display boundary', () => {
+        expect(resolveSpecDisplayName('cli install nudge', '512-cli-install-nudge'))
+            .toBe('CLI Install Nudge');
+    });
+
+    it('acronym-cases the humanized slug fallback', () => {
+        expect(resolveSpecDisplayName(undefined, '512-cli-install-nudge'))
+            .toBe('CLI Install Nudge');
+    });
+
     it('prefers the recorded name over the slug', () => {
         expect(resolveSpecDisplayName('Readable Spec Names', '515-readable-spec-names'))
             .toBe('Readable Spec Names');

--- a/src/core/utils/specDisplayName.ts
+++ b/src/core/utils/specDisplayName.ts
@@ -1,12 +1,77 @@
 import { deriveSpecName } from '../../features/specs/specContextManager';
 
+const ACRONYMS: Record<string, string> = {
+    cli: 'CLI',
+    api: 'API',
+    ui: 'UI',
+    ux: 'UX',
+    id: 'ID',
+    url: 'URL',
+    uri: 'URI',
+    css: 'CSS',
+    html: 'HTML',
+    json: 'JSON',
+    yaml: 'YAML',
+    md: 'MD',
+    ai: 'AI',
+    sdk: 'SDK',
+    pr: 'PR',
+    db: 'DB',
+    ide: 'IDE',
+    npm: 'npm',
+    ci: 'CI',
+    cd: 'CD',
+    io: 'IO',
+    os: 'OS',
+    sql: 'SQL',
+    http: 'HTTP',
+    https: 'HTTPS',
+    vscode: 'VS Code',
+};
+
+function caseWord(word: string): string {
+    const lower = word.toLowerCase();
+    const acronym = ACRONYMS[lower];
+    if (acronym) {
+        return acronym;
+    }
+    return word.charAt(0).toUpperCase() + word.slice(1);
+}
+
+/**
+ * Title-case a slug or lowercase feature name while preserving known acronyms
+ * (CLI, API, VS Code, …). Feature specs are named by slugs and capitalised for
+ * display; a naive title-case mangles acronyms ("cli" → "Cli"), so this is the
+ * one shared caser both the viewer header and the specs tree route through.
+ * Not for living-spec headings — those are authored and shown verbatim.
+ */
+export function toDisplayCase(name: string): string {
+    const words = name.replace(/[-_]+/g, ' ').split(/\s+/).filter(Boolean);
+    if (words.length === 0) {
+        return name.trim();
+    }
+    const out: string[] = [];
+    for (let i = 0; i < words.length; i++) {
+        const lower = words[i].toLowerCase();
+        if (lower === 'vs' && words[i + 1]?.toLowerCase() === 'code') {
+            out.push('VS', 'Code');
+            i++;
+            continue;
+        }
+        out.push(caseWord(words[i]));
+    }
+    return out.join(' ');
+}
+
 /**
  * Resolve the readable display name for a spec, by preference:
  * recorded name → document heading (living specs) → humanized slug.
  *
  * Presentation-only: the directory slug stays the stable identifier.
  * Empty or whitespace-only inputs are treated as absent so a blank
- * label never wins over the humanized-slug fallback.
+ * label never wins over the humanized-slug fallback. Feature names (recorded
+ * or slug-derived) are acronym-aware title-cased; a living-spec heading is
+ * authored and returned verbatim.
  */
 export function resolveSpecDisplayName(
     specName: string | undefined | null,
@@ -15,11 +80,11 @@ export function resolveSpecDisplayName(
 ): string {
     const recorded = specName?.trim();
     if (recorded) {
-        return recorded;
+        return toDisplayCase(recorded);
     }
     const docHeading = heading?.trim();
     if (docHeading) {
         return docHeading;
     }
-    return deriveSpecName(specDir);
+    return toDisplayCase(deriveSpecName(specDir));
 }

--- a/src/features/specs/__tests__/specExplorerProvider.test.ts
+++ b/src/features/specs/__tests__/specExplorerProvider.test.ts
@@ -1053,7 +1053,7 @@ describe('SpecExplorerProvider', () => {
             expect(groups).toHaveLength(1);
             expect(groups[0].label).toBe('Active (1)');
             const specs = await filteredProvider.getChildren(groups[0]);
-            expect(specs.map(s => s.label)).toEqual(['Tree group counts']);
+            expect(specs.map(s => s.label)).toEqual(['Tree Group Counts']);
         });
 
         it('matches by specName when slug alone does not match', async () => {
@@ -1066,7 +1066,7 @@ describe('SpecExplorerProvider', () => {
             expect(groups).toHaveLength(1);
             expect(groups[0].label).toBe('Active (1)');
             const specs = await filteredProvider.getChildren(groups[0]);
-            expect(specs.map(s => s.label)).toEqual(['Design — tighten safety']);
+            expect(specs.map(s => s.label)).toEqual(['Design — Tighten Safety']);
         });
 
         it('returns empty root when filter matches zero specs', async () => {

--- a/webview/src/spec-viewer/FullViewer.stories.tsx
+++ b/webview/src/spec-viewer/FullViewer.stories.tsx
@@ -476,11 +476,11 @@ export const Implementing172: Story = {
 
 // ── 172 · narrow pane · the rail folds to a horizontal strip ──
 // Below a container width of 900px the doc-rail becomes a horizontal scrolling
-// strip. Each step keeps its nested artifact chips (#504); the pane is pinned
-// narrow so those sub-docs stay inside their own step column instead of bleeding
-// into the neighbouring tab (#560).
+// strip. Each step and its own files form one inline unit — the step tab
+// followed by a row of its artifact chips — with a divider between units, so a
+// step reads with its own files instead of colliding with the next one.
 export const NarrowPaneFold172: Story = {
-    name: '172 · Narrow pane (rail folds horizontal, nested sub-docs)',
+    name: '172 · Narrow pane (rail folds horizontal, inline step+files units)',
     render: () => (
         <div style="width: 760px; max-width: 100%; height: 100vh; overflow: hidden;">
             <InteractiveViewer

--- a/webview/src/spec-viewer/components/OverviewDossier.tsx
+++ b/webview/src/spec-viewer/components/OverviewDossier.tsx
@@ -307,6 +307,9 @@ export function CoverageSection({ state }: { state: ViewerState }) {
     if (!rows || rows.length === 0) return null;
 
     const traced = rows.filter(r => r.tests.length > 0).length;
+    // Nothing traced reads as a failing 0/N when the pipeline never maps tests;
+    // the section reappears once any requirement gains a linked test.
+    if (traced === 0) return null;
     // Untraced requirements lead — the gaps are the signal.
     const ordered = [...rows.filter(r => r.tests.length === 0), ...rows.filter(r => r.tests.length > 0)];
     const rest = ordered.slice(COVERAGE_SHOWN);

--- a/webview/src/spec-viewer/components/SpecHeader.tsx
+++ b/webview/src/spec-viewer/components/SpecHeader.tsx
@@ -145,7 +145,7 @@ export function SpecHeader() {
             <div class="spec-header-row">
                 <div class="spec-header-main">
                     {ns.specContextName && (
-                        <h1 class={`spec-header-title${ns.titleFromHeading ? ' spec-header-title--authored' : ''}`}>
+                        <h1 class="spec-header-title">
                             {ns.specContextName}
                         </h1>
                     )}

--- a/webview/src/spec-viewer/components/__tests__/OverviewDossier.test.tsx
+++ b/webview/src/spec-viewer/components/__tests__/OverviewDossier.test.tsx
@@ -1,6 +1,6 @@
 /** @jest-environment jsdom */
 import { h, render } from 'preact';
-import { IntentSection, OverviewTiming } from '../OverviewDossier';
+import { IntentSection, OverviewTiming, CoverageSection } from '../OverviewDossier';
 import type { ViewerState } from '../../types';
 
 const base = (overrides: Partial<ViewerState>): ViewerState => ({
@@ -188,5 +188,34 @@ describe('OverviewTiming', () => {
             expect(host.querySelector('.dossier-timing__duration--folded')).toBeNull();
             expect(host.textContent).toContain('4m');
         });
+    });
+});
+
+describe('CoverageSection', () => {
+    it('renders when at least one requirement has a linked test', () => {
+        const host = document.createElement('div');
+        render(h(CoverageSection, {
+            state: base({
+                coverage: [
+                    { req: 'FR-1', tasks: ['T001'], tests: ['auth.test.ts'] },
+                    { req: 'FR-2', tasks: ['T002'], tests: [] },
+                ],
+            }),
+        }), host);
+        expect(host.querySelector('.dossier-section')).not.toBeNull();
+        expect(host.textContent).toContain('1/2 traced');
+    });
+
+    it('omits itself entirely when nothing is traced', () => {
+        const host = document.createElement('div');
+        render(h(CoverageSection, {
+            state: base({
+                coverage: [
+                    { req: 'FR-1', tasks: ['T001'], tests: [] },
+                    { req: 'FR-2', tasks: ['T002'], tests: [] },
+                ],
+            }),
+        }), host);
+        expect(host.querySelector('.dossier-section')).toBeNull();
     });
 });

--- a/webview/src/spec-viewer/components/__tests__/SpecHeader.test.tsx
+++ b/webview/src/spec-viewer/components/__tests__/SpecHeader.test.tsx
@@ -66,25 +66,25 @@ describe('the status badge tooltip', () => {
 });
 
 describe('the title', () => {
-    it('keeps the author capitalization when it came from the document heading', () => {
+    it('renders an authored heading verbatim, preserving deliberate internal casing', () => {
         navState.value = mockNavState({
             specContextName: 'SpecKit Extension Capture',
             titleFromHeading: true,
         });
         const container = renderInto();
 
-        expect(container.querySelector('.spec-header-title')?.className)
-            .toContain('spec-header-title--authored');
+        expect(container.querySelector('.spec-header-title')?.textContent)
+            .toBe('SpecKit Extension Capture');
 
         cleanup(container);
     });
 
-    it('leaves the slug capitalization on for a derived name', () => {
-        navState.value = mockNavState({ specContextName: 'my feature' });
+    it('renders an acronym-cased feature name unchanged, never re-mangling it', () => {
+        navState.value = mockNavState({ specContextName: 'CLI Install Nudge' });
         const container = renderInto();
 
-        expect(container.querySelector('.spec-header-title')?.className)
-            .not.toContain('spec-header-title--authored');
+        expect(container.querySelector('.spec-header-title')?.textContent)
+            .toBe('CLI Install Nudge');
 
         cleanup(container);
     });

--- a/webview/styles/spec-viewer/_base.css
+++ b/webview/styles/spec-viewer/_base.css
@@ -220,20 +220,37 @@ body {
         background: var(--bg-secondary);
     }
 
-    /* #504 nests each step's artifacts in a `.step-tab-group` (the tab plus a
-       `.step-substeps` column). In the horizontal fold that wrapper must own a
-       column sized to its WIDEST child — left as a plain block it collapses to
-       the tab button's width and the wider sub-doc chips overflow into the next
-       tab's column (#560). */
+    /* Folded strip: each step and its own files form one inline unit — the
+       StepTab followed by a horizontal row of its file chips — and neighbouring
+       units are divided so a step reads with its own artifacts rather than
+       colliding with the next step's. The whole strip scrolls with the rail. */
     .doc-rail .rail-group .step-tabs > .step-tab-group {
         display: flex;
-        flex-direction: column;
-        align-items: stretch;
+        flex-direction: row;
+        align-items: center;
+        gap: var(--space-2);
         flex: none;
     }
 
+    .doc-rail .rail-group .step-tabs > .step-tab-group + .step-tab-group {
+        padding-left: var(--space-2);
+        border-left: 1px solid var(--border);
+    }
+
     .doc-rail .step-tab-group .step-substeps {
+        flex-direction: row;
+        align-items: center;
+        gap: var(--space-1);
+        margin: 0;
         padding-left: 0;
+        width: auto;
+    }
+
+    .doc-rail .step-tab-group .step-substeps > li {
+        flex: none;
+    }
+
+    .doc-rail .step-tab-group .step-substeps .step-child {
         width: auto;
     }
 

--- a/webview/styles/spec-viewer/_content.css
+++ b/webview/styles/spec-viewer/_content.css
@@ -243,18 +243,14 @@ body[data-has-spec-context="true"] .meta-branch {
     color: var(--header-title);
     line-height: 1.2;
     letter-spacing: -0.015em;
-    /* Spec names arrive as lowercase dir slugs; presentation-only casing. */
-    text-transform: capitalize;
+    /* Casing is decided in data (toDisplayCase, acronym-aware) so it survives
+       here for both feature names and authored headings — no CSS capitalize,
+       which would mangle "CLI" and re-case an authored heading. */
+    text-transform: none;
     min-width: 0;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
-}
-
-/* A title read from the document's own H1 is already written by a human —
-   capitalizing it would turn "SpecKit" back into "Speckit". */
-.spec-header-title--authored {
-    text-transform: none;
 }
 
 /* Capability facts are readable content, so they take the body token.


### PR DESCRIPTION
Closes #571
Closes #572
Closes #573

Three related viewer fixes from a review pass.

## #571 — horizontal step strip no longer overlaps (inline units)
In the `@container viewer (max-width:900px)` fold, each `.step-tab-group` is now a horizontal flex row (StepTab + its file chips side by side), `.step-substeps` is a horizontal row, adjacent units get a `border-left` divider, and the strip scrolls horizontally instead of colliding: `Overview │ Specification Requirements │ Plan Nudge-Gate Research │ Tasks`. Scoped entirely inside the fold block — the wide vertical rail is untouched; #504 nesting semantics preserved.

## #572 — hide Coverage when nothing is traced
`CoverageSection` returns null when `traced === 0`. Pipeline specs never map requirements→tests, so the section was a structural yellow "0/N traced" that read like a failure. It reappears once any requirement gains a linked test.

## #573 — acronym-aware, consistent spec-name casing
Root cause was split casing: the header used CSS `text-transform: capitalize` on a lowercase data value (mangling `cli` → "Cli"), while the tree showed the raw lowercase. Added one shared `toDisplayCase` helper (CLI/API/UI/URL/**VS Code**/… → canonical) in `src/core/utils/specDisplayName.ts`, applied in `resolveSpecDisplayName` for feature names so the viewer header AND the specs tree get identical casing; dropped the CSS `capitalize` so data is authoritative. Living-spec headings still render their `#` heading verbatim (`viewer-ui.spec.md:188` preserved).

## Verify
132 suites / 1877 tests (new: caser unit tests, coverage-null tests, tree-label expectations). Manual: narrow the viewer pane <900px → inline step+files units, no overlap; a 0-traced spec's Overview has no Coverage section; a spec like "cli install nudge" shows **CLI Install Nudge** in both header and tree.