### PR TITLE
fix(speckit-ext): the health check can see the failures it exists to find

### DIFF
--- a/speckit-extension/scripts/doctor_bleed.py
+++ b/speckit-extension/scripts/doctor_bleed.py
@@ -213,15 +213,49 @@ def _early_source_signals(root, ctx: dict) -> list:
     return out
 
 
+#: Below this, the gap between elapsed time and the sum of step spans is ordinary
+#: dispatch latency. Above it, the per-step numbers are describing a minority of
+#: the run and should say so.
+UNATTRIBUTED_THRESHOLD = 0.25
+
+
+def _elapsed_gap(ctx: dict) -> dict | None:
+    """Elapsed time versus the time the steps actually account for."""
+    windows = _step_windows(ctx)
+    if not windows:
+        return None
+    durations = [(e - b).total_seconds() for b, e in windows.values()]
+    span_total = sum(durations)
+    begins = [b for b, _ in windows.values()]
+    ends = [e for _, e in windows.values()]
+    elapsed = (max(ends) - min(begins)).total_seconds()
+    if elapsed <= 0:
+        return None
+    return {"elapsed_seconds": elapsed, "step_span_seconds": span_total,
+            "unattributed_share": max(0.0, (elapsed - span_total) / elapsed)}
+
+
 def _time_share(ctx: dict) -> dict | None:
-    """A pre-implement step that consumed more of the run than implement itself."""
+    """A pre-implement step that consumed more of the run than implement itself.
+
+    Shares are computed against ELAPSED time, not the sum of step spans. Those
+    are not the same number: a step's boundary is stamped when the command body
+    reaches its start line, so work done before that — reading the plan, editing
+    files — lands between steps and belongs to none of them. Measured on a real
+    run, that gap was 49% of the clock. Dividing by the sum of spans quietly
+    removed it and roughly doubled every share it reported as "of the run".
+    """
     windows = _step_windows(ctx)
     if "implement" not in windows:
         return None
     durations = {s: (e - b).total_seconds() for s, (b, e) in windows.items()}
-    total = sum(durations.values())
-    if total <= 0:
+    span_total = sum(durations.values())
+    if span_total <= 0:
         return None
+    begins = [b for b, _ in windows.values()]
+    ends = [e for _, e in windows.values()]
+    elapsed = (max(ends) - min(begins)).total_seconds()
+    total = elapsed if elapsed > 0 else span_total
     impl = durations["implement"]
     worse = {s: d for s, d in durations.items()
              if s in STEP_ORDER_PRE_IMPLEMENT and d > impl}
@@ -231,6 +265,8 @@ def _time_share(ctx: dict) -> dict | None:
     return {
         "step": step, "share": dur / total, "seconds": dur,
         "implement_seconds": impl, "implement_share": impl / total,
+        "elapsed_seconds": elapsed, "step_span_seconds": span_total,
+        "unattributed_share": max(0.0, (elapsed - span_total) / total) if elapsed > 0 else 0.0,
     }
 
 
@@ -260,11 +296,23 @@ def check_bleed(root, feature_dir: Path, ctx: dict, report=None) -> tuple:
         findings.append(Finding(
             "bleed", "note",
             f"`{share['step']}` took longer than `implement`",
-            f"{share['step']} {share['seconds']:.0f}s ({share['share']:.0%} of the run) versus "
-            f"implement {share['implement_seconds']:.0f}s ({share['implement_share']:.0%}) — a "
-            f"hard planning phase can be a legitimate reason, so read this alongside the "
-            f"evidence above rather than on its own",
+            f"{share['step']} {share['seconds']:.0f}s ({share['share']:.0%} of elapsed time) "
+            f"versus implement {share['implement_seconds']:.0f}s "
+            f"({share['implement_share']:.0%}) — a hard planning phase can be a legitimate "
+            f"reason, so read this alongside the evidence above rather than on its own",
             share,
+        ))
+
+    gap = _time_share(ctx) or _elapsed_gap(ctx)
+    if gap and gap.get("unattributed_share", 0) >= UNATTRIBUTED_THRESHOLD:
+        findings.append(Finding(
+            "bleed", "warning",
+            f"{gap['unattributed_share']:.0%} of elapsed time belongs to no step",
+            f"{gap['elapsed_seconds']:.0f}s elapsed but the steps only account for "
+            f"{gap['step_span_seconds']:.0f}s — work done before a step stamps its own start "
+            f"is invisible to every per-step number, so those durations measure journaling "
+            f"latency more than they measure work",
+            {k: gap[k] for k in ("elapsed_seconds", "step_span_seconds", "unattributed_share")},
         ))
 
     if report is not None:

