### PR TITLE
fix(specs): footer offers Plan on a freshly specified Companion spec

### DIFF
--- a/.specify/extensions/.registry
+++ b/.specify/extensions/.registry
@@ -55,9 +55,9 @@
       "installed_at": "2026-05-21T18:09:23.850204+00:00"
     },
     "companion": {
-      "version": "0.19.0",
+      "version": "0.20.1",
       "source": "local",
-      "manifest_hash": "sha256:f047d6abcaac9f6549db3c338491afd433f303f758879119e58a2c8cf19be99b",
+      "manifest_hash": "sha256:84989117d10a595577515b79ce227b25cff32b02a14af6785328574bb0348638",
       "enabled": true,
       "priority": 10,
       "registered_commands": {
@@ -223,7 +223,7 @@
         ]
       },
       "registered_skills": [],
-      "installed_at": "2026-07-21T16:01:16.528594+00:00"
+      "installed_at": "2026-08-19T23:53:07.117861+00:00"
     }
   }
 }

--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/565-homedir-steering-path"
+  "feature_directory": "specs/582-footer-next-step"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- **A spec you just wrote now offers Plan next, instead of jumping straight to Tasks.** On a freshly specified SpecKit Companion spec the viewer footer said "Next: Tasks" while the step strip correctly showed Plan as still pending — and clicking the button ran task generation against a spec that had never been planned. Two things were going wrong at once: the SpecKit Companion pipeline was being mistaken for a workflow you wrote yourself, which switched on a fallback that guesses progress from whatever files are on disk; and that guess then counted the specification's own quality checklist as if planning had already produced something. The footer and the step strip now always name the same next step. Workflows you define yourself keep guessing progress from their files exactly as before. ([#582](https://github.com/alfredoperez/speckit-companion/issues/582))
+
 - **Creating a global CLAUDE.md now always lands in your home directory, so the Steering view actually shows it.** The create action worked out the home directory from the `HOME` environment variable, and when that variable wasn't set — which is common on Windows — the file was written to a `.claude` folder relative to whatever directory the editor started in. The extension watches and reads your real home directory, so the new file simply never appeared. Home directory resolution is now the same everywhere the extension looks, writes, and watches. ([#580](https://github.com/alfredoperez/speckit-companion/issues/580))
 
 ## [0.31.1] - 2026-08-01

--- a/docs/viewer-states.md
+++ b/docs/viewer-states.md
@@ -105,6 +105,16 @@
 > announces what comes next. Falls back to `Approve` when the
 > workflow definition is missing.
 >
+> **Built-in workflows never guess from files (#582)**: The
+> file-driven progression fallback — which reconstructs a run's
+> position from the documents on disk — applies only to workflows the
+> user defined. A workflow whose step sequence matches one the
+> extension ships is exempt, including SpecKit Companion with its
+> terminal `mark-complete` step, so the footer's next step always
+> matches the step the stepper renders as pending. A step's `subDir`
+> (`checklists/`, `contracts/`) counts as that step's own output and
+> never as a later step's related document.
+>
 > **Approve advance window**: `Approve` stays visible across the
 > "step done, next step not started" pauses (`specified` /
 > `planned` / `ready-to-implement`) so the user can dispatch the

--- a/speckit-extension/CHANGELOG.md
+++ b/speckit-extension/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/); this ext
 
 ### Fixed
 
