### PR TITLE
docs(docs): fix the documentation site against main per the docs review

### DIFF
--- a/website/src/content/docs/docs/anatomy/anatomy-of-the-overview.mdx
+++ b/website/src/content/docs/docs/anatomy/anatomy-of-the-overview.mdx
@@ -8,7 +8,7 @@ sidebar:
 
 import MediaSlot from '../../../../components/docs/MediaSlot.astro';
 
-The Overview is one of two views inside the spec viewer. Three things have to be true for it to appear: the spec is a regular feature spec rather than a living spec, its run record has something in it, and you haven't turned the view off with `speckit.viewer.activityPanel`, which ships on.
+By the end of this page you'll know what each region of the Overview is reading from, and which regions a thin page is missing. The Overview is one of two views inside the spec viewer. Three things have to be true for it to appear: the spec is a regular feature spec rather than a living spec, its run record has something in it, and you haven't turned the view off with `speckit.viewer.activityPanel`, which ships on.
 
 It's a reading surface, not a control panel. Nothing on it runs, re-runs, or re-checks the work. It's what your run wrote down, laid out in the order a future session needs it.
 
@@ -17,7 +17,7 @@ Read the whole page once before reading any region closely, because the shape te
 <MediaSlot
   feature="overview"
   still="overview-annotated.png"
-  caption="Every region on this page came out of one file next to the spec. That's the trade the Overview makes: it shows nothing it can't attribute, which is why a thin page is information rather than a bug."
+  caption="Every region on this page came out of one file next to the spec. A region with nothing recorded in it doesn't render, so a thin page means a thin record."
 />
 
 A page with two regions on it isn't a broken Overview. It's a run that recorded two regions.
@@ -26,8 +26,7 @@ A page with two regions on it isn't a broken Overview. It's a run that recorded 
 
 | Region | What it carries |
 | --- | --- |
-| Intent | The run's stated intent, its approach, the area it worked in, how the change was sized |
-| Run timing | One entry per phase, each with an elapsed time or nothing |
+| Intent | The run's stated intent, its approach, the area it worked in, how the change was sized, and a Run overview strip with one entry per phase |
 | Expectations | Constraints on one side, declared non-goals on the other |
 | Verified | Each check, the command the assistant reported running, the outcome it reported |
 | Decisions | The choice, why, and what was rejected |
@@ -36,7 +35,7 @@ A page with two regions on it isn't a broken Overview. It's a run that recorded 
 
 A region with nothing recorded in it doesn't render at all. A spec that recorded nothing shows a single line, "No activity recorded yet", rather than an empty frame.
 
-If the Companion Spec Kit extension isn't installed, a banner sits above everything else offering to install it, with a dismiss control. That banner is the reason a page might be thin: without the second half, most of what the Overview reads never gets written.
+If the Companion Spec Kit extension isn't installed, a banner sits above everything else offering to install it, with a dismiss control. Dismiss it once and it stays gone; setting `speckit.companion.installPrompt` to `false` suppresses it too. That banner is the reason a page might be thin: without the second half, most of what the Overview reads never gets written.
 
 ## Every section head carries a count
 
@@ -50,19 +49,19 @@ Skim the counts first. They tell you which region deserves the close read.
 
 This is the only region that answers "why does this spec exist?". Everything under it is evidence for the sentence at the top.
 
-Alongside the intent sit the approach, the working area, and a sizing line reading something like `Sized simple: 6 files, 8 tasks projected`. If the run loaded any living specs before drafting, they're listed here too, as links into the capability specs it read.
+Alongside the intent sit the approach, the working area, and a sizing line reading something like `Sized simple: 6 files, 8 tasks projected`. If the run loaded any living specs before drafting (a living spec is the durable spec for one capability of the codebase, kept next to the code), they're listed here too, as links into the capability specs it read.
 
 Read it first, then read down. If the intent doesn't match what you expected to find, stop there rather than auditing the coverage table of a run that was aiming somewhere else.
 
-## Run timing
+## Run overview
 
-A strip of phases sits under the intent, one entry each, with a summary at its head.
+A strip of phases sits inside the Intent region, under the intent sentence, one entry each, with the kicker "Run overview" and a summary at its head.
 
-A phase shows an elapsed time only when both ends of its span were recorded. Otherwise the phase is listed with no number, and the head reads "Timing coverage: N of M phases" instead of a total. The run only reports "X elapsed" when specify, plan, tasks and implement all measured cleanly and in order.
+A phase shows an elapsed time only when both ends of its span were recorded. Otherwise the phase is listed with no number, and the head reads "Timing coverage: N of M phases" instead of a total. When nothing was measured at all it reads "Timing not recorded". The run only reports "X elapsed" when specify, plan, tasks and implement all measured cleanly and in order.
 
 A blank duration isn't a bug or a zero. It's the page declining to guess at a span it can't stand behind.
 
-Two other markings show up here. A phase can read "folded into Plan", meaning the run collapsed it into an earlier phase rather than running it separately, so there's no span to report. And a phase still running has no end yet, so the viewer re-reads the record on every write and the running phase carries a timer that ticks each second.
+Two other markings show up here. A phase can read "folded into Plan", meaning the run collapsed it into an earlier phase rather than running it separately, so there's no span to report. And a phase still running has no end yet, so it's marked in flight with no duration; the viewer re-reads the record on every write, and the elapsed timer for a running step lives on the rail tab, not here.
 
 Where the timestamps come from decides how far to trust them. Step boundaries and per-task finishes are written by a script the command runs. The clarify and analyze closes, and the plan and tasks substep boundaries, are reported by the assistant at second precision. Both are recorded honestly; only the first is measured.
 
@@ -90,14 +89,16 @@ The last region is a table, and it's the one that most often carries bad news. R
 
 <MediaSlot
   feature="coverage"
-  caption="Untraced requirements sort to the top, so the table opens on its own gaps. A coverage section you have to scroll to find the problem in isn't reporting, it's filing."
+  caption="Untraced requirements sort to the top, so the first rows are the gaps rather than the rows that are fine."
 />
 
 Coverage is built up across three steps of the run: the requirement comes out of the spec, the tasks that delivered it out of implement, the tests out of what the run recorded.
 
-Each row lands in one of three states, not two. It has tests, it has none, or it names tests that aren't on disk. That third state used to render exactly like a real one, which is worse than no test at all, because it reads as coverage that exists. A row whose named file isn't there now reads "N tests not found".
+Each row lands in one of three states, not two. It has tests, it has none, or it names tests that aren't on disk. That third state used to render exactly like a real one, which is worse than no test at all, because it reads as coverage that exists. The evidence label takes one of four forms: "N tests", "No test linked", "N tests not found" when every named file is missing, or "K of N found" when only some are.
 
 That check is existence only. Nothing runs the test, and nothing checks it passes.
+
+The table shows six rows and folds the rest behind "Show all N requirements". Because untraced rows sort first, the six you see are the ones most likely to need attention.
 
 When requirements were recorded but none of them is traced, the table still renders and says so rather than hiding. Zero traced requirements is the most useful thing this page can tell you, and hiding it while the count two inches above still reads `0/7 traced` would report the problem and conceal the explanation at the same time.
 

--- a/website/src/content/docs/docs/anatomy/anatomy-of-the-spec-viewer.mdx
+++ b/website/src/content/docs/docs/anatomy/anatomy-of-the-spec-viewer.mdx
@@ -8,11 +8,11 @@ sidebar:
 
 import MediaSlot from '../../../../components/docs/MediaSlot.astro';
 
-The spec viewer opens your spec markdown as a page instead of a file. Same bytes on disk, rendered against the structure Spec Kit already writes into them.
+By the end of this page you'll be able to name every part of the spec viewer and say what each one is reading from. The viewer opens your spec markdown as a page instead of a file. Same bytes on disk, rendered against the structure Spec Kit already writes into them.
 
 <MediaSlot
   feature="spec-viewer"
-  caption="Nothing here is a second copy of your spec. Everything the page adds is a reading of markdown that was already on disk, which is why editing the file in a text editor still works."
+  caption="Everything the page adds is a reading of markdown already on disk, which is why editing the file in a text editor still works."
 />
 
 ## The header
@@ -21,7 +21,13 @@ The header leads with the spec's recorded name, then a status badge, the branch,
 
 Two statuses get a friendlier visible label than the value stored on disk: `tasking` reads as **Creating Tasks**, and `ready-to-implement` reads as **Tasks Created**. The stored values are unchanged, so a tool reading the file sees the canonical keys.
 
