### PR TITLE
fix(speckit-ext): implement runs the checks, and a guard doing its job is not a failure

### DIFF
--- a/speckit-extension/CHANGELOG.md
+++ b/speckit-extension/CHANGELOG.md
@@ -9,6 +9,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/); this ext
 ## [Unreleased]
 
 
+
+- The implement step now runs the project's own tests and build before calling the work done, and a spec is not marked complete over a failing suite the run introduced. It used to satisfy "validate against the spec" by reading the code — so a run could write tests, never execute them, and finish looking green. Where the checks genuinely cannot be run, that is recorded as a concern rather than written up as a verification that happened.
 ### Fixed
 
 - The health check's drift audit decides more carefully whether a run claimed its living specs were in sync. It reads the check's name and its outcome as separate things instead of searching the whole entry, so an unrelated note can no longer supply the verdict, and it understands negation — "no drift found" reads as clean, "not in sync" does not. It deliberately stays quiet on a bare "clean", because nothing distinguishes a clean project from a clean note about tooling, and wrongly accusing a run of dishonesty costs more than missing one.

--- a/speckit-extension/commands/speckit.companion.implement.md
+++ b/speckit-extension/commands/speckit.companion.implement.md
@@ -91,7 +91,14 @@ Execute `tasks.md` phase by phase in dependency order. Each phase is laid out as
 
 4. **After each wave, reconcile, then cross the join line.** Type-check/build the wave's files together and fix any seam drift, then run `--materialize` once more as a backstop — it is idempotent, so re-folding never double-counts, and it catches any finish whose fold was missed. `tasks.md` is owned only through `--materialize` (the script flips the boxes), so it never diverges from the journal. Now move past the `⟶ Wait` line to the next wave.
 
