### PR TITLE
fix(bench): sandbox baking works again against the current specify CLI

### DIFF
--- a/examples/todo-claude/bench/run-all.mjs
+++ b/examples/todo-claude/bench/run-all.mjs
@@ -57,12 +57,13 @@ if (cmd === 'prep') {
   // Surface the realistic feature ask — the lead text + plain-English Behavior,
   // but DROP the `Required affordance` block (the exact test-ids are the bench's
   // hidden grading key, not something a real user would type).
-  let prompt = ''
-  try {
-    const md = readFileSync(join(folderDir(MODES[0]), 'bench', 'prompts', `${size}.md`), 'utf8')
-    const body = (md.match(/^---\s*$([\s\S]*?)^---\s*$/m)?.[1] ?? md)
-    prompt = body.split(/\n\*\*Required affordance/i)[0].trim()
-  } catch { /* */ }
+  // Read from the canonical bench folder: the bake strips `bench/` out of every
+  // cell so the model never sees the oracle, so the cell has no prompts to read.
+  const promptFile = join(BENCH_DIR, 'prompts', `${size}.md`)
+  const md = readFileSync(promptFile, 'utf8')
+  const body = (md.match(/^---\s*$([\s\S]*?)^---\s*$/m)?.[1] ?? md)
+  const prompt = body.split(/\n\*\*Required affordance/i)[0].trim()
+  if (!prompt) { console.error(`✗ empty feature prompt in ${relFromRepo(promptFile)}`); process.exit(1) }
   console.log(`\n── PASTE INTO specify (same in all ${MODES.length} folders) ───────────────\n${prompt}\n─────────────────────────────────────────────────────────────`)
 
   // Open each folder in its own VS Code window (unless --no-open). Best-effort.

--- a/examples/todo-claude/bench/sync-templates.mjs
+++ b/examples/todo-claude/bench/sync-templates.mjs
@@ -129,7 +129,7 @@ export function installSpeckit(dir) {
   rmSync(join(dir, '.claude'), { recursive: true, force: true })
   rmSync(join(dir, 'specs'), { recursive: true, force: true })
   mkdirSync(join(dir, 'specs'), { recursive: true })
-  const ok = specify(dir, ['init', '--here', '--integration', 'claude', '--force', '--no-git'])
+  const ok = specify(dir, ['init', '--here', '--integration', 'claude', '--force'])
   seedConstitution(dir) // overwrite init's [PROJECT_NAME] placeholder with the shared real one
   return ok
 }


### PR DESCRIPTION
## Summary

`/bench-sync` has been failing silently-ish: `specify` 0.12.16 removed the `--no-git` option, so `specify init` errored on every bake and both sandbox folders ended up with **no agent commands at all** — no stock `/speckit.*`, no companion skills. Any bench round started from that state would have measured nothing.

The flag was redundant anyway: the harness calls `gitInitCell(dir)` immediately before `installSpeckit(dir)`, so the cell already owns its git root by the time `specify init` runs.

## Technical

- `examples/todo-claude/bench/sync-templates.mjs` — drop `--no-git` from the `specify init` argv.

## How to verify

`node examples/todo-claude/bench/sync-templates.mjs` — both folders report `✓`, and afterwards `todo-speckit/.claude/skills/` holds the 10 stock skills while `todo-companion/.claude/skills/` holds those plus the 22 companion ones, with `doctor.py` and `run_trace.py` present under `.specify/extensions/companion/scripts/`.

## Gaps

Bench-harness only — nothing shipped in either extension changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)