-A living spec's header carries different facts, because a capability isn't a run: requirement and scenario counts, the globs the capability claims, where its spec lives, and an `N/M covered` count. That count appears only when the capability has a coverage file beside its spec. No file means no number, which reads the same as zero coverage without being it. [Living specs](/docs/guides/living-specs) covers what those files are.
+Under the title sits a run strip: a row of facts the badge and the rail don't already say. It shows tasks done out of total, requirements traced, concerns, checks, elapsed time (or `Timing N/M phases` while the record is partial), and a link to the pull request when one was recorded. Facts drop off from the least important end as the window narrows, and the strip doesn't render at all when there's nothing to say.
+
+A living spec's header carries different facts, because a capability isn't a run: requirement and scenario counts, the globs the capability claims, where its spec lives, and an `N/M covered` count. That count appears only when the capability has a coverage file beside its spec. No file means no number, which reads the same as zero coverage without being it. When source files matching the capability changed since its spec was last committed, the header adds a drift chip and an **Update** button that asks your assistant to bring the spec back in line with the code. [Living specs](/docs/guides/living-specs) covers what those files are.
+
+## The outline
+
+On the right of the page, an "On this page" outline lists the document's headings and tracks the one you're reading. It shows second-level headings by default; a **Subsections** toggle adds the third level, and the choice holds across document switches for that viewer session. When the page gets too narrow for a side column the outline folds into a disclosure above the document with the same links.
 
 ## The pipeline rail
 
@@ -29,7 +35,7 @@ The rail lists the documents of whichever workflow the spec recorded when it was
 
 <MediaSlot
   feature="workflow-documents"
-  caption="The rail is built from the workflow the spec recorded, not from a fixed list. That's what lets a custom workflow show its own documents under its own names."
+  caption="The built-in Plan step with its Research and Data Model sub-documents nested under it. The rail is built from the workflow the spec recorded, so a custom workflow lists its own documents the same way."
 />
 
 **Steps that produce a document get an entry. Steps that only do something don't.** Implement, Mark Complete, and any custom step marked action-only never appear in the rail, because there'd be nothing to open. Their actions live in the footer instead. This is the single most common "where did my step go" question, and the answer is that it was never a document.
@@ -46,42 +52,42 @@ The rail lists the documents of whichever workflow the spec recorded when it was
 | Current | The document you're looking at right now. |
 | Done | Its document exists, or the run recorded the step complete and the document is there to back that up. A check mark sits in the badge. |
 | In flight | The step is running. A spinning glyph replaces the check mark, and a timer counts the step's elapsed time. |
-| Locked | Disabled, under one narrow condition only. |
+| Locked | Disabled while a step ahead of it is running. |
 
 Current means the tab you're reading, which is not necessarily the step the run is on. Open an earlier document while implement is running and that document is Current; the header badge and the footer keep reporting the spec's real state. Clicking a tab never rewrites where the run thinks it is.
 
-Locked is the one worth being exact about. A tab is disabled only when three things are true at once: a step is currently running, the tab sits after that step in the rail, and its own document doesn't exist yet. That's the entire rule.
+Locked is the one worth being exact about. A tab is disabled only when four things are true at once: a step is currently running, the tab sits after that step in the rail, it isn't the tab you're already viewing, and its own document doesn't exist yet. That's the entire rule.
 
-The rail does not enforce sequential approval. Any step whose document exists stays freely clickable, including steps you already went past and steps ahead of where the run stopped.
+Separately from locking, a tab whose document isn't on disk can't be clicked, because there's nothing to open. The first tab is the exception, so a brand-new spec always has somewhere to land. The rail does not enforce sequential approval: any step whose document exists stays freely clickable, including steps you already went past and steps ahead of where the run stopped.
 
-### Implement counts itself
+### The implement percentage
 
-During implement, a step tab carries a live percentage next to the spinning glyph, counted straight from the checked boxes in `tasks.md`. So it advances as the work lands, rather than waiting for a hook to report in. Because implement produces no document of its own, the percentage renders on the last document tab, which is Tasks in both built-in workflows.
+During implement, a step tab carries a live percentage next to the spinning glyph, counted straight from the checked boxes in `tasks.md`. So it advances as the work lands, rather than waiting for a hook to report in. The percentage renders on the implement entry when the workflow gives implement a rail entry of its own. When it doesn't, which is the case for both built-in workflows because implement produces no document, it renders on the last document tab, which is Tasks.
 
 The same file watcher closes the step: when every task in `tasks.md` is checked and implement is underway, the extension records the close itself, without a hook firing or a terminal reporting back.
 
 <MediaSlot
   feature="step-rail"
-  caption="Every step that has produced its document carries a check. The one you are reading is highlighted, which is how the rail answers where am I without you counting."
+  caption="Every step that has produced its document carries a check, and the one you are reading is highlighted."
 />
 
-### When a document trails what it came from
+### The stale banner
 
 A document generated before the document above it changed gets a banner over it, saying it may be stale and naming why, with a **Regenerate** action in the banner. It's a warning, not a lock. The document stays readable and every other action stays available.
 
-### When the run record can't be read at all
+### The reset prompt for a broken run record
 
-A run record that's syntactically broken, from a truncated write, a hand edit, or merge-conflict markers, can't be parsed, so the viewer falls back to a plain read-only render of the spec and raises a notification naming the parse error and the file. That notification offers **Reset context**, which moves the broken file aside to a timestamped backup and writes a fresh skeleton in its place. The original bytes are never overwritten, so lifecycle history can be salvaged by hand. Dismissing the notification leaves the file untouched and reopening the spec offers the reset again.
+A run record that's syntactically broken, from a truncated write, a hand edit, or merge-conflict markers, can't be parsed, so the viewer falls back to a plain read-only render of the spec and raises a notification naming the parse error and the file. That notification offers **Reset context**, which moves the broken file aside to a timestamped backup and writes a fresh skeleton in its place. The original bytes are never overwritten, so lifecycle history can be salvaged by hand. The check runs only when a spec is first opened in a viewer tab; switching documents inside an open tab never re-triggers it, so a transient read failure mid-write can't wipe real history. Dismissing the notification leaves the file untouched, and opening the spec again offers the reset again.
 
 ## Requirements render as rows
 
-A bullet written the way Spec Kit writes them, `- **FR-001** The system must ...`, renders as the labeled row in the picture at the top. The prefix in front of the number decides which visual family the row belongs to, so FR, NFR and SC rows read as distinct without anyone tagging them by hand. A bullet that doesn't match that shape stays an ordinary bullet.
+A bullet written the way Spec Kit writes them, `- **FR-001** The system must ...`, renders as the labeled row in the picture at the top. The match is any prefix of two to five capital letters, a hyphen and a number, so FR, NFR and SC rows all qualify, and so does a prefix of your own. The prefix decides which visual family the row belongs to, so the families read as distinct without anyone tagging them by hand. A bullet that doesn't match that shape stays an ordinary bullet.
 
-## Acceptance scenarios stay sentences
+## How acceptance scenarios render
 
 An `**Acceptance Scenarios**:` section followed by a numbered list becomes an ordered list where Given, When and Then are emphasized in place.
 
-That's the whole transformation, and the restraint is the point. Each scenario stays one flowing sentence. It isn't split into a Given/When/Then table and it isn't stacked into three lines. A scenario that wrapped across several lines in the source is joined back into one first, so the sentence survives however it was typed.
+That's the whole transformation. Each scenario stays one flowing sentence. It isn't split into a Given/When/Then table and it isn't stacked into three lines. A scenario that wrapped across several lines in the source is joined back into one first, so the sentence survives however it was typed.
 
 ## Task phases and task lines
 
@@ -109,24 +115,25 @@ The footer renders from a catalog of five entries: Archive, Reactivate, Mark Com
 
 Approve is the internal name and you'll rarely see the word. At most one of the five is forward motion, and it's labeled with the next step's own name, so the button reads **Plan** or **Tasks**, with a context line above it reading `Next: Plan`. The label falls back to Approve only when the workflow definition is missing. Whatever it says, it records completion for the current step, records the start of the next one, refreshes the viewer, and dispatches that step's configured command to your AI provider.
 
-### There often isn't a forward button
+### When no forward button shows
 
-Five real states show no forward action at all:
+Six real states show no forward action at all:
 
 - the implement step, where closure belongs to Mark Completed instead
 - when the tab you're viewing isn't the spec's current step
 - when a later step is already ahead in the recorded history
 - when the step never started
 - while the current step is in flight
+- once the spec is implemented, completed or archived, where the footer reads "Run complete" or "Archived, read-only" instead
 
