### PR TITLE
docs(living-specs): sync the three capabilities the ticket batch drifted

### DIFF
--- a/src/core/core.spec.md
+++ b/src/core/core.spec.md
@@ -152,6 +152,16 @@ Configuration keys change shape across releases, so a reader SHALL be correct fo
 - **THEN** at every scope where the retired toggle was explicitly set, the merged value is the either-false-wins combination of the two explicit values at that scope, written only where it differs from the current value
 - **AND** a broad `false` propagates down while a narrower explicit `true` at a more specific scope is preserved, and scopes where the retired toggle was unset are left untouched
 
+Migrations run at the scopes a setting can actually be set at, and no further: every key this product contributes is window- or machine-scoped, so a folder-level pass reads nothing and a folder-level write is rejected outright. A test asserts that scope declaration, so a future resource-scoped key fails there rather than silently making the migration wrong for it. A write the host refuses SHALL be logged where the user can see it and the migration SHALL continue — one unwritable file must not leave the remaining keys unmigrated.
+
+#### Scenario: one scope's write is rejected
+- **WHEN** a settings file cannot be written
+- **THEN** the failure is reported through the extension's own output, and every other key and scope is still migrated
+
+#### Scenario: a key is contributed at resource scope
+- **WHEN** the manifest declares one
+- **THEN** the scope test fails, because the migration's two-tier shape no longer covers it
+
 ### Telemetry carries shapes, never content
 
 Every telemetry payload SHALL contain only enum-like values, booleans, versions, counts, and a random per-spec identifier. User-authored text — prompt content, file paths, spec names, custom workflow and step names — MUST never be sent. Any value read from disk or settings that could be free text MUST be coerced to a known allow-list before reporting, with anything unrecognized reduced to a neutral placeholder.

--- a/src/features/specs/specs.spec.md
+++ b/src/features/specs/specs.spec.md
@@ -67,6 +67,12 @@ The step-to-status pairing is the same rule. Every place that needs the status a
 - **WHEN** the reconciler derives a replacement status for a finished implement step
 - **THEN** it derives `implemented`, leaving the spec's closure to the user
 
+A helper that more than one layer needs SHALL live in the layer that owns it rather than being re-exported from where it used to live. A compatibility re-export leaves the same function reachable by two paths, so the next reader adds a caller against whichever they found first and the retired path never dies.
+
+#### Scenario: a shared helper moves to a lower layer
+- **WHEN** the move lands
+- **THEN** its old module no longer re-exports it, and every caller names the new home
+
 ### Status moves forward and never regresses out of a terminal state
 
 Status transitions SHALL be forward-only. A re-run, a double-fired hook, or a late-arriving write for an earlier step MUST record its event honestly in the log while leaving status and current step alone if the spec has already moved past that step. A spec that has reached a terminal state MUST NOT be dragged backwards by any subsequent write.

--- a/webview/src/spec-viewer/viewer-ui.spec.md
+++ b/webview/src/spec-viewer/viewer-ui.spec.md
@@ -267,6 +267,16 @@ Readable content MUST use the body and primary text tokens; the secondary and mu
 - **WHEN** a step is in flight
 - **THEN** the in-flight indicator renders without animation
 
+A button that fills itself with the accent colour SHALL take the accent's own ink token; a hardcoded white is unreadable on the accent in the default dark theme, which is mint. This holds for a button assembled imperatively as much as for one rendered from the shared variant map — a control built outside that map still has to meet the contrast floor, and three shipped at 1.54:1 before anyone measured.
+
+#### Scenario: a control is built imperatively rather than through the shared button
+- **WHEN** it renders
+- **THEN** it carries the same class the variant map would have given it, so one rule paints both
+
+#### Scenario: a story stands in for a control the product builds another way
+- **WHEN** the story renders a synthetic stand-in rather than the real control
+- **THEN** the baseline is not evidence, and the story mounts what production mounts instead
+
 ### Tolerance for an old on-disk shape lives at the one conversion point
 
 Where a spec written by an older version persisted a different shape for a field, the widened type SHALL be declared only on the function that converts it, not on the contract every consumer reads. Consumers all take the current shape; putting the legacy form in the shared type would make every reader handle a case only the converter ever sees.


### PR DESCRIPTION
## Summary

Six PRs merged today changed `core/`, `features/specs/` and the viewer webview without folding anything back, so three living specs described code that had moved. The drift check named them; this updates each in place.

**Why it happened:** the batch ran in light mode, which skips the spec pipeline by design — no spec folder, no fold at completion. That is the trade light mode makes, and this is the payment.

- **core** — the settings migration runs only at the scopes a setting can be set at, with a test pinning the scope declaration, and a refused write is logged and the migration continues.
- **specs** — a helper that moves to a lower layer leaves no compatibility re-export behind.
- **viewer-ui** — a control that fills itself with the accent takes the accent's ink, including one built imperatively rather than through the shared variant map; and a story that renders a synthetic stand-in is not evidence.

## How to verify

`python3 .specify/extensions/companion/scripts/drift.py --json` reports zero drifted capabilities.