### PR TITLE
fix(speckit-ext): drop stale .dev0 pin from speckit_version floor

### DIFF
--- a/speckit-extension/CHANGELOG.md
+++ b/speckit-extension/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/); this ext
 
 ## [Unreleased]
 
+### Fixed
+
+- **The minimum spec-kit version check no longer carries a stale `.dev0` pin.** The floor was pinned to `>=0.9.5.dev0` to admit spec-kit's own git-HEAD dev builds back when spec-kit's `main` was still on the 0.9.5 line — that line shipped stable long ago (spec-kit's `main` now builds `0.15.x`), so the pin had become dead weight and the only catalog entry not using a bare floor. Floor is now `>=0.9.5`, matching every other catalog entry's convention. No install behavior changes for anyone on a real release.
+
 ## [0.20.1] - 2026-08-01
 
 ### Changed

--- a/speckit-extension/extension.yml
+++ b/speckit-extension/extension.yml
@@ -13,11 +13,11 @@ extension:
 requires:
   # Floor is the workflow-engine surface the Companion workflow rides:
   # `specify workflow run`/`resume` plus the `command`/`gate`/`switch` step
-  # registry, all present from the 0.9.5 engine. The `.dev0` suffix is load-
-  # bearing: git/`uv` installs can report `0.9.5.dev0`, and PEP 440 sorts a
-  # dev build BELOW its final, so a bare `>=0.9.5` rejects exactly the builds
-  # this floor means to admit (this regressed once — don't simplify it away).
-  speckit_version: ">=0.9.5.dev0"
+  # registry, all present from the 0.9.5 engine. A bare floor is correct as
+  # long as spec-kit's released line has moved past 0.9.5 — `.dev0` is only
+  # needed when the floor equals the exact line spec-kit's git HEAD is
+  # currently building (see spec-kit's own pyproject.toml version).
+  speckit_version: ">=0.9.5"
   tools:
     - name: python3
       required: false


### PR DESCRIPTION
## Summary
The spec-kit extension's minimum version check was pinned to a "dev" pre-release build of spec-kit — a leftover from when spec-kit's own development version was still on that exact line, months ago. Spec-kit has since released well past it, so the special case no longer applies. The requirement is now a plain minimum version, matching how every other extension in the catalog declares its floor.

## Technical
- `speckit-extension/extension.yml`: `requires.speckit_version` `>=0.9.5.dev0` → `>=0.9.5`; comment rewritten to explain the floor is temporal — `.dev0` is only needed when the floor equals the exact version line spec-kit's git `main` is currently building, and spec-kit's `main` is now on `0.15.3.dev0`, well past `0.9.5`.
- `speckit-extension/CHANGELOG.md`: added `## [Unreleased]` entry.

## Review checklist
- ✅ **SpecKit extension** — affected
    - version requirement: `extension.yml` `requires.speckit_version`
- ✅ **Changelog** — `speckit-extension/CHANGELOG.md` (Unreleased)
- — **Docs** — no README/doc prose describes this floor value, nothing else references it
- ✅ **Verify**
    - no version bump (release flow bumps `extension.yml` `version` via `/publish-speckit-ext`)
    - confirmed spec-kit's published `pyproject.toml` is at `0.15.3.dev0` (well past the `0.9.5` floor)
    - confirmed via the live `catalog.community.json` that every other entry (~110+) uses a bare floor, none use `.dev0`

## Gaps / how to see it
- No functional behavior change for any real install today — this is a correctness/convention cleanup. Try: `python3 -c "from packaging.version import Version; from packaging.specifiers import SpecifierSet; print(Version('0.15.3.dev0') in SpecifierSet('>=0.9.5'))"` → `True`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