-The last is the one you'll meet most often. While the step runs, the forward-motion buttons are dropped and the context line reads "Step running, actions unlock when it settles". The closure actions, archive, complete, reactivate and refine, are unaffected.
+The in-flight one is the one you'll meet most often. While the step runs, the forward-motion buttons are dropped and the context line reads "Step running, actions unlock when it settles". The closure actions, archive, complete, reactivate and refine, are unaffected.
 
 ### Other actions
 
 A custom command is a slash command you defined yourself in settings, so that the viewer can dispatch it the same way it dispatches a workflow step. [Pick a pipeline](/docs/guides/pick-a-pipeline) has the shape of one.
 
-Yours appear in a collapsed **Other actions** menu in the footer, scoped to the tab or step you assign them to. It's a menu rather than a toolbar, and it renders only when the spec is still active, isn't at its closure gate, and the list isn't empty. The same commands are reachable from a **Run SpecKit Custom Command** quick pick.
+Yours appear in a collapsed **Other actions** menu in the footer, scoped to the tab or step you assign them to. It's a menu rather than a toolbar, and it renders only when the spec is still active, isn't at its closure gate (the point where the footer is offering Mark Completed or Reactivate), and the list isn't empty. Only the object form of a custom command reaches the footer; a bare string shows up in the quick pick and nowhere else. The same commands are reachable from a **Run SpecKit Custom Command** quick pick.
 
 ## Next
 
-The rail's other destination is the Overview, the record a finished run leaves behind. [Anatomy of the Overview](/docs/anatomy/anatomy-of-the-overview) takes that page apart the same way this one takes the viewer apart. To act on what you just read rather than only read it, [Review and refine](/docs/guides/review-and-refine) is the next guide.
+The rail's other destination is the Overview, the record a finished run leaves behind. [Anatomy of the Overview](/docs/anatomy/anatomy-of-the-overview) takes that page apart the same way this one takes the viewer apart. To act on what you read rather than only read it, [Review and refine](/docs/guides/review-and-refine) is the next guide.

--- a/website/src/content/docs/docs/anatomy/the-sidebar.mdx
+++ b/website/src/content/docs/docs/anatomy/the-sidebar.mdx
@@ -1,6 +1,6 @@
 ---
 title: The SpecKit sidebar
-description: What each of the four SpecKit views holds, and what every icon, count and hover action on a spec row means.
+description: What each of the four SpecKit views holds, and what every icon, count and hover action on a row means.
 sidebar:
   label: Sidebar
   order: 3
@@ -8,15 +8,15 @@ sidebar:
 
 import MediaSlot from '../../../../components/docs/MediaSlot.astro';
 
-The SpecKit icon in the activity bar opens a container with four views: Specs, Living Specs, Steering, and Settings & Feedback.
+By the end of this page you'll be able to read every icon, count and description line in the SpecKit sidebar, and know which view each action lives in. The SpecKit icon in the activity bar opens a container with four views: Specs, Living Specs, Steering, and Settings & Feedback.
 
 <MediaSlot
   feature="specs-sidebar"
   still="sidebar-triptych.png"
-  caption="Three of the four views, and the division of labour between them: your work, the standing instructions around it, and the specs that outlive any one change."
+  caption="Three of the four views. Specs tracks your work, Steering lists the files your provider and Spec Kit already read (the extension itself never reads them when it dispatches a step), and Living Specs lists the capability specs that outlive any one change."
 />
 
-Only two of them show on a fresh install with just the VS Code extension. Living Specs appears once the Companion Spec Kit extension is installed, and Settings & Feedback is hidden until you turn it on. So a first run usually looks like Specs and Steering, and that's correct, not a broken install.
+Only two of them show on a fresh install with only the VS Code extension. Living Specs appears once the Companion Spec Kit extension is installed, and Settings & Feedback is hidden until you turn it on. So a first run usually looks like Specs and Steering, and that's correct, not a broken install.
 
 The whole sidebar is a native VS Code tree, so the editor owns row height, indentation, keyboard navigation, and theming. You can reorder the views yourself: the order here is the default, not a lock.
 
@@ -36,7 +36,7 @@ Which group a spec lands in is read straight from the run record next to it. The
 
 An in-flight spec's row shows the active task and how long ago it last moved, in the form `T004 · 22h ago`. The relative time is measured from the most recent history entry, not from when the step started, so it answers "when did anything last happen here".
 
-Hover the row and a tooltip repeats the same three facts in full words: the slug, the status, and the last activity.
+That task label appears only after an implement task has finished; a spec that hasn't reached implement shows the relative time alone. Hover the row and a tooltip repeats the facts in full words: the display name, the status, the last activity, and a line saying so when a step is running.
 
 ### What each icon means
 
@@ -70,7 +70,7 @@ Read "complete" narrowly. It's a presence heuristic, not a judgement about the w
 
 ### The toolbar
 
-The Specs title bar shows four actions in a fixed order: Filter, Sort, More Actions, and New Spec as the trailing primary. The filter fuzzy-matches on both the slug and the recorded spec name, and submitting an empty value clears it. Everything else, including collapse and expand and the Spec Kit upgrade entries, lives behind More Actions.
+The Specs title bar shows up to five actions in a fixed order: Filter, Sort, More Actions, Open Pipeline Builder, and New Spec as the trailing primary. Pipeline Builder is a panel that draws the Companion pipeline as a graph of nodes and lets you edit it, so the button appears only when the Companion Spec Kit extension is installed. The filter fuzzy-matches on both the slug and the recorded spec name, and submitting an empty value clears it. Everything else, including collapse and expand, the Spec Kit upgrade entries, and Install Companion Extension, lives behind More Actions.
 
 ### Acting on several specs at once
 
@@ -78,13 +78,13 @@ Select several specs with shift-click or cmd-click and you can mark, archive, or
 
 Those two facts combine in a way worth knowing before you use them: an active filter narrows what a bulk action touches, because "visible" is what the filter left.
 
-### Resume, on hover
+### The Resume action
 
 An active or tasks-done row shows a Resume action on hover, but only when the Companion Spec Kit extension is installed. There's no stock equivalent.
 
 Resume reads the run record, works out where the spec stopped, and dispatches one command to your assistant. If the run stopped inside implement, it names the next unchecked task and continues from there instead of restarting the step. It sends text. It doesn't run the workflow, and it gets nothing back.
 
-### The one badge the sidebar sets
+### The install badge
 
 When the Companion Spec Kit extension isn't installed, the Specs view carries a single-dot badge tooltipped "Install SpecKit Companion", and VS Code aggregates that dot onto the activity bar icon, so it's visible even with the view collapsed. A pinned first row offers the same install in words. Both go away the moment the extension is present, with no reload.
 
@@ -99,7 +99,7 @@ A **capability** is a piece of behavior your codebase keeps having, rather than 
   caption="A capability spec reads in the same viewer a feature spec does. What changes is the header: globs instead of a branch, and a coverage count instead of a status."
 />
 
-The view appears only when the Companion Spec Kit extension is installed, and it starts collapsed.
+The view appears only when the Companion Spec Kit extension is installed, and it starts collapsed. Whether it lists anything is a second gate: a `living-specs.yml` at the repo root with `enabled: true`. Without that file, or with `enabled: false`, the view shows a single "Living Specs are off" row whose tooltip says what to set; a registry that won't parse shows "Can't read living-specs.yml" with the error instead.
 
 It's a directory tree rather than a flat list, so its shape mirrors where the capability specs actually live: a spec at `src/features/specs/specs.spec.md` shows up as a leaf under `src`, then `features`. Below the capabilities sits an **Orphans** group holding spec files no capability claims, omitted entirely when there are none.
 
@@ -109,17 +109,17 @@ Each capability row carries two numbers the extension works out for itself, with
 
 **Drift** means source files matching that capability changed since its living spec was last committed. When they have, the row's icon turns the warning color. The lookup is bounded by a timeout, so a slow repository renders the row as it would otherwise rather than stalling the tree.
 
-The title bar carries Refresh, Adopt Code Area, and Sync. The whole view is gated on a `living-specs.yml` at the repo root with `enabled: true`. The [living specs guide](/docs/guides/living-specs) covers the registry and the commands.
+The title bar carries Refresh, Adopt Code Area, and Sync. Right-click a capability row for its own menu: Check for Drift, Check Requirement Coverage, Copy Name, Copy Path, Copy Relative Path, and Delete, plus Update to Match Code on a row that has drifted. The [living specs guide](/docs/guides/living-specs) covers the registry and the commands.
 
 ## Steering
 
 A **steering document** is a standing instruction, not a per-run one. A spec says what to build this time; a steering document says how this project builds anything.
 