-5. On completion, validate the result against the spec's **Functional Requirements** and **Success Criteria**, and report a short summary of what was built and anything left undone.
+5. **Run the project's own checks before you call this done.** Validating against the spec's **Functional Requirements** and **Success Criteria** by reading is not validation — a test you wrote and never executed is a guess about your own code. Run the suite and the type-check/build the project actually uses (read them from its `package.json` scripts, `Makefile`, or the repo's own instructions; do not invent a command).
+
+   - **A test you authored that fails is your task, not a follow-up.** Fix it now. Shipping a red suite is a defect the run introduced, and it is the single most common way a finished-looking run is not finished.
+   - **A pre-existing test your change invalidated is also yours.** Renaming what a component shows breaks the test asserting the old text; updating it is part of the change, not scope creep.
+   - **A test file that does not compile counts as failing.** Check the suite actually ran, not merely that the command exited.
+   - **If you genuinely cannot run them** — no test script exists, or the environment forbids it — say so explicitly in the summary and record it as a concern below. Do not describe a read-through as though it were a run.
+
+   Then report a short summary of what was built and anything left undone.
 
 6. **Capture what was verified and decided** — the audit trail a resume/handoff needs, recorded the moment validation ends (best-effort; JSON when you can, bare text when not; skip silently if `python3` is unavailable):
    ```bash
@@ -102,10 +109,14 @@ Execute `tasks.md` phase by phase in dependency order. Each phase is laid out as
    python3 .specify/extensions/companion/scripts/write-context.py --feature-dir <feature_directory> --step implement --step-summary '{"summary": "<what shipped in one line>"}'
    python3 .specify/extensions/companion/scripts/write-context.py --feature-dir <feature_directory> --set last_action="<final breadcrumb, e.g. 'all tasks done — 18/18 tests pass'>"
    ```
+   The `--verified` entries are where "did it actually run" is settled, so record the command you ran and its real outcome — `"result": "142/142 pass"` — never a restatement of intent. If a check could not be run, record that as a `--concern` naming what was skipped and why, and do **not** record a `--verified` for it: a verification entry for a check that never happened is worse than no entry, because every later reader trusts it.
+
    One `--verified` per real check (tests, build, manual pass — include warnings you saw and judged benign), one `--coverage-req … --tests …` per requirement a test covers, one `--decision` per genuine implementation choice. Record `--concern` only for real friction — on a clean run record none (the empty list is itself the signal). All additive and de-duped; re-runs never duplicate.
 
 **Output**: working changes per `tasks.md`, with completed tasks checked off.
-7. **Mark the spec complete.** Once every task in `tasks.md` is checked off and the work validates, finish the lifecycle so the spec lands at `completed` instead of stopping at `implemented`. Run from the repository root (the feature directory resolves on its own):
+7. **Mark the spec complete.** Once every task in `tasks.md` is checked off and the work validates, finish the lifecycle so the spec lands at `completed` instead of stopping at `implemented`.
+
+   **"Validates" means the project's own checks ran and passed.** A spec MUST NOT be marked complete over a failing suite the run introduced — fix it, or leave the spec at `implemented` and say why. Completing on red is how a run that looks finished ships broken code, and the completed status is the one signal a reader trusts without opening anything. Where the checks genuinely could not be run, record that as a concern before completing, so the state says "finished, unverified" rather than implying "finished, verified". Run from the repository root (the feature directory resolves on its own):
    ```bash
    python3 .specify/extensions/companion/scripts/write-context.py --mark-complete --by ai
    ```

--- a/speckit-extension/nodes/implement/complete.md
+++ b/speckit-extension/nodes/implement/complete.md
@@ -4,7 +4,9 @@ kind: control
 command: implement
 reads: []
 ---
-7. **Mark the spec complete.** Once every task in `tasks.md` is checked off and the work validates, finish the lifecycle so the spec lands at `completed` instead of stopping at `implemented`. Run from the repository root (the feature directory resolves on its own):
+7. **Mark the spec complete.** Once every task in `tasks.md` is checked off and the work validates, finish the lifecycle so the spec lands at `completed` instead of stopping at `implemented`.
+
+   **"Validates" means the project's own checks ran and passed.** A spec MUST NOT be marked complete over a failing suite the run introduced — fix it, or leave the spec at `implemented` and say why. Completing on red is how a run that looks finished ships broken code, and the completed status is the one signal a reader trusts without opening anything. Where the checks genuinely could not be run, record that as a concern before completing, so the state says "finished, unverified" rather than implying "finished, verified". Run from the repository root (the feature directory resolves on its own):
    ```bash
    python3 .specify/extensions/companion/scripts/write-context.py --mark-complete --by ai
    ```

--- a/speckit-extension/nodes/implement/implement-exec.md
+++ b/speckit-extension/nodes/implement/implement-exec.md
@@ -22,7 +22,14 @@ reads: []
 
 4. **After each wave, reconcile, then cross the join line.** Type-check/build the wave's files together and fix any seam drift, then run `--materialize` once more as a backstop — it is idempotent, so re-folding never double-counts, and it catches any finish whose fold was missed. `tasks.md` is owned only through `--materialize` (the script flips the boxes), so it never diverges from the journal. Now move past the `⟶ Wait` line to the next wave.
 
-5. On completion, validate the result against the spec's **Functional Requirements** and **Success Criteria**, and report a short summary of what was built and anything left undone.
+5. **Run the project's own checks before you call this done.** Validating against the spec's **Functional Requirements** and **Success Criteria** by reading is not validation — a test you wrote and never executed is a guess about your own code. Run the suite and the type-check/build the project actually uses (read them from its `package.json` scripts, `Makefile`, or the repo's own instructions; do not invent a command).
+
+   - **A test you authored that fails is your task, not a follow-up.** Fix it now. Shipping a red suite is a defect the run introduced, and it is the single most common way a finished-looking run is not finished.
+   - **A pre-existing test your change invalidated is also yours.** Renaming what a component shows breaks the test asserting the old text; updating it is part of the change, not scope creep.
+   - **A test file that does not compile counts as failing.** Check the suite actually ran, not merely that the command exited.
+   - **If you genuinely cannot run them** — no test script exists, or the environment forbids it — say so explicitly in the summary and record it as a concern below. Do not describe a read-through as though it were a run.
+
+   Then report a short summary of what was built and anything left undone.
 
 6. **Capture what was verified and decided** — the audit trail a resume/handoff needs, recorded the moment validation ends (best-effort; JSON when you can, bare text when not; skip silently if `python3` is unavailable):
    ```bash
@@ -33,6 +40,8 @@ reads: []
    python3 .specify/extensions/companion/scripts/write-context.py --feature-dir <feature_directory> --step implement --step-summary '{"summary": "<what shipped in one line>"}'
    python3 .specify/extensions/companion/scripts/write-context.py --feature-dir <feature_directory> --set last_action="<final breadcrumb, e.g. 'all tasks done — 18/18 tests pass'>"
    ```
+   The `--verified` entries are where "did it actually run" is settled, so record the command you ran and its real outcome — `"result": "142/142 pass"` — never a restatement of intent. If a check could not be run, record that as a `--concern` naming what was skipped and why, and do **not** record a `--verified` for it: a verification entry for a check that never happened is worse than no entry, because every later reader trusts it.
+
    One `--verified` per real check (tests, build, manual pass — include warnings you saw and judged benign), one `--coverage-req … --tests …` per requirement a test covers, one `--decision` per genuine implementation choice. Record `--concern` only for real friction — on a clean run record none (the empty list is itself the signal). All additive and de-duped; re-runs never duplicate.
 
 **Output**: working changes per `tasks.md`, with completed tasks checked off.

--- a/speckit-extension/scripts/doctor_checks.py
+++ b/speckit-extension/scripts/doctor_checks.py
@@ -477,6 +477,21 @@ def _lost_entries(feature_dir: Path) -> list:
     return out
 
 
+#: A write that did not land because a guard correctly refused it. The commonest
+#: is a late hook trying to re-close a spec that mark-complete already finished —
+#: the system defending itself, not failing. Reporting those as problems put a
+#: false alarm in every single run, which is how a report stops being read.
+_EXPECTED_DECLINE = re.compile(
+    r"not regressing|already at currentStep|already (complete|completed)|"
+    r"left untouched|nothing to (do|sync)",
+    re.I,
+)
+
+
+def _is_expected_decline(event: dict) -> bool:
+    return bool(_EXPECTED_DECLINE.search(str(event.get("reason") or "")))
+
+
 def check_trace(feature_dir: Path, ctx: dict | None = None) -> tuple:
     """What the self-trace recorded: failures with reasons, volumes, churn.
 
@@ -500,7 +515,18 @@ def check_trace(feature_dir: Path, ctx: dict | None = None) -> tuple:
         ), []
 
     findings = []
-    failures = read.failures()
+    all_failures = read.failures()
+    declined = [e for e in all_failures if _is_expected_decline(e)]
+    failures = [e for e in all_failures if not _is_expected_decline(e)]
+    if declined:
+        findings.append(Finding(
+            "trace", "note",
+            f"{plural(len(declined), 'write')} correctly refused by a guard",
+            "a guard declined these rather than letting them land — most often a late hook "
+            "trying to re-close a spec that was already finished. Recorded so the count is "
+            "complete, not because anything went wrong: " + str(declined[0].get("reason"))[:160],
+            {"count": len(declined)},
+        ))
     if failures:
         by_reason: dict = {}
         for e in failures:

--- a/speckit-extension/tests/golden/commands/commands__speckit.companion.implement.md
+++ b/speckit-extension/tests/golden/commands/commands__speckit.companion.implement.md
@@ -91,7 +91,14 @@ Execute `tasks.md` phase by phase in dependency order. Each phase is laid out as
 
 4. **After each wave, reconcile, then cross the join line.** Type-check/build the wave's files together and fix any seam drift, then run `--materialize` once more as a backstop — it is idempotent, so re-folding never double-counts, and it catches any finish whose fold was missed. `tasks.md` is owned only through `--materialize` (the script flips the boxes), so it never diverges from the journal. Now move past the `⟶ Wait` line to the next wave.
 
-5. On completion, validate the result against the spec's **Functional Requirements** and **Success Criteria**, and report a short summary of what was built and anything left undone.
+5. **Run the project's own checks before you call this done.** Validating against the spec's **Functional Requirements** and **Success Criteria** by reading is not validation — a test you wrote and never executed is a guess about your own code. Run the suite and the type-check/build the project actually uses (read them from its `package.json` scripts, `Makefile`, or the repo's own instructions; do not invent a command).
+
+   - **A test you authored that fails is your task, not a follow-up.** Fix it now. Shipping a red suite is a defect the run introduced, and it is the single most common way a finished-looking run is not finished.
+   - **A pre-existing test your change invalidated is also yours.** Renaming what a component shows breaks the test asserting the old text; updating it is part of the change, not scope creep.
+   - **A test file that does not compile counts as failing.** Check the suite actually ran, not merely that the command exited.
+   - **If you genuinely cannot run them** — no test script exists, or the environment forbids it — say so explicitly in the summary and record it as a concern below. Do not describe a read-through as though it were a run.
+
+   Then report a short summary of what was built and anything left undone.
 
 6. **Capture what was verified and decided** — the audit trail a resume/handoff needs, recorded the moment validation ends (best-effort; JSON when you can, bare text when not; skip silently if `python3` is unavailable):
    ```bash
@@ -102,10 +109,14 @@ Execute `tasks.md` phase by phase in dependency order. Each phase is laid out as
    python3 .specify/extensions/companion/scripts/write-context.py --feature-dir <feature_directory> --step implement --step-summary '{"summary": "<what shipped in one line>"}'
    python3 .specify/extensions/companion/scripts/write-context.py --feature-dir <feature_directory> --set last_action="<final breadcrumb, e.g. 'all tasks done — 18/18 tests pass'>"
    ```
+   The `--verified` entries are where "did it actually run" is settled, so record the command you ran and its real outcome — `"result": "142/142 pass"` — never a restatement of intent. If a check could not be run, record that as a `--concern` naming what was skipped and why, and do **not** record a `--verified` for it: a verification entry for a check that never happened is worse than no entry, because every later reader trusts it.
+
    One `--verified` per real check (tests, build, manual pass — include warnings you saw and judged benign), one `--coverage-req … --tests …` per requirement a test covers, one `--decision` per genuine implementation choice. Record `--concern` only for real friction — on a clean run record none (the empty list is itself the signal). All additive and de-duped; re-runs never duplicate.
 
 **Output**: working changes per `tasks.md`, with completed tasks checked off.
-7. **Mark the spec complete.** Once every task in `tasks.md` is checked off and the work validates, finish the lifecycle so the spec lands at `completed` instead of stopping at `implemented`. Run from the repository root (the feature directory resolves on its own):
+7. **Mark the spec complete.** Once every task in `tasks.md` is checked off and the work validates, finish the lifecycle so the spec lands at `completed` instead of stopping at `implemented`.
+
+   **"Validates" means the project's own checks ran and passed.** A spec MUST NOT be marked complete over a failing suite the run introduced — fix it, or leave the spec at `implemented` and say why. Completing on red is how a run that looks finished ships broken code, and the completed status is the one signal a reader trusts without opening anything. Where the checks genuinely could not be run, record that as a concern before completing, so the state says "finished, unverified" rather than implying "finished, verified". Run from the repository root (the feature directory resolves on its own):
    ```bash
    python3 .specify/extensions/companion/scripts/write-context.py --mark-complete --by ai
    ```

--- a/speckit-extension/tests/test_queue_batch.py
+++ b/speckit-extension/tests/test_queue_batch.py
@@ -192,3 +192,48 @@ class AWriteWithNoTraceEntryIsVisible(unittest.TestCase):
              str(d / "specs" / "001-x")], capture_output=True, text=True).stdout
         self.assertIn("could not be recorded", out)
         self.assertIn("lower bound", out)
+
+
+class ImplementVerifiesItsOwnWork(unittest.TestCase):
+    """Three of six bench cells shipped a failing suite; stock shipped none.
+
+    The pipeline wrote tests and never ran them, and 'validate against the spec'
+    was satisfied by reading. These pin the instruction that closes that gap.
+    """
+
+    BODY = COMMANDS / "speckit.companion.implement.md"
+
+    def setUp(self):
+        self.text = self.BODY.read_text()
+
+    def test_the_step_requires_running_the_projects_checks(self):
+        self.assertIn("Run the project's own checks before you call this done", self.text)
+        self.assertIn("a test you wrote and never executed is a guess about your own code", self.text)
+        self.assertIn("do not invent a command", self.text)
+
+    def test_a_failing_test_it_authored_is_its_own_task(self):
+        self.assertIn("is your task, not a follow-up", self.text)
+
+    def test_a_test_invalidated_by_the_change_counts_too(self):
+        self.assertIn("pre-existing test your change invalidated is also yours", self.text)
+
+    def test_a_file_that_does_not_compile_counts_as_failing(self):
+        self.assertIn("does not compile counts as failing", self.text)
+
+    def test_an_unrunnable_check_is_declared_not_implied(self):
+        self.assertIn("Do not describe a read-through as though it were a run", self.text)
+        self.assertIn("do **not** record a `--verified` for it", self.text)
+
+    def test_completion_is_gated_on_the_checks_having_passed(self):
+        self.assertIn("MUST NOT be marked complete over a failing suite", self.text)
+        self.assertIn("finished, unverified", self.text)
+
+    def test_the_cost_is_bounded(self):
+        # The counter exists so this is measured rather than argued (#614).
+        import json
+        out = subprocess.run(
+            [sys.executable, str(SCRIPTS / "instruction-budget.py"), "--json"],
+            capture_output=True, text=True).stdout
+        impl = next(c for c in json.loads(out)["commands"]
+                    if c["command"] == "speckit.companion.implement.md")
+        self.assertLess(impl["total"], 60, "the verification rules must not blow the budget")


### PR DESCRIPTION
## Summary

Two fixes that came straight out of the final bench round. Both are about the same thing: a run that looks finished when it is not.

Refs #622.

## 1 · Implement runs the project's checks instead of reading the code

**Three of six bench cells shipped a failing test suite. Stock spec-kit shipped none in the same six.** One of the three did not even compile — a test file containing JSX named `.ts`.

The cause was the step's own wording. It said to validate against the spec's requirements and success criteria, and that was satisfied by *reading*. So the pipeline wrote tests, never ran them, and finished looking green.

Now:
- run the suite and build the project actually uses, read from its own scripts rather than invented
- a test the run authored that fails is **the run's task, not a follow-up**
- a pre-existing test the change invalidated is equally the run's
- a file that does not compile counts as failing — check the suite *ran*, not that the command exited
- where the checks genuinely cannot run, say so as a concern and **do not record a verification for a check that never happened** — a verified entry for work that did not occur is worse than none, because later readers trust it

Completion is gated to match: a spec is not marked complete over a red suite the run introduced, so "completed" stops implying "verified".

**Cost, measured rather than guessed** (using the counter from #614): implement goes from 46 to 51 directives.

## 2 · A guard doing its job is not a failure

Every companion cell in the final round reported the same problem — one failed capture call. The reason, in all three:

```
already at currentStep=implement / status=completed; not regressing to implement/implemented
```

That is the guard refusing to drag a spec that mark-complete already finished back to `implemented` — the system defending itself exactly as designed. A false alarm in three runs out of three is how a report stops being read.

A write declined by a guard is now a **note** that says so and keeps the count complete. Only genuine failures stay problems.

## Verification

785 spec-kit extension tests, all six gates. New tests pin each of the verification rules and assert the directive cost stays bounded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)