### PR TITLE
fix(packaging): keep docs video renders out of the .vsix

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -108,6 +108,8 @@ design/**
 storybook-static/**
 **/*.stories.tsx
 assets/mascot/**
+# Clip compositions, renders and site cards. Docs/README sources only; nothing at runtime reads them.
+media/**
 assets/social/**
 AGENTS.md
 package-lock.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- **The install is 1.7 MB, not 494 MB.** The extension package had been carrying every video render behind the README GIFs and the landing page, which nothing in the extension ever reads. They stay out of it now, so the download and the install are the size of the extension itself.
 - **A task is a line with an id on it.** Progress, the phase-complete notice and the check that implement has finished all count checkboxes in `tasks.md`, and they counted every checkbox — including the verification notes and prose checklists that sit among the tasks. The spec-kit half never counted those, so the two could disagree about whether a run was done. Both sides now require a task id (`T001`), which both task templates emit, and a shared set of cases holds them to it. A hand-written `tasks.md` whose items carry no id will read as no tasks; give them ids to have them counted.
 
 - **Build now reaches your assistant.** Every customisation the panel made — a hook, a reordered step, a swapped node, a rewritten one — was written into the extension's own copy of the commands, and your assistant reads a separate copy the installer rendered once at install time. So Build reported five commands and changed nothing that would ever run. It refreshes those copies now, and says how many and where.

--- a/tests/integration/builderShips.test.ts
+++ b/tests/integration/builderShips.test.ts
@@ -108,3 +108,41 @@ describe('the pipeline builder ships with what it reads', () => {
         expect(source).toContain("'speckit-extension', 'scripts', 'build-pipeline.py'");
     });
 });
+
+/**
+ * The other direction: what must NOT ship. Three times a whole tree landed in
+ * the package before anyone looked — `__screenshots__/**`, `website/**`, and
+ * 494 MB of `media/**` renders — because every guard here asserts what must be
+ * present and nothing asserted what must be absent. `vsce ls` would be the
+ * direct check, but it runs the full webpack build, so this holds the same
+ * property from the ignore list: a new top-level tree is either known to ship
+ * or has an explicit exclusion, and a tree that is neither fails the build
+ * until someone decides.
+ */
+const SHIPS_AT_TOP_LEVEL = new Set(['assets', 'capabilities', 'dist', 'speckit-extension', 'webview']);
+
+const excludedTrees = new Set(
+    ignore
+        .split('\n')
+        .map(line => line.trim())
+        .filter(line => line && !line.startsWith('#') && !line.startsWith('!'))
+        .filter(line => /^[^*/]+\/\*\*$/.test(line))
+        .map(line => line.slice(0, -3)),
+);
+
+describe('every top-level tree is either known to ship or explicitly kept out', () => {
+    const topLevelDirs = fs
+        .readdirSync(repoRoot, { withFileTypes: true })
+        .filter(d => d.isDirectory() && !d.name.startsWith('.') && d.name !== 'node_modules')
+        .map(d => d.name);
+
+    it.each(topLevelDirs)('%s', dir => {
+        expect(SHIPS_AT_TOP_LEVEL.has(dir) || excludedTrees.has(dir)).toBe(true);
+    });
+
+    it('keeps the documentation trees out', () => {
+        for (const tree of ['media', 'docs', 'website', 'examples', 'specs', 'design']) {
+            expect(excludedTrees.has(tree)).toBe(true);
+        }
+    });
+});


### PR DESCRIPTION
Closes #656.

## Summary

The package shipped the whole `media/` tree — the landing-video and feature-clip renders that only exist to make README GIFs. Nothing the extension loads at runtime is under it; README images resolve against `main` on GitHub. **The .vsix drops from 46.9 MB (494 MB with local untracked renders) to 1.7 MB**, and a before/after listing diff shows the only removed entries are under `extension/media/`.

## Technical

- `.vscodeignore` gains `media/**`. Verified no source under `src/`, `webview/`, `webpack.config.js` or `package.json` references `media/`; the only readers are `scripts/*.mjs` (build tooling, already excluded) and `website/` (reads the checkout, not the package). `assets/walkthrough/**` and `assets/media/**` still ship.
- From the review: this is the third time a whole tree landed in the package before anyone looked (`__screenshots__/**`, `website/**`, now `media/**`), because every packaging guard asserted what must be present and none what must be absent. `tests/integration/builderShips.test.ts` now holds the other direction: every top-level tree is either on the known-to-ship list or has an explicit `<tree>/**` exclusion, so a new tree fails the build until someone decides.

## Quality

- [x] Tests: 2658 pass (+9 for the new gate).
- [x] Changelog under `## [Unreleased]`, release-notes voice.
- [x] No version bump.

## How to verify

Install the built .vsix: the Get Started walkthrough images and the sidebar/provider icons (`assets/`) still render; F5 smoke of viewer, editor, pipeline builder. Marketplace README GIFs are served from `main` and unaffected.