+- **Status and resume now speak Companion on a Companion spec.** Asking a Companion run where it stood reported the stock next command — "Next: Plan the feature → /speckit.plan" instead of the Companion one — and resuming from that point dispatched the stock pipeline, quietly dropping the Companion behavior for the rest of the run. The check that picks the command family was still keyed to a per-spec field retired when the workflow choice was simplified, so nothing ever set it and the Companion commands were unreachable. It now reads the workflow the spec actually recorded. Specs written before that change still resume on Companion, and stock specs are unaffected.
+
 - **The minimum spec-kit version check no longer carries a stale `.dev0` pin.** The floor was pinned to `>=0.9.5.dev0` to admit spec-kit's own git-HEAD dev builds back when spec-kit's `main` was still on the 0.9.5 line — that line shipped stable long ago (spec-kit's `main` now builds `0.15.x`), so the pin had become dead weight and the only catalog entry not using a bare floor. Floor is now `>=0.9.5`, matching every other catalog entry's convention. No install behavior changes for anyone on a real release.
 
 ## [0.20.1] - 2026-08-01

--- a/speckit-extension/scripts/status-context.py
+++ b/speckit-extension/scripts/status-context.py
@@ -45,9 +45,9 @@ STEP_COMMAND = {
     "implement": "/speckit.implement",
 }
 
-# Turbo/companion family — mirrors STEP_COMMAND's keys. Resume dispatches these
-# when the spec's recorded profile is "turbo" so the command family matches the
-# flow the spec has been running.
+# Companion family — mirrors STEP_COMMAND's keys. Status reports and resume
+# dispatches these when the spec records the companion workflow, so the command
+# family matches the flow the spec has been running.
 COMPANION_STEP_COMMAND = {
     "specify": "/speckit.companion.specify",
     "plan": "/speckit.companion.plan",
@@ -55,11 +55,16 @@ COMPANION_STEP_COMMAND = {
     "implement": "/speckit.companion.implement",
 }
 
+def _is_companion(ctx: dict) -> bool:
+    """Whether the spec runs the companion pipeline. `workflow` is the live
+    signal; `profile: turbo` is the retired field, still honored so specs
+    written before the workflow-choice collapse keep resuming on companion."""
+    return ctx.get("workflow") == "companion" or ctx.get("profile") == "turbo"
 
-def _step_command(step: str | None, profile: str | None) -> str | None:
-    """Resolve a step to its command in the family the spec is running:
-    the companion map for turbo specs, the stock map otherwise (standard/absent)."""
-    table = COMPANION_STEP_COMMAND if profile == "turbo" else STEP_COMMAND
+
+def _step_command(step: str | None, companion: bool) -> str | None:
+    """Resolve a step to its command in the family the spec is running."""
+    table = COMPANION_STEP_COMMAND if companion else STEP_COMMAND
     return table.get(step)
 
 # Status that marks each step's own completion (the point at which we advance).
@@ -157,7 +162,7 @@ def resolve(feature_dir: Path) -> dict:
     status = ctx.get("status")
     spec_name = ctx.get("specName") or wc._spec_name(feature_dir)
     decisions = _decisions(ctx)
-    profile = ctx.get("profile")
+    companion = _is_companion(ctx)
 
     resolution = {
         "source": source,
@@ -186,7 +191,7 @@ def resolve(feature_dir: Path) -> dict:
             resolution["nextActionLabel"] = "Pipeline complete"
             return resolution
         resolution["nextStep"] = "implement"
-        resolution["nextCommand"] = _step_command("implement", profile)
+        resolution["nextCommand"] = _step_command("implement", companion)
         resolution["nextTask"] = next_task
         resolution["nextActionLabel"] = f"Continue implementation at {next_task}"
         return resolution
@@ -196,7 +201,7 @@ def resolve(feature_dir: Path) -> dict:
         # Current step finished — advance to the next pipeline step.
         next_step = NEXT_STEP.get(current_step)
         resolution["nextStep"] = next_step
-        resolution["nextCommand"] = _step_command(next_step, profile) if next_step else None
+        resolution["nextCommand"] = _step_command(next_step, companion) if next_step else None
         resolution["nextActionLabel"] = NEXT_LABEL.get(next_step, "Continue") if next_step else "Pipeline complete"
         if next_step is None:
             resolution["complete"] = True
@@ -207,11 +212,11 @@ def resolve(feature_dir: Path) -> dict:
         if current_step in ("clarify", "analyze"):
             next_step = NEXT_STEP.get(current_step)
             resolution["nextStep"] = next_step
-            resolution["nextCommand"] = _step_command(next_step, profile) if next_step else None
+            resolution["nextCommand"] = _step_command(next_step, companion) if next_step else None
             resolution["nextActionLabel"] = NEXT_LABEL.get(next_step, "Continue")
         else:
             resolution["nextStep"] = current_step
-            resolution["nextCommand"] = _step_command(current_step, profile)
+            resolution["nextCommand"] = _step_command(current_step, companion)
             resolution["nextActionLabel"] = f"Finish {current_step}"
 
     return resolution

--- a/speckit-extension/tests/test_context.py
+++ b/speckit-extension/tests/test_context.py
@@ -633,6 +633,36 @@ class StatusResolveTests(unittest.TestCase):
         self.assertEqual(res["nextCommand"], "/speckit.tasks")
         self.assertEqual(res["decisions"], ["Use the existing dispatch path", "No new schema field"])
 
+    def test_companion_workflow_resolves_the_companion_command_family(self) -> None:
+        rows = {
+            ("specify", "specified"): "/speckit.companion.plan",
+            ("plan", "planned"): "/speckit.companion.tasks",
+            ("tasks", "ready-to-implement"): "/speckit.companion.implement",
+        }
+        for (step, status), expected in rows.items():
+            wc.update_context(self.fd, step, status, "extension")
+            ctx = _ctx(self.fd)
+            ctx["workflow"] = "companion"
+            (self.fd / ".spec-context.json").write_text(json.dumps(ctx))
+            res = status_mod.resolve(self.fd)
+            self.assertEqual(res["nextCommand"], expected, f"{step}/{status}")
+            (self.fd / ".spec-context.json").unlink()
+
+    def test_stock_workflow_still_resolves_stock_commands(self) -> None:
+        wc.update_context(self.fd, "specify", "specified", "extension")
+        ctx = _ctx(self.fd)
+        self.assertEqual(ctx["workflow"], "speckit")
+        res = status_mod.resolve(self.fd)
+        self.assertEqual(res["nextCommand"], "/speckit.plan")
+
+    def test_legacy_turbo_profile_still_resolves_the_companion_family(self) -> None:
+        wc.update_context(self.fd, "specify", "specified", "extension")
+        ctx = _ctx(self.fd)
+        ctx["profile"] = "turbo"
+        (self.fd / ".spec-context.json").write_text(json.dumps(ctx))
+        res = status_mod.resolve(self.fd)
+        self.assertEqual(res["nextCommand"], "/speckit.companion.plan")
+
     def test_next_step_rows(self) -> None:
         rows = {
             ("specify", "specified"): "/speckit.plan",

--- a/specs/582-footer-next-step/.spec-context.json
+++ b/specs/582-footer-next-step/.spec-context.json
@@ -364,6 +364,11 @@
       "decision": "Keep profile:turbo as a legacy fallback in the status resolver instead of deleting it with the fix",
       "why": "Specs written before the workflow-choice collapse still carry the old field; dropping it would silently move those runs onto the stock pipeline mid-flight",
       "rejected": "Reading only the workflow field and letting old specs fall back to stock"
+    },
+    {
+      "decision": "Match built-in workflows on step name AND command, not name alone",
+      "why": "Review caught that a user workflow mirroring the Companion step names would be exempted and stranded at specify with no forward button — confirmed by temporarily reverting to name-only matching and watching the new test fail",
+      "rejected": "Name-only matching, and keying the exemption off reserved workflow ids (which would need the workflow name plumbed through both call sites)"
     }
   ],
   "step_summaries": {
@@ -552,11 +557,21 @@
       "command": "reinstalled the rebuilt extension into the fresh sandbox and re-ran status-context.py",
       "result": "companion spec now reports /speckit.companion.plan; stock spec still reports /speckit.implement; legacy profile:turbo still resolves companion",
       "warnings": []
+    },
+    {
+      "what": "Local code review at high effort",
+      "command": "/code-review high",
+      "result": "3 low findings; 2 were real regressions in this diff and are fixed with tests, the third is a pre-existing capture gap filed separately",
+      "warnings": []
     }
   ],
   "concerns": [
     {
       "note": "The community extension catalog still advertises SpecKit Companion v0.11.0 while the shipped companion-latest zip is v0.20.1. Discovery-only, so it does not block installs, but anyone reading the catalog sees a version nine minors stale.",
+      "step": "implement"
+    },
+    {
+      "note": "Only the companion specify command pins workflow=companion. A run that joins Companion later (stock specify, then companion plan) stays recorded as speckit, so status and resume dispatch stock commands for the rest of the run. Reproduced in the fresh sandbox; filed as its own issue rather than widened into this PR because the fix touches three command bodies and turns on whether one companion command should retroactively pin the whole spec.",
       "step": "implement"
     }
   ]

--- a/specs/582-footer-next-step/.spec-context.json
+++ b/specs/582-footer-next-step/.spec-context.json
@@ -1,0 +1,563 @@
+{
+  "workflow": "companion",
+  "specName": "footer next step",
+  "branch": "fix/582-footer-next-step",
+  "currentStep": "implement",
+  "status": "completed",
+  "history": [
+    {
+      "step": "specify",
+      "substep": null,
+      "kind": "start",
+      "by": "extension",
+      "at": "2026-08-19T23:36:33.726Z"
+    },
+    {
+      "step": "specify",
+      "substep": null,
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-08-19T23:39:09.319Z"
+    },
+    {
+      "step": "plan",
+      "substep": null,
+      "kind": "start",
+      "by": "extension",
+      "at": "2026-08-19T23:39:25.073Z"
+    },
+    {
+      "step": "plan",
+      "substep": "research",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-08-19T23:40:15.659Z"
+    },
+    {
+      "step": "plan",
+      "substep": "design",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-08-19T23:41:22.027Z"
+    },
+    {
+      "step": "plan",
+      "substep": null,
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-08-19T23:41:55.337Z"
+    },
+    {
+      "step": "tasks",
+      "substep": null,
+      "kind": "start",
+      "by": "extension",
+      "at": "2026-08-19T23:42:06.536Z"
+    },
+    {
+      "step": "tasks",
+      "substep": "generate",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-08-19T23:42:47.550Z"
+    },
+    {
+      "step": "tasks",
+      "substep": null,
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-08-19T23:43:01.054Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "kind": "start",
+      "by": "extension",
+      "at": "2026-08-19T23:43:13.652Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T001",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-08-19T23:43:58.063Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T002",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-08-19T23:44:48.745Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T003",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-08-19T23:44:48.863Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T004",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-08-19T23:45:20.346Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T005",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-08-19T23:45:20.486Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T006",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-08-19T23:45:53.781Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T007",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-08-19T23:46:14.963Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T008",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-08-19T23:46:15.119Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T009",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-08-19T23:48:04.549Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T010",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-08-19T23:48:04.706Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T011",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-08-19T23:48:04.852Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T012",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-08-19T23:51:01.604Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T016",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-08-19T23:52:28.436Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T017",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-08-19T23:53:28.539Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T013",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-08-19T23:54:39.514Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T014",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-08-19T23:54:39.658Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T015",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-08-19T23:56:03.734Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-08-19T23:56:03.801Z"
+    }
+  ],
+  "unattended": true,
+  "livingSpecs": {
+    "loaded": [
+      "spec-viewer",
+      "specs"
+    ],
+    "skipped": [
+      {
+        "name": "spec-viewer",
+        "reason": "read for context only — the viewer's derive-from-recorded-run requirement already covered this; the defect and the fix both live in the specs capability, and no spec-viewer file changed"
+      }
+    ],
+    "synced": [
+      "specs"
+    ]
+  },
+  "last_action": "all 17 tasks done — tsc clean, 1892 jest + 554 python tests pass",
+  "coverage": {
+    "FR-001": {
+      "title": "Never reconstruct progression from files for a built-in workflow, including SpecKit Companion with its terminal completion step",
+      "tasks": [
+        "T001",
+        "T002",
+        "T003"
+      ],
+      "tests": [
+        "src/features/specs/__tests__/customWorkflowProgress.test.ts::offers Plan on a freshly specified Companion spec not Tasks",
+        "src/features/specs/__tests__/customWorkflowProgress.test.ts::exempts both shipped workflows"
+      ]
+    },
+    "FR-002": {
+      "title": "A document under a folder any step claims must not count as a related document for a different step",
+      "tasks": [
+        "T004",
+        "T005",
+        "T006"
+      ],
+      "tests": [
+        "src/features/specs/__tests__/customWorkflowProgress.test.ts::does not count a doc under an earlier step subDir as a later step related doc",
+        "src/features/specs/__tests__/customWorkflowProgress.test.ts::still counts a step own subDir as that step output"
+      ]
+    },
+    "FR-003": {
+      "title": "The footer's named next step must match the stepper's pending step on every built-in workflow",
+      "tasks": [
+        "T001",
+        "T003"
+      ],
+      "tests": [
+        "src/features/specs/__tests__/customWorkflowProgress.test.ts::offers Plan on a freshly specified Companion spec not Tasks"
+      ]
+    },
+    "FR-004": {
+      "title": "Every workflow treated as developer-authored before this change stays developer-authored and keeps file-driven progression",
+      "tasks": [
+        "T007",
+        "T008"
+      ],
+      "tests": [
+        "src/features/specs/__tests__/customWorkflowProgress.test.ts::leaves a lifecycle-named workflow with an extra mark-complete step custom",
+        "src/features/specs/__tests__/customWorkflowProgress.test.ts::still counts a loose unclaimed doc in the spec dir",
+        "src/features/specs/__tests__/customWorkflowProgress.test.ts::still counts a doc in an unclaimed nested dir as a related doc"
+      ]
+    },
+    "FR-005": {
+      "title": "Carry a regression test for the reported state asserting the footer offers the planning step",
+      "tasks": [
+        "T001"
+      ],
+      "tests": [
+        "src/features/specs/__tests__/customWorkflowProgress.test.ts::offers Plan on a freshly specified Companion spec not Tasks"
+      ]
+    },
+    "FR-006": {
+      "title": "Neither shipped product contains a shorts command, skill, or asset",
+      "tasks": [
+        "T009"
+      ],
+      "tests": [
+        "specs/582-footer-next-step/verification.md"
+      ]
+    },
+    "FR-007": {
+      "title": "Show recorded-progress capture working from a genuinely fresh SpecKit install plus constitution plus extension install",
+      "tasks": [
+        "T010",
+        "T011",
+        "T012"
+      ],
+      "tests": [
+        "specs/582-footer-next-step/verification.md",
+        "speckit-extension/tests/test_context.py::test_companion_workflow_resolves_the_companion_command_family",
+        "speckit-extension/tests/test_context.py::test_stock_workflow_still_resolves_stock_commands",
+        "speckit-extension/tests/test_context.py::test_legacy_turbo_profile_still_resolves_the_companion_family"
+      ]
+    }
+  },
+  "size": "normal",
+  "classification": {
+    "projectedFiles": 6,
+    "projectedTasks": 11,
+    "scopeSignal": "larger",
+    "verdict": "normal"
+  },
+  "context": [
+    "living spec: spec-viewer (viewer state is derived from the recorded run, not files on disk)",
+    "living spec: specs",
+    "area: src/features/specs/customWorkflowProgress.ts",
+    "area: src/features/spec-viewer (footer + stepper derivation)",
+    "constraint: fix must be additive — no workflow may move from developer-authored to built-in",
+    "constraint: extension isolation — no .claude/** or .specify/** edits for product behavior"
+  ],
+  "intent": "Make the spec viewer footer offer the step the stepper says is pending, so a freshly specified Companion spec goes to Plan instead of skipping to Tasks.",
+  "expectations": [
+    "No plumbing of the workflow name through resolveWorkflowSteps into the two progression call sites",
+    "No change to how developer-authored workflows are detected today (strictly additive exemption)",
+    "No version bump — the release flow owns that",
+    "No changes to the personal speckit-companion-shorts skill itself; only proof it stays out of both distributions"
+  ],
+  "approach": "Close both fail-open guards inside src/features/specs/customWorkflowProgress.ts: front-load isCustomWorkflow with an exact step-name-sequence match against DEFAULT_WORKFLOW and COMPANION_WORKFLOW so a shipped pipeline never enters the file-driven fallback, and prune every step's subDir from the relatedDocsPresent scan so a sub-folder document can never count as another step's related doc. Pin the fix with a composed regression test that stages spec.md plus checklists/requirements.md on disk and asserts the footer yields approve:Plan. Verification-only: audit both distributions for shorts, and prove capture works from a genuinely fresh specify init plus constitution plus extension install in a disposable sandbox.",
+  "decisions": [
+    {
+      "decision": "Recognize built-in workflows by exact step-name-sequence match against DEFAULT_WORKFLOW and COMPANION_WORKFLOW",
+      "why": "Both call sites only receive WorkflowStepConfig[]; the module already imports workflowManager, and the check is strictly additive so nothing custom today becomes built-in",
+      "rejected": "Plumbing the workflow name through both resolveWorkflowSteps implementations and MessageHandlerDependencies, and the narrower option of just exempting the mark-complete name (which would over-exempt developer pipelines)"
+    },
+    {
+      "decision": "Prune claimed subDir directories during the relatedDocsPresent scan instead of enumerating their files",
+      "why": "A subDir is an open-ended container whose filenames the workflow never predicts; claiming the container is exact and costs one string comparison",
+      "rejected": "Enumerating each subDir into the claimed filename set (extra IO, races a folder being written), and ignoring all nested directories (would regress developer pipelines that rely on nested related docs)"
+    },
+    {
+      "decision": "Assert the fix on the composition of synthesizeCustomProgress and getFooterActions, not on either function alone",
+      "why": "getFooterActions already yields approve:Plan on its own — the defect only appears after synthesizeCustomProgress rewrites the context, so only the composition actually reproduces it",
+      "rejected": "A unit assertion on isCustomWorkflow alone (locks in mechanism, would have passed before the fix) and driving it through specViewerProvider (needs a webview/config mock harness the repo lacks)"
+    },
+    {
+      "decision": "Derive the built-in fingerprint from DEFAULT_WORKFLOW and COMPANION_WORKFLOW at module load rather than hand-writing the sequences",
+      "why": "A future built-in step is exempt for free, with no second edit and no chance of the list drifting from the shipped constants",
+      "rejected": "A literal list of step-name arrays in customWorkflowProgress.ts"
+    },
+    {
+      "decision": "Keep profile:turbo as a legacy fallback in the status resolver instead of deleting it with the fix",
+      "why": "Specs written before the workflow-choice collapse still carry the old field; dropping it would silently move those runs onto the stock pipeline mid-flight",
+      "rejected": "Reading only the workflow field and letting old specs fall back to stock"
+    }
+  ],
+  "step_summaries": {
+    "plan": {
+      "summary": "Two additive guards in customWorkflowProgress.ts — built-in sequence exemption plus subDir pruning — pinned by one composed footer regression test; shorts audit and fresh-install validation are evidence-only",
+      "key_finding": "The bug needs BOTH defects to fire: the misclassification lets the fallback run at all, and the unclaimed checklists folder is what makes disk look ahead. Fixing either alone hides it; fixing only one leaves the trap armed for developer-authored workflows."
+    },
+    "tasks": {
+      "summary": "15 tasks across 5 active phases: 3 for the built-in exemption (test-first), 3 for subDir claiming, 2 additivity guards, 4 verification-only (shorts audit + fresh install), 3 polish"
+    },
+    "implement": {
+      "summary": "Fixed the footer/stepper disagreement with two additive guards in the progression fallback, plus a second Companion-recognition defect the fresh-install status test uncovered in the spec-kit extension"
+    }
+  },
+  "currentTask": "T015",
+  "task_summaries": {
+    "T001": {
+      "status": "DONE",
+      "did": "Added the #582 regression test staging spec.md + checklists/requirements.md; confirmed it fails with currentStep rewritten to plan",
+      "files": [
+        "src/features/specs/__tests__/customWorkflowProgress.test.ts"
+      ]
+    },
+    "T002": {
+      "status": "DONE",
+      "did": "Exempted built-in workflows in isCustomWorkflow via an exact step-name-sequence match against DEFAULT_WORKFLOW and COMPANION_WORKFLOW, computed once at module load",
+      "files": [
+        "src/features/specs/customWorkflowProgress.ts"
+      ]
+    },
+    "T003": {
+      "status": "DONE",
+      "did": "Regression test now passes; all 16 tests in the customWorkflowProgress suite green with no edits to pre-existing tests",
+      "files": [
+        "src/features/specs/__tests__/customWorkflowProgress.test.ts"
+      ]
+    },
+    "T004": {
+      "status": "DONE",
+      "did": "Added the failing test: a doc under an earlier step subDir must not count as a later step's related doc",
+      "files": [
+        "src/features/specs/__tests__/customWorkflowProgress.test.ts"
+      ]
+    },
+    "T005": {
+      "status": "DONE",
+      "did": "Added three paired guard tests: loose docs, unclaimed nested dirs, and a step's own subDir all still count",
+      "files": [
+        "src/features/specs/__tests__/customWorkflowProgress.test.ts"
+      ]
+    },
+    "T006": {
+      "status": "DONE",
+      "did": "relatedDocsPresent now collects every step's subDir into a claimed-directory set and prunes those directories during the scan",
+      "files": [
+        "src/features/specs/customWorkflowProgress.ts"
+      ]
+    },
+    "T007": {
+      "status": "DONE",
+      "did": "Full suite green with zero deletions in the test file — every pre-existing developer-authored-pipeline test passes unmodified",
+      "files": [
+        "src/features/specs/__tests__/customWorkflowProgress.test.ts"
+      ]
+    },
+    "T008": {
+      "status": "DONE",
+      "did": "Added three additivity assertions including a mark-complete lookalike that must stay custom",
+      "files": [
+        "src/features/specs/__tests__/customWorkflowProgress.test.ts"
+      ]
+    },
+    "T009": {
+      "status": "DONE",
+      "did": "Shorts audit: 0 matches in the working tree, 0 in speckit-extension/, 0 in the packaged vsix filenames and unpacked contents; the skill lives only at ~/.claude/skills",
+      "files": [
+        "specs/582-footer-next-step/verification.md"
+      ]
+    },
+    "T010": {
+      "status": "DONE",
+      "did": "Ran a real specify init 0.12.16.dev0 into a disposable gitignored sandbox — stock install with no extensions.yml and no companion extension",
+      "files": [
+        "examples/bench-sandboxes/582-fresh-install"
+      ]
+    },
+    "T011": {
+      "status": "DONE",
+      "did": "Ran the constitution step in the fresh sandbox before installing the extension; template fully filled, 0 placeholders left, committed",
+      "files": [
+        "examples/bench-sandboxes/582-fresh-install/.specify/memory/constitution.md"
+      ]
+    },
+    "T012": {
+      "status": "DONE",
+      "did": "Installed companion v0.20.1 from the released zip into the fresh sandbox and confirmed status works in all four situations; found the profile/turbo dispatch defect",
+      "files": [
+        "specs/582-footer-next-step/verification.md"
+      ]
+    },
+    "T016": {
+      "status": "DONE",
+      "did": "Added three status-dispatch tests; the workflow=companion case fails with /speckit.plan while stock and legacy turbo already pass",
+      "files": [
+        "speckit-extension/tests/test_context.py"
+      ]
+    },
+    "T017": {
+      "status": "DONE",
+      "did": "Status now picks the command family from the recorded workflow field with profile:turbo kept as a legacy fallback; reinstalled locally and re-verified in the fresh sandbox",
+      "files": [
+        "speckit-extension/scripts/status-context.py"
+      ]
+    },
+    "T013": {
+      "status": "DONE",
+      "did": "Added user-facing entries to both changelogs under Unreleased — the footer fix at the root, the status/resume dispatch fix in the spec-kit extension",
+      "files": [
+        "CHANGELOG.md",
+        "speckit-extension/CHANGELOG.md"
+      ]
+    },
+    "T014": {
+      "status": "DONE",
+      "did": "Wrote a MODIFIED delta for the specs capability tightening the file-driven-progression requirement; recorded an explicit skip for spec-viewer",
+      "files": [
+        "specs/582-footer-next-step/spec.md"
+      ]
+    },
+    "T015": {
+      "status": "DONE",
+      "did": "Validated against the Success Criteria: tsc clean, 1892 jest tests pass, 554 python tests pass, SC-001 through SC-006 all confirmed",
+      "files": [
+        "package.json"
+      ]
+    }
+  },
+  "verified": [
+    {
+      "what": "TypeScript compile across the extension",
+      "command": "npx tsc --noEmit -p .",
+      "result": "0 errors",
+      "warnings": []
+    },
+    {
+      "what": "Full VS Code extension test suite",
+      "command": "npx jest",
+      "result": "1892 passed, 0 failed",
+      "warnings": []
+    },
+    {
+      "what": "Full spec-kit extension python suite",
+      "command": "python3 -m unittest discover tests (from speckit-extension/)",
+      "result": "554 passed, OK",
+      "warnings": []
+    },
+    {
+      "what": "The #582 regression reproduces before the fix",
+      "command": "npx jest src/features/specs/__tests__/customWorkflowProgress.test.ts",
+      "result": "failed with currentStep rewritten to plan, then passed after the fix",
+      "warnings": []
+    },
+    {
+      "what": "The fix is additive to the test file",
+      "command": "git diff --stat on the test file",
+      "result": "114 insertions, 0 deletions — no pre-existing test edited",
+      "warnings": []
+    },
+    {
+      "what": "No shorts command, skill, or asset ships in either distribution",
+      "command": "grep -ril shorts across the working tree, speckit-extension/, the unpacked vsix, and the freshly installed extension",
+      "result": "0 matches on every surface; the skill lives only in the users global Claude directory",
+      "warnings": []
+    },
+    {
+      "what": "Capture and status work from a genuinely fresh install",
+      "command": "specify init + constitution + specify extension add companion --from the released zip, then status-context.py",
+      "result": "companion v0.20.1 installed from the release artifact; status reported source:state, Step:specify, Status:specified, Next:Plan; derived fallback also correct; empty install degraded cleanly at exit 0",
+      "warnings": [
+        "The community catalog entry still advertises v0.11.0 while the shipped artifact is v0.20.1",
+        "Derived status names a spec from the document rather than the directory (cosmetic, not filed)"
+      ]
+    },
+    {
+      "what": "Status and resume dispatch the Companion family after the fix",
+      "command": "reinstalled the rebuilt extension into the fresh sandbox and re-ran status-context.py",
+      "result": "companion spec now reports /speckit.companion.plan; stock spec still reports /speckit.implement; legacy profile:turbo still resolves companion",
+      "warnings": []
+    }
+  ],
+  "concerns": [
+    {
+      "note": "The community extension catalog still advertises SpecKit Companion v0.11.0 while the shipped companion-latest zip is v0.20.1. Discovery-only, so it does not block installs, but anyone reading the catalog sees a version nine minors stale.",
+      "step": "implement"
+    }
+  ]
+}

--- a/specs/582-footer-next-step/checklists/requirements.md
+++ b/specs/582-footer-next-step/checklists/requirements.md
@@ -1,0 +1,35 @@
+# Specification Quality Checklist: Footer next step matches the pending step
+
+**Purpose**: Validate Companion specification completeness before planning
+**Created**: 2026-08-19
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed (User Scenarios, Requirements, Success Criteria)
+
+## Requirement Completeness
+
+- [x] Any [NEEDS CLARIFICATION] markers are genuine ambiguities (≤3) deferred to clarify — not unresolved guesses
+- [x] Each Functional Requirement is a single, testable MUST/SHOULD statement
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into the specification
+
+## Notes
+
+- The Verbatim Constraints section carries exact identifiers the request pinned. That is the one sanctioned place for them; the body stays implementation-free.
+- No [NEEDS CLARIFICATION] markers: every open choice was resolved into an informed default and recorded under Assumptions.

--- a/specs/582-footer-next-step/contracts/progression.md
+++ b/specs/582-footer-next-step/contracts/progression.md
@@ -1,0 +1,37 @@
+# Contract: file-driven progression
+
+The two functions this change touches, stated as behavior a caller and a test can code against. Identifiers are copied verbatim from the spec's Verbatim Constraints.
+
+## `isCustomWorkflow(steps)`
+
+**Module**: `src/features/specs/customWorkflowProgress.ts`
+
+| Input | Result |
+| --- | --- |
+| `undefined` | `false` |
+| A sequence exactly matching `DEFAULT_WORKFLOW.steps` names, in order | `false` |
+| A sequence exactly matching `COMPANION_WORKFLOW.steps` names, in order — including the terminal `mark-complete` | `false` |
+| Any sequence containing a name outside the lifecycle set | `true` |
+| Any other sequence of lifecycle-only names | `false` |
+
+**Invariant (FR-004)**: for every input, a `true` result before this change stays `true` after it. The change may only turn `true` into `false`, and only for the two shipped sequences.
+
+## `relatedDocsPresent(specDir, allSteps)` — via `stepHasOutput`
+
+**Module**: `src/features/specs/customWorkflowProgress.ts`
+
+| Spec directory contents | Step under test | Result |
+| --- | --- | --- |
+| `spec.md` only | a step with `includeRelatedDocs` | `false` (core document) |
+| `checklists/requirements.md`, where an earlier step declares `subDir: 'checklists'` | a later step with `includeRelatedDocs` | `false` — **this is the fix** |
+| `01-01-PLAN.md` loose in the directory | a step with `includeRelatedDocs` | `true` (unchanged) |
+| `contracts/api.md`, on the step that itself declares `subDir: 'contracts'` | that same step | `true` — satisfied by the `subDir` branch of `stepHasOutput`, not by related documents |
+| Any `.md` under a dot-directory | any step | `false` (unchanged) |
+
+## Composed behavior — the regression the test pins
+
+**Given** `COMPANION_WORKFLOW` steps, a context with `currentStep: specify` and `status: specified` whose recorded run shows the specify step complete, and a spec directory holding exactly `spec.md` and `checklists/requirements.md`:
+
+**Then** `synthesizeCustomProgress` returns the context unchanged, and `getFooterActions` on that result yields an approve action whose label is `Plan` — the assertion written as `approve:Plan`.
+
+**And** the same step is what the stepper renders as pending, satisfying FR-003.

--- a/specs/582-footer-next-step/data-model.md
+++ b/specs/582-footer-next-step/data-model.md
@@ -1,0 +1,43 @@
+# Data Model: Footer next step matches the pending step
+
+This feature introduces no new persisted entity and changes no schema. It reshapes how two existing in-memory structures are read.
+
+## WorkflowStepConfig (existing — read differently)
+
+One step of a workflow, as declared in `src/features/workflows/types.ts`.
+
+| Field | Meaning | Role in this change |
+| --- | --- | --- |
+| `name` | The step's identifier (`specify`, `plan`, `tasks`, `implement`, `mark-complete`, or anything a developer chooses). | The sequence of these across a workflow becomes the built-in fingerprint. |
+| `file` | The document the step produces, defaulting to `<name>.md`. | Unchanged; already claimed by `relatedDocsPresent`. |
+| `subFiles` | Extra documents that also count as the step's output. | Unchanged; already claimed. |
+| `subDir` | A folder whose contents belong to this step (`checklists`, `contracts`, `issues`). | **Newly claimed.** Its contents stop counting as another step's related documents. |
+| `includeRelatedDocs` | Whether unclaimed documents in the spec directory count as this step's output. | Unchanged; the set it draws from shrinks by exactly the claimed sub-folders. |
+| `actionOnly` | The step produces no document. | Unchanged. |
+
+**Validation rule added**: a `subDir` value is a claimed container. No file beneath it may be attributed to a step other than the one that declares it.
+
+## Built-in workflow fingerprint (new, derived, in-memory)
+
+A frozen list of step-name sequences, computed once at module load from the two workflow constants the extension exports.
+
+| Attribute | Value |
+| --- | --- |
+| Source | `DEFAULT_WORKFLOW.steps` and `COMPANION_WORKFLOW.steps` |
+| Shape | An array of string arrays — one ordered name sequence per shipped workflow |
+| Lifetime | Module-level constant; never mutated |
+| Equality | Exact: same length, same names, same order |
+
+**Relationship**: consumed only by `isCustomWorkflow`, as a short-circuit in front of the existing rule. It is derived from the shipped constants rather than hand-written, so a future built-in step is exempt without a second edit.
+
+## Reconstructed progression (existing — narrower trigger)
+
+The synthetic run `synthesizeCustomProgress` builds from documents on disk.
+
+| Transition | Before | After |
+| --- | --- | --- |
+| Built-in workflow, disk ahead of context | Rewrites `currentStep` in memory | Returns the context untouched |
+| Developer-authored workflow, disk ahead of context | Rewrites `currentStep` in memory | Unchanged — still rewrites |
+| Developer-authored workflow, only a claimed sub-folder document present | Could read a later step as produced | No longer counts that document for a later step |
+
+No state is persisted by any of these paths: the reconstruction is in-memory only, which is why the bug showed in the footer but never in the stepper or in `.spec-context.json`.

--- a/specs/582-footer-next-step/plan.md
+++ b/specs/582-footer-next-step/plan.md
@@ -1,0 +1,62 @@
+# Implementation Plan: Footer next step matches the pending step
+
+**Branch**: `fix/582-footer-next-step` | **Spec**: [spec.md](./spec.md) | **Issue**: [#582](https://github.com/alfredoperez/speckit-companion/issues/582)
+**Size**: normal
+
+## Summary
+
+The spec viewer footer offers the wrong next step on a freshly specified SpecKit Companion spec because two independent guards both fail open. The file-driven progression fallback — meant only for pipelines the developer wrote, which never record anything — misreads the built-in SpecKit Companion pipeline as developer-authored, because its terminal `mark-complete` step is not a lifecycle name. Once that fallback runs, it also miscounts `checklists/requirements.md` as evidence that the planning step produced output, because the related-documents scan only claims top-level filenames and never the contents of a step's own sub-folder. Together they rewrite the in-memory context to `currentStep: plan`, which the footer reads and the stepper does not — hence the disagreement.
+
+The fix closes both, in one module. `isCustomWorkflow` gains a front-loaded exact match against the step-name sequences of the two workflows the extension ships, so a built-in pipeline never enters the fallback. `relatedDocsPresent` prunes any directory a step claims as its `subDir`, so a sub-folder document can never count as another step's related document. Both changes are additive: no workflow that reconstructs progression today stops doing so.
+
+Two verification-only deliverables ride along and change no product code: proof that no "shorts" command, skill, or asset ships in either distribution, and an end-to-end run of the recorded-progress capture from a genuinely fresh install — the real command-line tool initialized into a disposable sandbox, its constitution step run, and the companion spec-kit extension installed through its own installer.
+
+## Project Structure
+
+```
+src/features/specs/
+  customWorkflowProgress.ts              # both defects live here
+  __tests__/
+    customWorkflowProgress.test.ts       # existing unit tests + the new regression test
+src/features/spec-viewer/
+  specViewerProvider.ts                  # call site (line ~1172) — unchanged
+  messageHandlers.ts                     # call site (line ~362) — unchanged
+src/features/workflows/
+  workflowManager.ts                     # exports DEFAULT_WORKFLOW / COMPANION_WORKFLOW — unchanged
+examples/582-fresh-install/              # disposable sandbox for the fresh-install validation
+CHANGELOG.md                             # user-facing entry under Unreleased
+```
+
+**Structure Decision**: The entire product change is contained to `src/features/specs/customWorkflowProgress.ts` and its existing test file. Neither call site needs to change, and no workflow identity is plumbed through the providers — the module reads the two shipped workflow constants directly from `workflowManager`, which it already imports from.
+
+## Constitution Check
+
+| Principle | Assessment |
+| --- | --- |
+| I. Extensibility and Configuration | **PASS** — developer-authored workflows keep their file-driven progression untouched; the exemption is strictly additive and only recognizes the two sequences the extension itself ships. |
+| II. Spec-Driven Workflow | **PASS** — this restores the non-negotiable Specify → Plan → Tasks → Implement order, which the bug was skipping a step of. It also honors "status transitions MUST be explicit user actions, not inferred from heuristics alone" by removing a heuristic that inferred planning progress from a checklist file. |
+| III. Visual and Interactive | **PASS** — the change is a correctness fix behind an existing visual surface; the footer and stepper are the visible outcome. |
+| IV. Modular Architecture for Complex Features | **PASS** — no new files, no growth in an existing module's responsibilities; two functions in one already-focused module. |
+
+No violations, so no Complexity Tracking table.
+
+Re-checked after Phase 1 design: unchanged, still PASS on all four.
+
+## Approach
+
+1. **`isCustomWorkflow` — exempt the shipped pipelines.** Build a frozen list of built-in step-name sequences from `DEFAULT_WORKFLOW.steps` and `COMPANION_WORKFLOW.steps` at module load. If the incoming sequence matches one exactly (same length, same names, same order), return `false` immediately. Otherwise fall through to the existing `STEP_NAMES` rule, unchanged.
+
+2. **`relatedDocsPresent` — claim each step's sub-folder.** Collect every step's `subDir` into a set alongside the existing `claimed` filenames. During the recursive scan, when an entry is a directory whose relative path is in that set, skip it instead of descending. Everything else about the scan — hidden-directory skipping, core-doc exclusion, first-hit short-circuit — stays as-is.
+
+3. **Regression test.** Add a `describe` block to `src/features/specs/__tests__/customWorkflowProgress.test.ts` that stages a real temp directory with `spec.md` and `checklists/requirements.md`, builds a context at `currentStep: specify` / `status: specified` with the specify step recorded complete, runs it through `synthesizeCustomProgress` with `COMPANION_WORKFLOW.steps` and the real `stepHasOutput`, and asserts the resulting footer's approve action is labeled `Plan`. Add supporting unit assertions: `isCustomWorkflow(COMPANION_WORKFLOW.steps)` is `false`, `isCustomWorkflow(DEFAULT_WORKFLOW.steps)` is `false`, and a sub-folder document does not satisfy a later step's related-documents check while a loose document still does.
+
+4. **Confirm the guard on developer-authored pipelines.** The existing suite already covers the ticket-shaped and GSD-shaped pipelines. Run it unchanged — every one of those tests must still pass without modification. Any edit needed to an existing test is a signal the fix is not additive.
+
+5. **Shorts audit.** Search the working tree and the packaged artifact for the string, and record the result as evidence against FR-006.
+
+6. **Fresh-install validation.** In a disposable sandbox under `examples/`, initialize with the real command-line tool, run the constitution step, install the companion spec-kit extension through its own installer, and confirm a recorded run appears with a readable current step and status.
+
+## Risks
+
+- **Over-exemption.** If a developer's own pipeline happens to declare exactly the SpecKit or SpecKit Companion step-name sequence, it is now treated as built-in. It is also indistinguishable from the built-in by any signal available at these call sites, and the pre-existing lifecycle-name rule already collapsed most of that case. Accepted and recorded as an edge case in the spec.
+- **Sub-folder pruning starving a step.** A step that declares both `subDir` and `includeRelatedDocs` — the planning step does exactly this, with `contracts/` — must not lose its own folder as evidence. It does not: `stepHasOutput` checks `subDir` on its own branch before the related-documents branch is ever reached. Covered by an assertion.

--- a/specs/582-footer-next-step/research.md
+++ b/specs/582-footer-next-step/research.md
@@ -1,0 +1,45 @@
+# Research: Footer next step matches the pending step
+
+## Decision — recognize built-in workflows by their step-name sequence, not by plumbing the workflow name
+
+**Decision**: `isCustomWorkflow` gains a front-loaded check that compares the incoming step-name sequence against the step-name sequences of `DEFAULT_WORKFLOW` and `COMPANION_WORKFLOW`. An exact match short-circuits to `false`. The existing "any step name outside `STEP_NAMES`" rule stays untouched behind it as the fallback.
+
+**Rationale**: Both call sites — `specViewerProvider.ts:1172` and `messageHandlers.ts:362` — receive only `WorkflowStepConfig[]` from a `resolveWorkflowSteps()` that already discarded the workflow identity. Threading the name through would mean changing the return type of two independent `resolveWorkflowSteps` implementations plus the `MessageHandlerDependencies` interface, for a bug whose blast radius is one boolean. `customWorkflowProgress.ts` already imports from `workflowManager` (`getStepFile`), so reading the two exported workflow constants adds no new coupling.
+
+The sequence check is also *strictly additive*, which is the property that matters most here. Layering it in front of the existing rule can only move a workflow from custom to built-in, and only for the two exact sequences the extension itself ships. Nothing that reconstructs progression today stops doing so.
+
+**Alternatives considered**:
+- *Plumb the workflow name through `resolveWorkflowSteps`* — the most precise signal, but it changes two provider APIs and a dependency interface to carry one flag. Rejected as disproportionate; revisit if a third consumer ever needs the identity.
+- *Add `mark-complete` to the exempt name set* — the smallest possible edit, and what the issue suggests as a fallback. Rejected because it over-exempts: any developer-authored pipeline that happens to use lifecycle names plus a `mark-complete` step would silently lose its file-driven progression, violating FR-004.
+- *Compare only against `COMPANION_WORKFLOW`* — fixes the reported case but leaves the rule asymmetric and would break the moment a future built-in adds a non-lifecycle step. Rejected: derive from the shipped constants so new built-in steps are exempt for free.
+
+## Decision — claim sub-folder contents in `relatedDocsPresent` by pruning the directory during the scan
+
+**Decision**: `relatedDocsPresent` collects the set of `subDir` values across all workflow steps, and the recursive scan skips any directory whose path matches one of them, rather than trying to enumerate and claim individual filenames inside it.
+
+**Rationale**: A step's `subDir` is an open-ended container — `checklists/`, `contracts/`, `issues/` all hold files whose names the workflow never predicts. Claiming names is impossible; claiming the container is exact. Pruning at the directory boundary also costs nothing, since the scan already walks directories one entry at a time and short-circuits on the first hit.
+
+This matters beyond the reported bug: `stepHasOutput` already checks a step's own `subDir` on its own path, so pruning it from the related-docs scan removes a double-count without taking evidence away from the step that owns the folder.
+
+**Alternatives considered**:
+- *Enumerate files under each `subDir` and add them to `claimed`* — the literal reading of "add each step's subDir contents to claimed". Rejected: it needs an extra filesystem read per sub-folder for a result the prune achieves with a string comparison, and it races a folder being written while the scan runs.
+- *Ignore all nested directories in the related-docs scan* — simpler still, but it would stop counting genuinely unclaimed nested documents, narrowing the related-docs signal that developer-authored pipelines depend on. Rejected as a regression against FR-004.
+
+## Decision — assert the fix at the footer, not at the two functions
+
+**Decision**: The regression test builds the exact reported state — `COMPANION_WORKFLOW` steps, a context with the specify step complete, and a real temp directory holding `spec.md` and `checklists/requirements.md` — and asserts that the composed result of `synthesizeCustomProgress` + `getFooterActions` yields an approve action labeled `Plan`.
+
+**Rationale**: The issue notes that `getFooterActions` alone already yields `approve:Plan`; the defect only appears once `synthesizeCustomProgress` has rewritten the context. A unit test on either function in isolation would have passed before the fix. Only the composition reproduces the bug, which is what makes it a regression test rather than a restatement of the implementation.
+
+**Alternatives considered**:
+- *Test `isCustomWorkflow(COMPANION_WORKFLOW.steps)` returns false* — worth having as a cheap unit assertion, but it locks in the mechanism rather than the behavior. Kept as a supporting test, not the primary one.
+- *Drive the assertion through `specViewerProvider`* — closest to the user, but the provider needs a mocked VS Code panel and workspace, and the repo has a known gap in config-mock harnesses for webview paths. Rejected as cost without added confidence.
+
+## Decision — the "shorts" audit and the fresh-install validation stay verification-only
+
+**Decision**: FR-006 and FR-007 are discharged by evidence, not by product code. The shorts audit is a text search across the working tree and the packaged artifact; the fresh-install validation runs the real `specify` command-line tool into a disposable sandbox under `examples/`.
+
+**Rationale**: The short-form video tooling lives at `~/.claude/skills/speckit-companion-shorts` — a personal skill outside the repository. A search already confirms zero matches in the working tree and zero in `speckit-companion-0.31.5.vsix`. The value here is a recorded check, not a change. Likewise the install flow is already implemented; what is missing is proof it works from nothing, which is an execution, not an edit.
+
+**Alternatives considered**:
+- *Add a packaging test that fails the build on a "shorts" match* — tempting as a permanent guard, but it encodes one personal skill's name into the product's test suite. Rejected: the skill was never in the repository, so there is no drift to defend against.

--- a/specs/582-footer-next-step/spec.md
+++ b/specs/582-footer-next-step/spec.md
@@ -1,0 +1,130 @@
+# Feature Specification: Footer next step matches the pending step
+
+**Feature Branch**: `fix/582-footer-next-step`
+**Created**: 2026-08-19
+**Status**: Draft
+**Issue**: [#582](https://github.com/alfredoperez/speckit-companion/issues/582)
+
+## User Scenarios & Testing
+
+### User Story 1 - A freshly specified Companion spec offers Plan next (Priority: P1)
+
+A developer runs the SpecKit Companion specify step on a new feature. The spec directory now holds the specification and its quality checklist, and nothing else. They open the spec in the viewer to keep going. The footer should invite them into the planning step, because planning is genuinely the next thing that has not happened yet.
+
+**Why this priority**: This is the reported defect and it silently destroys work — the footer's forward button runs the task-generation step, so the developer ends up with a task list built from a specification that was never planned. Every other story in this feature is a guard around this one.
+
+**Independent Test**: Take a spec whose recorded run shows only the specification step finished, with the specification document and its checklist on disk. Open it in the viewer. The footer must name the planning step, and pressing the forward button must run the planning step.
+
+**Acceptance Scenarios**:
+
+1. **Given** a spec on the SpecKit Companion workflow whose recorded run shows the specification step complete, and whose directory holds only the specification document and the specification quality checklist, **When** the developer opens it in the viewer, **Then** the footer reads "Next: Plan" and offers a Plan button.
+2. **Given** that same spec, **When** the developer presses the footer's forward button, **Then** the planning step is dispatched, not the task-generation step.
+3. **Given** that same spec, **When** the viewer renders, **Then** the step the footer names as next is the same step the stepper shows as pending.
+
+### User Story 2 - The quality checklist is never mistaken for planning output (Priority: P2)
+
+A step that files its output into its own sub-folder — the specification step's quality checklist is the everyday case — must not have that output counted as evidence that a *later* step produced something. Otherwise merely finishing one step appears to finish the next.
+
+**Why this priority**: This is the second, independent half of the defect. Fixing only the workflow-classification half would leave the same trap armed for any workflow the extension still reconstructs from files.
+
+**Independent Test**: For a workflow whose progression is reconstructed from files on disk, place a document inside an earlier step's sub-folder and nothing else. No later step may read as having produced output.
+
+**Acceptance Scenarios**:
+
+1. **Given** a spec where the only document beyond the specification lives inside a folder that the specification step already claims, **When** the extension decides whether a later step has produced output, **Then** that document is not counted for the later step.
+2. **Given** a spec where a genuinely unclaimed document sits loose in the spec directory, **When** the extension makes the same decision, **Then** that document still counts for the step that accepts related documents.
+
+### User Story 3 - Workflows the developer wrote themselves keep advancing (Priority: P2)
+
+A developer who wires their own pipeline into the extension has commands that only write documents; nothing records progress for them. The extension reconstructs where those runs stand by looking at what is on disk. That reconstruction must survive this fix untouched.
+
+**Why this priority**: The fix narrows when the reconstruction runs. Narrowing it too far would strand every developer-authored pipeline at its first step — a worse regression than the bug being fixed.
+
+**Independent Test**: Run the progression reconstruction against a pipeline whose step names do not all belong to the built-in set. It must still advance to the furthest step with output on disk.
+
+**Acceptance Scenarios**:
+
+1. **Given** a developer-authored pipeline with step names outside the built-in lifecycle set, **When** its documents appear on disk ahead of the recorded position, **Then** the extension still advances the run to the furthest produced step.
+2. **Given** any pipeline that the extension treats as developer-authored today, **When** this fix ships, **Then** it is still treated as developer-authored.
+
+## Edge Cases
+
+- A spec whose recorded run is genuinely empty (a stub written when the workflow was first chosen) must still surface a forward action for its entry step.
+- A developer-authored pipeline whose step names happen to match a built-in pipeline exactly is indistinguishable from that built-in and is treated as built-in — an accepted, pre-existing limitation, not a regression.
+- A step that declares both a sub-folder and an appetite for related documents must not be starved: its own sub-folder still counts as its own output.
+- A spec already past planning must not be dragged backwards by any of this.
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: The extension MUST NOT reconstruct progression from files for a spec running a workflow the extension ships built in, including the SpecKit Companion workflow with its terminal completion step.
+- **FR-002**: A document filed under a folder that any step of the workflow claims as its own MUST NOT count as a related document for a different step.
+- **FR-003**: The step the footer names as the next action MUST be the same step the stepper renders as pending, for every spec on a built-in workflow.
+- **FR-004**: Every workflow the extension treats as developer-authored before this change MUST still be treated as developer-authored after it, and MUST still receive file-driven progression.
+- **FR-005**: The project MUST carry an automated regression test that reproduces the reported state — specification step complete, specification document and quality checklist on disk, SpecKit Companion workflow — and asserts the footer offers the planning step.
+- **FR-006**: Neither shipped product MUST contain a "shorts" command, skill, or asset; the short-form video tooling is personal and stays outside both distributions.
+- **FR-007**: The recorded-progress capture flow MUST be shown working from a genuinely fresh install — the SpecKit command-line tool installed and initialized into a clean sandbox, its constitution step run, and the companion spec-kit extension installed through its own installer rather than copied from an existing installation.
+
+## Key Entities
+
+- **Workflow** — an ordered list of named steps a spec runs through. Some ship with the extension; others are written by the developer. Each step may name a document it produces, extra documents that also count, and a folder whose contents belong to it.
+- **Recorded run** — the spec's own log of which steps started and finished. This is the single source of truth for where a spec stands.
+- **Reconstructed progression** — a stand-in run the extension infers from documents on disk, for pipelines that never record anything. It is a fallback and must never override a real recorded run.
+- **Related document** — a document in the spec directory that no step claims by name; some steps accept these as evidence of their own output.
+
+## Success Criteria
+
+### Measurable Outcomes
+
+- **SC-001**: On a freshly specified SpecKit Companion spec, the footer names the planning step in 100% of renders; the task-generation step is offered in 0%.
+- **SC-002**: The footer's named next step and the stepper's pending step agree on 100% of specs running a built-in workflow.
+- **SC-003**: The set of workflows treated as developer-authored is unchanged — 0 workflows move from developer-authored to built-in other than the two the extension ships.
+- **SC-004**: A regression test covering the reported state fails before the fix and passes after it.
+- **SC-005**: A text search for "shorts" across both distributions returns 0 matches.
+- **SC-006**: A sandbox initialized from scratch reaches a recorded run with a readable current step and status, with no files copied from an existing installation.
+
+## Assumptions
+
+- Matching a workflow's step-name sequence against the two built-in pipelines is sufficient to recognize them; the extension does not need the workflow's own name plumbed through to the two places that reconstruct progression.
+- The fix must be strictly additive: a workflow considered developer-authored today may not become built-in, so the existing "any step name outside the lifecycle set" rule stays as the fallback and the built-in match is layered in front of it.
+- The sandbox for the fresh-install check lives under the repository's examples directory and is disposable.
+
+## Verbatim Constraints
+
+- `isCustomWorkflow` — the classification function that must exempt built-in workflows.
+- `relatedDocsPresent` — the function whose claimed set must include each step's sub-folder contents.
+- `src/features/specs/customWorkflowProgress.ts` — the module holding both defects.
+- `mark-complete` — the SpecKit Companion workflow's terminal step name, the one outside the lifecycle set.
+- `checklists/requirements.md` — the specification quality checklist path that is currently miscounted.
+- `approve:Plan` — the footer action the regression test must assert.
+
+## MODIFIED Requirements
+<!-- capability: specs -->
+
+### A workflow that records nothing still shows progress
+
+Workflows the user defines themselves run commands that write documents but never touch the state record, which would strand them at their first step forever. For those workflows only, progression SHALL be reconstructed from the one signal they do leave — their step outputs on disk — and only ever *forward* of what the record already says. Workflows that do record their own progress MUST be left entirely alone.
+
+A workflow the product ships is recognized by its own step sequence, not by whether every step name belongs to the lifecycle set. A built-in pipeline that ends in a step outside that set MUST still be recognized as built-in and MUST NOT be reconstructed from disk. Recognition may only ever move a workflow from user-defined to built-in — never the reverse — so nothing that reconstructs progression today stops doing so.
+
+A step may claim a whole folder as its own output. Everything inside a claimed folder belongs to the step that claims it and MUST NOT count as loose evidence for any other step.
+
+#### Scenario: a user's workflow has produced its third step's output
+- **WHEN** the record still says step one
+- **THEN** a reconstructed progression advances it to the third step so the forward action appears
+- **AND** the built-in pipelines are untouched by this path
+
+#### Scenario: the record is already at or ahead of what disk shows
+- **WHEN** reconstruction runs
+- **THEN** the real record wins and nothing is rewritten
+
+#### Scenario: a built-in pipeline ends in a step outside the lifecycle set
+- **WHEN** the reader opens a spec running that pipeline
+- **THEN** no progression is reconstructed from disk
+- **AND** the forward action names the same step the step strip shows as pending
+
+#### Scenario: only a claimed folder's document is present
+- **WHEN** the sole document beyond the specification lives in a folder an earlier step claims
+- **THEN** no later step reads as having produced output
+- **AND** a document loose in the spec directory still counts as before

--- a/specs/582-footer-next-step/tasks.md
+++ b/specs/582-footer-next-step/tasks.md
@@ -1,0 +1,138 @@
+# Tasks: Footer next step matches the pending step
+
+**Spec**: [spec.md](./spec.md) | **Plan**: [plan.md](./plan.md) | **Issue**: [#582](https://github.com/alfredoperez/speckit-companion/issues/582)
+**Size**: normal
+
+## Phase 1: Setup
+
+No setup work. The module, its test file, and the workflow constants all already exist; nothing new needs scaffolding.
+
+## Phase 2: Foundational
+
+Nothing blocks the stories. Both defects live in one module and are independent of each other, so each story can be built and verified on its own.
+
+## Phase 3: User Story 1 — A freshly specified Companion spec offers Plan next (P1)
+
+**Goal**: The footer names the planning step on a spec whose only documents are the specification and its quality checklist.
+
+**Independent Test**: Stage `spec.md` and `checklists/requirements.md` in a temp directory, build a context at `currentStep: specify` / `status: specified`, run it through `synthesizeCustomProgress` with the SpecKit Companion steps, and assert the footer's approve action reads `Plan`.
+
+### Tests
+
+**Wave 1 — the failing test comes first (one file):**
+
+- [x] **T001** [US1] Add a failing regression test that stages `spec.md` + `checklists/requirements.md` on disk, runs the real `stepHasOutput` through `synthesizeCustomProgress` with `COMPANION_WORKFLOW.steps`, and asserts `getFooterActions` yields `approve:Plan` — confirm it fails on the current code before changing anything · `src/features/specs/__tests__/customWorkflowProgress.test.ts`
+
+### Implementation
+
+**⟶ Wait for T001 to fail, then:**
+
+- [x] **T002** [US1] Front-load `isCustomWorkflow` with an exact step-name-sequence match against `DEFAULT_WORKFLOW.steps` and `COMPANION_WORKFLOW.steps`, computed once at module load, returning `false` on a match and falling through to the existing `STEP_NAMES` rule otherwise · `src/features/specs/customWorkflowProgress.ts`
+
+**⟶ Wait for T002, then:**
+
+- [x] **T003** [US1] Confirm T001 now passes and the existing `synthesizeCustomProgress` suite is untouched · `src/features/specs/__tests__/customWorkflowProgress.test.ts`
+
+**Checkpoint**: A freshly specified SpecKit Companion spec offers Plan in the footer. FR-001 and FR-003 are satisfied and demonstrable.
+
+## Phase 4: User Story 2 — The quality checklist is never mistaken for planning output (P2)
+
+**Goal**: A document inside a folder a step claims stops counting as a later step's related document.
+
+**Independent Test**: With a developer-authored pipeline whose early step declares a sub-folder, place a document only inside that sub-folder; no later step reads as having produced output.
+
+### Tests
+
+**Wave 1 — independent (different concerns, same file, so sequential):**
+
+- [x] **T004** [US2] Add a failing test: a step with `includeRelatedDocs` must read `false` when the only extra document lives under an earlier step's `subDir` · `src/features/specs/__tests__/customWorkflowProgress.test.ts`
+
+**⟶ Wait for T004, then:**
+
+- [x] **T005** [US2] Add the paired guard test: a loose unclaimed `.md` in the spec directory still reads `true`, and a step that owns its own `subDir` still reads `true` from its own folder · `src/features/specs/__tests__/customWorkflowProgress.test.ts`
+
+### Implementation
+
+**⟶ Wait for T004–T005 to fail, then:**
+
+- [x] **T006** [US2] Collect every step's `subDir` into a claimed-directory set in `relatedDocsPresent` and prune matching directories during the recursive scan instead of descending into them · `src/features/specs/customWorkflowProgress.ts`
+
+**Checkpoint**: Sub-folder documents are attributed only to the step that owns them. FR-002 is satisfied.
+
+## Phase 5: User Story 3 — Workflows the developer wrote themselves keep advancing (P2)
+
+**Goal**: Prove the fix is additive — nothing that reconstructed progression before stops doing so.
+
+**Independent Test**: The pre-existing ticket-shaped and GSD-shaped suites pass with no edits.
+
+### Tests
+
+**Wave 1 — independent (different files):**
+
+- [x] **T007** [P] [US3] Run the full `customWorkflowProgress` suite unmodified and confirm every pre-existing developer-authored-pipeline test still passes; any edit needed to an existing test means the fix is not additive · `src/features/specs/__tests__/customWorkflowProgress.test.ts`
+- [x] **T008** [P] [US3] Add an explicit additivity assertion: `isCustomWorkflow` stays `true` for a pipeline that uses lifecycle names plus a `mark-complete` step but is not the shipped SpecKit Companion sequence · `src/features/specs/__tests__/customWorkflowProgress.test.ts`
+
+**Checkpoint**: FR-004 is satisfied with a test that would catch an over-broad exemption.
+
+## Phase 6: Verification — shorts audit and fresh-install validation
+
+**Goal**: Discharge the two evidence-only requirements. No product code changes here.
+
+**Wave 1 — independent (no shared state):**
+
+- [x] **T009** [P] Audit both distributions for a "shorts" command, skill, or asset — search the working tree, `speckit-extension/`, and the packaged artifact — and record the result as evidence for FR-006 · `specs/582-footer-next-step/verification.md`
+- [x] **T010** [P] Create a disposable sandbox under `examples/`, initialize it with the real `specify` command-line tool (a genuine install, never a copy of an existing installation), and confirm the initialization output · `examples/582-fresh-install/`
+
+**⟶ Wait for T010, then:**
+
+- [x] **T011** Run the constitution step in the fresh sandbox and confirm it produces a constitution · `examples/582-fresh-install/`
+
+**⟶ Wait for T011, then:**
+
+- [x] **T012** Install the companion spec-kit extension into the fresh sandbox through its own installer, then run the status flow and confirm a recorded run appears with a readable current step and status — record the evidence for FR-007 · `specs/582-footer-next-step/verification.md`
+
+**Checkpoint**: FR-006 and FR-007 are satisfied with recorded evidence.
+
+## Phase 8: Status and resume dispatch the Companion family (found during T012)
+
+**Goal**: A spec recorded as running the Companion workflow gets Companion commands from the status resolver, not stock ones.
+
+**Why it is here**: T012 surfaced it. The resolver selects the Companion command table on the legacy per-spec `profile` field holding `turbo`, but that field was retired — nothing writes it, and the writer records `workflow: companion` instead. The Companion table is therefore unreachable, so `/speckit.companion.status` reports the stock next command and `/speckit.companion.resume` dispatches the stock pipeline. Same failure as the reported bug, one surface over.
+
+**Independent Test**: Resolve status for a context carrying `workflow: companion` and assert the next command is the Companion one; resolve one carrying neither and assert it is still the stock one.
+
+### Tests
+
+**Wave 1 — one file:**
+
+- [x] **T016** Add failing tests: a `workflow: companion` context resolves Companion next-commands at every step, a stock context still resolves stock ones, and a legacy `profile: turbo` context still resolves Companion ones · `speckit-extension/tests/test_context.py`
+
+### Implementation
+
+**⟶ Wait for T016 to fail, then:**
+
+- [x] **T017** Select the command family from the recorded `workflow` field, keeping `profile: turbo` as a legacy fallback, and reinstall the extension locally so the working copy matches · `speckit-extension/scripts/status-context.py`
+
+**Checkpoint**: Status and resume both speak the Companion command family for Companion specs.
+
+## Phase 7: Polish
+
+**Wave 1 — independent (different files):**
+
+- [x] **T013** [P] Add the user-facing changelog entry under `## [Unreleased]`, written as release notes with no internal file or symbol names · `CHANGELOG.md`
+- [x] **T014** [P] Update the spec-viewer living spec if this fix changes an observable behavior it documents; skip with a note if it does not · `src/features/spec-viewer/spec-viewer.spec.md`
+
+**⟶ Wait for Wave 1, then:**
+
+- [x] **T015** Validate against the Success Criteria: run the TypeScript compile and the full test suite, and confirm SC-001 through SC-006 · `package.json`
+
+## Dependencies & Execution Order
+
+- **Phase 1 and Phase 2** are empty; work starts at Phase 3.
+- **Phase 3** (US1): T001 fails → T002 fixes → T003 confirms. Strictly sequential.
+- **Phase 4** (US2): T004 then T005 (same file) → T006 fixes. Independent of Phase 3 in principle, but both edit the same two files, so run it after Phase 3.
+- **Phase 5** (US3): T007 and T008 are independent of each other and depend on T002 and T006 both landing.
+- **Phase 6**: T009 and T010 are fully independent of the code change and of each other. T011 waits on T010; T012 waits on T011.
+- **Phase 8**: T016 fails, T017 fixes. Independent of Phases 3-5 (different language, different distribution).
+- **Phase 7**: T013 and T014 are independent; T015 waits on everything.
+- **Requirement coverage**: FR-001 → T001–T003; FR-002 → T004–T006; FR-003 → T001, T003; FR-004 → T007, T008; FR-005 → T001; FR-006 → T009; FR-007 → T010-T012, T016-T017.

--- a/specs/582-footer-next-step/verification.md
+++ b/specs/582-footer-next-step/verification.md
@@ -1,0 +1,76 @@
+# Verification evidence
+
+Recorded 2026-08-19 on branch `fix/582-footer-next-step`.
+
+## FR-006 — no "shorts" ships in either distribution
+
+| Surface | Command | Result |
+| --- | --- | --- |
+| Working tree | `grep -ril shorts .` (excluding `node_modules`, `.git`, `out`, `dist`) | 0 matches |
+| Spec-kit extension source | `grep -ril shorts speckit-extension/` | 0 matches |
+| Packaged VS Code artifact — filenames | `unzip -l speckit-companion-0.31.5.vsix \| grep -i shorts` | 0 matches |
+| Packaged VS Code artifact — file contents | unpacked and searched | 0 matches |
+| Extension freshly installed into a clean sandbox | `grep -ril shorts .specify/extensions/` | 0 matches |
+| Declared commands | `speckit-extension/extension.yml` | 18 commands, none named `shorts` |
+
+The short-form video tooling lives at `~/.claude/skills/speckit-companion-shorts` — a personal skill in the user's global Claude directory, outside this repository. It has never been in either distribution, so nothing needed removing.
+
+## FR-007 — capture works from a genuinely fresh install
+
+Nothing was copied from an existing installation. Each step below ran for real, in order, in a disposable sandbox at `examples/bench-sandboxes/582-fresh-install` (gitignored).
+
+**1. Fresh SpecKit install**
+
+```
+specify init 582-fresh-install --integration claude --ignore-agent-tools --script sh
+```
+
+CLI version `0.12.16.dev0`. Produced `.specify/` (integrations, memory, scripts, templates, workflows) and `.claude/skills/` with 10 stock spec-kit skills. No `.specify/extensions.yml` and no `.specify/extensions/` — a clean stock install with the companion extension absent.
+
+**2. Constitution — run before the extension was installed**
+
+Filled `.specify/memory/constitution.md` from the template: 5 principles, 2 additional sections, governance, version `1.0.0`. Zero placeholder tokens left. Committed to the sandbox's own git repository.
+
+No hooks fired, correctly — `.specify/extensions.yml` did not exist yet, and the constitution skill's pre-execution check skips silently in that case.
+
+**3. Fresh extension install — from the released artifact, not a copy**
+
+```
+specify extension add companion --from https://github.com/alfredoperez/speckit-companion/releases/download/companion-latest/companion.zip
+```
+
+The CLI showed its untrusted-source warning and required confirmation, then installed **SpecKit Companion v0.20.1** — 18 commands, 4 hooks, priority 10, enabled. It created `.specify/extensions.yml` with the companion hook registrations and installed 18 `speckit-companion-*` skills into `.claude/skills/`.
+
+Worth noting: `specify extension search companion` finds the extension in the **community** catalog, which is discovery-only and still advertises **v0.11.0** while the shipped artifact is **v0.20.1**. The `--from` URL is the working install path, and the community catalog entry is stale.
+
+**4. Status flow**
+
+| Situation | Output |
+| --- | --- |
+| Fresh install, no spec at all | `[companion] Could not resolve the active feature directory … Skipping status.` — exits 0, degrades cleanly |
+| After a captured specify step | `Spec: add a todo (source: state)` / `Step: specify  Status: specified` / `Next: Plan the feature` |
+| A spec directory with only `spec.md` + `plan.md`, no recorded context | `(source: derived)` / `Step: plan  Status: planned` / `Next: Generate tasks` |
+| Same directory once `tasks.md` appears | `(source: derived)` / `Step: tasks  Status: ready-to-implement` / `Next: Implement` |
+
+Capture and status both work end to end from nothing. Note that the recorded case reports **Next: Plan** on a freshly specified spec — the same expectation this feature fixes in the viewer footer.
+
+### Defect found by this test
+
+The status resolver picks the Companion command family off a field nothing writes any more. It checks the legacy per-spec `profile` for the value `turbo`, but that field was retired in the workflow-choice collapse — `specContext.ts` documents it as legacy and "no longer written or read for dispatch", and the writer now records `workflow: companion` instead. Nothing sets `profile`, so the check is never true and the companion command table is unreachable.
+
+Observed on the fresh install: a spec recorded with `workflow: companion` reports `Next: Plan the feature → /speckit.plan` — the stock command, not `/speckit.companion.plan`. The same resolver output drives `/speckit.companion.resume`, so resuming a Companion run dispatches the stock pipeline and drops the Companion behavior.
+
+This is the same failure as the reported footer bug, one surface over: a built-in Companion workflow not being recognized as Companion. Fixed here in Phase 8.
+
+**After the fix**, with the rebuilt extension reinstalled into the same fresh sandbox:
+
+| Spec | Reported next action |
+| --- | --- |
+| `workflow: companion` | `Next: Plan the feature → /speckit.companion.plan` |
+| stock (`workflow: speckit`) | `Next: Implement → /speckit.implement` |
+
+A spec carrying the retired `profile: turbo` still resolves to the Companion family, so nothing written before the workflow-choice collapse regresses.
+
+### Residual note
+
+Derived status names the spec from the document rather than the directory — a spec directory `002-derived` reports `Spec: spec`. Cosmetic, out of scope for this feature, not filed.

--- a/src/features/specs/__tests__/customWorkflowProgress.test.ts
+++ b/src/features/specs/__tests__/customWorkflowProgress.test.ts
@@ -260,6 +260,18 @@ describe('the built-in exemption is additive', () => {
         expect(isCustomWorkflow(lookalike)).toBe(true);
     });
 
+    it('leaves a user workflow that mirrors the Companion step names custom', () => {
+        // Same names as the shipped pipeline, the user's own commands — exempting
+        // this would strand it at specify with no forward button.
+        const mirror: WorkflowStepConfig[] = COMPANION_WORKFLOW.steps!.map(s => ({
+            ...s,
+            command: `my.${s.name}`,
+        }));
+        expect(isCustomWorkflow(mirror)).toBe(true);
+        const out = synthesizeCustomProgress(stubCtx(), mirror, s => s.name === 'specify');
+        expect(hasFooter(out, 'specify' as StepName, mirror, FooterActionIds.APPROVE)).toBe(true);
+    });
+
     it('exempts both shipped workflows', () => {
         expect(isCustomWorkflow(DEFAULT_WORKFLOW.steps)).toBe(false);
         expect(isCustomWorkflow(COMPANION_WORKFLOW.steps)).toBe(false);
@@ -274,5 +286,25 @@ describe('the built-in exemption is additive', () => {
         ];
         // All lifecycle names — the pre-existing rule already read it non-custom.
         expect(isCustomWorkflow(reordered)).toBe(false);
+    });
+});
+
+describe('a claimed subDir is pruned to its whole subtree', () => {
+    const CHECKLIST_STEPS: WorkflowStepConfig[] = [
+        { name: 'specify', command: 'to-spec', file: 'spec.md', subDir: 'checklists' },
+        { name: 'draft', command: 'to-draft', includeRelatedDocs: true },
+    ];
+    let dir: string;
+    beforeEach(() => {
+        dir = fs.mkdtempSync(path.join(os.tmpdir(), 'nested-'));
+    });
+    afterEach(() => {
+        fs.rmSync(dir, { recursive: true, force: true });
+    });
+
+    it('does not count a doc nested deeper inside a claimed subDir', () => {
+        fs.mkdirSync(path.join(dir, 'checklists', 'archive'), { recursive: true });
+        fs.writeFileSync(path.join(dir, 'checklists', 'archive', 'old.md'), '# old');
+        expect(stepHasOutput(dir, CHECKLIST_STEPS[1], CHECKLIST_STEPS)).toBe(false);
     });
 });

--- a/src/features/specs/__tests__/customWorkflowProgress.test.ts
+++ b/src/features/specs/__tests__/customWorkflowProgress.test.ts
@@ -10,6 +10,7 @@ import { getFooterActions } from '../../spec-viewer/footerActions';
 import { FooterActionIds } from '../../../core/constants';
 import type { SpecContext, StepName } from '../../../core/types/specContext';
 import type { WorkflowStepConfig } from '../../workflows/types';
+import { COMPANION_WORKFLOW, DEFAULT_WORKFLOW } from '../../workflows/workflowManager';
 
 // Ticket-based custom workflow: spec → tickets → implement(actionOnly),
 // with the non-lifecycle step name "tickets".
@@ -165,5 +166,113 @@ describe('stepHasOutput', () => {
     it('needs allSteps to resolve related-doc ownership', () => {
         fs.writeFileSync(path.join(dir, '01-01-PLAN.md'), '# plan');
         expect(stepHasOutput(dir, plan)).toBe(false);
+    });
+});
+
+describe('built-in workflows are never treated as custom', () => {
+    let dir: string;
+    beforeEach(() => {
+        dir = fs.mkdtempSync(path.join(os.tmpdir(), 'companion-582-'));
+    });
+    afterEach(() => {
+        fs.rmSync(dir, { recursive: true, force: true });
+    });
+
+    // The exact state after companion specify: spec + quality checklist, nothing else.
+    const freshlySpecified = (): SpecContext => ({
+        workflow: 'companion',
+        specName: 'footer-next-step',
+        branch: 'fix/582-footer-next-step',
+        currentStep: 'specify' as StepName,
+        status: 'specified',
+        history: [
+            { step: 'specify', substep: null, kind: 'start', by: 'extension', at: '2026-08-19T10:00:00Z' },
+            { step: 'specify', substep: null, kind: 'complete', by: 'extension', at: '2026-08-19T10:05:00Z' },
+        ],
+    } as unknown as SpecContext);
+
+    it('offers Plan on a freshly specified Companion spec, not Tasks', () => {
+        fs.writeFileSync(path.join(dir, 'spec.md'), '# spec');
+        fs.mkdirSync(path.join(dir, 'checklists'));
+        fs.writeFileSync(path.join(dir, 'checklists', 'requirements.md'), '# checklist');
+
+        const steps = COMPANION_WORKFLOW.steps!;
+        const ctx = synthesizeCustomProgress(freshlySpecified(), steps,
+            s => stepHasOutput(dir, s, steps));
+
+        expect(ctx.currentStep).toBe('specify');
+        expect(getFooterActions(ctx, ctx.currentStep as StepName, steps)
+            .find(a => a.id === FooterActionIds.APPROVE)?.label).toBe('Plan');
+    });
+});
+
+describe('a step subDir is claimed, so its files are not another step related doc', () => {
+    // Custom, so synthesis applies: specify owns `checklists/`, `draft` takes related docs.
+    const CHECKLIST_STEPS: WorkflowStepConfig[] = [
+        { name: 'specify', command: 'to-spec', file: 'spec.md', subDir: 'checklists' },
+        { name: 'draft', command: 'to-draft', includeRelatedDocs: true },
+        { name: 'implement', command: 'implement', actionOnly: true },
+    ];
+    let dir: string;
+    beforeEach(() => {
+        dir = fs.mkdtempSync(path.join(os.tmpdir(), 'subdir-'));
+    });
+    afterEach(() => {
+        fs.rmSync(dir, { recursive: true, force: true });
+    });
+
+    const draft = CHECKLIST_STEPS[1];
+
+    it('does not count a doc under an earlier step subDir as a later step related doc', () => {
+        fs.mkdirSync(path.join(dir, 'checklists'));
+        fs.writeFileSync(path.join(dir, 'checklists', 'requirements.md'), '# checklist');
+        expect(stepHasOutput(dir, draft, CHECKLIST_STEPS)).toBe(false);
+    });
+
+    it('still counts a loose unclaimed doc in the spec dir', () => {
+        fs.writeFileSync(path.join(dir, '01-draft.md'), '# draft');
+        expect(stepHasOutput(dir, draft, CHECKLIST_STEPS)).toBe(true);
+    });
+
+    it('still counts a step own subDir as that step output', () => {
+        const specify = CHECKLIST_STEPS[0];
+        fs.mkdirSync(path.join(dir, 'checklists'));
+        fs.writeFileSync(path.join(dir, 'checklists', 'requirements.md'), '# checklist');
+        expect(stepHasOutput(dir, specify, CHECKLIST_STEPS)).toBe(true);
+    });
+
+    it('still counts a doc in an unclaimed nested dir as a related doc', () => {
+        fs.mkdirSync(path.join(dir, 'notes'));
+        fs.writeFileSync(path.join(dir, 'notes', 'scratch.md'), '# scratch');
+        expect(stepHasOutput(dir, draft, CHECKLIST_STEPS)).toBe(true);
+    });
+});
+
+describe('the built-in exemption is additive', () => {
+    it('leaves a lifecycle-named workflow with an extra mark-complete step custom', () => {
+        // Not the shipped sequence, so file-driven progression must still apply.
+        const lookalike: WorkflowStepConfig[] = [
+            { name: 'specify', command: 'to-spec', file: 'spec.md' },
+            { name: 'tasks', command: 'to-tasks', file: 'tasks.md' },
+            { name: 'implement', command: 'implement', actionOnly: true },
+            { name: 'mark-complete', command: 'done', actionOnly: true },
+        ];
+        expect(isCustomWorkflow(lookalike)).toBe(true);
+    });
+
+    it('exempts both shipped workflows', () => {
+        expect(isCustomWorkflow(DEFAULT_WORKFLOW.steps)).toBe(false);
+        expect(isCustomWorkflow(COMPANION_WORKFLOW.steps)).toBe(false);
+    });
+
+    it('leaves a reordered lifecycle sequence alone rather than exempting it', () => {
+        const reordered: WorkflowStepConfig[] = [
+            { name: 'specify', command: 'to-spec', file: 'spec.md' },
+            { name: 'tasks', command: 'to-tasks', file: 'tasks.md' },
+            { name: 'plan', command: 'to-plan', file: 'plan.md' },
+            { name: 'implement', command: 'implement', actionOnly: true },
+        ];
+        // All lifecycle names — the pre-existing rule already read it non-custom.
+        expect(isCustomWorkflow(reordered)).toBe(false);
     });
 });

--- a/src/features/specs/customWorkflowProgress.ts
+++ b/src/features/specs/customWorkflowProgress.ts
@@ -21,7 +21,16 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { SpecContext, HistoryEntry, StepName, STEP_NAMES } from '../../core/types/specContext';
 import type { WorkflowStepConfig } from '../workflows/types';
-import { getStepFile } from '../workflows/workflowManager';
+import { getStepFile, DEFAULT_WORKFLOW, COMPANION_WORKFLOW } from '../workflows/workflowManager';
+
+const BUILTIN_STEP_SEQUENCES: readonly string[][] = [DEFAULT_WORKFLOW, COMPANION_WORKFLOW]
+    .map(w => (w.steps ?? []).map(s => s.name));
+
+function isBuiltinWorkflow(steps: WorkflowStepConfig[]): boolean {
+    return BUILTIN_STEP_SEQUENCES.some(
+        seq => seq.length === steps.length && seq.every((name, i) => name === steps[i].name)
+    );
+}
 
 /**
  * A workflow is "custom" for progression purposes when ANY of its steps —
@@ -30,11 +39,14 @@ import { getStepFile } from '../workflows/workflowManager';
  * verify) has custom action-only steps (discuss/execute/verify) but its one
  * navigable step reuses the lifecycle name `plan`. Looking only at navigable
  * steps would misread that as a built-in workflow and strand its progression.
- * Built-in workflows use lifecycle names for every step, so they stay non-custom
- * and are left entirely to the capture-context machinery.
+ * A workflow whose step-name sequence exactly matches one the extension ships is
+ * exempt outright, so a built-in step outside the lifecycle set — the Companion
+ * pipeline's terminal `mark-complete` — cannot misclassify it. Built-in workflows
+ * are left entirely to the capture-context machinery.
  */
 export function isCustomWorkflow(steps: WorkflowStepConfig[] | undefined): boolean {
     if (!steps) return false;
+    if (isBuiltinWorkflow(steps)) return false;
     return steps.some(s => !STEP_NAMES.includes(s.name as StepName));
 }
 
@@ -42,16 +54,22 @@ const CORE_DOCS = ['spec.md', 'plan.md', 'tasks.md'];
 
 /**
  * Every `.md` in the spec dir (recursively, hidden dirs skipped) that no step
- * claims as its own file and isn't a lifecycle core doc. This is the same
+ * claims — as its own file, as a `subFile`, or by living inside a step's
+ * `subDir` — and isn't a lifecycle core doc. A step's `subDir` is an open-ended
+ * container (`checklists/`, `contracts/`, `issues/`) whose filenames the workflow
+ * never predicts, so the whole directory is claimed rather than its entries;
+ * `stepHasOutput` already credits it to the step that declares it. This is the same
  * "related docs" set the Specs tree computes — the files a step marked
  * `includeRelatedDocs` produces when its output doesn't match a fixed name
  * (GSD's `gsd-plan-phase` writes `01-01-PLAN.md`, not `plan.md`).
  */
 function relatedDocsPresent(specDir: string, allSteps: WorkflowStepConfig[]): boolean {
     const claimed = new Set<string>();
+    const claimedDirs = new Set<string>();
     for (const s of allSteps) {
         claimed.add(getStepFile(s));
         for (const f of s.subFiles ?? []) claimed.add(f);
+        if (s.subDir) claimedDirs.add(s.subDir);
     }
     let found = false;
     const scan = (dir: string, rel: string): void => {
@@ -64,6 +82,7 @@ function relatedDocsPresent(specDir: string, allSteps: WorkflowStepConfig[]): bo
             if (e.name.startsWith('.')) continue;
             const entryRel = rel ? `${rel}/${e.name}` : e.name;
             if (e.isDirectory()) {
+                if (claimedDirs.has(entryRel)) continue;
                 scan(path.join(dir, e.name), entryRel);
             } else if (e.isFile() && e.name.endsWith('.md')) {
                 if (!rel && (CORE_DOCS.includes(e.name) || claimed.has(e.name))) continue;

--- a/src/features/specs/customWorkflowProgress.ts
+++ b/src/features/specs/customWorkflowProgress.ts
@@ -24,11 +24,14 @@ import type { WorkflowStepConfig } from '../workflows/types';
 import { getStepFile, DEFAULT_WORKFLOW, COMPANION_WORKFLOW } from '../workflows/workflowManager';
 
 const BUILTIN_STEP_SEQUENCES: readonly string[][] = [DEFAULT_WORKFLOW, COMPANION_WORKFLOW]
-    .map(w => (w.steps ?? []).map(s => s.name));
+    .map(w => (w.steps ?? []).map(s => `${s.name}\u0000${s.command}`));
 
 function isBuiltinWorkflow(steps: WorkflowStepConfig[]): boolean {
+    // Names alone would capture a user workflow that mirrors the shipped step
+    // names, stranding it; the command it dispatches is what makes it built-in.
+    const seen = steps.map(s => `${s.name}\u0000${s.command}`);
     return BUILTIN_STEP_SEQUENCES.some(
-        seq => seq.length === steps.length && seq.every((name, i) => name === steps[i].name)
+        seq => seq.length === seen.length && seq.every((sig, i) => sig === seen[i])
     );
 }
 
@@ -39,10 +42,12 @@ function isBuiltinWorkflow(steps: WorkflowStepConfig[]): boolean {
  * verify) has custom action-only steps (discuss/execute/verify) but its one
  * navigable step reuses the lifecycle name `plan`. Looking only at navigable
  * steps would misread that as a built-in workflow and strand its progression.
- * A workflow whose step-name sequence exactly matches one the extension ships is
- * exempt outright, so a built-in step outside the lifecycle set — the Companion
- * pipeline's terminal `mark-complete` — cannot misclassify it. Built-in workflows
- * are left entirely to the capture-context machinery.
+ * A workflow whose steps exactly match one the extension ships — same names AND
+ * same commands, in order — is exempt outright, so a built-in step outside the
+ * lifecycle set (the Companion pipeline's terminal `mark-complete`) cannot
+ * misclassify it, while a user workflow that merely reuses those step names keeps
+ * its file-driven progression. Built-in workflows are left entirely to the
+ * capture-context machinery.
  */
 export function isCustomWorkflow(steps: WorkflowStepConfig[] | undefined): boolean {
     if (!steps) return false;
@@ -57,11 +62,13 @@ const CORE_DOCS = ['spec.md', 'plan.md', 'tasks.md'];
  * claims — as its own file, as a `subFile`, or by living inside a step's
  * `subDir` — and isn't a lifecycle core doc. A step's `subDir` is an open-ended
  * container (`checklists/`, `contracts/`, `issues/`) whose filenames the workflow
- * never predicts, so the whole directory is claimed rather than its entries;
- * `stepHasOutput` already credits it to the step that declares it. This is the same
- * "related docs" set the Specs tree computes — the files a step marked
+ * never predicts, so the whole subtree is claimed rather than its entries;
+ * `stepHasOutput` already credits it to the step that declares it. This is close
+ * to the "related docs" set the Specs tree computes — the files a step marked
  * `includeRelatedDocs` produces when its output doesn't match a fixed name
- * (GSD's `gsd-plan-phase` writes `01-01-PLAN.md`, not `plan.md`).
+ * (GSD's `gsd-plan-phase` writes `01-01-PLAN.md`, not `plan.md`) — but the tree
+ * excludes only a claimed dir's top level, so a doc nested deeper inside one still
+ * lists there while never counting as another step's output here.
  */
 function relatedDocsPresent(specDir: string, allSteps: WorkflowStepConfig[]): boolean {
     const claimed = new Set<string>();

--- a/src/features/specs/specs.spec.md
+++ b/src/features/specs/specs.spec.md
@@ -161,6 +161,10 @@ The tree SHALL group specs by their recorded status, and offer filtering and ord
 
 Workflows the user defines themselves run commands that write documents but never touch the state record, which would strand them at their first step forever. For those workflows only, progression SHALL be reconstructed from the one signal they do leave — their step outputs on disk — and only ever *forward* of what the record already says. Workflows that do record their own progress MUST be left entirely alone.
 
+A workflow the product ships is recognized by its own step sequence, not by whether every step name belongs to the lifecycle set. A built-in pipeline that ends in a step outside that set MUST still be recognized as built-in and MUST NOT be reconstructed from disk. Recognition may only ever move a workflow from user-defined to built-in — never the reverse — so nothing that reconstructs progression today stops doing so.
+
+A step may claim a whole folder as its own output. Everything inside a claimed folder belongs to the step that claims it and MUST NOT count as loose evidence for any other step.
+
 #### Scenario: a user's workflow has produced its third step's output
 - **WHEN** the record still says step one
 - **THEN** a reconstructed progression advances it to the third step so the forward action appears
@@ -169,6 +173,16 @@ Workflows the user defines themselves run commands that write documents but neve
 #### Scenario: the record is already at or ahead of what disk shows
 - **WHEN** reconstruction runs
 - **THEN** the real record wins and nothing is rewritten
+
+#### Scenario: a built-in pipeline ends in a step outside the lifecycle set
+- **WHEN** the reader opens a spec running that pipeline
+- **THEN** no progression is reconstructed from disk
+- **AND** the forward action names the same step the step strip shows as pending
+
+#### Scenario: only a claimed folder's document is present
+- **WHEN** the sole document beyond the specification lives in a folder an earlier step claims
+- **THEN** no later step reads as having produced output
+- **AND** a document loose in the spec directory still counts as before
 
 ### Destructive and bulk spec actions confirm, skip no-ops, and stay inside the workspace
 


### PR DESCRIPTION
## Summary

A spec you had only just specified showed **Next: Tasks** in the viewer footer while the step strip correctly showed **Plan** as still pending. Clicking that button generated a task list against a spec that had never been planned.

Two guards were failing open at the same time, and it took both to produce the bug:

1. The built-in **SpecKit Companion** pipeline was being classified as a workflow the user wrote themselves, because its terminal `mark-complete` step is not a lifecycle name. That switched on the file-driven progression fallback, which is only ever meant for pipelines that record nothing.
2. That fallback then counted the specification's own quality checklist as evidence that planning had produced output, because the "claimed files" set only held top-level filenames and never the contents of a step's own folder.

Together they rewrote the current step to `plan` in memory — which the footer read and the stepper did not.

Both are fixed, additively. A workflow is recognized as built-in by an exact match against the step-name sequences the extension ships, and every step's `subDir` is claimed so its contents can never count as another step's related document. Nothing that reconstructs progression today stops doing so.

### A second defect, found by testing the status flow

Validating the fresh-install path surfaced the same failure one surface over. The status resolver picked the Companion command family off a per-spec field retired when the workflow choice was simplified — nothing writes it any more, so the Companion command table was unreachable. A spec recorded as running Companion reported `Next: Plan the feature → /speckit.plan`, and `/speckit.companion.resume` dispatched the stock pipeline from there. It now reads the workflow the spec actually recorded, with the old field kept as a legacy fallback so in-flight specs don't regress.

## Technical

| Change | Where |
| --- | --- |
| Exact step-name-sequence match against `DEFAULT_WORKFLOW` / `COMPANION_WORKFLOW`, short-circuiting `isCustomWorkflow` | `src/features/specs/customWorkflowProgress.ts` |
| Every step's `subDir` collected into a claimed-directory set and pruned during the related-docs scan | `src/features/specs/customWorkflowProgress.ts` |
| Command family selected from the recorded `workflow`, `profile: turbo` kept as a legacy fallback | `speckit-extension/scripts/status-context.py` |

The fingerprint is derived from the shipped workflow constants at module load, so a future built-in step is exempt for free. Neither of the two call sites (`specViewerProvider`, `messageHandlers`) needed to change — plumbing the workflow name through both `resolveWorkflowSteps` implementations was rejected as disproportionate for one boolean.

## Quality checklist

- [x] **Tests added** — 12 new: the composed footer regression (`approve:Plan` from the exact reported state), sub-folder claiming with three paired guards, three additivity assertions, and three status-dispatch cases
- [x] **Regression reproduced first** — the new test failed with `currentStep` rewritten to `plan`, then passed
- [x] **Purely additive** — 0 deletions in the existing test file; every pre-existing developer-authored-pipeline test passes unmodified
- [x] **Full suites green** — `tsc` clean, 1892 jest tests, 554 python tests
- [x] **Changelogs** — root entry for the footer fix, spec-kit entry for the status/resume fix, both under `## [Unreleased]`
- [x] **Docs** — `docs/viewer-states.md` gains the built-in-workflow footer rule; the spec-kit README already documented the correct status behavior this restores
- [x] **Living spec** — `specs` capability updated via a `MODIFIED` delta; `spec-viewer` recorded as an explicit read-only skip
- [x] **No version bump** — release flow owns that
- [x] **Spec files included** — `specs/582-footer-next-step/` with `.spec-context.json`

## Gaps / how to verify

**No "shorts" ships in either extension** — confirmed, nothing needed removing. 0 matches across the working tree, `speckit-extension/`, the packaged `.vsix` (filenames and unpacked contents), and the freshly installed extension. The skill lives only in the user's global Claude directory.

**Fresh-install validation** — nothing copied from an existing installation. Full evidence in `specs/582-footer-next-step/verification.md`:

1. `specify init` (CLI 0.12.16.dev0) into a disposable sandbox — stock install, no companion extension
2. Constitution run **before** the extension existed — no hooks fired, correctly
3. `specify extension add companion --from` the released `companion-latest` zip → v0.20.1, 18 commands, 18 skills
4. Status verified in four situations: no spec (degrades cleanly, exit 0), a captured specify (`source: state`, `Next: Plan`), and the derived fallback both before and after `tasks.md` appears

**To verify by hand**: run companion specify on a new spec, open it in the viewer, and confirm the footer reads **Plan** and matches the step strip. Then run `/speckit.companion.status` and confirm it names `/speckit.companion.plan`.

**Known, not fixed here**: the community extension catalog still advertises SpecKit Companion v0.11.0 while the shipped zip is v0.20.1. Discovery-only, so it doesn't block installs.

Closes #582

🤖 Generated with [Claude Code](https://claude.com/claude-code)