### PR TITLE
fix(capture): one lock root, whatever temporary directory a process was given

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- **The editor and the terminal always queue on the same write lock.** Both halves worked out where the lock lives from the temporary directory their own process was given, so they agreed only when their environments did. A terminal started somewhere the editor's environment does not reach — over SSH, from a wrapper, inside a container — would take no lock the editor could see, and a write could be lost with nothing to say it happened. Both now use one fixed place.
+
 ### Added
 
 - **Attaching work to the pipeline is a choice, not a command name you have to know.** The Pipeline Builder could draw every hook your project runs, including the ones installed extensions registered, but adding one was a free-text box: to attach the automatic commit you had to already know it is spelled `speckit.git.commit`, and nothing in the panel told you. Choosing a kind now offers what this project actually has for that kind, each entry saying in plain words what it does, who registered it, and where it usually goes. The list is derived from your own registries, so an extension you install tomorrow appears without anything changing here, and a project without the git extension is offered none of its hooks. Typing a name by hand still works, beside the list rather than instead of it.

--- a/speckit-extension/scripts/capture-runtime.spec.md
+++ b/speckit-extension/scripts/capture-runtime.spec.md
@@ -332,6 +332,15 @@ Ordering SHALL NOT be applied to a step outside the canonical order: the canonic
 - **WHEN** the write is attempted
 - **THEN** it is refused by name rather than defaulting to another step
 
+### Both writers resolve the lock to one place, whatever environment they were given
+<!-- touches: speckit-extension/scripts/spec_context.py -->
+
+Where a spec's write lock lives SHALL NOT depend on the temporary directory the resolving process happens to have. Both halves read the same environment, so deriving it that way makes them agree only when their environments do, and stop sharing a lock silently when they do not — which is the lost write the lock exists to prevent, with nothing to say it happened. A terminal reached over a connection, from a wrapper, or inside a container is exactly the case that differs. A fixed root is the only way two processes that never meet can be sure they queue on one file, and it is what makes the directory's shared-host permissions load-bearing rather than decorative.
+
+#### Scenario: the editor and a terminal were given different temporary directories
+- **WHEN** each resolves where the lock lives
+- **THEN** they resolve to the same file
+
 ### The write lock is released once, after the publish, on whichever path ran
 
 A context write SHALL hold its lock until the publish has succeeded or failed, on every code path including the fallback one. A release attached to the first attempt let the fallback path publish unlocked, which is precisely the window the lock exists to close.

--- a/speckit-extension/scripts/spec_context.py
+++ b/speckit-extension/scripts/spec_context.py
@@ -383,7 +383,15 @@ def _lock_path(target: Path) -> Path:
     import tempfile
 
     key = hashlib.sha256(str(target.resolve()).encode("utf-8")).hexdigest()[:32]
-    root = Path(tempfile.gettempdir()) / "speckit-companion-locks"
+    # `/tmp` on posix, not the temporary directory this process happens to have.
+    # Both halves read the same environment variable, so they agree whenever
+    # their environments do — and silently stop sharing a lock when they do not,
+    # which is a lost write with nothing to say it happened. A fixed root is the
+    # only way two processes that never meet can be sure they queue on one file.
+    root = Path(
+        "/tmp" if os.name == "posix" and os.path.isdir("/tmp")
+        else tempfile.gettempdir()
+    ) / "speckit-companion-locks"
     root.mkdir(parents=True, exist_ok=True)
     # Sticky and world-writable, the way /tmp itself is: on a shared host the
     # first user to create this must not lock every other user out of locking.

