### PR TITLE
fix(bench): the health composite cannot exceed 100

### DIFF
--- a/examples/todo-claude/bench/lib.mjs
+++ b/examples/todo-claude/bench/lib.mjs
@@ -689,7 +689,13 @@ export function computeOverall(r) {
   const ratio = (p, t) => (t ? Math.max(0, Math.min(1, p / t)) : 0)
   const correctness = (r.buildPass ? 1 : 0) * ratio(r.acceptancePassed, r.acceptanceTotal) * ratio(r.regressionPassed, r.regressionTotal)
   const q = r.quality || {}
-  const rb = ['readability', 'conventions', 'scope'].map((k) => q[k]).filter((n) => typeof n === 'number')
+  // Rubric dimensions are 0-5. Clamp per dimension: a judge that answers on a
+  // different scale must not inflate the composite past its 30-point share —
+  // an Overall above 100 is arithmetically impossible and was being rendered.
+  const rb = ['readability', 'conventions', 'scope']
+    .map((k) => q[k])
+    .filter((n) => typeof n === 'number' && Number.isFinite(n))
+    .map((n) => Math.max(0, Math.min(5, n)))
   const rubric = rb.length ? rb.reduce((a, b) => a + b, 0) / (rb.length * 5) : 0
   const captureRaw = r.capture ? ratio(r.capture.pass, r.capture.pass + r.capture.fail) : 0
   // Each doctor problem costs a tenth of the capture component, floored at zero:
@@ -715,9 +721,12 @@ export function renderReport(rows) {
   const qual = (r) => {
     const q = r?.quality
     if (!q) return r ? '—' : '—'
-    const nums = ['readability', 'conventions', 'scope'].map((k) => q[k]).filter((n) => typeof n === 'number')
-    if (!nums.length) return '—'
-    return `${(nums.reduce((a, b) => a + b, 0) / nums.length).toFixed(1)}/5`
+    const raw = ['readability', 'conventions', 'scope'].map((k) => q[k]).filter((n) => typeof n === 'number')
+    if (!raw.length) return '—'
+    const nums = raw.map((n) => Math.max(0, Math.min(5, n)))
+    const flag = raw.some((n) => n < 0 || n > 5) ? ' ⚠︎out-of-range' : ''
+    const missing = raw.length < 3 ? ` (${raw.length}/3 dims)` : ''
+    return `${(nums.reduce((a, b) => a + b, 0) / nums.length).toFixed(1)}/5${missing}${flag}`
   }
   const dur = (r, step) => (step === 'total' ? r?.timing?.totalSec : r?.timing?.perStep?.[step])
   const cell = (r, fn) => (r ? fn(r) : '—')

--- a/examples/todo-claude/bench/overall.test.mjs
+++ b/examples/todo-claude/bench/overall.test.mjs
@@ -1,0 +1,38 @@
+// Unit test: the health composite is a 0-100 scale and must stay inside it.
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { computeOverall } from './lib.mjs'
+
+const perfect = {
+  buildPass: true,
+  acceptancePassed: 3, acceptanceTotal: 3,
+  regressionPassed: 5, regressionTotal: 5,
+  capture: { pass: 20, fail: 0 },
+  doctor: { problems: 0 },
+}
+
+test('a perfect cell scores exactly 100', () => {
+  assert.equal(computeOverall({ ...perfect, quality: { readability: 5, conventions: 5, scope: 5 } }), 100)
+})
+
+test('a judge answering on the wrong scale cannot exceed 100', () => {
+  // A 0-10 judge writing 10s used to push rubric past its 30-point share.
+  const out = computeOverall({ ...perfect, quality: { readability: 10, conventions: 10, scope: 10 } })
+  assert.ok(out <= 100, `expected <= 100, got ${out}`)
+  assert.equal(out, 100)
+})
+
+test('negative rubric values floor at zero rather than subtracting', () => {
+  const out = computeOverall({ ...perfect, quality: { readability: -5, conventions: -5, scope: -5 } })
+  assert.equal(out, computeOverall({ ...perfect, quality: null }))
+})
+
+test('a missing rubric costs its whole share and nothing more', () => {
+  assert.equal(computeOverall({ ...perfect, quality: null }), 70)
+})
+
+test('every doctor problem costs a tenth of the capture share', () => {
+  const clean = computeOverall({ ...perfect, quality: { readability: 5, conventions: 5, scope: 5 } })
+  const oneProblem = computeOverall({ ...perfect, doctor: { problems: 1 }, quality: { readability: 5, conventions: 5, scope: 5 } })
+  assert.ok(oneProblem < clean)
+})


### PR DESCRIPTION
## Summary

The Overall health score is documented and built as a 0-100 composite — correctness 45, rubric 30, capture 25. It was rendering **105 and 124** for the easy row, and Quality as **10.0/5**, with nothing flagging either.

Rubric dimensions (`readability`, `conventions`, `scope`) are 0-5 and were summed unclamped, so a judge answering on a 0-10 scale pushed the rubric term to double its 30-point share. Two failures stacked: a value outside the contract was accepted silently, and an arithmetically impossible total was printed as if it were a result.

## Technical

- `lib.mjs` `computeOverall` — clamp each rubric dimension to `[0, 5]`, and drop non-finite values.
- `lib.mjs` `renderReport` — clamp for display, append `⚠︎out-of-range` when a raw value was outside the contract, and show `(n/3 dims)` when a judge supplied fewer than the three dimensions, so a partial rubric is visible rather than silently averaged over what happened to be there.
- `overall.test.mjs` — new: a perfect cell scores exactly 100; a wrong-scale judge cannot exceed 100; negative values floor at zero rather than subtracting; a missing rubric costs exactly its share; a doctor problem costs part of the capture share.

## How to verify

`node --test examples/todo-claude/bench/overall.test.mjs` — 5 pass. Reverting `lib.mjs` alone fails 2, so the tests fail in the right direction.

## Gaps

Bench-harness only. Rows already in `stats.jsonl` keep their recorded rubric values; the composite corrects on the next capture of that size.

🤖 Generated with [Claude Code](https://claude.com/claude-code)