### PR TITLE
fix(companion): changelog link opens the offered version's release

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/582-footer-next-step"
+  "feature_directory": "specs/585-changelog-link"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- **"View Changelog" on the update notification now opens the version it just offered you.** Both this extension and its spec-kit companion publish their releases into one shared list, so the link — which asked GitHub for whichever release was newest — could land on the spec-kit extension's notes instead: a different product, a different version number, and changes that had nothing to do with the update you were being offered. The link now points straight at the offered version's own release. Which version you're told about was always correct; only the link was wrong. ([#585](https://github.com/alfredoperez/speckit-companion/issues/585))
+
+
 ## [0.31.2] - 2026-08-19
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@ All notable changes to this project will be documented in this file.
 
 - **"View Changelog" on the update notification now opens the version it just offered you.** Both this extension and its spec-kit companion publish their releases into one shared list, so the link — which asked GitHub for whichever release was newest — could land on the spec-kit extension's notes instead: a different product, a different version number, and changes that had nothing to do with the update you were being offered. The link now points straight at the offered version's own release. Which version you're told about was always correct; only the link was wrong. ([#585](https://github.com/alfredoperez/speckit-companion/issues/585))
 
-
 ## [0.31.2] - 2026-08-19
 
 ### Fixed

--- a/specs/585-changelog-link/.spec-context.json
+++ b/specs/585-changelog-link/.spec-context.json
@@ -154,6 +154,12 @@
       "command": "npx tsc --noEmit -p . && npx jest",
       "result": "tsc clean, 1895 passed, 0 failed",
       "warnings": []
+    },
+    {
+      "what": "Local code review at high effort",
+      "command": "/code-review high",
+      "result": "no bugs found; one low finding about a leaked mock call, fixed",
+      "warnings": []
     }
   ],
   "step_summaries": {
@@ -161,5 +167,11 @@
       "summary": "Changelog link resolves by tag from the offered version; the last live /releases/latest is gone from shipped source"
     }
   },
-  "last_action": "4/4 tasks done — tsc clean, 1895 tests pass"
+  "last_action": "4/4 tasks done — tsc clean, 1895 tests pass",
+  "concerns": [
+    {
+      "note": "The vscode mock had no withProgress/ProgressLocation, so the Skip branch of the update notification was untestable. Extended the mock rather than dropping the test — this is the config-mock harness gap CLAUDE.md already flags.",
+      "step": "implement"
+    }
+  ]
 }

