### PR TITLE
fix(speckit-ext): release the capture lock after the publish, not before

### DIFF
--- a/speckit-extension/scripts/spec_context.py
+++ b/speckit-extension/scripts/spec_context.py
@@ -252,8 +252,84 @@ def _is_more_advanced(ctx: dict, step: str) -> bool:
     return cur in STEP_ORDER and STEP_ORDER[cur] > STEP_ORDER[step]
 
 
+#: Set by the writer script only. A read-modify-write pair is not atomic just
+#: because the write is: two writers can each read the same copy and the second
+#: publish silently discards the first one's field. Twelve simultaneous captures
+#: left four recorded, with no warning and no failure anywhere (#620).
+#:
+#: Readers (the health check, the fold reader) never set this, so they are never
+#: blocked and never block a writer.
+_WRITE_LOCK_ENABLED = False
+#: One held lock per target path, opened on read and released on publish.
+_HELD_LOCKS: dict = {}
+
+
+def enable_write_lock() -> None:
+    """Serialise this process's read-modify-write against other writers."""
+    global _WRITE_LOCK_ENABLED
+    _WRITE_LOCK_ENABLED = True
+
+
+def _lock_path(target: Path) -> Path:
+    """Where the lock for a context file lives.
+
+    Deliberately NOT beside the context file: a spec directory is the user's,
+    and a stray `.spec-context.json.lock` there would be committed, shipped and
+    puzzled over. It also cannot be the context file itself — publishing renames
+    over it, so a later writer would lock a different inode than the one already
+    held. A stable per-path file in the system temp directory is neither.
+    """
+    import hashlib
+    import tempfile
+
+    key = hashlib.sha256(str(target.resolve()).encode("utf-8")).hexdigest()[:32]
+    root = Path(tempfile.gettempdir()) / "speckit-companion-locks"
+    root.mkdir(parents=True, exist_ok=True)
+    return root / f"{key}.lock"
+
+
+def _acquire_lock(target: Path) -> None:
+    if not _WRITE_LOCK_ENABLED or str(target) in _HELD_LOCKS:
+        return
+    try:
+        import atexit
+        import fcntl
+
+        fh = open(_lock_path(target), "w")
+        fcntl.flock(fh.fileno(), fcntl.LOCK_EX)
+        _HELD_LOCKS[str(target)] = fh
+        # A writer that resolves to "nothing to do" returns without publishing,
+        # so the release has a second home at process exit.
+        atexit.register(_release_lock, target)
+    except Exception:  # noqa: BLE001 — locking is best-effort, never fatal
+        # No fcntl, an unwritable temp dir, a filesystem without locking: fall
+        # back to the previous behaviour rather than refusing to record anything.
+        pass
+
+
+def _release_lock(target: Path) -> None:
+    fh = _HELD_LOCKS.pop(str(target), None)
+    if fh is None:
+        return
+    try:
+        import fcntl
+
+        fcntl.flock(fh.fileno(), fcntl.LOCK_UN)
+    except Exception:  # noqa: BLE001
+        pass
+    try:
+        fh.close()
+    except OSError:
+        pass
+
+
 def read_ctx(target: Path) -> dict:
-    """Read the existing context, tolerating absence or corruption."""
+    """Read the existing context, tolerating absence or corruption.
+
+    When this process is a writer, the read also takes the lock and holds it
+    until the matching publish, so the whole read-modify-write is one turn.
+    """
+    _acquire_lock(target)
     if target.is_file():
         try:
             ctx = json.loads(target.read_text(encoding="utf-8"))
@@ -281,6 +357,8 @@ def atomic_write(target: Path, ctx: dict) -> None:
         return
     except ImportError:
         pass
