### PR TITLE
chore: ignore the tooling each assistant writes into the repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,15 @@ webview/src/pipeline-builder/__screenshots__/diff/
 # loosening the rules that keep those fixtures tracked.
 .agents/skills/higgsfield-*/
 .claude/skills/higgsfield-*
+skills-lock.json
+
+# Hook wiring each assistant writes into the repo when a skill installs its
+# hooks. Same class as the skills above: tooling for whoever is working here,
+# and every one of them is rewritten on the next install.
+.codex/hooks.json
+.cursor/hooks.json
+.github/hooks/
+
+# Mascot explorations, named by timestamp. The poses that survive are picked
+# by hand into assets/mascot/poses/, which stays tracked.
+assets/mascot/explore/


### PR DESCRIPTION
Four kinds of untracked file kept appearing in Source Control, none of them part of either shipped extension.

- `skills-lock.json` — the lockfile for skills installed by `npx skills add`. The skill bodies are already ignored; the lockfile was not.
- `.codex/hooks.json`, `.cursor/hooks.json`, `.github/hooks/` — hook wiring each assistant writes when a skill installs its hooks, rewritten on every install.
- `assets/mascot/explore/` — explorations named by timestamp. The poses that survive are picked by hand into `assets/mascot/poses/`, which stays tracked.

Ignored by name rather than by loosening the rules that keep `.agents/` and `.claude/` tracked, since those are the committed manual-testing fixtures.

Verified no tracked file is caught by the new rules.

Also deleted locally, not part of this diff: `media/feature-clips/_test-explainer/`, a scratch composition with four bundled fonts.