-The view gathers what your AI provider already reads, plus Spec Kit's own project files, into one tree next to your specs. It doesn't invent a format, and nothing in it is read by the extension when it dispatches a step. The [steering guide](/docs/guides/steering) has the tree shape, the authoring actions, and the provider boundary.
+The view gathers what your AI provider already reads, plus Spec Kit's own project files, into one tree next to your specs. When the Companion Spec Kit extension is installed a Companion node sits first, with its Configuration file, its Commands, and its Templates when the install ships any. It doesn't invent a format, and nothing in it is read by the extension when it dispatches a step. The [steering guide](/docs/guides/steering) has the tree shape, the authoring actions, and the provider boundary.
 
 ## Settings & Feedback
 
-Four rows and nothing else: Open Settings, Report a Bug, Request a Feature, and Rate on Marketplace. It's hidden by default; turn on `speckit.views.settings.visible` to get it. `speckit.views.steering.visible` is the matching switch for Steering, which is on out of the box.
+Five rows and nothing else: Pipeline Builder, Open Settings, Report a Bug, Request a Feature, and Rate on Marketplace. It's hidden by default; turn on `speckit.views.settings.visible` to get it. `speckit.views.steering.visible` is the matching switch for Steering, which is on out of the box.
 
 ## What the sidebar won't tell you
 

--- a/website/src/content/docs/docs/guides/customize.mdx
+++ b/website/src/content/docs/docs/guides/customize.mdx
@@ -6,6 +6,8 @@ sidebar:
   order: 5
 ---
 
+By the end of this page you'll have a slash command of your own in the viewer's quick pick, and a `companion.yml` that attaches work to a Companion command, reorders its nodes, or swaps the whole pipeline, without forking anything.
+
 Two different customizations get confused with each other, so they're worth separating before either one makes sense.
 
 A **custom command** is a slash command of your own that the extension can dispatch. It's yours, it's listed in a quick pick, and you run it when you want to. It lives in VS Code settings.
@@ -33,7 +35,7 @@ Everything in `speckit.customCommands` appears in the **SpecKit: Run Custom Comm
 }
 ```
 
-A bare string is the short form: `"review"` becomes `/speckit.review`. The object form gives you the rest.
+A bare string is the short form: `"review"` becomes `/speckit.review`, and it appears in the quick pick only. The object form gives you the rest, and it's the only form that also reaches the viewer's footer.
 
 | Property | What it does |
 | --- | --- |
@@ -47,11 +49,11 @@ A bare string is the short form: `"review"` becomes `/speckit.review`. The objec
 
 Write `${specDir}` anywhere in the command and it's substituted with the spec's directory. With `requiresSpecDir` set and no `${specDir}` anywhere in the string, the directory is appended to the end instead.
 
-**Where they show up in the viewer.** In a collapsed **Other actions** menu in the footer, scoped to the tab or step you assigned them to. It's a menu, not a toolbar, and it renders only when the spec is still active, isn't at its closure gate, and the list isn't empty. If you defined a command and can't find it, one of those three is the reason.
+**Where they show up in the viewer.** In a collapsed **Other actions** menu in the footer, scoped to the tab or step you assigned them to. It's a menu, not a toolbar, and it renders only when the spec is still active, isn't at its closure gate (the footer is offering Mark Completed or Reactivate), and the list isn't empty. If you defined a command and can't find it, one of those three is the reason, or it's a bare string.
 
 ## Node hooks
 
-`.specify/companion.yml` attaches your own work before or after any named node inside a Companion command, without forking the command.
+`.specify/companion.yml` attaches your own work before or after any named node inside a Companion command, without forking the command. The file is deltas only: it changes the commands you name and nothing else.
 
 ```yaml
 commands:
@@ -78,6 +80,19 @@ Add `background: true` to any hook and it starts without the run waiting for it,
 
 The file changes only the commands you name. Everything else keeps its shipped definition, and with no file at all every command runs exactly as it ships.
 
+## The rest of companion.yml
+
+Hooks are the most common entry, but the same file carries four more keys.
+
+| Key | What it does |
+| --- | --- |
+| `commands.<name>.nodes` | A recipe: replaces the command's node order with the list you give, so you can drop a node or add one of your own. Dropping a node that a kept node still reads from is refused at load time. |
+| `commands.<name>.phases` | Renames and regroups the command's phases, each with its own `nodes` list. It replaces the shipped grouping whole, and a phase name becomes a hook anchor. |
+| `workflow` | Names a file under `.specify/companion/workflows/` that replaces this whole configuration, so a project can keep several pipelines and switch between them. The reserved name `shipped` selects none. |
+| `debug` | Read by the build-time renderers only. On an installed project it does nothing. |
+
+A node file at `.specify/companion/nodes/<command>/<node id>.md` replaces the shipped node of that id, and `_frame.md` in the same folder replaces the step's preamble. The Pipeline Builder, opened from the Specs sidebar's toolbar, draws the pipeline these settings resolve to and can write hooks and node edits back into this file for you.
+
 ## What executing this actually means
 
 Nothing runs `companion.yml` for you. There is no engine.
@@ -99,4 +114,4 @@ A file that can't be parsed contributes nothing at all, rather than contributing
 
 ## Next
 
-Custom commands show up in the footer's **Other actions** menu, so [anatomy of the spec viewer](/docs/anatomy/anatomy-of-the-spec-viewer) is where to see the surface you just added to. If you're customizing because the built-in workflows don't fit, [Pick a pipeline](/docs/guides/pick-a-pipeline) has the option of defining your own outright.
+Custom commands show up in the footer's **Other actions** menu, so [anatomy of the spec viewer](/docs/anatomy/anatomy-of-the-spec-viewer) is where to see the surface they land on. If you're customizing because the built-in workflows don't fit, [Pick a pipeline](/docs/guides/pick-a-pipeline) has the option of defining your own outright.

--- a/website/src/content/docs/docs/guides/living-specs.mdx
+++ b/website/src/content/docs/docs/guides/living-specs.mdx
@@ -8,13 +8,15 @@ sidebar:
 
 import MediaSlot from '../../../../components/docs/MediaSlot.astro';
 
+By the end of this page you'll have a registry that turns living specs on, know where each capability's spec and its two sibling files go, and know which of the five commands computes an answer and which asks your assistant for one.
+
 A feature spec describes one change. It's written, it's implemented, and after that it's a record of something that happened rather than a description of what the code does now. Read a folder of them a year later and you have an archaeology problem: the current behavior is the sum of thirty specs, minus the parts later specs undid.
 
 A **living spec** describes a capability instead: a piece of behavior your codebase keeps having. It's registered once, it lives next to the code it describes, and it's updated by the runs that change that code rather than replaced by them.
 
 <MediaSlot
   feature="living-specs-explained"
-  caption="The same requirements, filed by what they describe rather than by when they were written. That's the whole move, and it's why a shipped feature spec can be archived without losing anything."
+  caption="The two layouts side by side: a colocated spec sitting in the source directory it describes, and a central capabilities folder holding one spec per capability, each row carrying its coverage count or a drift flag."
 />
 
 The trade is that a feature spec is finished when the feature ships, and a living spec never is. Everything below is about who keeps it current, because the answer is not "it happens automatically".
@@ -37,10 +39,12 @@ capabilities:
 | Key | What it does |
 | --- | --- |
 | `enabled` | The opt-in switch. With no registry, or with this unset, every living-specs command behaves as if the feature weren't there. |
-| `exempt` | Globs that never count as drift, repo-wide. Config files, tests, and generated directories are the usual entries. |
+| `exempt` | Globs that never count as drift, repo-wide. Leave it out and the default is `*.config.*`, `*.test.*` and `**/migrations/**`. |
 | `name` | The capability's identifier. It's also the folder name when the spec location is derived rather than given. |
 | `match` | The globs whose files belong to this capability. A file belongs if it matches one of these and none of the capability's own `exclude` globs. |
 | `spec` | Where this capability's spec lives. Optional, and the next section is about what happens when you leave it out. |
+
+An older layout is still read: a `livingSpecs:` block inside `.specify/companion.yml` with the same keys. If both exist, `living-specs.yml` wins and the old block is reported as stale.
 
 ## Where the spec lives
 
@@ -50,7 +54,9 @@ Two layouts, and the registry picks between them by whether you wrote a `spec:` 
 
 **Central.** Leave `spec:` out and the location is derived: `capabilities/<name>/spec.md`. This suits a capability whose code is spread across several directories with no obvious home.
 
