### PR TITLE
chore(living-specs): sync drifted capabilities after the fix-tickets + viewer-polish merges

### DIFF
--- a/capabilities/workflows/spec.md
+++ b/capabilities/workflows/spec.md
@@ -12,10 +12,17 @@ A workflow is the ordered pipeline a spec travels — which step comes next, whi
 
 The extension SHALL provide the stock SpecKit pipeline and the SpecKit Companion pipeline as built-ins, and SHALL merge any user-defined workflows from settings alongside them. The default for new specs is named by a single configuration key, `speckit.defaultWorkflow`; an unrecognized value falls back to the first available workflow with a logged note rather than leaving a spec pipeline-less.
 
+When that key is left unset, the effective default SHALL resolve to the Companion pipeline where the companion spec-kit extension is installed for the workspace root, and to the stock pipeline otherwise — so an installed workspace starts specs on Companion without the user having to name it. An explicitly-set value at any scope always wins over this install-derived default, most-specific scope first; unset is distinguished from an explicit value by inspecting the setting per scope, and a schema-default-only reading counts as unset. Only the workflow-pick sites (Create-Spec pre-selection, per-feature resolution) consult this effective default; adoption telemetry keeps reporting the RAW configured value, so an install-derived default never counts as an explicit Companion choice.
+
 #### Scenario: the configured default names a workflow that no longer exists
 - **WHEN** a spec's workflow is resolved and the configured default is not among the available workflows
 - **THEN** the first available workflow is used
 - **AND** the substitution is logged rather than surfaced as an error
+
+#### Scenario: the default is unset and the companion extension is installed
+- **WHEN** a workflow-pick site resolves the effective default with `speckit.defaultWorkflow` unset at every scope
+- **THEN** the Companion pipeline is chosen where the companion extension is installed, else the stock pipeline
+- **AND** an explicit value set at any scope overrides this, and telemetry still reports the raw configured value rather than the install-derived one
 
 #### Scenario: the Companion pipeline is chosen
 - **WHEN** a spec selects it
@@ -82,7 +89,7 @@ Resolving a workflow for rendering — tree rows, viewer initialization — SHAL
 
 #### Scenario: a spec with no recorded workflow is rendered in the sidebar
 - **WHEN** its workflow is resolved for display
-- **THEN** the default workflow is returned
+- **THEN** the effective default workflow is returned (the explicit setting when set, else the install-derived default)
 - **AND** the spec's context file is not created or modified
 
 ### Persisting a workflow choice must never destroy existing spec context

--- a/src/ai-providers/ai-providers.spec.md
+++ b/src/ai-providers/ai-providers.spec.md
@@ -42,7 +42,17 @@ Providers that drive a CLI in a terminal SHALL inherit a common lifecycle — ve
 
 #### Scenario: the CLI is not installed
 - **WHEN** a provider that declares an install hint dispatches and its binary is absent
-- **THEN** the user is told what to install with a copyable install command and the dispatch fails loudly rather than sending text into a shell that cannot act on it
+- **THEN** the user is told how to get it and the dispatch fails loudly rather than sending text into a shell that cannot act on it
+- **AND** the hint is either a copyable install command (package-manager CLIs) or an "Open Install Page" link that opens the tool's download page (download-based tools such as the `agy` CLI), matching how that tool is actually obtained
+
+### A CLI provider is a terminal target; an editor-chat provider is not
+
+Each provider SHALL be classifiable as dispatching either to a VS Code terminal (every CLI provider — including Antigravity, which runs the real `agy` binary interactively with `-i` rather than a non-existent `antigravity` command) or to the host editor's chat/panel (the in-editor chat and GUI-panel providers). An unknown provider value MUST default to the terminal classification, so a newly-added CLI provider is covered without editing this predicate. This classification is what lets a terminal-only affordance — such as the CLI install nudge — fire for CLI dispatch and stay silent for editor-chat dispatch.
+
+#### Scenario: a newly-added provider is classified
+- **WHEN** the terminal-versus-editor classification is asked about a provider it has never seen
+- **THEN** it answers "terminal", so the new CLI provider behaves like the others without a code change
+- **AND** only the in-editor chat and GUI-panel providers are excluded
 
 ### The prompt is never pasted into visible terminal scrollback
 