+    finally:
+        _release_lock(target)
     tmp = target.with_suffix(target.suffix + ".tmp")
     try:
         tmp.write_text(json.dumps(ctx, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
@@ -291,6 +369,8 @@ def atomic_write(target: Path, ctx: dict) -> None:
         except OSError:
             pass
         raise
+    finally:
+        _release_lock(target)
 
 
 def canonical_log(ctx: dict) -> list:

--- a/speckit-extension/scripts/spec_context.py
+++ b/speckit-extension/scripts/spec_context.py
@@ -350,26 +350,27 @@ def atomic_write(target: Path, ctx: dict) -> None:
     and no debris when the write fails.
     """
     try:
-        import companion_config as cc
-
-        cc.atomic_write_text(str(target),
-                             json.dumps(ctx, indent=2, ensure_ascii=False) + "\n")
-        return
-    except ImportError:
-        pass
-    finally:
-        _release_lock(target)
-    tmp = target.with_suffix(target.suffix + ".tmp")
-    try:
-        tmp.write_text(json.dumps(ctx, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
-        os.replace(tmp, target)
-    except OSError:
         try:
-            tmp.unlink(missing_ok=True)  # don't litter on a failed write
-        except OSError:
+            import companion_config as cc
+
+            cc.atomic_write_text(str(target),
+                                 json.dumps(ctx, indent=2, ensure_ascii=False) + "\n")
+            return
+        except ImportError:
             pass
-        raise
+        tmp = target.with_suffix(target.suffix + ".tmp")
+        try:
+            tmp.write_text(json.dumps(ctx, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+            os.replace(tmp, target)
+        except OSError:
+            try:
+                tmp.unlink(missing_ok=True)  # don't litter on a failed write
+            except OSError:
+                pass
+            raise
     finally:
+        # One release, after the publish (or its failure) on either path — an
+        # early release on the fallback path would reopen the #620 window.
         _release_lock(target)
 
 

--- a/speckit-extension/scripts/write-context.py
+++ b/speckit-extension/scripts/write-context.py
@@ -872,6 +872,15 @@ def main() -> int:
     import io
     import time
 
+    # This process mutates the record, so its read and its publish must be one
+    # turn against other writers. Readers never enable this and are never blocked.
+    try:
+        from spec_context import enable_write_lock
+
+        enable_write_lock()
+    except ImportError:
+        pass
+
     argv = list(sys.argv[1:])
     started = time.monotonic()
     out_buf, err_buf = io.StringIO(), io.StringIO()

--- a/speckit-extension/tests/test_concurrent_capture.py
+++ b/speckit-extension/tests/test_concurrent_capture.py
@@ -1,0 +1,68 @@
+"""Two writers must not silently discard each other's work (#620)."""
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+WRITER = REPO / "speckit-extension" / "scripts" / "write-context.py"
+
+
+class ConcurrentCapturesAllSurvive(unittest.TestCase):
+    def _cell(self):
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        d = Path(tmp.name)
+        (d / "specs" / "001-x").mkdir(parents=True)
+        subprocess.run(["git", "init", "-q", "."], cwd=d, check=True)
+        return d
+
+    def _ctx(self, d):
+        return json.loads((d / "specs" / "001-x" / ".spec-context.json").read_text())
+
+    def _set(self, d, pair):
+        return subprocess.run(
+            [sys.executable, str(WRITER), "--feature-dir", "specs/001-x", "--set", pair],
+            cwd=d, capture_output=True, text=True)
+
+    def test_twelve_simultaneous_writes_all_land(self):
+        # The exact repro: twelve writers issued at once left four recorded,
+        # with no warning, no failure, and a perfectly valid document.
+        d = self._cell()
+        pairs = [f"k{i}=v{i}" for i in range(1, 13)]
+        with ThreadPoolExecutor(max_workers=12) as pool:
+            list(pool.map(lambda p: self._set(d, p), pairs))
+        ctx = self._ctx(d)
+        kept = sorted(k for k in ctx if k.startswith("k"))
+        self.assertEqual(len(kept), 12, f"lost {12 - len(kept)} of 12 concurrent writes: {kept}")
+
+    def test_the_document_stays_valid_and_leaves_no_debris(self):
+        d = self._cell()
+        with ThreadPoolExecutor(max_workers=8) as pool:
+            list(pool.map(lambda p: self._set(d, p), [f"a{i}=1" for i in range(8)]))
+        self.assertIsInstance(self._ctx(d), dict)
+        self.assertEqual(list((d / "specs" / "001-x").glob("*.tmp")), [])
+
+    def test_sequential_writes_are_unaffected(self):
+        d = self._cell()
+        for i in range(1, 6):
+            self._set(d, f"zz{i}=v{i}")
+        self.assertEqual(len([k for k in self._ctx(d) if k.startswith("zz")]), 5)
+
+    def test_a_lock_file_is_not_left_holding_the_record_hostage(self):
+        # A second run must not block on a stale lock from a finished process.
+        d = self._cell()
+        self._set(d, "first=1")
+        r = self._set(d, "second=2")
+        self.assertEqual(r.returncode, 0)
+        ctx = self._ctx(d)
+        # --set coerces a numeric value, so compare against the coerced form.
+        self.assertEqual(ctx.get("first"), 1)
+        self.assertEqual(ctx.get("second"), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Follow-up to #626. The lock release sat in a `finally` attached to the **first** `try` block, so on the `ImportError` fallback path it ran before the fallback's write and rename — leaving that publish unlocked, which is precisely the window #620 exists to close.

```python
try:
    import companion_config as cc
    ...
    return
except ImportError:
    pass
finally:
    _release_lock(target)     # ← released here
tmp.write_text(...)           # ← ...then publishes unlocked
os.replace(tmp, target)
```

Now one release, after the publish or its failure, on whichever path ran.

## Honesty about the evidence

**I could not demonstrate a lost write from this.** It needs `companion_config` to be unimportable, and even then the exposed span is only the final publish rather than the whole read-modify-write, so a 12-way race forced down the fallback path kept 12 of 12 both with and without the fix.

So this is **correct by construction, not by measurement** — I would rather say that plainly than present a narrow structural fix as a proven one.

## Verification

- 758 spec-kit extension tests green.
- A 12-writer race forced down the fallback path (a stub `companion_config` that raises `ImportError`) keeps 12 of 12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)