### PR TITLE
feat(bench): one command runs a whole round

### DIFF
--- a/.claude/commands/bench-experiment.md
+++ b/.claude/commands/bench-experiment.md
@@ -1,0 +1,79 @@
+---
+allowed-tools: Bash(node ../speckit-bench/sync-templates.mjs:*), Bash(node ../speckit-bench/run-all.mjs:*), Bash(npm run compile:*), Bash(git -C:*), Bash(date:*), Bash(ps:*), Agent, Workflow, AskUserQuestion
+description: Run one full benchmark round on Conduit and report it against previous sweeps
+---
+
+## Your task
+
+Run one complete round of the benchmark and report what changed. The user says "run an experiment and bench it" and expects the whole thing without being asked for details.
+
+The harness lives in the sibling [`speckit-bench`](https://github.com/alfredoperez/speckit-bench) repo and the app it measures in [`conduit`](https://github.com/alfredoperez/conduit). Its `README.md` is the reference; this command is the procedure.
+
+### 1. Name the sweep
+
+`$ARGUMENTS` is what the experiment is testing. Turn it into a short label — "hook anchors", "living specs off", "fresh baseline". If there is nothing to name, use today's date and call it a baseline repeat, which is also useful: it is how the noise floor gets measured.
+
+### 2. Check the machine first
+
+Twelve clones of a React app are about 8GB of files Spotlight has never seen, and indexing them has taken this machine to a load average of 260. Before baking:
+
+```bash
+ls ~/dev/projects/.metadata_never_index || echo "MISSING"
+```
+
+If it is missing, or if `ps aux | grep mds_stores` shows Spotlight busy, tell the user to run `sudo mdutil -i off ~/dev/projects` and wait for them. Do not start a round on a machine that is already struggling.
+
+### 3. Bake
+
+```bash
+npm run compile                          # the driver dispatches the GUI preamble from dist/
+node ../speckit-bench/sync-templates.mjs --sizes easy,medium,hard,oversized --ext code --sweep "<label>"
+```
+
+`--ext code` measures the extension in `COMPANION_DIR`, which is what an experiment on unreleased work needs. Use `--ext latest` only when the question is explicitly about the published build.
+
+The bake prints the three versions it recorded and fails loudly if any cell can read what it is. Report the versions; do not report the arm mapping unless asked, and never pass it to a driver or a judge.
+
+### 4. Prep and drive
+
+```bash
+node ../speckit-bench/run-all.mjs prep --sizes easy,medium,hard,oversized
+```
+
+Then one driver per cell, all twelve at once, following step 3 of `/bench-run-all` — the same GUI preamble, the same settle-wait, capture for the Companion arms only, and **the cell's letter, never its arm**. Twelve drivers in parallel is fine; the round costs the slowest cell rather than the sum.
+
+Expect 20 to 30 minutes.
+
+### 5. Measure — with nothing else running
+
+```bash
+node ../speckit-bench/run-all.mjs capture --sizes easy,medium,hard,oversized --no-reset
+```
+
+This runs a build and two test passes in each of twelve cells. **Do not start the judges while it runs.** Stacking twelve judge agents on top of it is what took the machine down; it costs nothing to wait the ten minutes.
+
+`--no-reset` keeps the diffs so the judges have something to read.
+
+### 6. Judge — after capture finishes, in small batches
+
+A rubric judge per cell and a comparative reviewer per size, as `/bench-capture` steps 3 and 4 describe. Run them **three or four at a time**, not twelve. Then re-run `capture` once to fold the rubric into the composite.
+
+If the machine is under load, or the user has other work to do, stop after step 5 and say so: the oracle, wall-clock and test columns are complete without the judges, and the composite can be filled in later.
+
+### 7. Report
+
+```bash
+node ../speckit-bench/run-all.mjs compare --metric work
+node ../speckit-bench/run-all.mjs compare --metric oracle
+node ../speckit-bench/run-all.mjs compare --metric wall
+```
+
+Lead with what moved and whether it moved more than the spread of the sweeps before it. A change smaller than that spread has not been measured — say so plainly rather than reporting it as a result.
+
+**Read `work`, not `overall`, when comparing the stock arm to a Companion one.** `overall` gives a quarter of its weight to lifecycle capture, which stock does not have and never will, so it caps stock at 75 by construction. `work` is correctness plus rubric and every arm can reach 100.
+
+Then commit the round in `speckit-bench` — `stats.jsonl`, `history.jsonl`, `runs/`, `reviews/`, `REPORT.md` — with a message naming the sweep and what it was testing.
+
+### If something is incomplete
+
+Say which cells are missing and which columns they cost. A round with eleven of twelve cells and no rubrics is still worth pushing; a round reported as complete when it is not is worse than no round.

--- a/.claude/handoffs/option-b-investigation.md
+++ b/.claude/handoffs/option-b-investigation.md
@@ -1,0 +1,79 @@
+# Option B — "materialize per wave instead of per task"
+
+**Verdict: do not do it for speed. It saves no wall clock.** There is a real problem underneath it, but it is a scaling problem, not a today problem, and it is worth about 30 lines. The actual time in this run went somewhere else entirely, and that is the part worth acting on.
+
+Evidence below is all from one measured run: `specs/609-living-spec-navigation` on `speckit-companion`, 24 tasks, implement = 29.9 min. Raw data in that spec's `.trace.jsonl` and `.spec-context.json` `history[]`.
+
+---
+
+## What B was supposed to save, and why it doesn't
+
+The instruction in `speckit-extension/presets/_parts/timing.md` (and `nodes/implement/implement-exec.md`) says: on each task finish, run `--append`, then run `--materialize`. Two calls per task, 48 for 24 tasks.
+
+The theory was that 48 calls means 48 agent round-trips. **It does not.** The agent put both in one shell invocation:
+
+```
+append -> its materialize gap, across all 24 tasks:
+  min 0.10s   median 0.11s   max 0.12s
+  gaps over 2s (i.e. a genuinely separate round-trip): 0 of 24
+```
+
+So B removes zero round-trips. What it removes is script time and bytes:
+
+```
+op              calls        bytes   % of all bytes      ms
+task-append        24      120,313         9%           585
+materialize        24      580,253        42%          1177
+...
+TOTAL              83    1,384,212                     5228
+```
+
+**1.2 seconds of script time and 580 KB of writes, inside a 29.9-minute step.** That is 0.07% of implement. Cutting it to 6 wave-joins saves roughly one second and costs live per-task progress in the panel, which is the thing the whole finish-only timing model exists to provide.
+
+## The real problem hiding under B
+
+`materialize_log` (`speckit-extension/scripts/task_sync.py:315`) **replays the entire append log on every call.** Call *n* folds *n* lines. That is O(n²) folds and a full rewrite of a growing `.spec-context.json` each time:
+
+```
+materialize bytes, first -> last: 18215, 18710, 19200, 19727 ... 29413, 29974, 30709
+```
+
+24 tasks → 300 fold operations, 580 KB. It is linear-ish in bytes here only because the file is small. Extrapolating the same shape:
+
+- 50 tasks → ~1275 folds, ~2.5 MB
+- 100 tasks → ~5050 folds, ~10 MB
+
+Nothing in this repo has hit that yet (the largest spec so far is this one). **The fix is not "fold less often" — it is "fold only what is new."** Track the last-folded line offset (or a folded-line count) in the context, and have `materialize_log` start from there. Idempotency is currently bought by replaying everything and deduping on `(implement, task_id)`; an offset gives the same guarantee for free, and re-folding from an offset is still safe because the dedupe stays.
+
+That is the change worth making. It keeps per-task progress, keeps the idempotency contract, and removes the quadratic term. Roughly: one new field, one `enumerate` with a skip, one test that a second materialize after a third append folds exactly one line.
+
+## Where implement's 30 minutes actually went
+
+This is the part I would act on before touching capture at all.
+
+```
+24 tasks, 29.9 min, median 52s per task
+slowest tasks (seconds from the previous finish):
+  T009  307s   writing the failing tests for the rules resolver
+  T022  219s   the docs task
+  T024  160s   the validation pass (3 test suites)
+  T014  139s   rebuild + hunting for how to emit a new command
+  T016  127s   writing the failing TS tests
+top 5 tasks = 15.9 min = 53% of implement
+```
+
+Three findings, in order of what they cost:
+
+**1. The suites ran three times, not once.** Full Python is ~65s, full Jest ~40s. They were run at each phase boundary and again at T024. The doctor counted **41 of 227 commands as repeats of something already run**. Running them once, at the validation task, saves ~3 minutes. The phase-boundary reconciliation in `implement-exec.md` says "type-check/build the wave's files together" — it should say type-check, and explicitly *not* the full suites.
+
+**2. Registering a new command is discovered by trial and error.** T014 took 139s, and part of it was wasted: `emission_sync.create_command` takes the *bare* step name (`living-show`), not the full command id, and calling it with the full id silently created five directories named `speckit-companion-speckit.companion.living-show` that then had to be deleted. Two of the seven areas (`.gemini/commands` toml, `.github/prompts`) were skipped by `create_command` entirely and had to be written by hand, and `.specify/extensions/.registry` had to be edited separately for 8 agents. **Nothing documents this sequence.** `check-command-emissions.py` reports the gap perfectly but says nothing about how to close it. One paragraph — in `speckit-extension/docs/` or as a `--fix` mode on that checker — removes ~2 minutes from every future command and the wrong-name cleanup entirely.
+
+**3. Contracts were written before the CLI shape was known.** `specs/609-.../contracts/living-show.md` says `--requirement` takes a capability name; the implementation added a separate `--capability` flag instead. Harmless here because I caught it, but the plan step writing an interface contract it has not yet had to satisfy is a systematic drift source. Worth considering whether `contracts/` should be written or amended at the end of implement rather than in plan.
+
+## Recommendation for whoever picks this up
+
+- **Do not implement B as described.** It trades a visible feature (per-task progress) for one second.
+- **Do implement the incremental fold** in `materialize_log`: last-folded offset, skip what is already folded. Small, keeps every current guarantee, removes the quadratic term before a 100-task spec finds it.
+- **Do fix the suite-repeat instruction** in `implement-exec.md` — that is the actual 3 minutes.
+- **Do document the new-command registration path.** Biggest ratio of time saved to work required of anything here.
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,30 +29,6 @@ jobs:
       - name: Run tests
         run: npm test
 
-  visual:
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 24
-          cache: npm
-
-      - name: Install dependencies
-        run: npm ci
-
-      # Geometry only, never pixels: font rasterisation differs between a
-      # developer's Mac and this runner, so a pixel gate here would cry wolf on
-      # every push. The baselines are compared locally with `npm run test:visual`.
-      # Chrome is preinstalled on ubuntu-latest, which is what `channel: 'chrome'`
-      # drives — no browser download.
-      - name: Pipeline Builder layout (real browser, both widths and themes)
-        run: npm run test:visual:ci
-
   capture-suite:
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
The four `/bench-*` commands are the steps of a benchmark round. Nothing was the round itself, so running one meant remembering the order, which flags matter, and two things that were learned the hard way today:

- **The judges must not run while the capture pass does.** Capture runs a build and two test passes in each of twelve clones. Twelve judge agents on top of that took the machine to a load average of 260.
- **Spotlight has to be off for the cells first.** Twelve clones are roughly 8GB of `node_modules` it has never seen, and indexing them was the single largest CPU consumer on the box — larger than the agents.

`/bench-experiment <what you are testing>` does the whole thing: checks the machine, compiles, bakes against the extension in the checkout, drives every cell blind to its arm, measures with nothing else running, judges in small batches afterwards, and reports.

It also encodes which number to read. `overall` gives a quarter of its weight to lifecycle capture, which the stock arm does not have and never will, so it caps stock at 75 by construction — `work` is correctness plus rubric and every arm can reach 100. And it says plainly when a change is smaller than the spread of the sweeps before it, rather than reporting noise as a result.

`examples/README.md` points at it as the entry point, with the step-at-a-time commands behind it.