@@ -118,6 +128,7 @@ Surfaces the extension does not own — a host editor's chat, another extension'
 #### Scenario: the host editor exposes no chat command
 - **WHEN** none of the candidate chat commands are registered in the running editor
 - **THEN** the user is warned that no built-in chat was found and told to switch to a CLI provider
+- **AND** a host that ships its own CLI provider (an Antigravity host, whose `agy` CLI the dedicated Antigravity provider runs) is named directly rather than pointed at the generic switch-to-CLI hint
 - **AND** nothing throws
 
 #### Scenario: the host drops the prompt it is handed

--- a/src/core/core.spec.md
+++ b/src/core/core.spec.md
@@ -74,6 +74,8 @@ A span SHALL be reported as trustworthy only when both of its boundaries were st
 - **WHEN** a step's start or end was written by something other than the extension
 - **THEN** the span is marked untrusted and no elapsed time is rendered for it
 
+A derived step entry MAY additionally carry a `folded` marker — set only by the in-memory step-history derivation for a fast-path step whose boundaries were stamped inside its anchoring phase — which is independent of duration trust; the derivation rule and its rendering live in the specs and viewer-UI capabilities, and the field is never persisted alongside the log.
+
 #### Scenario: the whole run's elapsed time is requested
 - **WHEN** a run-level timing summary is derived from the history log
 - **THEN** a start, end, and elapsed span appear only if every expected phase has a trustworthy closed span; otherwise the summary reports how many phases were measured and stays incomplete
@@ -123,6 +125,11 @@ Configuration keys change shape across releases, so a reader SHALL be correct fo
 - **THEN** the new key is written at the workspace level and the old one is removed there
 - **AND** re-running the migration changes nothing
 
+#### Scenario: two toggles are collapsed into one
+- **WHEN** two former notification toggles are merged into the single surviving completion toggle
+- **THEN** at every scope where the retired toggle was explicitly set, the merged value is the either-false-wins combination of the two explicit values at that scope, written only where it differs from the current value
+- **AND** a broad `false` propagates down while a narrower explicit `true` at a more specific scope is preserved, and scopes where the retired toggle was unset are left untouched
+
 ### Telemetry carries shapes, never content
 
 Every telemetry payload SHALL contain only enum-like values, booleans, versions, counts, and a random per-spec identifier. User-authored text — prompt content, file paths, spec names, custom workflow and step names — MUST never be sent. Any value read from disk or settings that could be free text MUST be coerced to a known allow-list before reporting, with anything unrecognized reduced to a neutral placeholder.
@@ -139,10 +146,11 @@ Every telemetry payload SHALL contain only enum-like values, booleans, versions,
 #### Scenario: the extension activates
 - **WHEN** the activation event fires
 - **THEN** it carries only versions, a spec count, a companion-installed boolean, and enum-like feature-flag states — never a spec name, path, or user-authored workflow name
+- **AND** the default-workflow flag reports the user's raw configured value (an unset default reads as stock `speckit`), never the install-derived effective default, so the adoption metric counts only an explicit Companion choice
 
 ### Engagement is counted without naming what was engaged
 
-The extension SHALL emit a bare event when a spec, a living spec, or a steering document is opened, and when a living-spec drift or sync runs — carrying no property at all, so a count can never be tied to a name or path. The install-banner funnel is likewise reported as fixed `shown`/`clicked` × surface literals produced only by our own call sites. Opened-in-viewer events MUST be de-duplicated per session so a re-rendering panel cannot inflate the count, and the de-dupe key used for that MUST be an internal identity that is never sent. A de-dupe slot MUST be claimed only after an event actually emits, so an open that happened while telemetry was off or uninitialized still fires once telemetry becomes available.
+The extension SHALL emit a bare event when a spec, a living spec, or a steering document is opened, and when a living-spec drift or sync runs — carrying no property at all, so a count can never be tied to a name or path. The install-banner funnel is likewise reported as fixed `shown`/`clicked` × surface literals produced only by our own call sites. The set of install-prompt surfaces is a closed allow-list (create-spec, activity, sidebar badge, pinned row, welcome, terminal); a surface value that arrives untrusted — such as a command argument wired from a `viewsWelcome` button — MUST be coerced to a known member of that allow-list before it is reported, and an unrecognized value dropped rather than sent. Opened-in-viewer events MUST be de-duplicated per session so a re-rendering panel cannot inflate the count, and the de-dupe key used for that MUST be an internal identity that is never sent. A de-dupe slot MUST be claimed only after an event actually emits, so an open that happened while telemetry was off or uninitialized still fires once telemetry becomes available.
 
 #### Scenario: the same spec is re-revealed in the viewer
 - **WHEN** the panel re-renders and would re-emit the open event
