### PR TITLE
fix: make the workflow layer say when it did not do what it was asked

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -58,8 +58,10 @@ speckit-extension/**
 !speckit-extension/scripts/task_sync.py
 !speckit-extension/scripts/living_spec_fold.py
 !speckit-extension/scripts/run_trace.py
-# The shared atomic-write helper. The capture writers publish through it, so a
-# .vsix without it would import-fail in stock mode.
+# The shared atomic-write helper. The capture writers publish through it; each
+# guards the import and falls back to its old fixed-`.tmp` write, so leaving it
+# out would silently downgrade the crash-safety guarantee rather than fail loudly
+# — which is exactly the kind of quiet regression it exists to prevent.
 !speckit-extension/scripts/companion_config.py
 .specify/**
 .opencode/**

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -58,6 +58,9 @@ speckit-extension/**
 !speckit-extension/scripts/task_sync.py
 !speckit-extension/scripts/living_spec_fold.py
 !speckit-extension/scripts/run_trace.py
+# The shared atomic-write helper. The capture writers publish through it, so a
+# .vsix without it would import-fail in stock mode.
+!speckit-extension/scripts/companion_config.py
 .specify/**
 .opencode/**
 .serena/**

--- a/examples/todo-gsd-superpowers/.specify/feature.json
+++ b/examples/todo-gsd-superpowers/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "featureDir": "specs/001-clear-completed"
+  "feature_directory": "specs/001-clear-completed"
 }

--- a/examples/todo-living-central/.specify/feature.json
+++ b/examples/todo-living-central/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "featureDir": "specs/001-clear-completed"
+  "feature_directory": "specs/001-clear-completed"
 }

--- a/examples/todo-living-colocated/.specify/feature.json
+++ b/examples/todo-living-colocated/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "featureDir": "specs/001-clear-completed"
+  "feature_directory": "specs/001-clear-completed"
 }

--- a/examples/todo-matt-skills/.specify/feature.json
+++ b/examples/todo-matt-skills/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "featureDir": "specs/001-clear-completed"
+  "feature_directory": "specs/001-clear-completed"
 }

--- a/package.json
+++ b/package.json
@@ -869,6 +869,30 @@
         }
       ],
       "commandPalette": [
+                {
+                    "command": "speckit.workflowEditor.removeSection",
+                    "when": "false"
+                },
+                {
+                    "command": "speckit.workflowEditor.addUserStory",
+                    "when": "false"
+                },
+                {
+                    "command": "speckit.workflowEditor.approveAndContinue",
+                    "when": "false"
+                },
+                {
+                    "command": "speckit.workflowEditor.regenerate",
+                    "when": "false"
+                },
+                {
+                    "command": "speckit.workflowEditor.navigateToPhase",
+                    "when": "false"
+                },
+                {
+                    "command": "speckit.workflowEditor.editSource",
+                    "when": "false"
+                },
         {
           "command": "speckit.create"
         },

--- a/package.json
+++ b/package.json
@@ -870,6 +870,10 @@
       ],
       "commandPalette": [
                 {
+                    "command": "speckit.workflowEditor.refineSection",
+                    "when": "false"
+                },
+                {
                     "command": "speckit.workflowEditor.removeSection",
                     "when": "false"
                 },

--- a/speckit-extension/commands/speckit.companion.classify.md
+++ b/speckit-extension/commands/speckit.companion.classify.md
@@ -1,10 +1,10 @@
 ---
-description: "Classify the change size (small | normal | oversized) so the Companion workflow can right-size the pipeline"
+description: "Classify the change size (simple | normal | oversized) so the Companion workflow can right-size the pipeline"
 ---
 
 # Classify Change Size
 
-Emit a single complexity signal — `small`, `normal`, or `oversized` — that the Companion
+Emit a single complexity signal — `simple`, `normal`, or `oversized` — that the Companion
 workflow's routing step reads to right-size the pipeline. On the workflow path there is no
 `complexityFastPath` on/off setting: the thresholds live here, in the workflow, not in a
 VS Code toggle.
@@ -32,14 +32,15 @@ ambiguous estimate never skips a phase.
 Print exactly one line so the size is visible in the run log:
 
 ```text
-[companion] size=<small|normal|oversized>
+[companion] size=<simple|normal|oversized>
 ```
 
 Expose the same value as structured output `size` (so a `switch` node can read
 `steps.classify.output.size`). Routing contract:
 
 <!-- speckit-companion:part routing -->
-- `small` → the workflow folds toward implement (less ceremony).
+- `simple` → the workflow folds toward implement (less ceremony). `simple` is the verdict
+  every reader of the recorded size expects; `small` names the *bar*, never the verdict.
 - `oversized` → the workflow prints a visible warning and still runs the **full** pipeline — it
   never silently skips a phase.
 - `normal` (and any unresolved value) → the full pipeline.

--- a/speckit-extension/commands/speckit.companion.implement.md
+++ b/speckit-extension/commands/speckit.companion.implement.md
@@ -184,6 +184,12 @@ This is one step in the Companion pipeline. How the run continues depends on the
 - **Degrade gracefully on a one-shot environment.** If your environment runs one step and then stops, the handoff simply does not fire: finish this step, record its progress, and stop. The run stays valid and resumable, and the next step is triggered manually (by the developer or the companion panel). Completion likewise stays a manual action there.
 <!-- /speckit-companion:part self-advance -->
 
+**Pin the workflow identity before handing off.** Record that this spec runs the **Companion** workflow, so the next dispatch is a Companion command and not a stock one. A spec that joined Companion after `specify` has never had this written, and the shared writer defaults `workflow` to `speckit` — so without this the footer advance silently dispatches stock `/speckit.implement`'s successor. Idempotent, and a required deterministic write (skip only if `python3` is genuinely unavailable):
+
+```bash
+python3 .specify/extensions/companion/scripts/write-context.py --feature-dir <feature_directory> --set workflow=companion
+```
+
 <!-- speckit-companion:part orchestrator -->
 ## Node hooks — run the project's `before`/`after` inserts
 

--- a/speckit-extension/commands/speckit.companion.plan.md
+++ b/speckit-extension/commands/speckit.companion.plan.md
@@ -162,6 +162,12 @@ This is one step in the Companion pipeline. How the run continues depends on the
 - **Degrade gracefully on a one-shot environment.** If your environment runs one step and then stops, the handoff simply does not fire: finish this step, record its progress, and stop. The run stays valid and resumable, and the next step is triggered manually (by the developer or the companion panel). Completion likewise stays a manual action there.
 <!-- /speckit-companion:part self-advance -->
 
+**Pin the workflow identity before handing off.** Record that this spec runs the **Companion** workflow, so the next dispatch is a Companion command and not a stock one. A spec that joined Companion after `specify` has never had this written, and the shared writer defaults `workflow` to `speckit` — so without this the footer advance silently dispatches stock `/speckit.plan`'s successor. Idempotent, and a required deterministic write (skip only if `python3` is genuinely unavailable):
+
+```bash
+python3 .specify/extensions/companion/scripts/write-context.py --feature-dir <feature_directory> --set workflow=companion
+```
+
 <!-- speckit-companion:part orchestrator -->
 ## Node hooks — run the project's `before`/`after` inserts
 

--- a/speckit-extension/commands/speckit.companion.tasks.md
+++ b/speckit-extension/commands/speckit.companion.tasks.md
@@ -164,6 +164,12 @@ This is one step in the Companion pipeline. How the run continues depends on the
 - **Degrade gracefully on a one-shot environment.** If your environment runs one step and then stops, the handoff simply does not fire: finish this step, record its progress, and stop. The run stays valid and resumable, and the next step is triggered manually (by the developer or the companion panel). Completion likewise stays a manual action there.
 <!-- /speckit-companion:part self-advance -->
 
+**Pin the workflow identity before handing off.** Record that this spec runs the **Companion** workflow, so the next dispatch is a Companion command and not a stock one. A spec that joined Companion after `specify` has never had this written, and the shared writer defaults `workflow` to `speckit` — so without this the footer advance silently dispatches stock `/speckit.tasks`'s successor. Idempotent, and a required deterministic write (skip only if `python3` is genuinely unavailable):
+
+```bash
+python3 .specify/extensions/companion/scripts/write-context.py --feature-dir <feature_directory> --set workflow=companion
+```
+
 <!-- speckit-companion:part orchestrator -->
 ## Node hooks — run the project's `before`/`after` inserts
 

--- a/speckit-extension/nodes/implement/handoff.md
+++ b/speckit-extension/nodes/implement/handoff.md
@@ -11,3 +11,9 @@ reads: []
 <!-- speckit-companion:part self-advance -->
 
 <!-- /speckit-companion:part self-advance -->
+
+**Pin the workflow identity before handing off.** Record that this spec runs the **Companion** workflow, so the next dispatch is a Companion command and not a stock one. A spec that joined Companion after `specify` has never had this written, and the shared writer defaults `workflow` to `speckit` — so without this the footer advance silently dispatches stock `/speckit.implement`'s successor. Idempotent, and a required deterministic write (skip only if `python3` is genuinely unavailable):
+
+```bash
+python3 .specify/extensions/companion/scripts/write-context.py --feature-dir <feature_directory> --set workflow=companion
+```

--- a/speckit-extension/nodes/plan/handoff.md
+++ b/speckit-extension/nodes/plan/handoff.md
@@ -11,3 +11,9 @@ reads: []
 <!-- speckit-companion:part self-advance -->
 
 <!-- /speckit-companion:part self-advance -->
+
+**Pin the workflow identity before handing off.** Record that this spec runs the **Companion** workflow, so the next dispatch is a Companion command and not a stock one. A spec that joined Companion after `specify` has never had this written, and the shared writer defaults `workflow` to `speckit` — so without this the footer advance silently dispatches stock `/speckit.plan`'s successor. Idempotent, and a required deterministic write (skip only if `python3` is genuinely unavailable):
+
+```bash
+python3 .specify/extensions/companion/scripts/write-context.py --feature-dir <feature_directory> --set workflow=companion
+```

--- a/speckit-extension/nodes/tasks/handoff.md
+++ b/speckit-extension/nodes/tasks/handoff.md
@@ -11,3 +11,9 @@ reads: []
 <!-- speckit-companion:part self-advance -->
 
 <!-- /speckit-companion:part self-advance -->
+
+**Pin the workflow identity before handing off.** Record that this spec runs the **Companion** workflow, so the next dispatch is a Companion command and not a stock one. A spec that joined Companion after `specify` has never had this written, and the shared writer defaults `workflow` to `speckit` — so without this the footer advance silently dispatches stock `/speckit.tasks`'s successor. Idempotent, and a required deterministic write (skip only if `python3` is genuinely unavailable):
+
+```bash
+python3 .specify/extensions/companion/scripts/write-context.py --feature-dir <feature_directory> --set workflow=companion
+```

--- a/speckit-extension/presets/_parts/routing.md
+++ b/speckit-extension/presets/_parts/routing.md
@@ -1,4 +1,5 @@
-- `small` → the workflow folds toward implement (less ceremony).
+- `simple` → the workflow folds toward implement (less ceremony). `simple` is the verdict
+  every reader of the recorded size expects; `small` names the *bar*, never the verdict.
 - `oversized` → the workflow prints a visible warning and still runs the **full** pipeline — it
   never silently skips a phase.
 - `normal` (and any unresolved value) → the full pipeline.

--- a/speckit-extension/scripts/run_trace.py
+++ b/speckit-extension/scripts/run_trace.py
@@ -143,9 +143,14 @@ def _enforce_cap(path: Path) -> None:
         keep.reverse()
         dropped = dropped_before + (len(lines) - len(keep))
         header = json.dumps({"truncated": dropped}, separators=(",", ":")) + "\n"
-        tmp = path.with_suffix(path.suffix + ".tmp")
-        tmp.write_text(header + "".join(keep), encoding="utf-8")
-        tmp.replace(path)
+        try:
+            import companion_config as cc
+
+            cc.atomic_write_text(str(path), header + "".join(keep))
+        except ImportError:
+            tmp = path.with_suffix(path.suffix + ".tmp")
+            tmp.write_text(header + "".join(keep), encoding="utf-8")
+            tmp.replace(path)
     except (OSError, ValueError):
         pass
 

--- a/speckit-extension/scripts/spec_context.py
+++ b/speckit-extension/scripts/spec_context.py
@@ -77,6 +77,16 @@ def _repo_root_for(path: Path) -> Path:
     return _repo_root()
 
 
+#: Set while the tracer re-resolves the feature dir after main() has restored the
+#: real streams — the complaint was already printed once, on the tee'd stream.
+_QUIET_POINTER = False
+
+
+def quiet_pointer_complaints(quiet: bool) -> None:
+    global _QUIET_POINTER
+    _QUIET_POINTER = bool(quiet)
+
+
 def _pointer_complaint(message: str) -> None:
     """Say why the active-spec pointer did not resolve.
 
@@ -84,6 +94,8 @@ def _pointer_complaint(message: str) -> None:
     how a stale or misspelled pointer turns into an audit of the wrong spec —
     or of nothing at all — that still reports clean.
     """
+    if _QUIET_POINTER:
+        return
     print(f"[companion] {message}", file=sys.stderr)
 
 
@@ -180,19 +192,25 @@ def resolve_feature_dir(root: Path, explicit: str | None) -> Path | None:
                 if not resolved.is_dir():
                     # A pointer naming a directory that is gone is worse than no
                     # pointer: callers resolve it, audit nothing, and report clean.
+                    # Say so, then fall through to the remaining rungs — returning
+                    # here would skip the git-branch match and make the caller's
+                    # "checked … git branch prefix" message untrue.
                     _pointer_complaint(
                         f"{feature_json} points at {fd}, which does not exist — "
                         f"the pointer is stale. Pass --feature-dir, or re-run the "
                         f"step that maintains it.")
-                    return None
-                return resolved
-            # The file parsed but carried no key this resolver reads. Silence here
-            # is what let four fixtures ship a `featureDir` spelling that nothing
-            # ever read, so name the file and the keys that would have worked.
-            _pointer_complaint(
-                f"{feature_json} has no recognised key — expected "
-                f"'feature_directory' (or stock spec-kit's 'FEATURE_DIR'), "
-                f"found {sorted(data) if isinstance(data, dict) else type(data).__name__}.")
+                else:
+                    return resolved
+            else:
+                # The file parsed but carried no key this resolver reads. Silence
+                # here is what let four fixtures ship a `featureDir` spelling that
+                # nothing ever read, so name the file and the keys that would have
+                # worked. Only for a genuinely keyless file — a stale pointer has
+                # already said its own, different thing above.
+                _pointer_complaint(
+                    f"{feature_json} has no recognised key — expected "
+                    f"'feature_directory' (or stock spec-kit's 'FEATURE_DIR'), "
+                    f"found {sorted(data) if isinstance(data, dict) else type(data).__name__}.")
         except (json.JSONDecodeError, OSError) as exc:
             _pointer_complaint(f"{feature_json} could not be read ({exc}).")
 

--- a/speckit-extension/scripts/spec_context.py
+++ b/speckit-extension/scripts/spec_context.py
@@ -77,6 +77,16 @@ def _repo_root_for(path: Path) -> Path:
     return _repo_root()
 
 
+def _pointer_complaint(message: str) -> None:
+    """Say why the active-spec pointer did not resolve.
+
+    Resolution is best-effort and must never raise, but failing in silence is
+    how a stale or misspelled pointer turns into an audit of the wrong spec —
+    or of nothing at all — that still reports clean.
+    """
+    print(f"[companion] {message}", file=sys.stderr)
+
+
 def _git_branch(root: Path) -> str | None:
     try:
         out = subprocess.run(
@@ -166,9 +176,25 @@ def resolve_feature_dir(root: Path, explicit: str | None) -> Path | None:
             fd = data.get("feature_directory") or data.get("FEATURE_DIR")
             if fd:
                 p = Path(fd)
-                return p if p.is_absolute() else root / p
-        except (json.JSONDecodeError, OSError):
-            pass
+                resolved = p if p.is_absolute() else root / p
+                if not resolved.is_dir():
+                    # A pointer naming a directory that is gone is worse than no
+                    # pointer: callers resolve it, audit nothing, and report clean.
+                    _pointer_complaint(
+                        f"{feature_json} points at {fd}, which does not exist — "
+                        f"the pointer is stale. Pass --feature-dir, or re-run the "
+                        f"step that maintains it.")
+                    return None
+                return resolved
+            # The file parsed but carried no key this resolver reads. Silence here
+            # is what let four fixtures ship a `featureDir` spelling that nothing
+            # ever read, so name the file and the keys that would have worked.
+            _pointer_complaint(
+                f"{feature_json} has no recognised key — expected "
+                f"'feature_directory' (or stock spec-kit's 'FEATURE_DIR'), "
+                f"found {sorted(data) if isinstance(data, dict) else type(data).__name__}.")
+        except (json.JSONDecodeError, OSError) as exc:
+            _pointer_complaint(f"{feature_json} could not be read ({exc}).")
 
     # 5. git current branch -> numeric-prefix match
     branch = _git_branch(root)
@@ -221,7 +247,22 @@ def read_ctx(target: Path) -> dict:
 
 
 def atomic_write(target: Path, ctx: dict) -> None:
-    """Crash-safe write: serialize to a temp file, then rename over the target."""
+    """Crash-safe write: serialize to a unique temp file, then rename over the target.
+
+    Routed through the shared helper so this file gets the same guarantees the
+    config writer already had: a unique temp name (a fixed `<path>.tmp` let two
+    concurrent writers truncate each other's temp and publish half a document,
+    which the reader then swallows as `{}`), a flush to disk before the rename,
+    and no debris when the write fails.
+    """
+    try:
+        import companion_config as cc
+
+        cc.atomic_write_text(str(target),
+                             json.dumps(ctx, indent=2, ensure_ascii=False) + "\n")
+        return
+    except ImportError:
+        pass
     tmp = target.with_suffix(target.suffix + ".tmp")
     try:
         tmp.write_text(json.dumps(ctx, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")

--- a/speckit-extension/scripts/task_sync.py
+++ b/speckit-extension/scripts/task_sync.py
@@ -81,6 +81,15 @@ def _mark_tasks_done(tasks_md: Path, ids: set) -> None:
             changed = True
     if not changed:
         return
+    try:
+        import companion_config as cc
+
+        cc.atomic_write_text(str(tasks_md), "".join(lines))
+        return
+    except ImportError:
+        pass
+    except OSError:
+        return
     tmp = tasks_md.with_suffix(tasks_md.suffix + ".tmp")
     try:
         tmp.write_text("".join(lines), encoding="utf-8")

--- a/speckit-extension/scripts/write-context.py
+++ b/speckit-extension/scripts/write-context.py
@@ -652,8 +652,15 @@ def _main() -> int:
         else:
             for line in declined:
                 print(f"[companion] {line}", file=sys.stderr)
-            _record_outcome(bool(captured),
-                            "; ".join(declined) or "no capture flag produced a write")
+            if declined:
+                # A call that wrote some of what was asked and silently dropped the
+                # rest is the failure this reporting exists to surface. `ok` means
+                # "everything asked for landed", so a partial call is not ok — and
+                # the reason names both halves so the trace is actionable.
+                landed = f"{len(captured)} write(s) landed; " if captured else ""
+                _record_outcome(False, landed + "; ".join(declined))
+            else:
+                _record_outcome(bool(captured), "no capture flag produced a write")
         return 0
 
     # Lifecycle modes stay exclusive — these are alternative readings of one
@@ -888,7 +895,19 @@ def _trace_call(argv: list, out: str, err: str, ms: int) -> None:
         root = _repo_root()
         feature_dir = None
         try:
-            resolved = resolve_feature_dir(root, _flag_value(argv, "--feature-dir"))
+            # main() already printed any pointer complaint on the tee'd stream;
+            # this second resolve is bookkeeping, so it must stay quiet.
+            try:
+                from spec_context import quiet_pointer_complaints
+            except ImportError:
+                quiet_pointer_complaints = None
+            if quiet_pointer_complaints:
+                quiet_pointer_complaints(True)
+            try:
+                resolved = resolve_feature_dir(root, _flag_value(argv, "--feature-dir"))
+            finally:
+                if quiet_pointer_complaints:
+                    quiet_pointer_complaints(False)
             # resolve_feature_dir can name a directory that does not exist; a trace
             # line has nowhere to land there, so it falls through to unattributed.
             if resolved is not None and resolved.is_dir():

--- a/speckit-extension/scripts/write-context.py
+++ b/speckit-extension/scripts/write-context.py
@@ -536,6 +536,9 @@ def _main() -> int:
     # A ladder here recorded the first and dropped the rest, exit 0, with the
     # caller told only about the one that landed.
     captured: list[str] = []
+    #: Writers that declined, with the reason each gave. Kept apart from
+    #: `captured` so a decline can never be counted as a write.
+    declined: list[str] = []
     try:
         if args.classification:
             target = set_classification(feature_dir, args.classification)
@@ -572,7 +575,13 @@ def _main() -> int:
                 if args.coverage_tests else None
             )
             target = upsert_coverage(feature_dir, args.coverage_req, cov_tasks, cov_tests, args.coverage_title)
-            captured.append(f"[companion] Upserted coverage for {args.coverage_req} in {target}")
+            if target is None:
+                # NOT appended to `captured` — that list is what marks the call a
+                # write, so a decline recorded there would report itself as success.
+                declined.append(f"coverage for {args.coverage_req} was not written "
+                                f"(no coverage entry could be resolved in {feature_dir})")
+            else:
+                captured.append(f"[companion] Upserted coverage for {args.coverage_req} in {target}")
         if args.step_summary:
             target = upsert_step_summary(feature_dir, args.step, args.step_summary)
             captured.append(f"[companion] Recorded {args.step} step summary in {target}")
@@ -641,7 +650,10 @@ def _main() -> int:
             _record_outcome(False, f"Refusing --set {', '.join(repr(k) for k in refused)} — "
                                    f"lifecycle keys are managed by the capture/mark-complete writers.")
         else:
-            _record_outcome(bool(captured), "no capture flag produced a write")
+            for line in declined:
+                print(f"[companion] {line}", file=sys.stderr)
+            _record_outcome(bool(captured),
+                            "; ".join(declined) or "no capture flag produced a write")
         return 0
 
     # Lifecycle modes stay exclusive — these are alternative readings of one
@@ -689,9 +701,11 @@ def _main() -> int:
 
     # `target is not None` is the writers' shared success signal, including for
     # --tasks-file, which reports itself on stderr and is deliberately excluded
-    # from the stdout block below.
-    _record_outcome(target is not None,
-                    "the write did not land (see the reason above)")
+    # from the stdout block below. A writer that declines returns None without
+    # raising, so the reason it printed must be carried into the trace — a
+    # recorded failure whose cause is only on the terminal cannot be diagnosed
+    # from the trace file afterwards, which is the trace file's whole job.
+    _record_outcome(target is not None, _DECLINED)
 
     if target is not None and not args.tasks_file:
         if args.mark_complete:
@@ -809,6 +823,11 @@ class _Tee:
 # call is not a decline, and a refused append that prints neither reads as
 # whichever branch the heuristic happened to take.
 _OUTCOME: dict = {}
+#: Stand-in recorded when a writer declines by returning None. The real cause is
+#: whatever it printed, which is only readable after main() stops teeing output —
+#: _trace_call swaps this for that line so the trace carries the cause, not a
+#: pointer to a terminal nobody kept.
+_DECLINED = "\x00declined"
 
 
 def _record_outcome(ok: bool, reason: str | None = None) -> None:
@@ -825,6 +844,12 @@ def _companion_lines(text: str) -> list:
 def _first_companion_line(text: str) -> str | None:
     lines = _companion_lines(text)
     return lines[0] if lines else None
+
+
+def _last_companion_line(text: str) -> str | None:
+    """The most recent `[companion]` line — for a decline, the complaint itself."""
+    lines = _companion_lines(text)
+    return lines[-1] if lines else None
 
 
 def main() -> int:
@@ -853,6 +878,9 @@ def _trace_call(argv: list, out: str, err: str, ms: int) -> None:
         op = _classify_op(argv)
         if _OUTCOME:
             ok, reason = _OUTCOME["ok"], _OUTCOME["reason"]
+            if reason == _DECLINED:
+                reason = (_last_companion_line(err) or _last_companion_line(out)
+                          or f"the {op} writer declined to write and printed no reason")
         else:
             # _main died before recording anything — the crash itself is the outcome.
             ok, reason = False, _first_companion_line(err) or "the writer exited without recording an outcome"

--- a/speckit-extension/tests/golden/commands/commands__speckit.companion.classify.md
+++ b/speckit-extension/tests/golden/commands/commands__speckit.companion.classify.md
@@ -1,10 +1,10 @@
 ---
-description: "Classify the change size (small | normal | oversized) so the Companion workflow can right-size the pipeline"
+description: "Classify the change size (simple | normal | oversized) so the Companion workflow can right-size the pipeline"
 ---
 
 # Classify Change Size
 
-Emit a single complexity signal — `small`, `normal`, or `oversized` — that the Companion
+Emit a single complexity signal — `simple`, `normal`, or `oversized` — that the Companion
 workflow's routing step reads to right-size the pipeline. On the workflow path there is no
 `complexityFastPath` on/off setting: the thresholds live here, in the workflow, not in a
 VS Code toggle.
@@ -32,14 +32,15 @@ ambiguous estimate never skips a phase.
 Print exactly one line so the size is visible in the run log:
 
 ```text
-[companion] size=<small|normal|oversized>
+[companion] size=<simple|normal|oversized>
 ```
 
 Expose the same value as structured output `size` (so a `switch` node can read
 `steps.classify.output.size`). Routing contract:
 
 <!-- speckit-companion:part routing -->
-- `small` → the workflow folds toward implement (less ceremony).
+- `simple` → the workflow folds toward implement (less ceremony). `simple` is the verdict
+  every reader of the recorded size expects; `small` names the *bar*, never the verdict.
 - `oversized` → the workflow prints a visible warning and still runs the **full** pipeline — it
   never silently skips a phase.
 - `normal` (and any unresolved value) → the full pipeline.

--- a/speckit-extension/tests/golden/commands/commands__speckit.companion.implement.md
+++ b/speckit-extension/tests/golden/commands/commands__speckit.companion.implement.md
@@ -184,6 +184,12 @@ This is one step in the Companion pipeline. How the run continues depends on the
 - **Degrade gracefully on a one-shot environment.** If your environment runs one step and then stops, the handoff simply does not fire: finish this step, record its progress, and stop. The run stays valid and resumable, and the next step is triggered manually (by the developer or the companion panel). Completion likewise stays a manual action there.
 <!-- /speckit-companion:part self-advance -->
 
+**Pin the workflow identity before handing off.** Record that this spec runs the **Companion** workflow, so the next dispatch is a Companion command and not a stock one. A spec that joined Companion after `specify` has never had this written, and the shared writer defaults `workflow` to `speckit` — so without this the footer advance silently dispatches stock `/speckit.implement`'s successor. Idempotent, and a required deterministic write (skip only if `python3` is genuinely unavailable):
+
+```bash
+python3 .specify/extensions/companion/scripts/write-context.py --feature-dir <feature_directory> --set workflow=companion
+```
+
 <!-- speckit-companion:part orchestrator -->
 ## Node hooks — run the project's `before`/`after` inserts
 

--- a/speckit-extension/tests/golden/commands/commands__speckit.companion.plan.md
+++ b/speckit-extension/tests/golden/commands/commands__speckit.companion.plan.md
@@ -162,6 +162,12 @@ This is one step in the Companion pipeline. How the run continues depends on the
 - **Degrade gracefully on a one-shot environment.** If your environment runs one step and then stops, the handoff simply does not fire: finish this step, record its progress, and stop. The run stays valid and resumable, and the next step is triggered manually (by the developer or the companion panel). Completion likewise stays a manual action there.
 <!-- /speckit-companion:part self-advance -->
 
+**Pin the workflow identity before handing off.** Record that this spec runs the **Companion** workflow, so the next dispatch is a Companion command and not a stock one. A spec that joined Companion after `specify` has never had this written, and the shared writer defaults `workflow` to `speckit` — so without this the footer advance silently dispatches stock `/speckit.plan`'s successor. Idempotent, and a required deterministic write (skip only if `python3` is genuinely unavailable):
+
+```bash
+python3 .specify/extensions/companion/scripts/write-context.py --feature-dir <feature_directory> --set workflow=companion
+```
+
 <!-- speckit-companion:part orchestrator -->
 ## Node hooks — run the project's `before`/`after` inserts
 

--- a/speckit-extension/tests/golden/commands/commands__speckit.companion.tasks.md
+++ b/speckit-extension/tests/golden/commands/commands__speckit.companion.tasks.md
@@ -164,6 +164,12 @@ This is one step in the Companion pipeline. How the run continues depends on the
 - **Degrade gracefully on a one-shot environment.** If your environment runs one step and then stops, the handoff simply does not fire: finish this step, record its progress, and stop. The run stays valid and resumable, and the next step is triggered manually (by the developer or the companion panel). Completion likewise stays a manual action there.
 <!-- /speckit-companion:part self-advance -->
 
+**Pin the workflow identity before handing off.** Record that this spec runs the **Companion** workflow, so the next dispatch is a Companion command and not a stock one. A spec that joined Companion after `specify` has never had this written, and the shared writer defaults `workflow` to `speckit` — so without this the footer advance silently dispatches stock `/speckit.tasks`'s successor. Idempotent, and a required deterministic write (skip only if `python3` is genuinely unavailable):
+
+```bash
+python3 .specify/extensions/companion/scripts/write-context.py --feature-dir <feature_directory> --set workflow=companion
+```
+
 <!-- speckit-companion:part orchestrator -->
 ## Node hooks — run the project's `before`/`after` inserts
 

--- a/speckit-extension/tests/test_workflow_integrity.py
+++ b/speckit-extension/tests/test_workflow_integrity.py
@@ -2,7 +2,7 @@
 import json, os, subprocess, sys, tempfile, unittest
 from pathlib import Path
 
-REPO = Path("/Users/alfredoperez/dev/GitHub/speckit-companion")
+REPO = Path(__file__).resolve().parents[2]
 SCRIPTS = REPO / "speckit-extension" / "scripts"
 sys.path.insert(0, str(SCRIPTS))
 WRITER = SCRIPTS / "write-context.py"
@@ -17,7 +17,9 @@ class PointerFailsLoudly(unittest.TestCase):
     """#607 — a pointer that cannot resolve must say so, not resolve to nothing."""
 
     def _cell(self):
-        d = Path(tempfile.mkdtemp())
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        d = Path(tmp.name)
         (d / ".specify").mkdir()
         (d / "specs" / "001-x").mkdir(parents=True)
         subprocess.run(["git", "init", "-q", "."], cwd=d, check=True)
@@ -54,7 +56,9 @@ class DeclineCarriesItsReason(unittest.TestCase):
     """#615 — a recorded failure must carry the cause, not a pointer to lost output."""
 
     def _cell(self):
-        d = Path(tempfile.mkdtemp())
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        d = Path(tmp.name)
         (d / "specs" / "001-x").mkdir(parents=True)
         subprocess.run(["git", "init", "-q", "."], cwd=d, check=True)
         return d
@@ -127,7 +131,9 @@ class CaptureWritesAreAtomic(unittest.TestCase):
                           f"{name} still publishes without the shared atomic helper")
 
     def test_the_context_writer_publishes_through_the_helper(self):
-        d = Path(tempfile.mkdtemp())
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        d = Path(tmp.name)
         (d / "specs" / "001-x").mkdir(parents=True)
         subprocess.run(["git", "init", "-q", "."], cwd=d, check=True)
         run_writer(d, "--feature-dir", "specs/001-x", "--set", "size=simple")
@@ -154,10 +160,87 @@ class SilentPaletteCommandsAreHidden(unittest.TestCase):
                if str(e.get("when", "")).strip() == "false"}
         self.assertTrue(self.STUBS <= pal, f"still reachable: {sorted(self.STUBS - pal)}")
 
-    def test_the_working_refine_command_stays_reachable(self):
+    def test_no_workflow_editor_command_is_palette_reachable(self):
+        # refineSection dispatches real work, but only when the webview passes it
+        # (uri, sectionId, prompt). From the palette it gets none of them and
+        # sends an undefined prompt to the terminal — the same defect as the six
+        # silent stubs, so it is suppressed too. It stays fully usable in-webview.
+        contributed = {c["command"] for c in self.pkg["contributes"]["commands"]
+                       if c["command"].startswith("speckit.workflowEditor.")}
         pal = {e["command"] for e in self.pkg["contributes"]["menus"]["commandPalette"]
                if str(e.get("when", "")).strip() == "false"}
-        self.assertNotIn("speckit.workflowEditor.refineSection", pal)
+        self.assertTrue(contributed <= pal,
+                        f"palette-reachable and argument-dependent: {sorted(contributed - pal)}")
+
+
+class PartialCaptureIsNotClean(unittest.TestCase):
+    """#615 review — a call that wrote some of what was asked must not report ok."""
+
+    def _cell(self):
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        d = Path(tmp.name)
+        (d / "specs" / "001-x").mkdir(parents=True)
+        subprocess.run(["git", "init", "-q", "."], cwd=d, check=True)
+        return d
+
+    def test_a_decline_beside_a_write_still_reaches_the_trace(self):
+        d = self._cell()
+        run_writer(d, "--feature-dir", "specs/001-x", "--step", "plan",
+                   "--step-summary", "did stuff", "--coverage-req", "FR-002", "--tests", "")
+        rows = [json.loads(l) for l in
+                (d / "specs" / "001-x" / ".trace.jsonl").read_text().splitlines() if l.strip()]
+        last = rows[-1]
+        self.assertFalse(last["ok"], "a partly-dropped capture must not report clean")
+        self.assertIn("FR-002", last["reason"] or "")
+        self.assertIn("landed", last["reason"] or "")
+
+
+class StalePointerFallsThroughToTheBranch(unittest.TestCase):
+    """#607 review — complaining must not skip the remaining resolution rungs."""
+
+    def test_a_stale_pointer_still_resolves_by_branch(self):
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        d = Path(tmp.name)
+        (d / ".specify").mkdir()
+        (d / "specs" / "001-x").mkdir(parents=True)
+        for cmd in (["git", "init", "-q", "."], ["git", "checkout", "-q", "-b", "001-x"]):
+            subprocess.run(cmd, cwd=d, check=True)
+        (d / "specs" / "001-x" / "spec.md").write_text("# x\n")
+        subprocess.run(["git", "add", "-A"], cwd=d, check=True)
+        subprocess.run(["git", "-c", "user.email=t@t", "-c", "user.name=t",
+                        "commit", "-q", "-m", "init"], cwd=d, check=True)
+        (d / ".specify" / "feature.json").write_text(
+            json.dumps({"feature_directory": "specs/999-gone"}))
+        r = run_writer(d, "--set", "size=simple")
+        self.assertIn("stale", r.stderr)
+        self.assertTrue((d / "specs" / "001-x" / ".spec-context.json").is_file(),
+                        "the branch rung must still be reached after the complaint")
+
+    def test_a_stale_pointer_is_not_also_called_keyless(self):
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        d = Path(tmp.name)
+        (d / ".specify").mkdir()
+        (d / "specs" / "001-x").mkdir(parents=True)
+        subprocess.run(["git", "init", "-q", "."], cwd=d, check=True)
+        (d / ".specify" / "feature.json").write_text(
+            json.dumps({"feature_directory": "specs/999-gone"}))
+        r = run_writer(d, "--set", "size=simple")
+        self.assertNotIn("no recognised key", r.stderr)
+
+    def test_the_complaint_is_printed_once(self):
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        d = Path(tmp.name)
+        (d / ".specify").mkdir()
+        (d / "specs" / "001-x").mkdir(parents=True)
+        subprocess.run(["git", "init", "-q", "."], cwd=d, check=True)
+        (d / ".specify" / "feature.json").write_text(
+            json.dumps({"feature_directory": "specs/999-gone"}))
+        r = run_writer(d, "--set", "size=simple")
+        self.assertEqual(r.stderr.count("the pointer is stale"), 1)
 
 
 if __name__ == "__main__":

--- a/speckit-extension/tests/test_workflow_integrity.py
+++ b/speckit-extension/tests/test_workflow_integrity.py
@@ -1,0 +1,164 @@
+"""Tests for the workflow-integrity batch (#607 #584 #611 #603 #593 #615)."""
+import json, os, subprocess, sys, tempfile, unittest
+from pathlib import Path
+
+REPO = Path("/Users/alfredoperez/dev/GitHub/speckit-companion")
+SCRIPTS = REPO / "speckit-extension" / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+WRITER = SCRIPTS / "write-context.py"
+
+
+def run_writer(cwd, *args):
+    return subprocess.run([sys.executable, str(WRITER), *args], cwd=cwd,
+                          capture_output=True, text=True)
+
+
+class PointerFailsLoudly(unittest.TestCase):
+    """#607 — a pointer that cannot resolve must say so, not resolve to nothing."""
+
+    def _cell(self):
+        d = Path(tempfile.mkdtemp())
+        (d / ".specify").mkdir()
+        (d / "specs" / "001-x").mkdir(parents=True)
+        subprocess.run(["git", "init", "-q", "."], cwd=d, check=True)
+        return d
+
+    def test_a_stale_pointer_names_the_missing_directory(self):
+        d = self._cell()
+        (d / ".specify" / "feature.json").write_text(
+            json.dumps({"feature_directory": "specs/999-gone"}))
+        r = run_writer(d, "--set", "size=simple")
+        self.assertIn("does not exist", r.stderr)
+        self.assertIn("stale", r.stderr)
+
+    def test_an_unrecognised_key_names_the_keys_that_work(self):
+        d = self._cell()
+        (d / ".specify" / "feature.json").write_text(json.dumps({"featureDir": "specs/001-x"}))
+        r = run_writer(d, "--set", "size=simple")
+        self.assertIn("no recognised key", r.stderr)
+        self.assertIn("feature_directory", r.stderr)
+        self.assertIn("featureDir", r.stderr)  # says what it actually found
+
+    def test_a_good_pointer_still_resolves_silently(self):
+        d = self._cell()
+        (d / ".specify" / "feature.json").write_text(
+            json.dumps({"feature_directory": "specs/001-x"}))
+        r = run_writer(d, "--set", "size=simple")
+        self.assertNotIn("no recognised key", r.stderr)
+        self.assertNotIn("stale", r.stderr)
+        ctx = json.loads((d / "specs" / "001-x" / ".spec-context.json").read_text())
+        self.assertEqual(ctx.get("size"), "simple")
+
+
+class DeclineCarriesItsReason(unittest.TestCase):
+    """#615 — a recorded failure must carry the cause, not a pointer to lost output."""
+
+    def _cell(self):
+        d = Path(tempfile.mkdtemp())
+        (d / "specs" / "001-x").mkdir(parents=True)
+        subprocess.run(["git", "init", "-q", "."], cwd=d, check=True)
+        return d
+
+    def _failures(self, d):
+        p = d / "specs" / "001-x" / ".trace.jsonl"
+        rows = [json.loads(l) for l in p.read_text().splitlines() if l.strip()]
+        return [r for r in rows if not r.get("ok")]
+
+    def test_a_declined_write_records_why(self):
+        d = self._cell()
+        run_writer(d, "--feature-dir", "specs/001-x", "--coverage-req", "FR-002", "--tests", "")
+        fails = self._failures(d)
+        self.assertTrue(fails, "the decline must be recorded as a failure")
+        reason = fails[-1]["reason"] or ""
+        self.assertNotIn("see the reason above", reason)
+        self.assertIn("FR-002", reason)
+
+    def test_a_decline_is_never_counted_as_a_write(self):
+        d = self._cell()
+        r = run_writer(d, "--feature-dir", "specs/001-x", "--coverage-req", "FR-002", "--tests", "")
+        self.assertNotIn("Upserted coverage for FR-002 in None", r.stdout)
+        self.assertTrue(self._failures(d))
+
+
+class ClassifySpeaksTheSharedVocabulary(unittest.TestCase):
+    """#611 — the standalone command must emit the word every consumer reads."""
+
+    BODY = REPO / "speckit-extension" / "commands" / "speckit.companion.classify.md"
+
+    def test_the_emitted_verdict_is_simple_not_small(self):
+        text = self.BODY.read_text()
+        self.assertIn("size=<simple|normal|oversized>", text)
+        self.assertNotIn("size=<small|normal|oversized>", text)
+
+    def test_the_routing_contract_names_simple(self):
+        text = self.BODY.read_text()
+        routing = text.split("part routing -->")[1].split("<!-- /speckit-companion:part routing")[0]
+        self.assertIn("`simple`", routing)
+
+    def test_the_writer_accepts_the_word_the_command_emits(self):
+        import re
+        text = self.BODY.read_text()
+        emitted = set(re.search(r"size=<([^>]+)>", text).group(1).split("|"))
+        accepted = set(re.search(r"verdict \(([a-z|]+)\)",
+                                 (SCRIPTS / "write-context.py").read_text()).group(1).split("|"))
+        self.assertEqual(emitted, accepted)
+
+
+class WorkflowIdentityIsPinnedEveryStep(unittest.TestCase):
+    """#584 — a spec joining mid-run must be pinned before the next dispatch."""
+
+    def test_every_pipeline_command_pins_the_workflow(self):
+        cmds = REPO / "speckit-extension" / "commands"
+        for step in ("specify", "plan", "tasks", "implement"):
+            body = (cmds / f"speckit.companion.{step}.md").read_text()
+            self.assertIn("--set workflow=companion", body,
+                          f"{step} never pins the workflow, so a mid-run join keeps stock dispatch")
+
+
+class CaptureWritesAreAtomic(unittest.TestCase):
+    """#603 — the capture runtime must not use a shared temp name."""
+
+    def test_no_capture_script_uses_a_fixed_temp_suffix_as_its_only_path(self):
+        import companion_config as cc
+        self.assertTrue(hasattr(cc, "atomic_write_text"))
+        for name in ("spec_context.py", "task_sync.py", "run_trace.py"):
+            src = (SCRIPTS / name).read_text()
+            self.assertIn("atomic_write_text", src,
+                          f"{name} still publishes without the shared atomic helper")
+
+    def test_the_context_writer_publishes_through_the_helper(self):
+        d = Path(tempfile.mkdtemp())
+        (d / "specs" / "001-x").mkdir(parents=True)
+        subprocess.run(["git", "init", "-q", "."], cwd=d, check=True)
+        run_writer(d, "--feature-dir", "specs/001-x", "--set", "size=simple")
+        target = d / "specs" / "001-x" / ".spec-context.json"
+        self.assertEqual(json.loads(target.read_text())["size"], "simple")
+        leftovers = list(target.parent.glob("*.tmp"))
+        self.assertEqual(leftovers, [], "a completed write left temp debris")
+
+
+class SilentPaletteCommandsAreHidden(unittest.TestCase):
+    """#593 — a command that only writes a log line must not be reachable."""
+
+    STUBS = {
+        "speckit.workflowEditor.removeSection", "speckit.workflowEditor.addUserStory",
+        "speckit.workflowEditor.approveAndContinue", "speckit.workflowEditor.regenerate",
+        "speckit.workflowEditor.navigateToPhase", "speckit.workflowEditor.editSource",
+    }
+
+    def setUp(self):
+        self.pkg = json.loads((REPO / "package.json").read_text())
+
+    def test_every_silent_stub_is_suppressed_from_the_palette(self):
+        pal = {e["command"] for e in self.pkg["contributes"]["menus"]["commandPalette"]
+               if str(e.get("when", "")).strip() == "false"}
+        self.assertTrue(self.STUBS <= pal, f"still reachable: {sorted(self.STUBS - pal)}")
+
+    def test_the_working_refine_command_stays_reachable(self):
+        pal = {e["command"] for e in self.pkg["contributes"]["menus"]["commandPalette"]
+               if str(e.get("when", "")).strip() == "false"}
+        self.assertNotIn("speckit.workflowEditor.refineSection", pal)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=1)


### PR DESCRIPTION
## Summary

Six workflow-integrity tickets in one branch, one commit each. They share a shape: **each one was a failure that reported success.** A pointer that resolved to nothing and audited nothing. A spec that dispatched stock commands for the rest of its run. A size verdict dropped in silence. A torn record swallowed as `{}`. A capture failure recorded without its cause. Six commands that ran to complete silence.

They ship together because they are one subsystem and one theme; splitting them into six branches would have been most of a day of ceremony for changes that touch the same files.

Closes #607, #584, #611, #603, #615, #593.

## What each one does

| ticket | before | after |
|---|---|---|
| **#607** | a pointer naming a missing directory resolved to nothing, silently | says the pointer is stale and names it, then **falls through** to the remaining resolution rungs |
| | a pointer with an unrecognised key did the same | names the file, the keys that would have worked, and what it actually found |
| | four example fixtures shipped a `featureDir` spelling nothing reads | corrected to `feature_directory` |
| **#584** | only specify recorded the workflow identity, so a spec joining later kept dispatching stock commands | pinned before handoff in plan, tasks and implement; idempotent |
| **#611** | the standalone classify command emitted `small`; every consumer branches on `simple` | emits `simple`. `small` still names the *bar*, which is shared with specify's own sizing text |
| **#603** | the three most-written files each published through a fixed `<path>.tmp` with no flush | all three publish through the one shared atomic writer |
| **#615** | a declined write recorded `"the write did not land (see the reason above)"`, pointing at terminal output the trace does not carry | carries the writer's own complaint; a partial capture reports `ok: false` naming both halves; a decline can never register as a write |
| **#593** | six commands reachable from the palette that only wrote a log line | suppressed, along with `refineSection`, which from the palette receives none of its three arguments |

## Verification

- **745** spec-kit extension tests (21 new across two modules), **1942** VS Code tests, all six CI gates.
- Every new test was run against the unfixed code first and fails there.
- End-to-end probes rather than unit tests alone: stale pointer → complains and still resolves by branch; wrong key → names both spellings; good pointer → silent; 12 concurrent writers → valid document, no debris; partial capture → `ok: false` with `"1 write(s) landed; coverage for FR-002 was not written (…)"`.

## Notes for the reviewer

**The packaging gate caught a shipping regression.** Routing three `.vsix`-shipped scripts through `companion_config` made them import a module that was not in the packing list. Each call site guards the import and falls back, so it would have quietly downgraded crash-safety rather than failing loudly — the helper now ships.

**One thing this does not fix, filed as #620.** Making each write atomic does not stop two writers starting from the same stale copy. Twelve simultaneous captures leave a valid document containing four of them, with no warning and no trace failure. Atomicity is not isolation; that is a separate change.

## Gaps

`#593` takes the ticket's Option A (hide) rather than deleting the ~600 lines behind those commands, per the ticket's own "A now, B when the editor surface lands".

🤖 Generated with [Claude Code](https://claude.com/claude-code)