--- a/speckit-extension/scripts/doctor_checks.py
+++ b/speckit-extension/scripts/doctor_checks.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 import re
 import sys
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
@@ -166,17 +166,36 @@ def check_record(feature_dir: Path, ctx: dict, now: datetime | None = None) -> t
                 {"tasks": missing},
             ))
 
+    # Batching is a LOCAL property: several tasks stamped together. Measuring
+    # first-to-last across the whole run missed the strongest possible case — a
+    # run journaling four tasks at the identical millisecond, three times over,
+    # scored a 60s span and warned about nothing. Cluster first, then judge each
+    # cluster on its own span.
     finishes = _task_finish_times(ctx)
-    if len(finishes) >= BURST_MIN_TASKS:
-        span = (finishes[-1][1] - finishes[0][1]).total_seconds()
-        if span <= BURST_WINDOW_SECONDS:
-            findings.append(Finding(
-                "record", "warning",
-                f"{len(finishes)} task finishes recorded inside {span:.0f}s — journaling was batched",
-                "the per-task timestamps reflect when the batch was written, not how long "
-                "each task took; the summaries are still trustworthy, the durations are not",
-                {"tasks": [t for t, _ in finishes], "span_seconds": span},
-            ))
+    clusters, current = [], []
+    for entry in finishes:
+        if current and (entry[1] - current[0][1]).total_seconds() > BURST_WINDOW_SECONDS:
+            clusters.append(current)
+            current = []
+        current.append(entry)
+    if current:
+        clusters.append(current)
+
+    bursts = [c for c in clusters if len(c) >= BURST_MIN_TASKS]
+    if bursts:
+        worst = max(bursts, key=len)
+        span = (worst[-1][1] - worst[0][1]).total_seconds()
+        batched = sum(len(c) for c in bursts)
+        extra = (f" across {len(bursts)} batches" if len(bursts) > 1 else "")
+        findings.append(Finding(
+            "record", "warning",
+            f"{batched} task finishes recorded in bursts{extra} — journaling was batched",
+            f"the largest batch stamped {len(worst)} tasks inside {span:.1f}s; those "
+            "timestamps reflect when the batch was written, not how long each task "
+            "took, so the summaries are still trustworthy and the durations are not",
+            {"tasks": [t for c in bursts for t, _ in c],
+             "batches": len(bursts), "largest_batch": len(worst), "span_seconds": span},
+        ))
 
     for step, by, at, why in _attribution_anomalies(ctx):
         findings.append(Finding(
@@ -248,6 +267,22 @@ def check_triage(feature_dir: Path, ctx: dict) -> tuple:
 _COMPLETION_OPS = ("mark-complete",)
 
 
+#: Unattributed capture failures carry `spec: null` — they could not resolve a
+#: spec, which is the whole reason they matter — so they can only be matched to a
+#: run by time. The window is the first-to-last history entry, and the failures
+#: worth finding happen OUTSIDE it: before the first entry exists, or after the
+#: last one lands. An unpadded window discarded exactly those, so a run that
+#: silently lost writes reported "failures: 0". Pad it, and never drop in silence.
+WINDOW_PAD = timedelta(minutes=5)
+
+
+def _in_window(ts, start, end) -> bool:
+    """True when a timestamp falls inside the padded run window, or cannot be placed."""
+    if ts is None or start is None or end is None:
+        return True  # undateable: count it rather than hide it
+    return start <= ts <= end
+
+
 def _completion_attempts(feature_dir: Path, ctx: dict) -> list:
     """Completion attempts belonging to THIS spec.
 
@@ -265,7 +300,7 @@ def _completion_attempts(feature_dir: Path, ctx: dict) -> list:
 
     shared = run_trace.read(Path(feature_dir).parent)
     if shared is not None:
-        start, end = run_window(ctx)
+        start, end = run_window(ctx, WINDOW_PAD)
         rel = Path(feature_dir).name
         for e in shared.events:
             if e.get("op") not in _COMPLETION_OPS:
@@ -273,8 +308,7 @@ def _completion_attempts(feature_dir: Path, ctx: dict) -> list:
             spec = e.get("spec")
             if spec and rel not in str(spec):
                 continue
-            ts = parse_time(e.get("at"))
-            if not (start and end and ts is not None and start <= ts <= end):
+            if not _in_window(parse_time(e.get("at")), start, end):
                 continue
             out.append(e)
     return out
@@ -492,15 +526,22 @@ def _unattributed_failures(feature_dir: Path, ctx: dict) -> list:
     read = run_trace.read(log.parent)
     if read is None:
         return []
-    start, end = run_window(ctx)
-    out = []
+    start, end = run_window(ctx, WINDOW_PAD)
+    out, dropped = [], 0
     for e in read.events:
         if e.get("ok"):
             continue
-        ts = parse_time(e.get("at"))
-        if start and end and ts is not None and not (start <= ts <= end):
+        if not _in_window(parse_time(e.get("at")), start, end):
+            dropped += 1
             continue
         out.append(e)
+    if dropped:
+        # Say what was set aside. Silently discarding a failure because of when it
+        # happened is how "0 problems" got reported for a run that lost writes.
+        out.append({"op": "outside-window", "ok": False, "spec": None,
+                    "reason": f"{plural(dropped, 'further failed capture call')} in the "
+                              f"repo-level log fell outside this run's window and were "
+                              f"not attributed to it"})
     return out
 
 

--- a/speckit-extension/scripts/write-context.py
+++ b/speckit-extension/scripts/write-context.py
@@ -124,7 +124,7 @@ from living_spec_fold import (  # noqa: E402,F401
 
 
 def update_context(
-    feature_dir: Path, step: str, status: str, by: str, kind: str = "start",
+    feature_dir: Path, step: str, status: str | None, by: str, kind: str = "start",
     substep: str | None = None,
 ) -> Path | None:
     target = feature_dir / ".spec-context.json"
@@ -147,7 +147,13 @@ def update_context(
     fill_required(ctx, feature_dir, branch)
 
     ctx["currentStep"] = step
-    ctx["status"] = status
+    # A start carries the step forward and leaves status alone. `--status` used to
+    # default to "specified" and was written on every branch, so opening a step
+    # without naming a status was indistinguishable from asking to go back to the
+    # first one: a run would read currentStep=implement alongside status=specified
+    # for the whole step, and only the later complete repaired it.
+    if status is not None:
+        ctx["status"] = status
 
     if kind == "complete":
         # Deterministic self-close. Idempotent: skip if the step is already closed,
@@ -317,7 +323,8 @@ def mark_spec_complete(feature_dir: Path, by: str) -> Path | None:
 def _main() -> int:
     parser = argparse.ArgumentParser(description="Write/update a feature's .spec-context.json")
     parser.add_argument("--step", default="specify")
-    parser.add_argument("--status", default="specified")
+    # No default: a caller that does not name a status does not want one changed.
+    parser.add_argument("--status", default=None)
     parser.add_argument("--by", default="extension")
     parser.add_argument("--kind", default="start", choices=["start", "complete"])
     parser.add_argument(
@@ -670,8 +677,8 @@ def _main() -> int:
             tasks_md = Path(args.tasks_file)
             if not tasks_md.is_absolute():
                 tasks_md = root / tasks_md
-            # Task-sync operates on the implement step; the global --status default
-            # ("specified") would be an incoherent terminal status here.
+            # Task-sync operates on the implement step, so a caller that named no
+            # status means "implemented" here rather than "leave it alone".
             final_status = args.status if args.status != parser.get_default("status") else "implemented"
             target = sync_tasks(feature_dir, tasks_md, final_status, args.by)
         elif args.mark_complete:
@@ -731,7 +738,8 @@ def _main() -> int:
         elif args.task:
             print(f"[companion] Journaled finish for task {args.task} in {target} (by={args.by})")
         else:
-            print(f"[companion] Updated {target} (currentStep={args.step}, status={args.status}, kind={args.kind}, by={args.by})")
+            _shown = args.status if args.status is not None else "unchanged"
+            print(f"[companion] Updated {target} (currentStep={args.step}, status={_shown}, kind={args.kind}, by={args.by})")
     return 0
 
 

--- a/speckit-extension/tests/test_measurement_honesty.py
+++ b/speckit-extension/tests/test_measurement_honesty.py
@@ -1,0 +1,142 @@
+"""The health check must not hide the failures it exists to find (#622)."""
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+SCRIPTS = REPO / "speckit-extension" / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import doctor_bleed  # noqa: E402
+import doctor_checks  # noqa: E402
+
+WRITER = SCRIPTS / "write-context.py"
+
+
+def iso(dt):
+    return dt.strftime("%Y-%m-%dT%H:%M:%S.") + f"{dt.microsecond // 1000:03d}Z"
+
+
+class BurstsAreJudgedPerCluster(unittest.TestCase):
+    """Batching is local. Measuring first-to-last across the run missed the worst cases."""
+
+    def _ctx(self, groups):
+        base = datetime(2026, 8, 26, 12, 0, 0, tzinfo=timezone.utc)
+        history, n = [], 0
+        for offset, count in groups:
+            for _ in range(count):
+                n += 1
+                history.append({"step": "implement", "task": f"T{n:03d}", "kind": "complete",
+                                "by": "ai", "at": iso(base + timedelta(seconds=offset))})
+        return {"currentStep": "implement", "status": "implemented", "history": history}
+
+    def _warned(self, ctx):
+        # check_record skips outright when the context file is absent, so the
+        # fixture has to exist on disk for the burst logic to be reached at all.
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        d = Path(tmp.name)
+        (d / ".spec-context.json").write_text(json.dumps(ctx))
+        _status, findings = doctor_checks.check_record(d, ctx)
+        return [f for f in findings if "batched" in f.title]
+
+    def test_four_tasks_at_one_instant_warn_even_when_the_run_is_long(self):
+        # The exact shape that produced zero warnings: 3 clusters of 4, 30s apart.
+        ctx = self._ctx([(0, 4), (30, 4), (60, 4)])
+        warned = self._warned(ctx)
+        self.assertTrue(warned, "identical-timestamp clusters must warn")
+        ev = warned[0].evidence
+        self.assertEqual(ev["batches"], 3)
+        self.assertEqual(ev["largest_batch"], 4)
+        self.assertEqual(len(ev["tasks"]), 12)
+
+    def test_tasks_spread_across_real_time_do_not_warn(self):
+        self.assertFalse(self._warned(self._ctx([(0, 1), (60, 1), (120, 1), (180, 1)])))
+
+    def test_one_tight_cluster_still_warns(self):
+        self.assertTrue(self._warned(self._ctx([(0, 3)])))
+
+
+class ElapsedTimeIsTheDenominator(unittest.TestCase):
+    """Shares said 'of the run' while dividing by the sum of step spans."""
+
+    def _ctx(self):
+        base = datetime(2026, 8, 26, 12, 0, 0, tzinfo=timezone.utc)
+        def at(sec):
+            return iso(base + timedelta(seconds=sec))
+        # 100s elapsed; steps account for 40s. 60% belongs to no step.
+        return {"currentStep": "implement", "status": "implemented", "history": [
+            {"step": "specify", "kind": "start", "by": "extension", "at": at(0)},
+            {"step": "specify", "kind": "complete", "by": "extension", "at": at(30)},
+            {"step": "implement", "kind": "start", "by": "extension", "at": at(90)},
+            {"step": "implement", "kind": "complete", "by": "extension", "at": at(100)},
+        ]}
+
+    def test_the_share_is_measured_against_elapsed_time(self):
+        share = doctor_bleed._time_share(self._ctx())
+        self.assertIsNotNone(share)
+        # specify is 30s of 100s elapsed, not 30s of the 40s of step spans.
+        self.assertAlmostEqual(share["share"], 0.30, places=2)
+        self.assertAlmostEqual(share["elapsed_seconds"], 100, places=0)
+        self.assertAlmostEqual(share["step_span_seconds"], 40, places=0)
+
+    def test_time_belonging_to_no_step_is_reported(self):
+        gap = doctor_bleed._elapsed_gap(self._ctx())
+        self.assertAlmostEqual(gap["unattributed_share"], 0.60, places=2)
+
+    def test_a_run_with_no_gap_reports_none(self):
+        base = datetime(2026, 8, 26, 12, 0, 0, tzinfo=timezone.utc)
+        def at(sec):
+            return iso(base + timedelta(seconds=sec))
+        ctx = {"currentStep": "implement", "status": "implemented", "history": [
+            {"step": "specify", "kind": "start", "by": "extension", "at": at(0)},
+            {"step": "specify", "kind": "complete", "by": "extension", "at": at(50)},
+            {"step": "implement", "kind": "start", "by": "extension", "at": at(50)},
+            {"step": "implement", "kind": "complete", "by": "extension", "at": at(100)},
+        ]}
+        self.assertLess(doctor_bleed._elapsed_gap(ctx)["unattributed_share"], 0.01)
+
+
+class AStepStartLeavesStatusAlone(unittest.TestCase):
+    """Opening a step used to be indistinguishable from asking for 'specified'."""
+
+    def _cell(self):
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        d = Path(tmp.name)
+        (d / "specs" / "001-x").mkdir(parents=True)
+        subprocess.run(["git", "init", "-q", "."], cwd=d, check=True)
+        return d
+
+    def _status(self, d):
+        ctx = json.loads((d / "specs" / "001-x" / ".spec-context.json").read_text())
+        return ctx["currentStep"], ctx["status"]
+
+    def _write(self, d, *args):
+        return subprocess.run([sys.executable, str(WRITER), "--feature-dir", "specs/001-x", *args],
+                              cwd=d, capture_output=True, text=True)
+
+    def test_a_start_carries_the_step_without_rewinding_status(self):
+        d = self._cell()
+        self._write(d, "--step", "tasks", "--status", "ready-to-implement", "--kind", "complete")
+        self.assertEqual(self._status(d), ("tasks", "ready-to-implement"))
+        self._write(d, "--step", "implement", "--kind", "start", "--by", "extension")
+        self.assertEqual(self._status(d), ("implement", "ready-to-implement"))
+
+    def test_an_explicit_status_on_a_start_is_still_honoured(self):
+        d = self._cell()
+        self._write(d, "--step", "specify", "--status", "specifying", "--kind", "start")
+        self.assertEqual(self._status(d), ("specify", "specifying"))
+
+    def test_a_complete_still_sets_its_status(self):
+        d = self._cell()
+        self._write(d, "--step", "plan", "--status", "planned", "--kind", "complete")
+        self.assertEqual(self._status(d), ("plan", "planned"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Fix round 2 of the [[Workflow Proof Plan]]. Five probe runs against the freshly-fixed build reported **"0 problems"** while having silently lost data. Four mechanisms were hiding it — all found by the probes, all reproduced deterministically, all fixed here.

Refs #622 (the full hunt ticket).

## What was wrong

| mechanism | effect |
|---|---|
| Failures outside a computed time window were discarded **before counting** | a run whose captures failed reported `failures: 0`. Proven by changing nothing but a timestamp. |
| The same filter sat on the completion check | a **refused** mark-complete was reported as **never attempted** — the two outcomes that check exists to tell apart |
| The burst detector measured first-to-last across the whole run | a run journaling **four tasks at the identical millisecond, three times over** scored a 60s span and warned about nothing |
| Step shares were labelled "of the run" while dividing by the sum of step spans | on a real run this hid **49% of the clock** and roughly doubled every share |
| A step start with no explicit status rewrote status to `specified` | a run read `currentStep=implement` alongside `status=specified` for the whole step, repaired only by the later complete |

## What changed

- `doctor_checks.py` — pad the run window; anything still outside is **reported, not dropped**. Same at the completion-attempt site.
- `doctor_checks.py` — cluster task finishes, then judge each cluster's own span. Evidence now carries `batches` and `largest_batch`.
- `doctor_bleed.py` — divide by elapsed time; add a warning naming the share of elapsed time that belongs to no step at all.
- `write-context.py` — `--status` no longer defaults to a real lifecycle value, and a `start` leaves status alone unless one is named. `complete` and `--advance` are unchanged (they pass an explicit status).

## Verified against the probe data, not only unit tests

- probe-4 reported "0 problems" → now reports its **2 lost capture calls**
- probe-3 warned about nothing → now **"12 task finishes recorded in bursts across 3 batches"**
- probe-1 → **"49% of elapsed time belongs to no step"** (308s elapsed, 158s accounted for); specify's share corrected from 44% to 23%
- a step start after `tasks complete` used to leave `implement / specified`; now `implement / ready-to-implement`

## Tests

9 new tests in `test_measurement_honesty.py`, **5 of which fail against the unfixed code**. 754 extension tests, all six gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)