@@ -166,11 +174,16 @@ VS Code context keys SHALL be written through a single wrapper that accepts only
 
 ### A spec's display name resolves by preference without changing its identity
 
-A readable display name SHALL be resolved by preference — a recorded name first, then a document heading, then a humanized form of the directory slug — while the directory slug remains the stable identifier. A blank or whitespace-only candidate MUST be treated as absent so it can never win over the humanized-slug fallback.
+A readable display name SHALL be resolved by preference — a recorded name first, then a document heading, then a humanized form of the directory slug — while the directory slug remains the stable identifier. A blank or whitespace-only candidate MUST be treated as absent so it can never win over the humanized-slug fallback. A recorded name and a slug-derived name SHALL be title-cased through one shared acronym-aware caser — known acronyms (CLI, API, UI, JSON, VS Code, …) keep their canonical casing rather than being mangled to "Cli"/"Json" — and that same caser is the one both the viewer header and the specs tree route through. A document heading is authored prose and is returned verbatim, never re-cased.
 
 #### Scenario: a spec has no recorded name
 - **WHEN** a display name is needed and the recorded name is empty or whitespace
 - **THEN** a document heading is used when present, otherwise the humanized slug — and the slug still identifies the spec
+
+#### Scenario: a spec name carries an acronym
+- **WHEN** a recorded or slug-derived name contains a known acronym token
+- **THEN** the shared caser title-cases the name while preserving the acronym's canonical form
+- **AND** a living-spec heading is left exactly as authored
 
 ### Shared primitives absorb host and shell differences
 

--- a/src/features/spec-editor/spec-editor.spec.md
+++ b/src/features/spec-editor/spec-editor.spec.md
@@ -31,13 +31,14 @@ The workflow the user picked SHALL be carried into the new spec's own state reco
 - **THEN** the creation instruction seeds that workflow into the spec's record
 - **AND** later steps dispatch from that recorded choice
 
-### The picker offers only workflows that can actually run
+### The picker never offers a silent degrade, but Companion stays visible as install-to-enable
 
-The workflow list SHALL be built from what the active AI provider supports and what is genuinely installed, so the picker never lists an option that would silently degrade to something else. Every builder that feeds a workflow list MUST share one predicate — this repo has shipped a bug where one of two independent list builders was gated and the other was not, and the ungated one was the one that rendered.
+The workflow list SHALL be built from what the active AI provider supports, so a provider-incompatible custom workflow is omitted. The Companion entry is the deliberate exception: because starting a spec is the highest-intent install moment, Companion is ALWAYS listed — even when the spec-kit extension is absent — but labeled as install-to-enable and carrying its not-installed state, so it is never a *silent* degrade. A not-installed pick is intercepted before any dispatch (see the install-first requirement below) rather than quietly running stock. Every builder that feeds a workflow list MUST share one predicate — this repo has shipped a bug where one of two independent list builders was gated and the other was not, and the ungated one was the one that rendered.
 
 #### Scenario: the companion piece is not installed
 - **WHEN** the panel builds its workflow list
-- **THEN** the Companion entry is absent rather than present-and-degrading
+- **THEN** the Companion entry is still present, labeled as install-to-enable and flagged not-installed
+- **AND** picking it is intercepted with an install-first prompt rather than silently producing a stock spec
 
 #### Scenario: a user-defined workflow names a step the active provider cannot run
 - **WHEN** the list is built
@@ -47,10 +48,12 @@ The workflow list SHALL be built from what the active AI provider supports and w
 
 When a chosen action needs the companion piece and it is absent, the host SHALL either downgrade to the equivalent stock action or, when there is no equivalent, refuse to start at all. Either way the user gets a non-blocking explanation and a one-click way to install. Dispatching a command the AI cannot resolve is never acceptable. When the panel surfaces its install prompt, and when the user takes it, the host SHALL record the exposure and the click so install-prompt adoption can be measured.
 
