### PR TITLE
fix(companion): resolve the global steering path from os.homedir()

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/394-adopt-codex-design"
+  "feature_directory": "specs/565-homedir-steering-path"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Creating a global CLAUDE.md now always lands in your home directory, so the Steering view actually shows it.** The create action worked out the home directory from the `HOME` environment variable, and when that variable wasn't set — which is common on Windows — the file was written to a `.claude` folder relative to whatever directory the editor started in. The extension watches and reads your real home directory, so the new file simply never appeared. Home directory resolution is now the same everywhere the extension looks, writes, and watches. ([#580](https://github.com/alfredoperez/speckit-companion/issues/580))
+
 ## [0.31.1] - 2026-08-01
 
 ### Changed

--- a/specs/565-homedir-steering-path/.spec-context.json
+++ b/specs/565-homedir-steering-path/.spec-context.json
@@ -1,0 +1,259 @@
+{
+  "workflow": "companion",
+  "specName": "homedir steering path",
+  "branch": "fix/homedir-steering-path",
+  "currentStep": "implement",
+  "status": "completed",
+  "history": [
+    {
+      "step": "specify",
+      "substep": null,
+      "kind": "start",
+      "by": "extension",
+      "at": "2026-08-17T00:47:47.131Z"
+    },
+    {
+      "step": "specify",
+      "substep": null,
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-08-17T00:49:32.722Z"
+    },
+    {
+      "step": "plan",
+      "substep": null,
+      "kind": "start",
+      "by": "extension",
+      "at": "2026-08-17T00:49:32.801Z"
+    },
+    {
+      "step": "plan",
+      "substep": null,
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-08-17T00:49:32.879Z"
+    },
+    {
+      "step": "tasks",
+      "substep": null,
+      "kind": "start",
+      "by": "extension",
+      "at": "2026-08-17T00:49:32.959Z"
+    },
+    {
+      "step": "tasks",
+      "substep": null,
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-08-17T00:49:33.037Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "kind": "start",
+      "by": "extension",
+      "at": "2026-08-17T00:49:46.716Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T001",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-08-17T00:49:54.655Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T002",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-08-17T00:50:04.323Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T003",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-08-17T00:51:49.123Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T004",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-08-17T00:52:02.392Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T005",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-08-17T00:52:33.765Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-08-17T00:52:33.851Z"
+    }
+  ],
+  "unattended": true,
+  "livingSpecs": {
+    "loaded": [
+      "steering"
+    ],
+    "synced": [
+      "steering"
+    ]
+  },
+  "last_action": "simplified, re-verified — 134 suites / 1884 tests pass in 5.0s",
+  "coverage": {
+    "FR-001": {
+      "title": "Resolve the user's home directory from the operating system rather than the environment variable when creating a global steering file",
+      "tests": [
+        "src/features/steering/__tests__/steeringManager.test.ts::writes the global steering file under the OS home directory when HOME is unset"
+      ]
+    },
+    "FR-002": {
+      "title": "The write location must match the location the extension watches and reads for global steering files",
+      "tests": [
+        "src/features/steering/__tests__/steeringManager.test.ts::writes to the same home directory when HOME is set normally"
+      ]
+    },
+    "FR-003": {
+      "title": "Never create a global steering file at a path relative to the current working directory",
+      "tests": [
+        "src/features/steering/__tests__/steeringManager.test.ts::never resolves the target to a path relative to the current working directory"
+      ]
+    },
+    "FR-004": {
+      "title": "Existing behavior is unchanged where the home-directory environment variable is set correctly",
+      "tests": [
+        "src/features/steering/__tests__/steeringManager.test.ts::leaves the existing file untouched when the user cancels the overwrite prompt"
+      ]
+    },
+    "FR-005": {
+      "title": "Retain automated coverage proving the created file's location derives from the operating system's home directory",
+      "tests": [
+        "src/features/steering/__tests__/steeringManager.test.ts"
+      ]
+    }
+  },
+  "size": "simple",
+  "classification": {
+    "projectedFiles": 3,
+    "projectedTasks": 5,
+    "scopeSignal": "smaller",
+    "verdict": "simple"
+  },
+  "context": [
+    "living spec: steering",
+    "area: src/features/steering/steeringManager.ts",
+    "constraint: home-directory resolution must match the watchers fixed in PR #579"
+  ],
+  "intent": "Make global steering file creation resolve the home directory from the OS so the write location matches where the extension watches and reads.",
+  "expectations": [
+    "No migration or cleanup of stray .claude folders previously created at a relative path",
+    "No changes to the watcher scoping already fixed in PR #579",
+    "No Windows-specific override beyond the OS-reported home directory"
+  ],
+  "approach": "Resolve the home directory via Node's os.homedir() in steeringManager instead of process.env.HOME, and add test coverage for the unset/empty case.",
+  "currentTask": "T005",
+  "task_summaries": {
+    "T001": {
+      "status": "DONE",
+      "did": "Imported the Node os module into the steering manager",
+      "files": [
+        "src/features/steering/steeringManager.ts"
+      ]
+    },
+    "T002": {
+      "status": "DONE",
+      "did": "Resolved the global .claude directory from os.homedir() instead of process.env.HOME",
+      "files": [
+        "src/features/steering/steeringManager.ts"
+      ]
+    },
+    "T003": {
+      "status": "DONE",
+      "did": "Added 5 regression tests for global steering file path resolution; verified 3 fail against the old code",
+      "files": [
+        "src/features/steering/__tests__/steeringManager.test.ts",
+        "tests/__mocks__/vscode.ts"
+      ]
+    },
+    "T004": {
+      "status": "DONE",
+      "did": "Added an Unreleased Fixed changelog entry in user-facing release-note voice",
+      "files": [
+        "CHANGELOG.md"
+      ]
+    },
+    "T005": {
+      "status": "DONE",
+      "did": "Verified TypeScript compile and full suite: 134 suites / 1884 tests pass, no regressions",
+      "files": [
+        "(verification)"
+      ]
+    }
+  },
+  "verified": [
+    {
+      "what": "TypeScript compilation",
+      "command": "npm run compile",
+      "result": "clean, no errors",
+      "warnings": []
+    },
+    {
+      "what": "Full test suite",
+      "command": "npm test",
+      "result": "134 suites / 1884 tests pass (was 133/1879 before; +1 suite, +5 tests)",
+      "warnings": []
+    },
+    {
+      "what": "Regression test genuinely catches the bug",
+      "command": "temporarily reverted the fix and re-ran the new test",
+      "result": "3 of 5 cases fail against the old process.env.HOME code and pass against os.homedir()",
+      "warnings": []
+    },
+    {
+      "what": "Simplification pass and re-verification",
+      "command": "code-simplifier agent + npm run compile + npm test",
+      "result": "134 suites / 1884 tests pass; suite time down from 16.4s to 5.0s after removing the 3s timer waits; regression property re-confirmed (3 of 5 still fail against the old code)",
+      "warnings": []
+    }
+  ],
+  "decisions": [
+    {
+      "decision": "Use os.homedir() with no environment-variable fallback at all",
+      "why": "os.homedir() already consults the platform-appropriate source on every OS and always returns an absolute path, so a HOME fallback could only reintroduce the relative-path bug",
+      "rejected": "process.env.HOME || os.homedir()"
+    },
+    {
+      "decision": "Extend the shared vscode mock with withProgress, ProgressLocation, and workspace.openTextDocument",
+      "why": "CLAUDE.md requires VS Code API gaps to be filled in tests/__mocks__/vscode.ts rather than stubbed per test file",
+      "rejected": "Mocking NotificationUtils inside the new test file"
+    },
+    {
+      "decision": "Mock NotificationUtils in the test file instead of adding withProgress/ProgressLocation to the shared vscode mock",
+      "why": "The real withProgress runs its task, so each case awaited a 3s auto-dismiss timer and the file took ~12s; mocking our own notification module keeps the test focused on path resolution and leaves the shared mock unchanged",
+      "rejected": "Extending the shared vscode mock with withProgress + ProgressLocation"
+    }
+  ],
+  "step_summaries": {
+    "implement": {
+      "summary": "Global steering file creation now resolves the home directory via os.homedir(), with 5 regression tests and a changelog entry"
+    }
+  },
+  "concerns": [
+    {
+      "note": "The living-spec fold appended the ADDED requirement after the ## Uncovered section instead of inside ## Requirements; corrected by hand in this change. Worth a fix in the fold script so placement is right automatically.",
+      "step": "implement"
+    }
+  ]
+}

