### PR TITLE
fix(webview): restore the Pipeline Builder props that made main unbuildable

### DIFF
--- a/webview/src/pipeline-builder/index.tsx
+++ b/webview/src/pipeline-builder/index.tsx
@@ -252,7 +252,6 @@ function App() {
                     graph={graph}
                     selected={selected}
                     onOpenNode={openNode}
-                        vscode.postMessage({ type: 'restoreNode', command, nodeId })}
                     onReorder={(command, order) =>
                         vscode.postMessage({ type: 'reorderNodes', command, order })}
                     onSetPhases={(command, phases, renamed) =>
@@ -262,12 +261,15 @@ function App() {
                     onNewStep={newStep}
                     onRemoveNode={(command, nodeId, order, phases) =>
                         send({ type: 'removeNode', command, nodeId, order, phases })}
-                        send({ type: 'moveNode', command, nodeId, order, phases })}
                     onOpenFrame={command => {
                         setSide({ kind: 'node', at: { command, nodeId: '_frame' } });
                         setNotice(null);
                         setBody(null);
                         vscode.postMessage({ type: 'readFrame', command });
+                    }}
+                    onOpenTemplate={command => {
+                        setSide({ kind: 'template', command });
+                        setNotice(null);
                     }}
                     onEditHook={(command, hook) => {
                         setNotice(null);


### PR DESCRIPTION
## Summary

`npm run package` has been failing on `main` since #634 merged, so no `.vsix` could be built and nothing could be installed. Three props went missing from one call site during that rebuild and left the file unable to parse. Found while trying to run `/install-local` after #650.

## Technical

93 TypeScript errors, every one in `webview/src/pipeline-builder/index.tsx`. Two of them were syntax errors (`TS1381`, `TS1005`) and the other 91 were the implicit-any cascade behind the parse failure, which clears with it.

- **`onRestoreNode` and `onMoveNode`** were removed from `Canvas`'s `Props` in #634, but their callback bodies stayed behind at the call site with no prop name in front of them — two orphaned expression statements in the middle of a JSX attribute list. `Canvas` neither declares nor destructures either prop, and both actions are still dispatched from the side panel (`index.tsx:384` and `:404`, which is the path `wiring.test.tsx` covers), so the orphans are deleted rather than rewired. No behaviour is lost.
- **`onOpenTemplate`** is still required by `Props` and was simply dropped. Restored. The template panel is local state (`side.kind === 'template'`) reading `graph.choices.fragments`, which is already loaded, so it needs no message to the extension — it matches `onOpenFrame` minus the read.

## Review checklist

- ✅ **webview** — affected
    - `pipeline-builder/index.tsx`: two orphaned lines removed, one prop restored
- — **VS Code extension** — `src/` untouched
- — **speckit-extension** — untouched
- — **Changelog** — no user-facing behaviour change; this restores a build that was broken between releases, and the Pipeline Builder behaves as its stories and tests already describe
- ✅ **Verify**
    - `npm run package-web`: **compiled successfully** — the first clean webview build since #634
    - `npm run compile`: clean
    - `npx jest`: 163 suites / 2658 tests pass
    - the stories already pass `onOpenTemplate`, `onRemoveNode` and the rest, so the restored shape matches what the fixtures assert

## Gaps / how to see it

- This is why the last locally-installed build was 0.32.32 and the repo is at 0.32.0 — the bump-and-package step could not complete.
- Worth a follow-up: CI runs `test` and `capture-suite` but evidently not `npm run package`, or this would have been caught at #634. A packaging gate would have.
- Try: `npm run package` on `main` before this change and after.

Closes #651