--- a/specs/585-changelog-link/.spec-context.json
+++ b/specs/585-changelog-link/.spec-context.json
@@ -1,0 +1,165 @@
+{
+  "workflow": "companion",
+  "specName": "changelog link",
+  "branch": "fix/585-changelog-link",
+  "currentStep": "implement",
+  "status": "completed",
+  "history": [
+    {
+      "step": "specify",
+      "substep": null,
+      "kind": "start",
+      "by": "extension",
+      "at": "2026-08-20T11:07:06.456Z"
+    },
+    {
+      "step": "specify",
+      "substep": null,
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-08-20T11:07:43.956Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "kind": "start",
+      "by": "extension",
+      "at": "2026-08-20T11:08:10.001Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T001",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-08-20T11:08:10.097Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T002",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-08-20T11:08:24.397Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T003",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-08-20T11:08:24.565Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "task": "T004",
+      "kind": "complete",
+      "by": "ai",
+      "at": "2026-08-20T11:08:58.832Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "kind": "complete",
+      "by": "extension",
+      "at": "2026-08-20T11:08:58.917Z"
+    }
+  ],
+  "unattended": true,
+  "size": "simple",
+  "classification": {
+    "projectedFiles": 4,
+    "projectedTasks": 4,
+    "scopeSignal": "smaller",
+    "verdict": "simple"
+  },
+  "coverage": {
+    "FR-001": {
+      "title": "The changelog address the update notification opens must identify the offered version explicitly, never asking the host which release is newest",
+      "tasks": [
+        "T001",
+        "T002"
+      ],
+      "tests": [
+        "src/speckit/updateChecker.test.ts::opens the offered versions own release not the shared latest lookup"
+      ]
+    },
+    "FR-002": {
+      "title": "No shipped code path may resolve a release through the shared latest lookup",
+      "tasks": [
+        "T004"
+      ],
+      "tests": [
+        "src/speckit/updateChecker.test.ts::opens the offered versions own release not the shared latest lookup"
+      ]
+    }
+  },
+  "intent": "Make the update notification's View Changelog button open the release notes for the version it just offered, instead of whichever product published most recently.",
+  "approach": "Build the changelog address from the version already in scope at the link site so it resolves by tag rather than by the shared latest lookup, and pin it with a test on the mocked browser-open.",
+  "expectations": [
+    "No change to how the newer version is detected — that filter is already correct",
+    "No version bump on the branch; the release flow owns it"
+  ],
+  "context": [
+    "area: src/speckit/updateChecker.ts",
+    "constraint: CLAUDE.md forbids a bare /releases/latest lookup because both products share one releases list"
+  ],
+  "currentTask": "T004",
+  "task_summaries": {
+    "T001": {
+      "status": "DONE",
+      "did": "Added the failing test; confirmed the button opens /releases/latest instead of the offered version",
+      "files": [
+        "src/speckit/updateChecker.test.ts"
+      ]
+    },
+    "T002": {
+      "status": "DONE",
+      "did": "Changelog link now resolves by tag from the offered version instead of the shared latest lookup",
+      "files": [
+        "src/speckit/updateChecker.ts"
+      ]
+    },
+    "T003": {
+      "status": "DONE",
+      "did": "Added the user-facing changelog entry under Unreleased",
+      "files": [
+        "CHANGELOG.md"
+      ]
+    },
+    "T004": {
+      "status": "DONE",
+      "did": "Confirmed no shipped source resolves a release through the shared latest lookup; tsc clean and 1895 jest tests pass",
+      "files": [
+        "src/speckit/updateChecker.ts"
+      ]
+    }
+  },
+  "verified": [
+    {
+      "what": "The offered version reproduces the wrong link before the fix",
+      "command": "npx jest src/speckit/updateChecker.test.ts",
+      "result": "failed with /releases/latest, passed after the fix",
+      "warnings": []
+    },
+    {
+      "what": "No shipped source resolves a release through the shared latest lookup",
+      "command": "grep -rn releases/latest src/ webview/ speckit-extension/scripts/ excluding tests and comments",
+      "result": "0 live occurrences; the two remaining mentions are comments warning against it",
+      "warnings": []
+    },
+    {
+      "what": "Full suites",
+      "command": "npx tsc --noEmit -p . && npx jest",
+      "result": "tsc clean, 1895 passed, 0 failed",
+      "warnings": []
+    }
+  ],
+  "step_summaries": {
+    "implement": {
+      "summary": "Changelog link resolves by tag from the offered version; the last live /releases/latest is gone from shipped source"
+    }
+  },
+  "last_action": "4/4 tasks done — tsc clean, 1895 tests pass"
+}

--- a/specs/585-changelog-link/checklists/requirements.md
+++ b/specs/585-changelog-link/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Changelog link opens the right product's release
+
+**Purpose**: Validate Companion specification completeness before planning
+**Created**: 2026-08-20
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed (User Scenarios, Requirements, Success Criteria)
+
+## Requirement Completeness
+
+- [x] Any [NEEDS CLARIFICATION] markers are genuine ambiguities (≤3) deferred to clarify — not unresolved guesses
+- [x] Each Functional Requirement is a single, testable MUST/SHOULD statement
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into the specification
+
+## Notes
+
+- Fast-tracked as a simple change: one line plus its test. Verbatim Constraints carries the pinned identifiers.