--- a/specs/565-homedir-steering-path/.spec-context.json
+++ b/specs/565-homedir-steering-path/.spec-context.json
@@ -111,7 +111,7 @@
       "steering"
     ]
   },
-  "last_action": "simplified, re-verified — 134 suites / 1884 tests pass in 5.0s",
+  "last_action": "PR #581 opened for review — not merged",
   "coverage": {
     "FR-001": {
       "title": "Resolve the user's home directory from the operating system rather than the environment variable when creating a global steering file",

--- a/specs/565-homedir-steering-path/checklists/requirements.md
+++ b/specs/565-homedir-steering-path/checklists/requirements.md
@@ -1,0 +1,35 @@
+# Specification Quality Checklist: Consistent home-directory resolution for global steering files
+
+**Purpose**: Validate Companion specification completeness before planning
+**Created**: 2026-08-16
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed (User Scenarios, Requirements, Success Criteria)
+
+## Requirement Completeness
+
+- [x] Any [NEEDS CLARIFICATION] markers are genuine ambiguities (≤3) deferred to clarify — not unresolved guesses
+- [x] Each Functional Requirement is a single, testable MUST/SHOULD statement
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into the specification
+
+## Notes
+
+- No [NEEDS CLARIFICATION] markers: the three open choices (platform coverage, the empty-string fallback, and migration of any stray file) were resolved as informed defaults and recorded under Assumptions.
+- Implementation-level file paths are confined to the Approach section, which is the simple-mode plan rather than part of the specification proper.

--- a/specs/565-homedir-steering-path/plan.md
+++ b/specs/565-homedir-steering-path/plan.md
@@ -1,0 +1,4 @@
+# Implementation Plan: Consistent home-directory resolution for global steering files
+
+> This change was classified as **simple**, so the plan lives inline with the spec.
+> See [Approach](./spec.md#approach) for the implementation approach, and [tasks.md](./tasks.md) for the task checklist.

--- a/specs/565-homedir-steering-path/spec.md
+++ b/specs/565-homedir-steering-path/spec.md
@@ -1,0 +1,89 @@
+# Feature Specification: Consistent home-directory resolution for global steering files
+
+**Feature**: Creating a global steering file always targets the real home directory
+**Issue**: [#580](https://github.com/alfredoperez/speckit-companion/issues/580)
+**Created**: 2026-08-16
+**Status**: Draft
+
+## User Scenarios & Testing
+
+### User Story 1 - Creating a global steering file puts it where the extension looks (Priority: P1)
+
+A developer opens the Steering view and asks the extension to create their global guidance file. The extension creates the file in the user's home directory, opens it in the editor, and the Steering view immediately lists it. This holds on every operating system, including when the environment does not advertise a home directory through the usual variable — the extension falls back to what the operating system itself reports rather than writing into whatever folder the editor happened to start in.
+
+**Why this priority**: This is the whole defect. Without it, the create action silently produces a file in an unpredictable location that the extension never displays again, and the user is left believing the feature is broken.
+
+**Independent Test**: Trigger "create global steering file" in an environment where the home-directory variable is unset, then confirm the new file lands in the operating system's reported home directory and appears in the Steering view.
+
+**Acceptance Scenarios**:
+
+1. **Given** the environment does not define a home-directory variable, **When** the user creates the global steering file, **Then** the file is created inside the operating system's reported home directory, not in a folder relative to the current working directory.
+2. **Given** the environment does define a home-directory variable pointing at the usual location, **When** the user creates the global steering file, **Then** the file is created in that same home directory exactly as it was before this change.
+3. **Given** the global steering file has just been created, **When** the Steering view refreshes, **Then** the newly created file is listed, because it was written to the location the view watches and reads.
+4. **Given** a global steering file already exists at the resolved location, **When** the user creates it again, **Then** the existing overwrite confirmation is still offered and cancelling still leaves the file untouched.
+
+### User Story 2 - Home-directory resolution is consistent everywhere (Priority: P2)
+
+Every part of the extension that needs the user's home directory resolves it the same way, so the folder that is watched for changes, the folder that is read to list files, and the folder that is written to when creating a file can never disagree.
+
+**Why this priority**: Prevents this class of defect from recurring. The watchers were already corrected; this closes the last remaining inconsistent path so the three operations stay aligned.
+
+**Independent Test**: Search the extension source for home-directory resolution and confirm a single approach is used throughout.
+
+**Acceptance Scenarios**:
+
+1. **Given** the extension source, **When** home-directory resolution is reviewed, **Then** no code path derives the home directory from the environment variable alone.
+2. **Given** the reading, watching, and writing paths for global guidance files, **When** each resolves the home directory, **Then** all three produce the same folder.
+
+## Edge Cases
+
+- The environment variable for the home directory is unset entirely — resolution must still yield a valid absolute home directory.
+- The environment variable is set but empty — this must be treated the same as unset, not as an empty relative path.
+- The target folder does not yet exist — creation must still succeed, as it does today.
+- The file already exists — the overwrite prompt and the cancel path must behave exactly as before.
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: The extension MUST resolve the user's home directory from the operating system rather than from the home-directory environment variable when creating a global steering file.
+- **FR-002**: The location written when creating a global steering file MUST match the location the extension watches for changes and reads when listing global steering files.
+- **FR-003**: The extension MUST NOT create a global steering file at a path relative to the current working directory under any environment configuration.
+- **FR-004**: Existing behavior on systems where the home-directory environment variable is set correctly MUST be unchanged, including the overwrite confirmation, the cancel path, opening the created file in the editor, and the confirmation notification.
+- **FR-005**: The project MUST retain automated coverage proving the created file's location is derived from the operating system's home directory and not from the environment variable.
+
+## Success Criteria
+
+### Measurable Outcomes
+
+- **SC-001**: Creating a global steering file with no home-directory environment variable set produces the file in the operating system's home directory in 100% of attempts.
+- **SC-002**: The created file appears in the Steering view without any manual refresh, on every supported operating system.
+- **SC-003**: Zero code paths in the extension resolve the home directory from the environment variable.
+- **SC-004**: The existing test suite continues to pass with no regressions.
+
+## Assumptions
+
+- The operating system's reported home directory is the correct target on all supported platforms; no separate Windows-specific override is needed beyond it.
+- The empty-string fallback currently in place exists only to satisfy type requirements and has no intentional behavior worth preserving.
+- No user has come to depend on a global steering file previously created at a relative path; no migration or cleanup of such a stray file is required.
+
+## Approach
+
+- Resolve the home directory in `src/features/steering/steeringManager.ts` from Node's operating-system home-directory helper instead of the environment variable, matching what the file watchers and the Steering explorer already do.
+- Add the operating-system module import to that file.
+- Add focused test coverage asserting the created file's path is rooted at the operating system's home directory even when the environment variable is unset or empty.
+- No user-facing behavior changes on correctly configured systems, so no README or long-form documentation updates apply; the changelog gets a fix entry.
+
+**Dependencies**: none. This is the follow-up to the watcher scoping fix already merged in PR #579.
+
+## ADDED Requirements
+<!-- capability: steering -->
+
+### A file the view creates lands where the view watches and reads
+
+Every location the view resolves for a user-scope file SHALL be derived from the operating system's reported home directory, so the folder written to when creating a file, the folder watched for changes, and the folder read when listing are always the same. Deriving any one of them from an environment variable instead lets them disagree — an unset variable yields a path relative to the editor's working directory, and the created file becomes invisible to the view that just created it.
+
+#### Scenario: creating the global rules file with no home variable set
+- **WHEN** the user creates the global rules file in an environment that does not define the home-directory variable
+- **THEN** the file is created under the operating system's reported home directory
+- **AND** the view lists it without a manual refresh

--- a/specs/565-homedir-steering-path/tasks.md
+++ b/specs/565-homedir-steering-path/tasks.md
@@ -1,0 +1,9 @@
+# Tasks: Consistent home-directory resolution for global steering files
+
+**Spec**: [spec.md](./spec.md) · **Approach**: [spec.md#approach](./spec.md#approach)
+
+- [x] **T001** Import the Node operating-system module in the steering manager + src/features/steering/steeringManager.ts
+- [x] **T002** Resolve the global steering directory from the operating system's home directory instead of the environment variable + src/features/steering/steeringManager.ts
+- [x] **T003** [P] Add test coverage proving the created file path is rooted at the operating system's home directory when the environment variable is unset or empty + src/features/steering/__tests__/steeringManager.test.ts
+- [x] **T004** [P] Add a changelog entry under Unreleased for the fix + CHANGELOG.md
+- [x] **T005** Verify the full test suite and TypeScript compilation pass with no regressions + (verification)

--- a/src/features/steering/__tests__/steeringManager.test.ts
+++ b/src/features/steering/__tests__/steeringManager.test.ts
@@ -1,0 +1,97 @@
+import * as vscode from 'vscode';
+import * as os from 'os';
+import * as path from 'path';
+import { SteeringManager } from '../steeringManager';
+
+jest.mock('../../../extension', () => ({
+    getAIProvider: jest.fn(),
+}));
+
+jest.mock('../../../core/utils/configManager', () => ({
+    ConfigManager: {
+        getInstance: jest.fn().mockReturnValue({
+            loadSettings: jest.fn(),
+            getPath: jest.fn().mockReturnValue('.claude/steering'),
+        }),
+    },
+}));
+
+jest.mock('../../../core/utils/notificationUtils', () => ({
+    NotificationUtils: {
+        showAutoDismissNotification: jest.fn().mockResolvedValue(undefined),
+    },
+}));
+
+describe('SteeringManager.createUserSteeringFile', () => {
+    const outputChannel = { appendLine: jest.fn() } as unknown as vscode.OutputChannel;
+    let manager: SteeringManager;
+    const originalHome = process.env.HOME;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        (vscode.workspace.fs.stat as jest.Mock).mockRejectedValue(new Error('not found'));
+        manager = new SteeringManager(outputChannel);
+    });
+
+    afterEach(() => {
+        if (originalHome === undefined) {
+            delete process.env.HOME;
+        } else {
+            process.env.HOME = originalHome;
+        }
+    });
+
+    function writtenPath(): string {
+        const call = (vscode.workspace.fs.writeFile as jest.Mock).mock.calls[0];
+        return call[0].fsPath;
+    }
+
+    function createdDirPath(): string {
+        const call = (vscode.workspace.fs.createDirectory as jest.Mock).mock.calls[0];
+        return call[0].fsPath;
+    }
+
+    it('writes the global steering file under the OS home directory when HOME is unset', async () => {
+        delete process.env.HOME;
+
+        await manager.createUserSteeringFile();
+
+        expect(createdDirPath()).toBe(path.join(os.homedir(), '.claude'));
+        expect(writtenPath()).toBe(path.join(os.homedir(), '.claude', 'CLAUDE.md'));
+    });
+
+    it('writes the global steering file under the OS home directory when HOME is empty', async () => {
+        process.env.HOME = '';
+
+        await manager.createUserSteeringFile();
+
+        expect(writtenPath()).toBe(path.join(os.homedir(), '.claude', 'CLAUDE.md'));
+    });
+
+    it('never resolves the target to a path relative to the current working directory', async () => {
+        delete process.env.HOME;
+
+        await manager.createUserSteeringFile();
+
+        const target = writtenPath();
+        expect(path.isAbsolute(target)).toBe(true);
+        expect(target.startsWith(os.homedir())).toBe(true);
+    });
+
+    it('writes to the same home directory when HOME is set normally', async () => {
+        process.env.HOME = os.homedir();
+
+        await manager.createUserSteeringFile();
+
+        expect(writtenPath()).toBe(path.join(os.homedir(), '.claude', 'CLAUDE.md'));
+    });
+
+    it('leaves the existing file untouched when the user cancels the overwrite prompt', async () => {
+        (vscode.workspace.fs.stat as jest.Mock).mockResolvedValue({});
+        (vscode.window.showWarningMessage as jest.Mock).mockResolvedValue('Cancel');
+
+        await manager.createUserSteeringFile();
+
+        expect(vscode.workspace.fs.writeFile).not.toHaveBeenCalled();
+    });
+});

--- a/src/features/steering/steering.spec.md
+++ b/src/features/steering/steering.spec.md
@@ -130,6 +130,15 @@ Any parse or read failure while assembling a section SHALL yield an empty result
 - **THEN** no group entries are produced
 - **AND** the rest of the tree renders normally
 
+### A file the view creates lands where the view watches and reads
+
+Every location the view resolves for a user-scope file SHALL be derived from the operating system's reported home directory, so the folder written to when creating a file, the folder watched for changes, and the folder read when listing are always the same. Deriving any one of them from an environment variable instead lets them disagree — an unset variable yields a path relative to the editor's working directory, and the created file becomes invisible to the view that just created it.
+
+#### Scenario: creating the global rules file with no home variable set
+- **WHEN** the user creates the global rules file in an environment that does not define the home-directory variable
+- **THEN** the file is created under the operating system's reported home directory
+- **AND** the view lists it without a manual refresh
+
 ## Uncovered
 
 _None — every file in the area was read._

--- a/src/features/steering/steeringManager.ts
+++ b/src/features/steering/steeringManager.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import * as os from 'os';
 import * as path from 'path';
 import { getAIProvider } from '../../extension';
 import { ConfigManager } from '../../core/utils/configManager';
@@ -186,7 +187,7 @@ Analyze the document and:
     }
 
     async createUserSteeringFile() {
-        const claudeDir = path.join(process.env.HOME || '', '.claude');
+        const claudeDir = path.join(os.homedir(), '.claude');
         const filePath = path.join(claudeDir, 'CLAUDE.md');
 
         try {

--- a/tests/__mocks__/vscode.ts
+++ b/tests/__mocks__/vscode.ts
@@ -153,6 +153,7 @@ export const workspace = {
         delete: jest.fn().mockResolvedValue(undefined),
     },
     workspaceFolders: undefined as any,
+    openTextDocument: jest.fn().mockResolvedValue({}),
     findFiles: jest.fn().mockResolvedValue([]),
     createFileSystemWatcher: jest.fn().mockImplementation(createMockFileSystemWatcher),
     getConfiguration: jest.fn().mockReturnValue({


### PR DESCRIPTION
## Summary

Creating a global `CLAUDE.md` from the Steering view could write the file somewhere the extension never looks. The create action worked out your home directory from the `HOME` environment variable, and when that variable isn't set — common on Windows — the file landed in a `.claude` folder relative to whatever directory the editor happened to start in. Since the extension watches and reads your real home directory, the new file simply never showed up.

This is the follow-up to #579, which fixed the same class of bug on the watcher side. Home-directory resolution is now consistent everywhere the extension writes, watches, and reads.

## Technical

- `createUserSteeringFile` in `src/features/steering/steeringManager.ts` now builds the directory with `path.join(os.homedir(), '.claude')` instead of `path.join(process.env.HOME || '', '.claude')`. `os.homedir()` consults the platform-appropriate source and always returns an absolute path, so no `HOME` fallback is kept — a fallback could only reintroduce the relative-path bug.
- This was the **last** `process.env.HOME` in `src/`; the watchers (`src/core/fileWatchers.ts`, #579) and `steeringExplorerProvider.ts` were already on `os.homedir()`, so the write, watch, and read paths can no longer disagree.
- New `src/features/steering/__tests__/steeringManager.test.ts` covers `HOME` unset, `HOME` empty, the absolute-path guarantee, the normal `HOME` case, and the existing overwrite-cancel path. Confirmed genuine by reverting the fix: 3 of the 5 fail against the old code.
- `tests/__mocks__/vscode.ts` gains one line — `workspace.openTextDocument` — which this path needs. `NotificationUtils` is mocked in the test file rather than adding `withProgress`/`ProgressLocation` to the shared mock: the real `withProgress` runs its task, so every case would await the 3s auto-dismiss timer and the file took ~12s on its own.

## Review checklist

- ✅ **VS Code extension** — affected
    - steering: `src/features/steering/steeringManager.ts` (user-scope file creation)
    - tests: one new suite + one line in the shared vscode mock
- — **SpecKit extension** — not touched
- ✅ **Changelog** — root only, correct for a `src/**` change
    - `CHANGELOG.md`, new `[Unreleased] › Fixed` entry in user-facing voice
- ✅ **Docs** — none required
    - the docs-map row for this change-type is "the README section that documented the broken behavior"; the README never documented where the global file is created, so there is nothing to reconcile
    - no setting, provider, status, sidebar action, or viewer surface changed
- ✅ **Living spec**
    - `src/features/steering/steering.spec.md` gains a requirement pinning that a file the view creates lands where the view watches and reads — the invariant that was missing when this regressed
- ✅ **Verify**
    - `npm run compile` clean
    - `npm test` — 134 suites / 1884 tests pass (was 133 / 1879)
    - regression property re-confirmed after the simplification pass
    - no version bump
- ✅ **Spec artifacts**
    - `specs/565-homedir-steering-path/` committed, spec status `completed`
    - demo fixtures untouched

## Gaps / how to see it

- The living-spec fold appended the new requirement *after* the `## Uncovered` section instead of inside `## Requirements`; corrected by hand here. The placement bug in the fold script is worth its own fix — noted as a concern on the spec.
- No migration for anyone who already has a stray relative `.claude/CLAUDE.md` from the old behavior; it's inert and out of scope.
- Try: in a shell with `HOME` unset, launch VS Code and use the Steering view's create-global-file action — the file should appear in your home directory and show up in the tree without a manual refresh.

Closes #580

🤖 Generated with [Claude Code](https://claude.com/claude-code)