+Because Create Spec is the highest-intent install moment, an ordinary (non-Auto, non-custom) Companion pick made without the companion piece SHALL present its benefits and a one-click install FIRST — a modal offering install, "use SpecKit instead", or cancel — before any spec is created, so install is never a surprise. Choosing install kicks off the install and aborts creation (creating a stock spec then would silently run the wrong workflow); "use SpecKit instead" takes the graceful stock downgrade; cancel creates nothing and leaves the editor interactive. The default workflow the panel pre-selects SHALL be the effective default — the user's explicit choice when set, otherwise Companion when the extension is installed — not the raw stock fallback.
+
 #### Scenario: the Companion entry point is chosen without the companion piece
-- **WHEN** the user submits
-- **THEN** the stock equivalent runs
-- **AND** a dismissible warning offers to install the missing piece
+- **WHEN** the user submits an ordinary Companion pick
+- **THEN** a benefits-and-install-first prompt appears before anything is created
+- **AND** installing aborts creation to be re-run once installed, declining takes the stock equivalent, and cancelling creates nothing
 
 #### Scenario: the hands-off run is requested without the companion piece
 - **WHEN** the user triggers it

--- a/src/features/specs/specs.spec.md
+++ b/src/features/specs/specs.spec.md
@@ -130,6 +130,8 @@ Any command belonging to the Companion namespace SHALL be recognized by its shar
 - **THEN** nothing is dispatched at all
 - **AND** the user is told why
 
+When a phase or workflow step actually dispatches to a terminal, the dispatch path SHALL fire the shared once-per-session terminal install nudge (owned by the speckit-cli capability) — except on the fell-back path, which already surfaces its own install warning. This is a call-through at dispatch time, not gating logic this capability owns: the nudge's own gate decides whether anything renders, and it can never block the dispatched command.
+
 ### Reading a record is tolerant; writing one is strict
 
 The reader SHALL accept records written by older versions, by other tools, and by an AI that got a field's shape slightly wrong — normalizing legacy field names, superseded status vocabulary, and loosely-typed values into the canonical shape in memory. Unknown top-level fields MUST survive a read/write round-trip, because another writer may own them. A genuinely absent record and a record that could not be read MUST be distinguishable to the caller, so a transient read failure is never mistaken for "no record here."

--- a/src/features/steering/steering.spec.md
+++ b/src/features/steering/steering.spec.md
@@ -30,14 +30,14 @@ Every file-name label, create-action title, and scope path SHALL be resolved fro
 - **THEN** the create action appears inside that scope's group
 - **AND** its title names the provider's real filename
 
-### Sections appear only when they hold content, except the two stable entry points
+### Sections appear only when they hold content, and the provider node stays the stable entry point
 
-The root SHALL omit any section with nothing in it, and SHALL always show the Companion and provider nodes so those two remain findable. An always-visible empty section trains users to ignore the view; a disappearing entry point makes install and configuration undiscoverable.
+The root SHALL omit any section with nothing in it, and SHALL always show the provider node so it remains findable. The Companion node SHALL appear only when the companion extension is installed (surfacing its Configuration and Commands); when it is absent the node is omitted here entirely — the install nudge lives on the higher-signal surfaces (the activity-bar badge, the pinned Specs CTA, and Create Spec) rather than as a warning row in this tree. An always-visible empty section trains users to ignore the view.
 
 #### Scenario: a workspace with no SpecKit scaffolding
 - **WHEN** the project has no constitution, scripts, or templates
 - **THEN** the SpecKit project-files section is absent entirely
-- **AND** the Companion and provider nodes are still present
+- **AND** the provider node is still present, while the Companion node appears only if the companion extension is installed
 
 ### A provider's label and its mark resolve from one decision
 
@@ -50,7 +50,7 @@ The row's display name and its icon SHALL derive from the same provider resoluti
 
 #### Scenario: a provider ships no official mark
 - **WHEN** that provider is configured