--- a/src/features/specs/specContextWriter.ts
+++ b/src/features/specs/specContextWriter.ts
@@ -78,13 +78,33 @@ function realPath(target: string): string {
  * identical to `spec_context._lock_path`; `crossProcessContextLock.spec.ts`
  * pins the two against each other.
  */
+/**
+ * Where every lock lives, whatever temporary directory this process was given.
+ *
+ * Both halves read the same environment variable, so they agree whenever their
+ * environments do — and silently stop sharing a lock when they do not, which is
+ * a lost write with nothing to say it happened. A fixed root is the only way two
+ * processes that never meet can be sure they queue on one file. Must match
+ * `_lock_path` in `spec_context.py`.
+ */
+function lockRoot(): string {
+    if (process.platform !== 'win32') {
+        try {
+            if (fs.statSync('/tmp').isDirectory()) return '/tmp';
+        } catch {
+            /* no /tmp: fall through to whatever this process was given */
+        }
+    }
+    return os.tmpdir();
+}
+
 export function specContextLockPath(target: string): string {
     const key = crypto
         .createHash('sha256')
         .update(realPath(target), 'utf8')
         .digest('hex')
         .slice(0, 32);
-    return path.join(os.tmpdir(), 'speckit-companion-locks', `${key}.lock`);
+    return path.join(lockRoot(), 'speckit-companion-locks', `${key}.lock`);
 }
 
 /**

--- a/src/features/specs/specs.spec.md
+++ b/src/features/specs/specs.spec.md
@@ -337,6 +337,10 @@ Two updates to the same spec's state record that arrive at the same time both la
 - **WHEN** a waiter checks whether the lock's owner is still alive
 - **THEN** its answer counts only when the token says the two number processes the same way, since two containers sharing one temporary directory read every live holder as dead, and taking the lock on that basis is the lost write the lock exists to prevent
 
+#### Scenario: the two writers were given different temporary directories
+- **WHEN** each resolves where the lock lives
+- **THEN** they resolve to the same place, because reading the environment means they agree only when their environments do and stop sharing a lock silently when they do not
+
 #### Scenario: the lock's owner cannot be read
 - **WHEN** a waiter would reclaim it
 - **THEN** it does not, because an unreadable owner means the file was replaced or was momentarily unreadable, not that nobody holds it

--- a/tests/integration/crossProcessContextLock.spec.ts
+++ b/tests/integration/crossProcessContextLock.spec.ts
@@ -204,6 +204,30 @@ describeWithPython('cross-process run-record lock (#629)', () => {
         expect(fs.existsSync(lock)).toBe(false);
     });
 
+    it('both halves agree on the lock root whatever temporary directory they were given', () => {
+        // They read the same environment variable, so they agree whenever their
+        // environments do — and silently stop sharing a lock when they do not,
+        // which is a lost write with nothing to say it happened.
+        const { specDir } = makeCell();
+        const target = path.join(specDir, '.spec-context.json');
+        const ours = specContextLockPath(target);
+
+        const ask = (env: NodeJS.ProcessEnv): string =>
+            execFileSync('python3', [
+                '-c',
+                'import sys;sys.path.insert(0,"speckit-extension/scripts");'
+                + 'import spec_context as sc;from pathlib import Path;'
+                + 'print(sc._lock_path(Path(sys.argv[1])))',
+                target,
+            ], { encoding: 'utf-8', env, cwd: process.cwd() }).trim();
+
+        expect(ask({ ...process.env })).toBe(ours);
+        expect(ask({ ...process.env, TMPDIR: '/var/folders/zz/nowhere/T' })).toBe(ours);
+        const stripped = { ...process.env };
+        delete stripped.TMPDIR;
+        expect(ask(stripped)).toBe(ours);
+    });
+
     it('a live holder from another pid scope is waited for, not read as dead', async () => {
         // Two containers sharing one temp dir number processes differently, so
         // the holder's pid is meaningless here and frequently unused. Taking the


### PR DESCRIPTION
Both halves of the write lock worked out where it lives from the temporary directory their own process happened to be given. They read the same environment variable, so they agreed whenever their environments did — and silently stopped sharing a lock when they did not. A terminal started somewhere the editor's environment does not reach, over SSH or from a wrapper or inside a container, would take a lock the editor could not see, and a concurrent write could be lost with nothing to say it happened.

Both now resolve to one fixed place. A test drives the Python half with a hostile `TMPDIR` and with none at all, and asserts it still lands on the file the extension chose.

This closes the one real finding of the three in #680. The other two do not survive checking, and I have said so on the issue rather than leaving it open on my own bad report:

- The claim that giving up on the lock leaves the process thinking it holds one is wrong. A give-up never records the lock as held, so the next write in that process retries properly. I probed it.
- The sticky bit on the lock directory was called unconditional and pointless. With a fixed root it is load-bearing: the directory is now genuinely shared between users on a host, which is exactly what it is for.

Closes #680.