-You can mix both in one registry, and the sidebar's Living Specs tree mirrors whichever you chose, so a colocated spec appears nested under its source directories.
+You can mix both in one registry, and the sidebar's Living Specs tree mirrors whichever you chose, so a colocated spec appears nested under its source directories. `/speckit.companion.living-move` moves a capability from one layout to the other later, so the first choice isn't final.
+
+Each spec has two sibling files, derived from its name. For a colocated `<stem>.spec.md` they are `<stem>.arch.md` and `<stem>.coverage.md` in the same directory. For a central `capabilities/<name>/spec.md` they are `spec.arch.md` and `spec.coverage.md` beside it. The architecture file is free-form notes about how the capability is built. The coverage file maps requirements to the tests that exercise them, and it's what the coverage count on a sidebar row and in the viewer header is read from. Neither is generated; you create them at those paths yourself.
 
 Two more rules decide which capability a given file belongs to.
 
@@ -62,16 +68,17 @@ Any spec file in the tree that no capability claims shows up under **Orphans** i
 
 ## The commands
 
-All four are named `/speckit.companion.living-<verb>`, and all four come from the Companion Spec Kit extension. Install only the VS Code extension and neither they nor the Living Specs view exist.
+All five are named `/speckit.companion.living-<verb>`, and all five come from the Companion Spec Kit extension. Install only the VS Code extension and neither they nor the Living Specs view exist.
 
 | Command | What it does |
 | --- | --- |
 | `/speckit.companion.living-adopt` | Drafts a spec for one code area you name, then a script registers the capability. The drafting is assistant work, read from the code's surface, and every draft is marked as a starting point. |
 | `/speckit.companion.living-sync` | Rewrites the affected specs from your current changes. Also assistant work. "Update, don't regenerate" is an instruction in the command, not something a script enforces. |
-| `/speckit.companion.living-drift` | Lists, per capability, the source files that changed since that capability's spec was last committed. It separates the ones that went through the pipeline without being folded back from the ones the spec never saw. |
-| `/speckit.companion.living-coverage` | Reads each capability's coverage file and reports what it finds. |
+| `/speckit.companion.living-drift` | Lists, per capability, the source files that changed since that capability's spec was last committed. It separates the ones that went through the pipeline without being folded back from the ones the spec never saw. Committed history only by default; `--working` counts uncommitted edits and untracked files as drift too. |
+| `/speckit.companion.living-coverage` | Reads each capability's coverage file and reports what it finds. `--capability <name>` limits it to one. |
+| `/speckit.companion.living-move` | Moves a capability's spec and its sibling files between the colocated and central layouts and rewrites the registry to match, after showing you the paths and pausing for confirmation. |
 
-The split down the middle of that table matters. Drift and coverage are backed by scripts that compute the answer, so they're deterministic and repeatable. Adopt and sync are prompts your assistant follows, so their quality is your assistant's quality.
+The split in that table matters. Drift, coverage and move are backed by scripts that compute the answer, so they're deterministic and repeatable. Adopt and sync are prompts your assistant follows, so their quality is your assistant's quality.
 
 ## How a run folds back
 
@@ -100,7 +107,7 @@ Drift and coverage never gate anything. Both are read-only reports that always e
 
 A capability whose spec isn't committed yet, or a CI checkout without enough history, is skipped with the reason named and counted. The all-clear line is reserved for a run where every capability was actually examined.
 
-Two more files are recognized but never generated. The resolver derives an architecture sibling and a coverage sibling for every capability's spec, and living-coverage reads the coverage one. Nothing writes either of them. They're paths you author yourself, which is why a capability with no coverage file shows no coverage number, and why that looks exactly like zero coverage on screen.
+The architecture and coverage siblings are recognized but never generated. Nothing writes either of them, which is why a capability with no coverage file shows no coverage number, and why that looks exactly like zero coverage on screen.
 
 ## Next
 

--- a/website/src/content/docs/docs/guides/pick-a-pipeline.mdx
+++ b/website/src/content/docs/docs/guides/pick-a-pipeline.mdx
@@ -8,16 +8,16 @@ sidebar:
 
 import MediaSlot from '../../../../components/docs/MediaSlot.astro';
 
-A **workflow** is the ordered set of steps a spec goes through, and the command that gets dispatched at each one. "Pipeline" is the same thing said conversationally.
+By the end of this page you'll have picked one of the two shipped workflows for your next spec, set it as the default if you want, and seen what it takes to define one of your own. A **workflow** is the ordered set of steps a spec goes through, and the command that gets dispatched at each one. "Pipeline" is the same thing said conversationally.
 
 It's chosen once, when the spec is created, and recorded on the spec. From then on, every surface reads that recording: the rail in the viewer lists that workflow's documents, the sidebar lists the same documents, and the footer's forward button dispatches that workflow's command for the step you're on. So this is a decision you make per spec, not a global mode you switch between.
 
 <MediaSlot
   feature="own-workflow"
-  caption="Choosing here is the last easy moment. Afterwards the spec carries this choice, and every rail, document list and dispatch is derived from it."
+  caption="The workflow is recorded on the spec when it is created, and every rail, document list and dispatch afterwards is derived from that recording."
 />
 
-Open **SpecKit: Create New Spec**. The **Workflow** choice is the whole decision, and it comes pre-selected.
+Open **SpecKit: New Spec**. The **Workflow** choice in the Create New Spec panel is the whole decision, and it comes pre-selected.
 
 ## The two that ship
 
@@ -40,19 +40,19 @@ Two things differ, and the extra step is only the visible one.
 }
 ```
 
-`"speckit"` or `"companion"`. The setting decides which workflow **Create New Spec** pre-selects, and nothing else. It doesn't restrict what you can pick, and it has no effect on specs that already exist.
+`"speckit"` or `"companion"`. The setting decides which workflow the Create New Spec panel pre-selects, and nothing else. It doesn't restrict what you can pick, and it has no effect on specs that already exist.
 
-Leave it unset and installing the Companion Spec Kit extension is enough to make Companion the pre-selected one. An explicit value at any scope always wins, including an explicit `"speckit"`.
+The setting's declared default is `"speckit"`, but the picker only honors a value you set yourself. Leave it unset and installing the Companion Spec Kit extension is enough to make Companion the pre-selected one. An explicit value at any scope always wins, including an explicit `"speckit"`.
 
 ## When the Companion Spec Kit extension is missing
 
-Companion still appears in **Create New Spec**, marked **Install to enable**, instead of being hidden. You can see what you don't have.
+Companion still appears in the Create New Spec panel, marked **Install to enable**, instead of being hidden. You can see what you don't have.
 
 Dispatch a Companion step anyway and the four pipeline commands downgrade to their stock twins, with a one-click install prompt. Commands that have no stock twin, mark-complete among them, are suppressed rather than dispatched into a void.
 
 ## The Auto button
 
-**Create New Spec** carries an **Auto** button. It dispatches `/speckit.companion.auto`, which runs specify through mark-complete without pauses. It needs the Companion Spec Kit extension, and without it the button aborts with a message.
+The Create New Spec panel carries an **Auto** button when the selected workflow supports it, which the Companion workflow does. It dispatches `/speckit.companion.auto`, which runs specify through mark-complete without pauses. It needs the Companion Spec Kit extension, and without it the button aborts with a message.
 
 Auto is one command handed to your assistant, which then follows it. The extension isn't stepping through the workflow itself, which is why there's no progress bar for it and no way to pause it from the editor.
 
@@ -82,21 +82,23 @@ That's the smallest valid one. Every property in it does a job:
 | Property | What it does |
 | --- | --- |
 | `name` | The workflow's identifier, lowercase and hyphenated. It's what gets recorded on a spec. |
-| `displayName` | What **Create New Spec** shows in the picker. |
+| `displayName` | What the Create New Spec panel shows in the picker. |
 | `steps[].name` | The step's identifier, used to match history entries and sub-documents to it. |
 | `steps[].label` | What the rail and the footer call this step. Defaults to the capitalized name. |
 | `steps[].command` | The slash command dispatched for this step, written without the leading slash. A slash is added at dispatch, and one you include is stripped. |
 | `steps[].file` | The document this step produces, which is what the rail opens. Defaults to `{name}.md`. |
 | `steps[].actionOnly` | Set when the step produces no document. It gets no rail entry at all, and its actions live in the footer. Implement is the usual case. |
 
-Custom workflows are validated, deduplicated, and offered in **Create New Spec** next to the two built-ins. The sidebar and the viewer then build their document lists and step rails from whatever your workflow declares, which is the payoff: a workflow whose steps are named Design and Review renders as Design and Review, not as a translation into someone else's vocabulary.
+Custom workflows are validated, deduplicated, and offered in the Create New Spec panel next to the two built-ins. The sidebar and the viewer then build their document lists and step rails from whatever your workflow declares, which is the payoff: a workflow whose steps are named Design and Review renders as Design and Review, not as a translation into someone else's vocabulary.
 
 <MediaSlot
   feature="make-it-yours"
-  caption="A workflow you defined is not a second-class one. It's recorded on the spec and drives the rail exactly the way a built-in does."
+  caption="Three steps of a custom workflow shown over the commands they dispatch: your own command for Research, the stock ones for Specify and Implement."
 />
 
-A step can carry more than the seven properties above: an explicit list of sub-files, a subdirectory to scan for children, a per-step model or reasoning effort when your provider is Claude Code, and a list of providers the whole workflow is limited to. Those are all optional, and the settings schema in VS Code will complete them for you.
+A step can carry more than the seven properties above: `subFiles`, an explicit list of sub-documents; `subDir`, a subdirectory to scan for children; `includeRelatedDocs`, which groups the folder's unassigned markdown under this step; and `model` and `effort`, a per-step model or reasoning effort when your provider is Claude Code.
+
+The workflow itself takes three more. `supportedAiProviders` limits the whole workflow to the providers you list, hiding it from the picker otherwise. `commands` adds buttons next to a step's actions, each with a `name`, a `command` and the `step` it belongs to. `steering` names reference folders the workflow reads that aren't specs; they appear under the Steering view and are kept out of spec detection. All of these are optional, and the settings schema in VS Code will complete them for you.
 
 ## Next
 

--- a/website/src/content/docs/docs/guides/review-and-refine.mdx
+++ b/website/src/content/docs/docs/guides/review-and-refine.mdx
@@ -8,14 +8,14 @@ sidebar:
 
 import MediaSlot from '../../../../components/docs/MediaSlot.astro';
 
-Open a spec in the viewer and hover any line. A comment button appears on it. Click it, type, and the card pins directly beneath the line it annotates.
+By the end of this page you'll have commented on a spec line by line, seen those comments land in the spec's own folder, and handed the pending ones to your AI as one edit request. Open a spec in the viewer and hover any line. A comment button appears on it. Click it, type, and the card pins directly beneath the line it annotates.
 
 <MediaSlot
   feature="inline-comments"
-  caption="A comment sits with the sentence it's about, which is the difference between review that gets acted on and a list of notes somebody has to reconcile against the document later."
+  caption="Each comment is pinned under the line it annotates, and the card records whether it is still pending or has been sent."
 />
 
-The composer reads what kind of line you're on: user story, task, section, acceptance scenario or paragraph. Each offers a matching quick action. Those are suggestion phrasings that fill in the comment text. They don't edit anything themselves.
+The composer reads what kind of line you're on: user story, task, section, acceptance scenario or paragraph. Each offers a matching quick action. Most are suggestion phrasings that fill in the comment text without editing anything. The exception is a task line, which also offers **Toggle**: that one flips the task's checkbox in place.
 
 ## What you can comment on
 
@@ -31,7 +31,7 @@ A card starts collapsed, showing your text and whether it's **Pending** or **App
 
 | Action | When it's offered |
 | --- | --- |
-| **Refine** | While the comment is still pending |
+| **Refine** | While the comment is still pending. It sends every pending comment on the document, not only this one |
 | **Edit** | Any time the spec is active |
 | **Delete** | Any time the spec is active |
 
@@ -47,24 +47,24 @@ Adding a comment writes it straight into the spec's run record, `.spec-context.j
 
 **Nothing is duplicated by a reload.** Reopen the tab and every stored comment for that document is re-anchored onto the freshly rendered page. Re-rendering twice doesn't give you two copies of the same card.
 
