### PR TITLE
fix(speckit-ext): a directory in the membership is not undescribed code

### DIFF
--- a/speckit-extension/scripts/living_validate.py
+++ b/speckit-extension/scripts/living_validate.py
@@ -274,6 +274,17 @@ def _files_for(pattern: str, paths: list, rsp) -> set:
     return {f for f in paths if rsp._glob_matches(pattern, f)}
 
 
+def _only_files(paths: set, root: str) -> set:
+    """Drop the directories.
+
+    `repo_paths` carries the folders too, because a marker naming a directory does mean
+    something on disk. Membership is a different question: nobody changes a directory, so
+    a registry glob covering a parent folder its requirements never name as a folder would
+    otherwise read as uncovered code, on every project that has one.
+    """
+    return {p for p in paths if os.path.isfile(os.path.join(root, p))}
+
+
 def _marker_glob_in(line: str, globs: set) -> bool:
     m = _TOUCHES_RE.match(line)
     if not m:
@@ -421,6 +432,7 @@ def check_living_spec(text: str, path: str, root: str | None = ".",
             claimed |= _files_for(g, paths, rsp)
         for ex in cap.get("exclude") or []:
             claimed -= _files_for(ex, paths, rsp)
+        claimed = _only_files(claimed, root)
 
         # Only judge markers that name something real. One that names nothing is
         # `unmatched-touches-glob`'s finding, and calling it orphaned too names one fault twice.
@@ -447,7 +459,8 @@ def check_living_spec(text: str, path: str, root: str | None = ".",
                 described = set()
                 for _, _, files in real:
                     described |= files
-                dark = [g for g in cap_globs if _files_for(g, paths, rsp) - described]
+                dark = [g for g in cap_globs
+                        if _only_files(_files_for(g, paths, rsp), root) - described]
                 if dark and len(dark) < len(cap_globs):
                     findings.append(_finding(
                         WARNING, "capability-claims-undescribed-code", path, 1,

--- a/speckit-extension/tests/test_capability_coverage.py
+++ b/speckit-extension/tests/test_capability_coverage.py
@@ -175,6 +175,18 @@ class MembershipAndRequirementsMustDescribeTheSameCode(unittest.TestCase):
         self.assertIn("unmatched-touches-glob", codes(found))
         self.assertNotIn("requirements-outside-capability", codes(found))
 
+    def test_a_parent_directory_in_the_membership_is_not_uncovered_code(self):
+        # `src/features/**` reaches the `src/features/article` folder itself, which no marker
+        # names as a folder and nobody can change. Counting it made this fire on every project
+        # whose registry claims a parent directory.
+        (self.root / "src/features/article/create-article").mkdir(parents=True, exist_ok=True)
+        (self.root / "src/features/article/create-article/index.ts").write_text("export {};\n")
+        self._registry("src/features/article/**")
+        found = self._check(spec_with(REQ.format(
+            heading="An article is written",
+            glob="src/features/article/create-article/**", verb="accept a draft")))
+        self.assertNotIn("capability-claims-undescribed-code", codes(found))
+
     def test_no_registry_entry_means_nothing_to_judge(self):
         (self.root / "living-specs.yml").write_text("enabled: true\ncapabilities: []\n", encoding="utf-8")
         found = self._check(spec_with(REQ.format(


### PR DESCRIPTION
## Summary

Running the new membership check against a real Conduit checkout — rather than the fixture alone, which carries no source tree — turned up one false positive in it and six real defects in the fixture.

The false positive is the one that matters for the product: `repo_paths` carries folders as well as files, so a registry glob covering a parent directory read as uncovered code. That fired on any project whose registry claims `src/features/comment/**` while its requirements name the slices beneath it — the cry-wolf shape that gets a check switched off within a week.

## Technical

- Membership is compared on files only. A directory is still a real path for a marker naming one, so `repo_paths` is unchanged; only the membership comparison filters.
- A test pins the case: a capability claiming `src/features/article/**` whose requirement names `src/features/article/create-article/**` reports nothing.

## What it found in the bench fixture (committed separately, in `speckit-bench`)

Six of nine Conduit capabilities claimed code no requirement described. Article authoring was blind to **15 of its 23 files**, including the whole `create-article` and `update-article` slices — the code the medium feature edits. A change there resolved the capability and received **zero** requirements, so the pre-briefed run was handed an empty list and read as briefed.

That is what "the pre-briefed run got nothing for the area it was about to change" actually was. It means every living-spec measurement taken on this fixture was measuring an arm that read almost nothing, and none of those numbers should be quoted until a round is re-run.

After widening each marker to the slice that produces the behaviour its requirement already states: a change under `create-article` now resolves 2 requirements where it resolved 0, and the fixture validates clean.

## Review checklist

- ✅ **SpecKit extension** — `living_validate.py` membership comparison only
- — **VS Code extension** — not touched
- — **Changelog** — the check it refines is unreleased, added in #726
- ✅ **Verify**
    - `pytest speckit-extension/tests` — 1403 passed, 8 skipped
    - `living_validate.py` — 59 specs, nothing to report
    - the Conduit fixture, against a real checkout — clean
- ✅ **Review** — the false positive this fixes was found by running the check against real source, which is the step the first review could not do

## Gaps / how to see it

- Closes item 4 of #713. All four items are now done.
- The bench fixture change is `speckit-bench@62f942f`.
- Try: give a capability a registry glob covering a parent directory and a requirement naming a slice beneath it. Before, the parent folder was reported as undescribed code; now nothing is reported.