--- a/specs/585-changelog-link/plan.md
+++ b/specs/585-changelog-link/plan.md
@@ -1,0 +1,3 @@
+# Implementation Plan: Changelog link opens the right product's release
+
+> The approach lives in the spec: [`./spec.md#approach`](./spec.md#approach). Tasks: [`./tasks.md`](./tasks.md).

--- a/specs/585-changelog-link/spec.md
+++ b/specs/585-changelog-link/spec.md
@@ -1,0 +1,58 @@
+# Feature Specification: Changelog link opens the right product's release
+
+**Feature Branch**: `fix/585-changelog-link`
+**Created**: 2026-08-20
+**Status**: Draft
+**Issue**: [#585](https://github.com/alfredoperez/speckit-companion/issues/585)
+
+## User Scenarios & Testing
+
+### User Story 1 - View Changelog shows the version I was just offered (Priority: P1)
+
+A developer sees the notification telling them a new version of the extension is available, and clicks View Changelog to decide whether to update. They should land on the release notes for exactly the version the notification named.
+
+**Why this priority**: It is the whole feature. Landing on a different product's notes gives the developer version numbers and changes that have nothing to do with the update they were offered, which is worse than no link at all.
+
+**Independent Test**: Trigger the update notification with a known newer version, choose View Changelog, and assert the opened address points at that version's own release.
+
+**Acceptance Scenarios**:
+
+1. **Given** the notification offers a specific new version, **When** the developer clicks View Changelog, **Then** the address opened names that exact version.
+2. **Given** the other product published its release more recently, **When** the developer clicks View Changelog, **Then** the address is unaffected by that.
+
+## Edge Cases
+
+- The developer chooses Skip instead: nothing is opened, and the skipped version is remembered as before.
+- The developer dismisses the notification without choosing: nothing is opened.
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: The changelog address the update notification opens MUST identify the offered version explicitly, and MUST NOT ask the release host to decide which release is newest.
+- **FR-002**: No shipped code path may resolve a release through the shared "latest" lookup, since both products publish into one list and either can win it.
+
+## Success Criteria
+
+### Measurable Outcomes
+
+- **SC-001**: The address opened by View Changelog names the offered version in 100% of cases, regardless of which product published most recently.
+- **SC-002**: A search of shipped source for the shared latest-release lookup returns 0 results.
+
+## Assumptions
+
+- The offered version is already known at the moment the link is built, so no extra lookup is needed to construct an exact address.
+
+## Verbatim Constraints
+
+- `src/speckit/updateChecker.ts` — the file holding the link.
+- `releases/latest` — the shared lookup that must not appear in shipped source.
+- `View Changelog` — the notification action this covers.
+
+## Approach
+
+- Build the changelog address from the version the notification already carries, so it resolves by tag instead of by "whichever is newest". One line in `src/speckit/updateChecker.ts`.
+- Cover it in `src/speckit/updateChecker.test.ts`: assert the opened address for a known offered version, using the already-mocked `openExternal`.
+- Add the user-facing entry to the root `CHANGELOG.md` under `## [Unreleased]`.
+
+Dependencies: none. The version is already in scope at the link site, and the test harness already mocks both the notification and the browser open.

--- a/specs/585-changelog-link/tasks.md
+++ b/specs/585-changelog-link/tasks.md
@@ -1,0 +1,8 @@
+# Tasks: Changelog link opens the right product's release
+
+- [x] **T001** Add a failing test asserting View Changelog opens the offered version's own release address · `src/speckit/updateChecker.test.ts`
+- [x] **T002** Build the changelog address from the offered version so it resolves by tag · `src/speckit/updateChecker.ts`
+- [x] **T003** [P] Add the user-facing changelog entry under Unreleased · `CHANGELOG.md`
+- [x] **T004** Verify no shipped source still resolves a release through the shared latest lookup, and run the suites · `src/`
+
+T001 blocks T002; T003 is independent; T004 waits on all.

--- a/src/speckit/updateChecker.test.ts
+++ b/src/speckit/updateChecker.test.ts
@@ -114,4 +114,21 @@ describe('UpdateChecker', () => {
             'Skip'
         );
     });
+    it('opens the offered version\'s own release, not the shared latest lookup', async () => {
+        const context = buildContext('0.22.0');
+        // A spec-kit release published more recently would win /releases/latest.
+        mockReleases([{ tag_name: 'speckit-ext-v1.0.0' }, { tag_name: 'v0.23.1' }]);
+        jest.spyOn(require('vscode').window, 'showInformationMessage')
+            .mockResolvedValue('View Changelog' as any);
+        const openSpy = require('vscode').env.openExternal as jest.Mock;
+        openSpy.mockClear();
+
+        await new UpdateChecker(context, buildOutputChannel()).checkForUpdates(true);
+        await new Promise(r => setImmediate(r));
+
+        expect(openSpy).toHaveBeenCalledTimes(1);
+        const opened = String(openSpy.mock.calls[0][0]);
+        expect(opened).toContain('/releases/tag/v0.23.1');
+        expect(opened).not.toContain('/releases/latest');
+    });
 });

