### PR TITLE
test(speckit-ext): build the unconfigured case from a bare project

### DIFF
--- a/speckit-extension/tests/test_sandbox_build.py
+++ b/speckit-extension/tests/test_sandbox_build.py
@@ -6,9 +6,13 @@ is only safe if a project that configured nothing gets exactly the pipeline it
 had before. Everything added is scaffolding: markers a tool reads, and text only
 where a project asked for it.
 
-This builds one of the repository's own sandbox projects and holds the output
-against the shipped bodies. It is the test that would fail if any of this had
-started quietly editing instructions.
+This builds a copy of one of the repository's own sandbox projects and holds
+the output against the shipped bodies. It is the test that would fail if any of
+this had started quietly editing instructions.
+
+The copy leaves out the sandbox's gitignored `.specify/companion.yml` and the
+other install artifacts, so the project under test is unconfigured by
+construction rather than by whatever a developer last tried there.
 
 Stdlib `unittest` only.
 """
@@ -16,6 +20,7 @@ from __future__ import annotations
 
 import importlib
 import re
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -34,29 +39,47 @@ assemble = importlib.import_module("assemble-nodes")
 
 MARKER = re.compile(r"<!-- /?speckit-companion:(?:node|phase|hook) [\w-]+ -->")
 
+#: Gitignored in the sandbox: local experiments and install output the build reads.
+LOCAL_ONLY = shutil.ignore_patterns("companion.yml", "extensions.yml", "extensions", "presets")
+
+
+def copy_sandbox(into: Path, config: str = "") -> Path:
+    """A fresh copy of the sandbox's `.specify/` holding exactly the given config."""
+    project = into / "project"
+    shutil.copytree(SANDBOX / ".specify", project / ".specify", ignore=LOCAL_ONLY)
+    if config:
+        (project / ".specify" / "companion.yml").write_text(config, encoding="utf-8")
+    return project
+
+
+def build(project: Path, out: Path) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(SCRIPTS / "build-pipeline.py"),
+         "--project", str(project), "--out", str(out)],
+        capture_output=True, text=True,
+    )
+
 
 class BuildingASandboxProjectChangesNothing(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         if not SANDBOX.is_dir():
             raise unittest.SkipTest(f"no sandbox project at {SANDBOX}")
-        cls._out = tempfile.TemporaryDirectory()
-        result = subprocess.run(
-            [sys.executable, str(SCRIPTS / "build-pipeline.py"),
-             "--project", str(SANDBOX), "--out", cls._out.name],
-            capture_output=True, text=True,
-        )
+        cls._tmp = tempfile.TemporaryDirectory()
+        cls.project = copy_sandbox(Path(cls._tmp.name))
+        out = Path(cls._tmp.name) / "out"
+        result = build(cls.project, out)
         if result.returncode != 0:
             raise AssertionError(f"the sandbox build failed:\n{result.stdout}\n{result.stderr}")
         cls.stdout = result.stdout
         cls.built = {
-            command: (Path(cls._out.name) / f"speckit.companion.{command}.md").read_text(encoding="utf-8")
+            command: (out / f"speckit.companion.{command}.md").read_text(encoding="utf-8")
             for command in assemble.decomposed_commands()
         }
 
     @classmethod
     def tearDownClass(cls):
-        cls._out.cleanup()
+        cls._tmp.cleanup()
 
     def test_an_unconfigured_project_gets_the_shipped_bodies_byte_for_byte(self):
         for command, body in self.built.items():
@@ -102,8 +125,28 @@ class BuildingASandboxProjectChangesNothing(unittest.TestCase):
         # A build writes to its output directory. Reaching into the project's own
         # `.specify/` uninvited is how a trial run becomes a change nobody asked
         # for.
-        self.assertFalse((SANDBOX / ".specify" / "extensions" / "companion" / "commands").exists(),
+        self.assertFalse((self.project / ".specify" / "extensions" / "companion" / "commands").exists(),
                          "the build wrote into the sandbox instead of the output directory")
+
+
+class AConfiguredSandboxGetsItsHooks(unittest.TestCase):
+    # The same project with one hook written into it: the marker lands and the
+    # body stops being the shipped one. The config under test is written here,
+    # so this holds whatever a developer left in the real sandbox.
+    CONFIG = (
+        "commands:\n  implement:\n    hooks:\n      after:\n"
+        "        implement-exec:\n          - { type: prompt, text: \"x\" }\n"
+    )
+
+    def test_a_written_hook_shows_up_as_a_hook_marker(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            project = copy_sandbox(Path(tmp), self.CONFIG)
+            result = build(project, Path(tmp) / "out")
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            body = (Path(tmp) / "out" / "speckit.companion.implement.md").read_text(encoding="utf-8")
+        shipped = (EXT / "commands" / "speckit.companion.implement.md").read_text(encoding="utf-8")
+        self.assertIn("<!-- speckit-companion:hook after-implement-exec", body)
+        self.assertNotEqual(body, shipped)
 
 
 if __name__ == "__main__":

--- a/speckit-extension/tests/test_sandbox_build.py
+++ b/speckit-extension/tests/test_sandbox_build.py
@@ -1,85 +1,53 @@
 #!/usr/bin/env python3
-"""Building a real project must not change what the assistant is asked to do.
+"""Building an unconfigured project must not change what the assistant is asked to do.
 
-The whole architecture — node boundaries, phases, hooks, decisions, templates —
-is only safe if a project that configured nothing gets exactly the pipeline it
-had before. Everything added is scaffolding: markers a tool reads, and text only
-where a project asked for it.
-
-This builds a copy of one of the repository's own sandbox projects and holds
-the output against the shipped bodies. It is the test that would fail if any of
-this had started quietly editing instructions.
-
-The copy leaves out the sandbox's gitignored `.specify/companion.yml` and the
-other install artifacts, so the project under test is unconfigured by
-construction rather than by whatever a developer last tried there.
+Node boundaries, phases, hooks, decisions and templates are only safe if a
+project that configured nothing gets exactly the shipped pipeline. Everything
+added is scaffolding: markers a tool reads, and text only where a project asked.
 
 Stdlib `unittest` only.
 """
 from __future__ import annotations
 
+import hashlib
 import importlib
 import re
-import shutil
-import subprocess
 import sys
-import tempfile
 import unittest
 from pathlib import Path
 
 EXT = Path(__file__).resolve().parent.parent
 SCRIPTS = EXT / "scripts"
-REPO = EXT.parent
-SANDBOX = REPO / "examples" / "todo-claude"
 sys.path.insert(0, str(SCRIPTS))
+sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 import _command_parts as cp  # noqa: E402
+from builder_harness import Project  # noqa: E402
 
 assemble = importlib.import_module("assemble-nodes")
 
 MARKER = re.compile(r"<!-- /?speckit-companion:(?:node|phase|hook) [\w-]+ -->")
 
-#: Gitignored in the sandbox: local experiments and install output the build reads.
-LOCAL_ONLY = shutil.ignore_patterns("companion.yml", "extensions.yml", "extensions", "presets")
+
+def snapshot(root: Path) -> dict:
+    return {str(p.relative_to(root)): hashlib.sha256(p.read_bytes()).hexdigest()
+            for p in root.rglob("*") if p.is_file()}
 
 
-def copy_sandbox(into: Path, config: str = "") -> Path:
-    """A fresh copy of the sandbox's `.specify/` holding exactly the given config."""
-    project = into / "project"
-    shutil.copytree(SANDBOX / ".specify", project / ".specify", ignore=LOCAL_ONLY)
-    if config:
-        (project / ".specify" / "companion.yml").write_text(config, encoding="utf-8")
-    return project
-
-
-def build(project: Path, out: Path) -> subprocess.CompletedProcess:
-    return subprocess.run(
-        [sys.executable, str(SCRIPTS / "build-pipeline.py"),
-         "--project", str(project), "--out", str(out)],
-        capture_output=True, text=True,
-    )
-
-
-class BuildingASandboxProjectChangesNothing(unittest.TestCase):
+class BuildingAnUnconfiguredProjectChangesNothing(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        if not SANDBOX.is_dir():
-            raise unittest.SkipTest(f"no sandbox project at {SANDBOX}")
-        cls._tmp = tempfile.TemporaryDirectory()
-        cls.project = copy_sandbox(Path(cls._tmp.name))
-        out = Path(cls._tmp.name) / "out"
-        result = build(cls.project, out)
-        if result.returncode != 0:
-            raise AssertionError(f"the sandbox build failed:\n{result.stdout}\n{result.stderr}")
-        cls.stdout = result.stdout
+        cls.project = Project()
+        cls.addClassCleanup(cls.project.close)
+        specify = cls.project.root / ".specify"
+        cls.before = snapshot(specify)
+        out = cls.project.root / "out"
+        cls.stdout = cls.project.build_ok("--out", str(out))
+        cls.after = snapshot(specify)
         cls.built = {
             command: (out / f"speckit.companion.{command}.md").read_text(encoding="utf-8")
             for command in assemble.decomposed_commands()
         }
-
-    @classmethod
-    def tearDownClass(cls):
-        cls._tmp.cleanup()
 
     def test_an_unconfigured_project_gets_the_shipped_bodies_byte_for_byte(self):
         for command, body in self.built.items():
@@ -88,8 +56,6 @@ class BuildingASandboxProjectChangesNothing(unittest.TestCase):
                 self.assertEqual(body, shipped)
 
     def test_the_instructions_are_untouched_once_the_scaffolding_comes_off(self):
-        # The stronger form of the same claim: even if the markers moved, the
-        # text the assistant reads must equal the frozen golden.
         for command, body in self.built.items():
             with self.subTest(command=command):
                 golden = Path(cp.golden_path(f"commands/speckit.companion.{command}.md"))
@@ -97,8 +63,6 @@ class BuildingASandboxProjectChangesNothing(unittest.TestCase):
                                  golden.read_text(encoding="utf-8"))
 
     def test_the_only_additions_are_comment_markers(self):
-        # Every line the build added must be an HTML comment: invisible when the
-        # body is rendered, and never another thing for the assistant to obey.
         for command, body in self.built.items():
             with self.subTest(command=command):
                 added = set(body.splitlines()) - set(
@@ -107,9 +71,6 @@ class BuildingASandboxProjectChangesNothing(unittest.TestCase):
                     self.assertRegex(line.strip(), MARKER.pattern)
 
     def test_the_scaffolding_stays_a_small_share_of_the_body(self):
-        # It is not free — the markers are characters the model reads — so the
-        # cost is asserted rather than assumed. A jump here means something
-        # started emitting per-line markers.
         for command, body in self.built.items():
             with self.subTest(command=command):
                 marker_chars = sum(len(line) + 1 for line in body.splitlines()
@@ -121,32 +82,26 @@ class BuildingASandboxProjectChangesNothing(unittest.TestCase):
         self.assertIn("classify-size = simple", self.stdout)
         self.assertIn("a run of this pipeline writes", self.stdout)
 
-    def test_nothing_was_written_into_the_sandbox_itself(self):
-        # A build writes to its output directory. Reaching into the project's own
-        # `.specify/` uninvited is how a trial run becomes a change nobody asked
-        # for.
-        self.assertFalse((self.project / ".specify" / "extensions" / "companion" / "commands").exists(),
-                         "the build wrote into the sandbox instead of the output directory")
+    def test_nothing_was_written_into_the_project_itself(self):
+        self.assertEqual(self.before, self.after,
+                         "the build wrote into the project instead of the output directory")
 
 
-class AConfiguredSandboxGetsItsHooks(unittest.TestCase):
-    # The same project with one hook written into it: the marker lands and the
-    # body stops being the shipped one. The config under test is written here,
-    # so this holds whatever a developer left in the real sandbox.
+class AConfiguredProjectGetsItsHooks(unittest.TestCase):
     CONFIG = (
         "commands:\n  implement:\n    hooks:\n      after:\n"
         "        implement-exec:\n          - { type: prompt, text: \"x\" }\n"
     )
 
     def test_a_written_hook_shows_up_as_a_hook_marker(self):
-        with tempfile.TemporaryDirectory() as tmp:
-            project = copy_sandbox(Path(tmp), self.CONFIG)
-            result = build(project, Path(tmp) / "out")
-            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
-            body = (Path(tmp) / "out" / "speckit.companion.implement.md").read_text(encoding="utf-8")
-        shipped = (EXT / "commands" / "speckit.companion.implement.md").read_text(encoding="utf-8")
-        self.assertIn("<!-- speckit-companion:hook after-implement-exec", body)
-        self.assertNotEqual(body, shipped)
+        project = Project()
+        self.addCleanup(project.close)
+        project.set_config(self.CONFIG)
+        out = project.root / "out"
+        project.build_ok("--out", str(out))
+        body = (out / "speckit.companion.implement.md").read_text(encoding="utf-8")
+        self.assertIn("<!-- speckit-companion:hook after-implement-exec-0 -->\nx\n"
+                      "<!-- /speckit-companion:hook after-implement-exec-0 -->", body)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #657.

## Summary

Two tests in the spec-kit suite asserted that an *unconfigured* project builds the shipped command bodies byte-for-byte — against `examples/todo-claude`, whose `.specify/companion.yml` is gitignored. Anyone who had experimented with hooks there had a local config CI never sees, and the two tests went red only on that machine. **The tests now build from a project that is unconfigured by construction**, so local sandbox state can no longer poison them.

## Technical

- The first pass copied the sandbox and stripped the ignored files. The review showed that once stripped, the sandbox contributes nothing the build reads (a bare `.specify/` gives byte-identical bodies), that `ignore_patterns` matched basenames at every depth, and that untracked `companion/nodes/**` would still leak through. So the copy is gone: the tests use the existing `builder_harness.Project` with an empty `.specify/`, and the configured case uses `Project.set_config` with one hook and asserts the full open/text/close marker triple.
- The "nothing written into the project" test was vacuous; it is now a sha256 snapshot of `.specify/` before and after the build.
- Temp dirs are released via `addClassCleanup`, so a failed build no longer leaks them.
- Verified the test still fails when a shipped body is edited.

## Quality

- [x] Spec-kit suite: 1205 pass, 8 skipped, both with and without a local `examples/todo-claude/.specify/companion.yml`. `check-shape-parity.py` OK.
- [x] Test-only; no changelog entry.
- [x] No version bump.

## How to verify

Drop any `companion.yml` into `examples/todo-claude/.specify/` and run `python3 -m pytest speckit-extension/tests/test_sandbox_build.py -q` — green either way.