### PR TITLE
fix(bench): grade index.html, not just src/

### DIFF
--- a/examples/todo-claude/bench/changedFiles.test.mjs
+++ b/examples/todo-claude/bench/changedFiles.test.mjs
@@ -1,0 +1,40 @@
+// Unit test: the changed-file surface must cover everything resetFolder restores.
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, writeFileSync, readFileSync, cpSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { changedSrcFiles, blastRadius, CANONICAL_DIR, CANONICAL_SRC } from './lib.mjs'
+
+function pristineCell() {
+  const cell = mkdtempSync(join(tmpdir(), 'bench-changed-'))
+  cpSync(CANONICAL_SRC, join(cell, 'src'), { recursive: true })
+  cpSync(join(CANONICAL_DIR, 'index.html'), join(cell, 'index.html'))
+  return cell
+}
+
+test('a pristine cell reports no changes', () => {
+  const cell = pristineCell()
+  try {
+    assert.deepEqual(changedSrcFiles(cell), [])
+  } finally { rmSync(cell, { recursive: true, force: true }) }
+})
+
+test('an edited index.html is seen as changed', () => {
+  const cell = pristineCell()
+  try {
+    const p = join(cell, 'index.html')
+    writeFileSync(p, readFileSync(p, 'utf8').replace('Todo App', 'Task Manager'))
+    const changed = changedSrcFiles(cell)
+    const html = changed.find((c) => c.path === 'index.html')
+    assert.ok(html, 'index.html must appear in the changed set')
+    assert.equal(html.status, 'modified')
+    assert.match(html.content, /Task Manager/)
+  } finally { rmSync(cell, { recursive: true, force: true }) }
+})
+
+test('index.html is in scope for easy and out of scope for medium', () => {
+  const changed = [{ path: 'index.html', status: 'modified', content: '' }]
+  assert.deepEqual(blastRadius('easy', changed).outOfScope, [])
+  assert.deepEqual(blastRadius('medium', changed).outOfScope, ['index.html'])
+})

--- a/examples/todo-claude/bench/lib.mjs
+++ b/examples/todo-claude/bench/lib.mjs
@@ -278,8 +278,15 @@ function listFilesRec(dir, baseRel = '', acc = []) {
   return acc
 }
 
-// Changed src/ files (added/modified/deleted) vs the pristine snapshot, with the
-// current content of each — the substrate for convention + blast-radius checks.
+// Root-level files that are part of the mutable working surface. Must stay in
+// step with resetFolder, which restores exactly src/ + these from the canonical
+// app: a file the harness resets but never diffs is invisible to every check
+// downstream, which is how the easy feature's tab-title half went ungraded.
+const ROOT_APP_FILES = ['index.html']
+
+// Changed working-surface files (added/modified/deleted) vs the pristine
+// snapshot, with the current content of each — the substrate for the behavioral
+// judge's evidence and the convention + blast-radius checks.
 export function changedSrcFiles(folderDir) {
   const cur = join(folderDir, 'src')
   const curFiles = new Set(listFilesRec(cur))
@@ -291,6 +298,11 @@ export function changedSrcFiles(folderDir) {
     else if (a !== readText(join(CANONICAL_SRC, f))) changed.push({ path: f, status: 'modified', content: a })
   }
   for (const f of baseFiles) if (!curFiles.has(f)) changed.push({ path: f, status: 'deleted', content: '' })
+  for (const f of ROOT_APP_FILES) {
+    const a = readText(join(folderDir, f))
+    const base = readText(join(CANONICAL_DIR, f))
+    if (a !== base) changed.push({ path: f, status: a ? 'modified' : 'deleted', content: a })
+  }
   return changed
 }
 
@@ -313,7 +325,7 @@ export function conventionChecks(changed) {
 
 // Files changed outside the area a given size is expected to touch (soft signal).
 const SCOPE = {
-  easy: [/^components\/Header\./, /^App\./],
+  easy: [/^components\/Header\./, /^App\./, /^index\.html$/],
   medium: [/^components\/(TodoItem|TodoList|AddTodo)\./, /^pages\/TodosPage\./, /^store\//, /^types\./, /^lib\//, /^App\./],
   hard: [/^pages\//, /^components\//, /^store\//, /^lib\/storage\./, /^types\./, /^App\./, /^main\./],
 }


### PR DESCRIPTION
## Summary

The bench's correctness oracle could not see one of the two files the easiest benchmark feature changes.

`changedSrcFiles` walked only `src/`, while `resetFolder` restores `src/` **and** `index.html` as the mutable working surface. A file the harness resets but never diffs is invisible to everything downstream: the behavioral judge's evidence, the convention checks, and the blast-radius count.

The easy feature is "rename the app title", which lands in `Header.tsx` and `index.html`. Both modes implemented it correctly — the tab title reads `Task Manager` in both cells — but the judge never received `index.html`, ruled the two tab-title scenarios absent, and returned:

```
{"n":2,"pass":false,"reason":"No index.html/document.title change present"}
{"n":3,"pass":false,"reason":"Tab title unchanged, likely still \"Todo App\""}
```

Note the "likely" — the judge was guessing from missing evidence. Acceptance was recorded as **1/3 for both modes** when the truth is 3/3, and that number feeds `correctness = build × acceptance-ratio × regression-ratio`, so the Overall health composite for both modes was wrong too.

## Technical

- `lib.mjs` — `ROOT_APP_FILES` (currently `index.html`) is now diffed against the canonical app alongside `src/`, with a comment tying it to `resetFolder` so the two do not drift apart again.
- `lib.mjs` — `SCOPE.easy` gains `/^index\.html$/`, so a legitimately-changed `index.html` is not then reported as out-of-scope. It stays out of scope for medium and hard, where changing it would be real creep.
- `changedFiles.test.mjs` — new: a pristine cell reports no changes, an edited `index.html` is seen as modified with its content, and `index.html` is in scope for easy but out of scope for medium.

## How to verify

`node --test examples/todo-claude/bench/changedFiles.test.mjs` — 3 pass. Reverting `lib.mjs` alone fails 2 of the 3, so the tests fail in the right direction.

## Gaps

Bench-harness only. The easy row already recorded in `stats.jsonl` carries the wrong acceptance and health numbers; it will correct itself on the next capture of that size.

🤖 Generated with [Claude Code](https://claude.com/claude-code)