### PR TITLE
fix(speckit-ext): release the capture lock after the publish, not before

### DIFF
--- a/speckit-extension/scripts/spec_context.py
+++ b/speckit-extension/scripts/spec_context.py
@@ -429,26 +429,28 @@ def atomic_write(target: Path, ctx: dict) -> None:
     """
     _guard_append_only(target, ctx)
     try:
-        import companion_config as cc
-
-        cc.atomic_write_text(str(target),
-                             json.dumps(ctx, indent=2, ensure_ascii=False) + "\n")
-        return
-    except ImportError:
-        pass
-    finally:
-        _release_lock(target)
-    tmp = target.with_suffix(target.suffix + ".tmp")
-    try:
-        tmp.write_text(json.dumps(ctx, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
-        os.replace(tmp, target)
-    except OSError:
         try:
-            tmp.unlink(missing_ok=True)  # don't litter on a failed write
-        except OSError:
+            import companion_config as cc
+
+            cc.atomic_write_text(str(target),
+                                 json.dumps(ctx, indent=2, ensure_ascii=False) + "\n")
+            return
+        except ImportError:
             pass
-        raise
+        tmp = target.with_suffix(target.suffix + ".tmp")
+        try:
+            tmp.write_text(json.dumps(ctx, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+            os.replace(tmp, target)
+        except OSError:
+            try:
+                tmp.unlink(missing_ok=True)  # don't litter on a failed write
+            except OSError:
+                pass
+            raise
     finally:
+        # One release, after the publish or its failure, on whichever path ran.
+        # Releasing in a finally attached to the first try let the fallback path
+        # publish unlocked, which is the window the lock exists to close.
         _release_lock(target)
 
 


### PR DESCRIPTION
## Summary

**Supersedes #627**, which no longer merges cleanly since `atomic_write` gained the append-only guard. Same one-line-shaped fix, reapplied on current `main`.

The lock release sat in a `finally` attached to the **first** `try` block, so on the `ImportError` fallback path it ran before that path's write and rename — leaving the publish unlocked, which is precisely the window the lock exists to close.

```python
try:
    import companion_config as cc
    ...
    return
except ImportError:
    pass
finally:
    _release_lock(target)     # ← released here
tmp.write_text(...)           # ← ...then publishes unlocked
```

Now one release, after the publish or its failure, on whichever path ran.

## Honesty about the evidence

**I could not demonstrate a lost write from this.** It needs `companion_config` to be unimportable, and even then the exposed span is only the final publish rather than the whole read-modify-write — a 12-way race forced down the fallback path keeps 12 of 12 both with and without the fix.

Correct by construction, not by measurement. Saying so rather than presenting a narrow structural fix as a proven one.

## Verification

785 spec-kit extension tests, all six gates. A 12-writer race forced down the fallback path (a stub `companion_config` raising `ImportError`) keeps 12 of 12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)