-Re-anchoring is best effort, and it helps to know how. A comment stays with its block of text, not with an exact source line number. If the spec is edited underneath it and that block no longer matches anything inline, the comment isn't lost. It stays in the Activity list under Run log.
+Re-anchoring is best effort, and it helps to know how. A comment stays with its block of text, not with an exact source line number. If the spec is edited underneath it and that block no longer matches anything inline, the comment isn't lost. Every comment is also listed, with its status, in the Activity list under Run log, and an unanchored one is still there.
 
 The record is ordinary JSON in the spec folder. Commit it and the review travels with the branch, which is what makes this different from comments in a chat window.
 
 ## Refine
 
-The **Refine** button is hidden while nothing is pending, and reads "Refine (N)" once you have N pending comments on the document you're looking at. Each pending card also carries its own Refine action.
+The **Refine** button is hidden while nothing is pending, and reads "✨ Refine (N)" once you have N pending comments on the document you're looking at. Each pending card also carries a Refine action, and it does the same thing as the footer button: every pending comment on the document goes, not only the card you pressed it on.
 
 <MediaSlot
   feature="review"
-  caption="Refine's whole job is to turn scattered notes into one instruction with enough context attached that the assistant doesn't have to guess which line you meant."
+  caption="Refine collects the pending comments on the document into one prompt, each with its line, its section heading and the source text it was written against."
 />
 
 Refine builds one prompt, and three things about its scope are worth knowing before you press it.
 
 **It's the current document only.** Pending comments on the document you're looking at, not your whole review. Comments on the plan don't ride along when you refine the spec.
 
-**Each comment carries its context.** Every one becomes a bullet naming the line and its section heading, quoting the source block, and then your comment. So the assistant gets the text you were looking at, not just a line number.
+**Each comment carries its context.** Every one becomes a bullet naming the line and its section heading, quoting the source block, and then your comment. So the assistant gets the text you were looking at, not only a line number.
 
 **It asks for an edit, not a rewrite.** The prompt tells the AI to edit that one file in place, not to regenerate it from a template and not to run any setup script.
 
@@ -84,7 +84,7 @@ When a spec's status is completed or archived, its comment cards still render wi
 
 **A comment didn't save.** The write is skipped and logged when the run record is missing or unreadable. The viewer creates that file on first open, so normally it's there; if it isn't, the spec folder is the place to look.
 
-**A comment vanished from the page after an edit.** It's in the Activity list under Run log. Re-anchoring gave up on placing it inline because the block it was attached to no longer matches anything in the document.
+**A comment vanished from the page after an edit.** It's still in the Activity list under Run log. Re-anchoring gave up on placing it inline because the block it was attached to no longer matches anything in the document.
 
 ## Next
 

--- a/website/src/content/docs/docs/guides/steering.mdx
+++ b/website/src/content/docs/docs/guides/steering.mdx
@@ -6,6 +6,8 @@ sidebar:
   order: 4
 ---
 
