### PR TITLE
fix(bench): the settle-wait no longer forces Companion's fast path off

### DIFF
--- a/examples/todo-claude/bench/lib.mjs
+++ b/examples/todo-claude/bench/lib.mjs
@@ -449,19 +449,47 @@ function cellStatus(cellDir) {
   return ctx && typeof ctx.status === 'string' ? ctx.status : null
 }
 
+// Lifecycle order, ranked. A step is settled once the status reaches ITS completed
+// form OR ANY LATER ONE — never equality. Two shipped Companion behaviours make
+// equality wrong, and both used to strand a driver:
+//   · the fast path folds specify→plan→tasks, landing on `ready-to-implement`
+//     without ever passing through `specified` or `planned`; and
+//   · mark-complete is the pipeline's terminal node, so implement lands on
+//     `completed`, not `implemented`.
+// Waiting for equality means the bench can only measure Companion with its own
+// right-sizing turned off, which is exactly the feature the comparison exists to
+// weigh. `in-progress` forms are absent on purpose: they rank below every
+// completed form, so they never satisfy a wait.
+export const STATUS_RANK = {
+  specifying: 0,
+  specified: 1,
+  planning: 1,
+  planned: 2,
+  tasking: 2,
+  'ready-to-implement': 3,
+  implementing: 3,
+  implemented: 4,
+  completed: 5,
+  archived: 6,
+}
+
 // Wait for a dispatched step to SETTLE before advancing: poll the cell's
-// `.spec-context.json` until its status reaches the step's completed form
-// (`specified`/`planned`/`ready-to-implement`/`implemented`). Resolves
-// { settled:true, status, waitedMs } on settle, or { settled:false, ... } on
-// timeout. Mirrors the GUI's settle-wait so the bench is a faithful proxy.
+// `.spec-context.json` until its status reaches the step's completed form or a
+// later one. Resolves { settled:true, status, waitedMs } on settle, or
+// { settled:false, ... } on timeout. Mirrors the GUI's settle-wait so the bench
+// is a faithful proxy.
 export async function waitForSettle(cellDir, step, timeoutMs = 600000, pollMs = 500) {
   const want = SETTLED_STATUS_BY_STEP[step]
   if (!want) throw new Error(`waitForSettle: unknown step "${step}"`)
+  const wantRank = STATUS_RANK[want]
   const startMs = Date.now()
   const elapsed = () => Math.max(0, Date.now() - startMs)
   for (;;) {
     const status = cellStatus(cellDir)
-    if (status === want) return { settled: true, status, waitedMs: elapsed() }
+    const rank = status == null ? undefined : STATUS_RANK[status]
+    if (rank !== undefined && rank >= wantRank) {
+      return { settled: true, status, waitedMs: elapsed(), folded: status !== want }
+    }
     if (elapsed() >= timeoutMs) return { settled: false, status, waitedMs: elapsed() }
     await new Promise((r) => setTimeout(r, pollMs))
   }

--- a/examples/todo-claude/bench/waitForSettle.test.mjs
+++ b/examples/todo-claude/bench/waitForSettle.test.mjs
@@ -58,6 +58,60 @@ test('times out cleanly when no .spec-context.json exists yet', async () => {
   }
 })
 
+test('the fast path settles specify and plan without their own statuses', async () => {
+  // Right-sizing folds specify→plan→tasks, so the run jumps straight to
+  // `ready-to-implement`. Waiting for `specified`/`planned` would strand the
+  // driver and force the fast path off — the feature the bench must measure.
+  const { cell, specDir } = makeCell()
+  try {
+    writeStatus(specDir, 'ready-to-implement')
+    for (const step of ['specify', 'plan', 'tasks']) {
+      const res = await waitForSettle(cell, step, 300, 50)
+      assert.equal(res.settled, true, `${step} should settle on a folded lifecycle`)
+      assert.equal(res.status, 'ready-to-implement')
+    }
+    assert.equal((await waitForSettle(cell, 'specify', 300, 50)).folded, true)
+  } finally {
+    rmSync(cell, { recursive: true, force: true })
+  }
+})
+
+test('implement settles when the pipeline auto-completes past it', async () => {
+  // mark-complete is Companion's terminal node, so implement lands on
+  // `completed`, never re-settling at `implemented`.
+  const { cell, specDir } = makeCell()
+  try {
+    writeStatus(specDir, 'completed')
+    const res = await waitForSettle(cell, 'implement', 300, 50)
+    assert.equal(res.settled, true)
+    assert.equal(res.status, 'completed')
+  } finally {
+    rmSync(cell, { recursive: true, force: true })
+  }
+})
+
+test('an in-flight status never satisfies its own step', async () => {
+  const { cell, specDir } = makeCell()
+  try {
+    writeStatus(specDir, 'implementing')
+    assert.equal((await waitForSettle(cell, 'implement', 300, 50)).settled, false)
+    // ...but it does satisfy the steps genuinely behind it.
+    assert.equal((await waitForSettle(cell, 'tasks', 300, 50)).settled, true)
+  } finally {
+    rmSync(cell, { recursive: true, force: true })
+  }
+})
+
+test('an unknown status never settles', async () => {
+  const { cell, specDir } = makeCell()
+  try {
+    writeStatus(specDir, 'small') // the wrong-vocabulary size word, as a status
+    assert.equal((await waitForSettle(cell, 'specify', 300, 50)).settled, false)
+  } finally {
+    rmSync(cell, { recursive: true, force: true })
+  }
+})
+
 test('SETTLED_STATUS_BY_STEP covers every measured step', () => {
   assert.deepEqual(Object.keys(SETTLED_STATUS_BY_STEP).sort(), ['implement', 'plan', 'specify', 'tasks'])
 })


### PR DESCRIPTION
## Summary

The bench could not measure Companion's right-sizing, because the settle-wait required the status to **equal** the step's completed form. Two shipped Companion behaviours never satisfy that:

- the **fast path** folds specify → plan → tasks and lands on `ready-to-implement`, never passing through `specified` or `planned`;
- **mark-complete is the pipeline's terminal node**, so implement lands on `completed` and never re-settles at `implemented`.

A driver hitting either had to work around it. In the easy baseline cell just run, the driver deleted the spec directory and re-ran specify with right-sizing deliberately forced to normal so that each step would settle on its own status. The run therefore measured Companion **with its headline feature disabled**, and its timings are not comparable against stock. That is a measurement instrument shaping the result it reports, which is the worst failure mode a bench has.

## Technical

- `lib.mjs` — add `STATUS_RANK` (the lifecycle, ranked, with in-flight forms ranking below every completed form so they never satisfy a wait) and settle at-or-past the step's completed form rather than on equality. The result now carries `folded: true` when the status overshot, so a driver can tell a folded lifecycle from an exact landing.
- `waitForSettle.test.mjs` — four new cases: the fast path settling specify/plan/tasks on `ready-to-implement`, implement settling on `completed`, an in-flight status never satisfying its own step but satisfying earlier ones, and an unrecognised status never settling.

## How to verify

`node --test examples/todo-claude/bench/waitForSettle.test.mjs` — 9 pass. Reverting `lib.mjs` alone fails exactly the 3 new behavioural cases, so the tests fail in the right direction.

## Gaps

Bench-harness only; nothing shipped in either extension changes. The easy baseline cell needs re-running against this — its recorded timings measured a pipeline with right-sizing forced off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)