-- **THEN** the neutral glyph is chosen deliberately rather than reached by falling through the lookup
+- **THEN** a themed Codicon matching the provider's own QuickPick icon is used when it declares one (Antigravity resolves to its rocket glyph), otherwise the neutral chat glyph is chosen deliberately rather than reached by falling through the lookup
 
 ### The Companion node reports install state and reads the installed extension live
 

--- a/src/speckit/speckit-cli.spec.md
+++ b/src/speckit/speckit-cli.spec.md
@@ -85,6 +85,20 @@ The prompt to install the companion CLI extension SHALL be shown when the prompt
 - **WHEN** the gate is evaluated with the extension absent
 - **THEN** nothing is shown — no banner and no fallback warning
 
+### Terminal dispatch carries a once-per-session install hint
+
+When a spec-kit command is dispatched to a terminal-CLI provider and the companion extension is absent, the extension SHALL show a single non-blocking install hint tagged to the `terminal` surface. Its gate is the conjunction: spec-kit is detected in the workspace, the companion extension is not installed, the shared install-nudge dismissal is unset, the active provider dispatches to a terminal (never an editor-chat provider — that surface has its own in-editor nudges), and it has not already shown this session. The hint reuses the shared install command and the same `installNudgeDismissed` flag as the other nudge surfaces — no parallel dismissal. It MUST NEVER block or fail the dispatched command: any failure while deciding or presenting it is swallowed so the command always proceeds, and the session slot and telemetry `shown` are recorded under the same gate the hint renders on.
+
+#### Scenario: a terminal dispatch runs without the extension
+- **WHEN** a command dispatches to a terminal-CLI provider, spec-kit is detected, the extension is absent, and the nudge has not shown this session
+- **THEN** one install hint is shown, tagged `terminal`, offering Install or "Don't show again"
+- **AND** a second dispatch in the same session shows nothing more
+
+#### Scenario: the active provider dispatches to editor chat, or the nudge was dismissed
+- **WHEN** the provider routes to the host editor's chat, or the shared dismissal is already set
+- **THEN** the terminal hint does not render
+- **AND** the dismissal is shared with every other install-prompt surface
+
 ### Two products share one release list and must never be confused
 
 This repository publishes two independently-versioned products into a single releases list. Any release lookup SHALL filter to the tag shape belonging to the product being asked about, and MUST reject drafts and prereleases. A lookup that resolves "the latest release" across both namespaces is a defect shape that has shipped before and MUST NOT be reintroduced anywhere — including links opened for the user.

--- a/webview/src/spec-editor/editor-ui.spec.md
+++ b/webview/src/spec-editor/editor-ui.spec.md
@@ -76,7 +76,7 @@ The editor MUST reject unsupported image formats and oversized files locally, wi
 
 ### The chosen workflow determines which submission affordances exist
 
-Submission affordances MUST be derived from the selected workflow's own declaration rather than hard-coded. A workflow that declares a hands-off orchestrator gets the hands-off affordance; a workflow that declares named entry commands gets a button per command; a workspace with only one workflow hides the chooser entirely instead of showing a one-item control. Adding a workflow must not require editing this surface.
+Submission affordances MUST be derived from the selected workflow's own declaration rather than hard-coded. A workflow that declares a hands-off orchestrator gets the hands-off affordance; a workflow that declares named entry commands gets a button per command; a workspace with only one workflow hides the chooser entirely instead of showing a one-item control. Adding a workflow must not require editing this surface. A workflow declaration MAY also carry an `installed` flag (the Companion entry sets it from whether the spec-kit extension is present) so the surface can present a not-installed workflow as install-to-enable; the install-first decision itself is made extension-side, so this is an inbound flag the editor renders rather than logic it owns.
 
 #### Scenario: the selected workflow has no hands-off mode
 - **WHEN** the user picks such a workflow

--- a/webview/src/spec-viewer/viewer-ui.spec.md
+++ b/webview/src/spec-viewer/viewer-ui.spec.md
@@ -179,18 +179,27 @@ Every section of the overview MUST hide itself when its data is empty, so a spec
 - **WHEN** a spec recorded no decisions
 - **THEN** the decisions section does not render at all
 
