### PR TITLE
fix(watchers): scope global Claude watchers to ~/.claude

### DIFF
--- a/src/core/fileWatchers.ts
+++ b/src/core/fileWatchers.ts
@@ -1,3 +1,4 @@
+import * as os from 'os';
 import * as path from 'path';
 import * as vscode from 'vscode';
 import { SpecExplorerProvider } from '../features/specs/specExplorerProvider';
@@ -180,8 +181,14 @@ function setupClaudeSettingsWatcher(
     context: vscode.ExtensionContext,
     steeringExplorer: SteeringExplorerProvider
 ): void {
+    // Base the pattern on `~/.claude` rather than `$HOME`. A RelativePattern
+    // whose pattern contains a path segment (e.g. `.claude/settings.json`) is
+    // treated as "complex" by VS Code and makes the base folder be watched
+    // *recursively* — which meant recursively watching the entire home
+    // directory and exhausting the inotify watch limit on Linux (ENOSPC).
+    const claudeDir = vscode.Uri.file(path.join(os.homedir(), '.claude'));
     const claudeSettingsWatcher = vscode.workspace.createFileSystemWatcher(
-        new vscode.RelativePattern(process.env.HOME || '', '.claude/settings.json')
+        new vscode.RelativePattern(claudeDir, 'settings.json')
     );
 
     claudeSettingsWatcher.onDidChange(() => {
@@ -198,8 +205,11 @@ function setupClaudeMdWatchers(
     context: vscode.ExtensionContext,
     steeringExplorer: SteeringExplorerProvider
 ): void {
+    // See `setupClaudeSettingsWatcher`: keep the base at `~/.claude` so the
+    // pattern stays simple and the watcher stays non-recursive.
+    const claudeDir = vscode.Uri.file(path.join(os.homedir(), '.claude'));
     const globalClaudeMdWatcher = vscode.workspace.createFileSystemWatcher(
-        new vscode.RelativePattern(process.env.HOME || '', '.claude/CLAUDE.md')
+        new vscode.RelativePattern(claudeDir, 'CLAUDE.md')
     );
     const projectClaudeMdWatcher = vscode.workspace.createFileSystemWatcher('**/CLAUDE.md');
 

--- a/tests/__mocks__/vscode.ts
+++ b/tests/__mocks__/vscode.ts
@@ -91,8 +91,14 @@ export class RelativePattern {
     base: string;
     pattern: string;
 
-    constructor(base: string | { uri: Uri }, pattern: string) {
-        this.base = typeof base === 'string' ? base : base.uri.fsPath;
+    constructor(base: string | Uri | { uri: Uri }, pattern: string) {
+        if (typeof base === 'string') {
+            this.base = base;
+        } else if ('fsPath' in base) {
+            this.base = base.fsPath;
+        } else {
+            this.base = base.uri.fsPath;
+        }
         this.pattern = pattern;
     }
 }

--- a/tests/unit/core/fileWatchers.spec.ts
+++ b/tests/unit/core/fileWatchers.spec.ts
@@ -1,3 +1,5 @@
+import * as os from 'os';
+import * as path from 'path';
 import * as vscode from 'vscode';
 import { setupFileWatchers } from '../../../src/core/fileWatchers';
 import { getFileWatcherPatterns } from '../../../src/core/specDirectoryResolver';
@@ -38,6 +40,30 @@ describe('setupSpecContextWatchers (via setupFileWatchers)', () => {
             .map(r => r.value)
             .filter(w => typeof w.pattern === 'string' && w.pattern.endsWith('.spec-context.json'));
     }
+
+    function globalClaudeWatchers(): any[] {
+        const results = (vscode.workspace.createFileSystemWatcher as jest.Mock).mock.results;
+        return results
+            .map(r => r.value)
+            .filter(w => w.pattern instanceof vscode.RelativePattern);
+    }
+
+    it('scopes global Claude watchers non-recursively to the .claude directory', () => {
+        setupFileWatchers(context, specExplorer, steeringExplorer, specViewer, outputChannel);
+
+        const patterns = globalClaudeWatchers().map(w => w.pattern);
+
+        expect(patterns).toHaveLength(2);
+        expect(patterns.map(relativePattern => relativePattern.base)).toEqual([
+            path.join(os.homedir(), '.claude'),
+            path.join(os.homedir(), '.claude'),
+        ]);
+        expect(patterns.map(relativePattern => relativePattern.pattern).sort()).toEqual([
+            'CLAUDE.md',
+            'settings.json',
+        ]);
+        expect(patterns.every(relativePattern => !/[\\/]/.test(relativePattern.pattern))).toBe(true);
+    });
 
     it('registers one spec-context watcher per configured spec-directory pattern', () => {
         setupFileWatchers(context, specExplorer, steeringExplorer, specViewer, outputChannel);


### PR DESCRIPTION
## Related Issue

Closes #578

## Description

The global Claude settings and `CLAUDE.md` watchers currently use `$HOME` as their
`RelativePattern` base with path-segment patterns. VS Code treats those patterns as complex and
watches the entire home directory recursively, which can exhaust the Linux inotify watch limit.

This change:

- scopes both global watchers to `~/.claude` using `os.homedir()`;
- uses the simple patterns `settings.json` and `CLAUDE.md`, keeping the watchers non-recursive;
- preserves the watched files, event handlers, and Steering refresh behavior;
- updates the VS Code test mock to accept a `Uri` as a `RelativePattern` base; and
- adds regression coverage for the watcher base and simple filename patterns.

This is an internal watcher-scoping fix with no UI or public API changes, so README and long-form
documentation updates are not applicable.

## Known Existing Issue (Out of Scope)

`createUserSteeringFile()` in `src/features/steering/steeringManager.ts` still builds the user Claude
directory with `path.join(process.env.HOME || '', '.claude')`. On Windows, when `HOME` is unset, this
produces a relative `.claude` path, so the file creation target can differ from the `os.homedir()`
path watched after this change.

This behavior predates this change and is separate from the recursive watcher/inotify issue. It is
intentionally left unchanged here to keep this fix focused.

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update
- [ ] Refactor / internal-only

## Testing

Automated verification:

```bash
npm run compile
npm test
```

- TypeScript compilation passes.
- Full test suite passes: 133 suites, 1,879 tests.
- Added a regression test confirming that both global Claude watchers use `~/.claude` as their base
  and contain no path separators in their filename patterns.

Manual verification on the same Arch Linux machine described in #578:

| Metric | Before | After |
| --- | --- | --- |
| Total inotify watches | 456,300 | 11,256 |
| Watch root requested by VS Code | `$HOME` | `~/.claude` |

The updated extension was packaged as a VSIX and installed locally for this verification.

## Checklist

- [x] Code follows the project's style guidelines (see `CONTRIBUTING.md`)
- [x] Self-review completed
- [x] Tests pass (`npm test`)
- [x] Updated `README.md` per the "Feature → README section map" in `CLAUDE.md` (N/A — internal-only watcher fix)
- [x] Documentation updated under `docs/` (N/A — no user-facing behavior or API change)
- [x] Tests added/updated (if applicable)
- [x] No new warnings generated