--- a/src/speckit/updateChecker.test.ts
+++ b/src/speckit/updateChecker.test.ts
@@ -31,6 +31,7 @@ describe('UpdateChecker', () => {
     afterEach(() => {
         jest.restoreAllMocks();
         require('vscode').window.showInformationMessage.mockClear();
+        require('vscode').env.openExternal.mockClear();
         delete (global as any).fetch;
     });
 
@@ -121,7 +122,6 @@ describe('UpdateChecker', () => {
         jest.spyOn(require('vscode').window, 'showInformationMessage')
             .mockResolvedValue('View Changelog' as any);
         const openSpy = require('vscode').env.openExternal as jest.Mock;
-        openSpy.mockClear();
 
         await new UpdateChecker(context, buildOutputChannel()).checkForUpdates(true);
         await new Promise(r => setImmediate(r));
@@ -130,5 +130,16 @@ describe('UpdateChecker', () => {
         const opened = String(openSpy.mock.calls[0][0]);
         expect(opened).toContain('/releases/tag/v0.23.1');
         expect(opened).not.toContain('/releases/latest');
+    });
+    it('opens nothing when the user skips', async () => {
+        const context = buildContext('0.22.0');
+        mockReleases([{ tag_name: 'v0.23.1' }]);
+        jest.spyOn(require('vscode').window, 'showInformationMessage')
+            .mockResolvedValue('Skip' as any);
+
+        await new UpdateChecker(context, buildOutputChannel()).checkForUpdates(true);
+        await new Promise(r => setImmediate(r));
+
+        expect(require('vscode').env.openExternal).not.toHaveBeenCalled();
     });
 });

--- a/src/speckit/updateChecker.ts
+++ b/src/speckit/updateChecker.ts
@@ -125,8 +125,9 @@ export class UpdateChecker {
             'Skip'
         ).then(async (selection) => {
             if (selection === 'View Changelog') {
-                // Open GitHub releases page
-                const releaseUrl = 'https://github.com/alfredoperez/speckit-companion/releases/latest';
+                // Resolve by tag: both products publish into one releases list, so
+                // `/releases/latest` can land on the spec-kit extension instead.
+                const releaseUrl = `https://github.com/alfredoperez/speckit-companion/releases/tag/v${latestVersion}`;
                 await vscode.env.openExternal(vscode.Uri.parse(releaseUrl));
             } else if (selection === 'Skip') {
                 // Remember skipped version

--- a/tests/__mocks__/vscode.ts
+++ b/tests/__mocks__/vscode.ts
@@ -202,6 +202,13 @@ export const window = {
         show: jest.fn(),
         dispose: jest.fn(),
     }),
+    withProgress: jest.fn().mockImplementation((_options: unknown, task: () => Promise<unknown>) => task()),
+};
+
+export const ProgressLocation = {
+    SourceControl: 1,
+    Window: 10,
+    Notification: 15,
 };
 
 export const commands = {


### PR DESCRIPTION
## Summary

The update notification's **View Changelog** button asked GitHub for whichever release was newest. Both this extension and its spec-kit companion publish into one shared releases list, so that lookup can return either product.

Publishing `v0.31.2` and `speckit-ext-v0.20.2` back to back made it live — the spec-kit release landed last, so `/releases/latest` now resolves to `speckit-ext-v0.20.2`. A user offered VS Code extension **0.31.2** and clicking through got the **spec-kit extension 0.20.2** notes: a different product, a different version number, unrelated changes.

The link now resolves by tag from the version already in scope at the link site.

**Not affected**: which version the user is told about. `selectLatestVsCodeRelease` already fetches the full `/releases` list and filters `^v\d+\.\d+\.\d+$`, excluding drafts and prereleases — that guard (from #274) was always correct. Only the link was wrong.

## Technical

One line in `src/speckit/updateChecker.ts`:

```diff
-const releaseUrl = 'https://github.com/alfredoperez/speckit-companion/releases/latest';
+const releaseUrl = `https://github.com/alfredoperez/speckit-companion/releases/tag/v${latestVersion}`;
```

This removes the last **live** `/releases/latest` from shipped source, which is what `CLAUDE.md` asks for. The two remaining mentions are comments warning against it.

## Quality checklist

- [x] **Test added** — asserts the opened address for a known offered version, with a more-recent spec-kit release in the list so the test would catch a regression to the shared lookup
- [x] **Regression reproduced first** — failed with `/releases/latest`, then passed
- [x] **Suites green** — `tsc` clean, 1895 jest tests
- [x] **Changelog** — root `CHANGELOG.md` under `## [Unreleased]`
- [x] **No version bump** — release flow owns it
- [x] **Spec files included** — `specs/585-changelog-link/` with `.spec-context.json` (fast-tracked as a simple change)
- [x] **Docs** — no doc maps to this; the behavior it restores was never documented as anything else

## Gaps / how to verify

Confirm the live condition still holds, then that the fix is immune to it:

```
$ gh api repos/alfredoperez/speckit-companion/releases/latest --jq .tag_name
speckit-ext-v0.20.2
```

The new test pins exactly this shape — a newer `speckit-ext-v*` release sitting ahead of the `v*` one — so a future revert to the shared lookup fails rather than passing silently.

Closes #585

🤖 Generated with [Claude Code](https://claude.com/claude-code)