+By the end of this page you'll know which files the Steering view lists for your provider, which of them the extension will write for you, and why none of them is read when a step is dispatched.
+
 A spec says what to build this time. A **steering document** says how this project builds anything: its conventions, its architecture, its testing habits. It's a standing instruction rather than a per-run one, and it applies to work that hasn't been specified yet.
 
 Your AI provider already has a place for those. Claude Code reads `CLAUDE.md`, Codex and OpenCode read `AGENTS.md`, and the others each have their own filename. The [provider matrix](https://github.com/alfredoperez/speckit-companion/blob/main/docs/providers.md) lists every path.
@@ -17,6 +19,9 @@ The Steering view doesn't invent a new format and doesn't add a layer. It gather
 ```text
 Steering
   Companion
+    Configuration
+    Commands
+    Templates
   <your configured provider>
     Project
       <the provider's project rule file, or the action that creates it>
@@ -68,20 +73,18 @@ What the view does own is a small set of authoring actions, and every one of the
 
 When a rule file doesn't exist yet, the create action sits inside that scope's group and names your provider's real filename, so you get "Create project-level GEMINI.md" rather than a hard-coded `CLAUDE.md`.
 
-The destructive actions stay narrow on purpose. Refine and Delete are offered only on the steering documents the extension generated. Provider-owned and Spec Kit-owned files can be opened and revealed from the tree, never deleted from it. The view is deliberately not a file manager for other people's configuration.
+The destructive actions stay narrow on purpose. Refine and Delete are offered on the documents under Steering Docs and on the files under References, which share the same row type. Provider-owned and Spec Kit-owned files can be opened and revealed from the tree, never deleted from it. The view is deliberately not a file manager for other people's configuration.
 
 ## The Companion node
 
-When the Companion Spec Kit extension is installed, a Companion node sits first in the tree and answers two questions: where its configuration lives, and which commands it provides.
+When the Companion Spec Kit extension is installed, a Companion node sits first in the tree and answers three questions: where its configuration lives, which commands it provides, and which templates it ships.
 
-Configuration opens `.specify/companion.yml` directly, which is the file [Pick a pipeline](/docs/guides/pick-a-pipeline) describes attaching your own work through. Commands lists the whole `/speckit.companion.*` set, read live from the installed extension's manifest, so a command added in a later release shows up without a new release of the VS Code half.
+Configuration opens `.specify/companion.yml` directly, which is the file [Custom commands and hooks](/docs/guides/customize) describes attaching your own work through. Commands lists the whole `/speckit.companion.*` set, read live from the installed extension's manifest, so a command added in a later release shows up without a new release of the VS Code half. Templates lists the markdown templates in the installed extension's templates folder, and the node is omitted when there are none.
 
 ## Steering support isn't universal
 
-Not every provider has a place to point at. With IDE Chat selected there's no steering, no agents, no hooks, and no MCP, because there's no provider-owned configuration to browse. MCP is the Model Context Protocol, the standard some assistants use to connect to external tools; a provider without it has no MCP section here.
-
-Hooks are the other uneven one: they exist on some providers and not others.
+Not every provider has a place to point at. With IDE Chat selected there's no rule file, no steering directory, no agents and no skills, because there's no provider-owned configuration to browse. Other providers fill in whichever of those they have, so the Agents and Skills groups appear only where the provider keeps such files.
 
 ## Next
 
-Which sections you get depends entirely on which provider you picked, so the [provider matrix](https://github.com/alfredoperez/speckit-companion/blob/main/docs/providers.md) is the page to read next. It lists every provider's rule file, steering directory, and which of agents, skills, hooks and MCP it supports.
+Which sections you get depends entirely on which provider you picked, so the [provider matrix](https://github.com/alfredoperez/speckit-companion/blob/main/docs/providers.md) is the page to read next. It lists every provider's rule file, steering directory, agents folder, and where its hooks and MCP servers are configured. MCP is the Model Context Protocol, the standard some assistants use to connect to external tools.

--- a/website/src/content/docs/docs/index.mdx
+++ b/website/src/content/docs/docs/index.mdx
@@ -12,12 +12,12 @@ Your specs already live in files. Spec Kit writes a `spec.md`, a `plan.md` and a
 
 <MediaSlot
   feature="readme-hero"
-  caption="The sidebar and the viewer, mid-plan. Neither is a new file format: this is the same folder your assistant already wrote, read at the altitude you actually work at."
+  caption="The sidebar and the viewer, mid-plan. Both read the folder your assistant already wrote; there is no second copy of the spec anywhere."
 />
 
-## The names, once
+## Terms used on this site
 
-Five terms do most of the work on this site, and two of them are easy to swap by accident.
+Seven terms do most of the work on this site, and two of them are easy to swap by accident.
 
 | Term | What it means here |
 | --- | --- |
@@ -26,6 +26,8 @@ Five terms do most of the work on this site, and two of them are easy to swap by
 | **Companion Spec Kit extension** | A second, separately installed piece that adds the `/speckit.companion.*` commands and records what each run did. |
 | **Workflow** | The ordered set of steps a spec follows. "Pipeline" is the same thing, said conversationally. |
 | **Run record** | The `.spec-context.json` file written next to a feature spec. Everything the Overview shows comes out of it. |
+| **Overview** | The second view inside the spec viewer. It lays out what the run record says: intent, timing, decisions, checks, coverage. |
+| **Steering view** | The sidebar view that lists the standing instruction files your AI provider and Spec Kit already read. |
 
 ## What the VS Code extension gives you
 
@@ -33,11 +35,11 @@ The spec viewer opens your markdown as a page rather than a file, with a rail do
 
 ## What the Companion Spec Kit extension adds
 
-It rides your Spec Kit runs and writes the run record: what each step did, when it started and finished, what it decided, what it verified. That record is what the Overview reads. It also brings the `/speckit.companion.*` command family, the Resume action, Living Specs, and a terminal `mark-complete` step that stock Spec Kit doesn't have.
+It rides your Spec Kit runs and writes the run record: what each step did, when it started and finished, what it decided, what it verified. That record is what the Overview reads. It also brings the `/speckit.companion.*` command family, the Resume action (a sidebar button that works out where a spec stopped and dispatches the next command), Living Specs, and a terminal `mark-complete` step that stock Spec Kit doesn't have.
 
 ## Either half works on its own
 
-Install only the VS Code extension and the viewer, the inline comments and the Specs sidebar all work. Living Specs, Resume and the Companion workflow are what the second half adds. Nothing breaks in between: a spec created without the Companion Spec Kit extension simply has less recorded on it.
+Install only the VS Code extension and the viewer, the inline comments and the Specs sidebar all work. Living Specs, Resume and the Companion workflow are what the second half adds. Nothing breaks in between: a spec created without the Companion Spec Kit extension has less recorded on it.
 
 ## What it isn't doing
 

--- a/website/src/content/docs/docs/install.mdx
+++ b/website/src/content/docs/docs/install.mdx
@@ -86,7 +86,7 @@ Installing from source is a global change to your `uv` tools, not a project-loca
 
 <GuidedStep n={3} title="Add the Companion Spec Kit extension">
 
-This is the half that rides your runs. It writes the run record next to each spec, and the VS Code extension reads that file.
+This is the half that rides your runs. It writes the run record, a `.spec-context.json` file that logs what each step did, next to each spec, and the VS Code extension reads that file.
 
 Run it from your project root. Copy the command whole: the short catalog form isn't supported, because the extension isn't listed in Spec Kit's catalog.
 
@@ -122,13 +122,13 @@ Two commands and two things on screen.
 
 <div slot="result">
 
-`companion` is in the list, at the version you just installed.
+`companion` is in the list, at the version you installed.
 
 Your assistant offers the `/speckit.companion.*` commands alongside the stock `/speckit.*` ones. Both families stay installed; adding one never removes the other.
 
 A **Living Specs** view has joined the sidebar.
 
-The Specs view's install dot is gone, and the Companion workflow in **Create New Spec** no longer carries the **Install to enable** label. Both clear the moment the extension is present, with no reload.
+The Specs view's install dot is gone, and the Companion workflow in **SpecKit: New Spec** no longer carries the **Install to enable** label. Both clear the moment the extension is present, with no reload.
 
 </div>
 
@@ -138,7 +138,9 @@ The Specs view's install dot is gone, and the Companion workflow in **Create New
 
 Re-run the exact same command from step 3. The `companion-latest/companion.zip` URL is a rolling asset that always serves the newest build, and `--force` refreshes an existing install in place. There's no version string to edit and no new URL to find.
 
-Inside the editor there's a path to the same thing: the Specs view's **More Actions** menu, then **Upgrade…**, then **Update spec-kit Extension**. It runs the same command in a terminal for you.
+Inside the editor there are two paths to the same result. The Specs view's **More Actions** menu has an **Install Companion Extension** entry, and its **Upgrade…** submenu has **Update spec-kit Extension**. Either runs `specify extension add companion --from <URL>` in a terminal for you. That command carries no `--force`: `extension add` already installs or updates against the same target, so the in-editor path leaves the flag off.
+
+The extension also nudges you toward this install on its own: a toast on activation when the project has a `.specify` folder but no Companion, a pinned row at the top of the Specs view, and a one-click prompt when you pick the Companion workflow without it. Set `speckit.companion.installPrompt` to `false` to turn all of them off, or choose **Don't show again** on the toast.
 
 ## When something didn't take
 

--- a/website/src/content/docs/docs/start/getting-started.mdx
+++ b/website/src/content/docs/docs/start/getting-started.mdx
@@ -18,7 +18,7 @@ export const MARKETPLACE = 'https://marketplace.visualstudio.com/items?itemName=
     because the extension is not listed in the Spec Kit catalog. */}
 export const COMPANION_COMMAND = 'specify extension add companion --from https://github.com/alfredoperez/speckit-companion/releases/download/companion-latest/companion.zip --force';
 
-SpecKit Companion is two halves that meet in one file. Five steps take you from an empty workspace to a finished spec you can read, assuming you already have an editor and a `specify` CLI that carries the `extension` subsystem. If you don't, or if either install misbehaves, [Install](/docs/install) has the prerequisites and the troubleshooting.
+By the end of this page you'll have both halves of SpecKit Companion installed, one spec created and run through its workflow, and a run record you can read in the Overview. It assumes you already have an editor and a `specify` CLI that carries the `extension` subsystem. If you don't, or if either install misbehaves, [Install](/docs/install) has the prerequisites and the troubleshooting.
 
 <GuidedStep n={1} title="Install the VS Code extension">
 
@@ -50,7 +50,7 @@ A SpecKit icon in the activity bar, with an empty **Specs** view behind it. It's
 
 <GuidedStep n={2} title="Add the Companion Spec Kit extension">
 
-The half that rides your runs. It writes a run record, `.spec-context.json`, next to each spec, and the VS Code extension reads that file.
+The half that rides your runs. It writes a run record, a `.spec-context.json` file logging what each step did, next to each spec, and the VS Code extension reads that file.
 
 It needs Spec Kit 0.9.5 or newer, and it needs a `specify` build that actually has `specify extension`. The stock PyPI package doesn't, which is the one failure worth reading [Install](/docs/install) for before you paste this.
 
@@ -74,7 +74,7 @@ The same command updates it later, because `companion-latest` always serves the 
 
 <GuidedStep n={3} title="Create your first spec">
 
-Click the SpecKit icon, then the `+` button in the Specs view. **Create New Spec** lists every workflow with its description. Describe what you want to build and let it run.
+Click the SpecKit icon, then the `+` button in the Specs view, or run **SpecKit: New Spec** from the command palette. The Create New Spec panel lists every workflow with its description. Describe what you want to build and let it run.
 
 <div slot="result">
 
@@ -85,8 +85,8 @@ A new spec under **Active**, named from what you typed, with the workflow record
 <MediaSlot
   slot="media"
   feature="specs-sidebar"
-  alt="The Specs sidebar: Active, Completed and Archived groups each with a count, one spec expanded to show its spec, plan and tasks documents with their own state marks, and the Living Specs and Steering views below."
-  caption="One spec is enough to see the shape the sidebar will keep: lifecycle groups on the outside, per-document state on the inside, and no separate index to keep in sync."
+  alt="The Specs sidebar: Active and Completed groups each with a count, one spec expanded to show its Specification, Plan and Tasks documents with their own state marks, and the Living Specs and Steering views below."
+  caption="The shape the sidebar keeps from the first spec on: lifecycle groups on the outside, per-document state on the inside, all read from the run record rather than a separate index."
 />
 
 </GuidedStep>
@@ -99,18 +99,18 @@ It records the current step complete, records the next one starting, refreshes t
 
 There often isn't a forward button, and that's a real state rather than a fault: [the spec viewer anatomy](/docs/anatomy/anatomy-of-the-spec-viewer) lists the five situations where forward motion disappears.
 
-**Create New Spec** also has an **Auto** button, which dispatches `/speckit.companion.auto` and runs specify through mark-complete without pauses.
+The Create New Spec panel also shows an **Auto** button for workflows that support it, which is the Companion workflow. It dispatches `/speckit.companion.auto` and runs specify through mark-complete without pauses.
 
 <div slot="result">
 
-While a step runs, the forward buttons drop and the footer reads "Step running, actions unlock when it settles". During implement the step tab shows a live percentage counted from checked boxes in `tasks.md`. When every task is checked, the extension's own file watcher closes the step, without waiting on a hook or a terminal.
+While a step runs, the forward buttons drop and the footer reads "Step running, actions unlock when it settles". During implement the step tab shows a live percentage counted from checked boxes in `tasks.md`. When every task is checked, the extension's own file watcher closes the step, without waiting on a hook or a terminal. Closing the spec itself is a separate action: Mark Completed in the footer, or the Companion workflow's own mark-complete step.
 
 </div>
 
 <MediaSlot
   slot="media"
   feature="run-in-flight"
-  caption="A run in progress reads as progress. The steps that haven't happened stay empty rather than pretending to be pending work."
+  caption="A spec after its first step: Specification carries a check, Plan and Tasks stay hollow because their documents don't exist yet, and the header reports how many phases have timing so far."
 />
 
 </GuidedStep>
@@ -121,9 +121,9 @@ Switch to **Overview**, the second view inside the spec viewer. It exists only f
 
 <div slot="result">
 
-The run's intent, its approach, the area it worked in, and how the change was sized. Under that, the expectations fence, the decisions with what each one rejected, and a coverage table counted as "N/M traced".
+The run's intent, its approach, the area it worked in, and how the change was sized. Under that, the expectations (the constraints the run had to honor and the non-goals it declared), the decisions with what each one rejected, and a coverage table that maps each requirement to the tasks that delivered it and the tests that exercise it, counted as "N/M traced".
 
-Timing is reported only where both ends of a phase were recorded. A phase that can't be measured cleanly is listed with no number, and the header reads "Timing coverage: N of M phases".
+A Run overview strip sits inside the Intent region, one entry per phase. Timing is reported only where both ends of a phase were recorded. A phase that can't be measured cleanly is listed with no number, and the strip's head reads "Timing coverage: N of M phases". When no phase was measured at all it reads "Timing not recorded".
 
 </div>
 
@@ -131,7 +131,7 @@ Timing is reported only where both ends of a phase were recorded. A phase that c
   slot="media"
   feature="overview"
   alt="The Overview read top to bottom: the run's intent, a per-phase timing strip, the approach, working area and size, the expectations fence, each verified check beside the command it ran, the decisions with what they rejected, and the requirement-to-test coverage table."
-  caption="This is the page a future session reads instead of re-deriving your reasoning from the diff. It's why the run record is worth committing."
+  caption="Every region on this page is read from the run record next to the spec. Commit that file and the page travels with the branch."
 />
 
 </GuidedStep>
@@ -142,8 +142,8 @@ It hands your assistant the command text, then reads whatever lands on disk. It 
 
 The Overview's verifications are a recorded report: the check, the command the assistant says it ran, and the outcome it reported. Nothing re-executes. One thing gets re-checked, and only for existence: a coverage test reference that looks like a file path is checked to see whether that file is there.
 
-Everything is plain files in your repo, both committable, with no extension-owned database. Install just the VS Code extension and the viewer, review comments and Specs sidebar still work. Living Specs, the Resume button and the Companion workflow are what the second half adds.
+Everything is plain files in your repo, both committable, with no extension-owned database. Install only the VS Code extension and the viewer, review comments and Specs sidebar still work. Living Specs, the Resume button and the Companion workflow are what the second half adds.
 
 ## Next
 
-Two directions from here. [Anatomy of the spec viewer](/docs/anatomy/anatomy-of-the-spec-viewer) names every part of the surface you just used. [Pick a pipeline](/docs/guides/pick-a-pipeline) is the one decision worth making before your second spec.
+Two directions from here. [Anatomy of the spec viewer](/docs/anatomy/anatomy-of-the-spec-viewer) names every part of the surface you used above. [Pick a pipeline](/docs/guides/pick-a-pipeline) is the one decision worth making before your second spec.


### PR DESCRIPTION
## Summary
The documentation site said several things the extension does not do: the wrong rule for when the Living Specs view appears, four living-specs commands where five ship, an in-editor updater that "runs the same command" when it runs without `--force`, and captions describing pictures that show something else. This fixes the facts on all eleven pages, adds what a reader needs and the pages left out, and rewrites every guide to open with what the reader will have done.

## Technical
- Living Specs gating: view is gated on `speckit.companion.installed`; `enabled: false` shows a "Living Specs are off" row (`specExplorerProvider.ts`)
- Toolbar and settings counts: five each, Pipeline Builder included (`overviewProvider.ts`, `package.json` menus)
- `living-move` added; `<stem>.arch.md` / `<stem>.coverage.md` named (`resolve-spec-paths.py`); `exempt`, legacy `livingSpecs:` block, `--working`, `--capability` documented
- Updater runs `extension add … --from <URL>` with no `--force` (`specKitExtensionInstall.ts:63`, #420); the three install nudges named
- Spec viewer: run strip and outline documented; four-condition tab lock; percent host; living header drift chip and Update
- Overview: "Run overview" inside Intent; no ticking timer in the dossier; four coverage label forms; banner suppression
- Customize: `nodes` recipes, `phases`, `workflow`, `debug`, node/frame overrides, Pipeline Builder
- Steering: Companion → Templates node; hooks/MCP node claims removed
- Review: card Refine dispatches every pending comment; task Toggle flips the checkbox
- Captions and alt text corrected where the image shows something else; images themselves untouched
- Every guide opens on an outcome; zero em dashes; zero just/simply/easily (grep-verified)

## Review checklist
- ✅ **Website** — affected
    - `website/src/content/docs/docs/**`: 11 pages, 145 insertions, 106 deletions
    - `npm run build` passes: 16 pages, search index built
- — **VS Code extension** — not touched
- — **SpecKit extension** — not touched
- — **Changelog** — n/a
    - docs site only; no extension behavior changed
- ✅ **Docs**
    - the docs are the change; the source of truth for each fact is cited in the commit messages
- ✅ **Verify**
    - site build green
    - no version bump

## Gaps / how to see it
- Images are out of scope and tracked in #643: the dark `inline-comments.png`, the run-in-flight and pick-a-pipeline posters, and screenshots for the steering, customize and living-specs guides wait for the Living Specs UX pass
- Two review findings were rejected on the code: scenario tables have no add-row button (the renderer emits bare cells), and `defaultWorkflow`'s declared default is not honored because the resolver uses `config.inspect`
- Try: `cd website && npm run dev`, open /docs/anatomy/the-sidebar and /docs/guides/living-specs

Related #643