+#### Scenario: coverage has rows but nothing is traced
+- **WHEN** the coverage rows exist but no requirement has a linked test
+- **THEN** the Coverage section hides entirely rather than showing a misleading "0 of N traced"
+- **AND** it reappears once any requirement gains a linked test
+
 #### Scenario: a section throws while rendering
 - **WHEN** the overview subtree fails
 - **THEN** an inline notice replaces it, the error is reported to the extension, and the rest of the viewer keeps working
 
-### A living spec's title is authored, not derived
+### The header renders the title it is given; casing is decided upstream
 
-A living spec's header MUST show the title as written in the document's own top-level heading and MUST NOT re-case it. Feature specs are named by directory slugs and are capitalised for display; a heading-derived title is a human's own words, and applying slug capitalisation to it silently mangles deliberate casing. The two cases are therefore distinguished explicitly rather than treated alike.
+The header MUST render the title exactly as supplied and MUST NOT re-case it or branch on where it came from. The authored-versus-derived decision belongs to the extension's shared display-name resolver: a feature name is acronym-aware title-cased there (a slug like "cli install nudge" arrives as "CLI Install Nudge"), and an authored living-spec heading arrives verbatim. Because that decision is already made when the title reaches the header, the header no longer carries a separate CSS state to distinguish the two cases — it prints one title uniformly.
 
-#### Scenario: a capability whose name carries internal capitals
-- **WHEN** the title comes from the document's heading
-- **THEN** it renders exactly as authored
-- **AND** the slug capitalisation applied to feature-spec titles is switched off
+#### Scenario: a feature name with an acronym is shown
+- **WHEN** the header receives a feature title resolved upstream
+- **THEN** it prints it as given — acronyms already in canonical form, words already capitalised
+- **AND** the header applies no casing of its own
+
+#### Scenario: a living spec's authored heading is shown
+- **WHEN** the title came from the document's own top-level heading
+- **THEN** the header prints it exactly as authored, because the resolver returned it verbatim
 
 ### Delegated click handling must survive non-element targets and late mounts
 
@@ -223,6 +232,11 @@ Recorded substep events are journal moments, not measured work. Each event carri
 - **WHEN** the timing summary reports itself not yet complete
 - **THEN** the run surfaces measured-of-expected phase coverage
 - **AND** no start, elapsed, or end figure is shown as if the run had settled
+
+#### Scenario: a spec was driven entirely through the CLI
+- **WHEN** the extension now marks a CLI-run's step spans as measured (both boundaries from an authoritative-enough writer) and reports them in the summary
+- **THEN** the viewer surfaces that trusted coverage as given rather than "0 of N"
+- **AND** the webview still sums nothing itself — the change is in the summary it renders, not in a webview derivation
 
 #### Scenario: a recorded substep event is displayed
 - **WHEN** a tracked substep is rendered in the phase history
@@ -309,3 +323,8 @@ Each pipeline step's related artifact documents MUST render as an indented sub-l
 - **WHEN** the reader clicks a nested artifact sub-item
 - **THEN** the viewer switches to that document and the sub-item reads as current
 - **AND** clicking the parent step still opens the step's own document
+
+#### Scenario: the pane is too narrow for a vertical rail
+- **WHEN** the container falls below the rail's fold width
+- **THEN** the rail folds into a horizontally-scrolling strip where each step and its own artifact chips form one inline unit, with a divider between units
+- **AND** a step reads beside its own files rather than colliding with the next step's column


### PR DESCRIPTION
Folds this session's merged behavior changes back into the 9 drifted living specs so `drift.py` reads clean again (the standing hygiene pass, like #550). **Living-spec `.spec.md` content only — no code.**

**Real deltas folded:** ai-providers (agy CLI + install-hint URL + terminal-vs-editor classification), spec-editor (Companion always listed + install-first modal — rewrote the old "entry absent" requirement the new behavior contradicts), speckit-cli (terminal install nudge + full gate), steering (Companion node only when installed + Antigravity rocket icon), core (merged notifications toggle + acronym caser + telemetry surfaces), viewer-ui (hidden empty coverage + inline step strip + acronym title + CLI trusted coverage), workflows (companion-as-default resolver).

**Incidental (noted, not fabricated):** editor-ui (an unused inbound `installed?` type field), specs (call-through wiring to the speckit-cli-owned nudge).

Verified: `drift.py` → all 14 capabilities in sync; compile clean; 1877 tests pass.