### PR TITLE
docs(living-specs): write down when a step should dispatch at all

### DIFF
--- a/capabilities/companion-commands/pipeline.spec.md
+++ b/capabilities/companion-commands/pipeline.spec.md
@@ -64,6 +64,18 @@ The vocabulary MUST be the same everywhere. Every step that records a size, and 
 - **WHEN** the standalone classification step reports a size
 - **THEN** the value it records is one every reader of the recorded size understands
 
+### A step dispatches to avoid reading, or to get a second pair of eyes, never for parallelism itself
+
+Handing work out is only ever worth its startup for one of two reasons: the worker reads something the main agent would otherwise carry to the end of the run, or it brings a perspective the main agent cannot hold at the same time as its own. A step that reads nothing but the artifacts the pipeline just wrote has no reading to offload, so its authoring pass stays inline however long it takes. This is why specify dispatches when a request names two or more code areas and plan dispatches per area, while tasks does not: tasks reads the plan, the spec and the design artifacts, all of them small, all of them already in hand, and none of them source. The second reason is what the optional adversarial review of the task list is for, and it is a panel of distinct lenses rather than a split of files.
+
+#### Scenario: a step's only inputs are the artifacts already written
+- **WHEN** it authors its own artifact
+- **THEN** it stays inline, because there is nothing to avoid reading
+
+#### Scenario: a step wants breadth rather than reading
+- **WHEN** it dispatches
+- **THEN** each worker carries a different lens over the same material, not a different slice of it
+
 ### Implement dispatches on how much a phase carries, not on every phase
 
 A worker pays the same startup whatever it is handed, so a phase small enough to read in passing costs more to hand out than to build. Implement SHALL dispatch a story phase only when it owns roughly five files or more, and build the rest inline in phase order, saying which it did which way. Setup, Foundational and Polish are never dispatched: Setup is trivial, Foundational blocks every story, Polish is cross-cutting.


### PR DESCRIPTION
## Summary

The answer to "should tasks dispatch workers?" is no, and this writes down the reasoning so the next version of that question answers itself.

Three separate questions this week were the same question: should specify fan out, should tasks, should implement fan out on every phase. Each was answered on its own, which produced one rule per step and no way to answer the fourth one.

## The rule

Handing work out is worth its startup for exactly two reasons:

1. The worker **reads** something the main agent would otherwise carry to the end of the run.
2. The worker brings a **perspective** the main agent cannot hold alongside its own.

Parallelism by itself is not one of them.

## What that settles

**Tasks: no.** It reads `plan.md`, the feature spec, `data-model.md`, `contracts/` and `research.md` — all small, all already in hand, none of them source code. There is no reading to offload, so the authoring pass stays inline however long it takes. No bench round needed, which is the point of having the rule.

The one place a panel earns its keep in tasks is the adversarial gap review, and that is reason 2, not reason 1: distinct lenses over the same material rather than a split of files. That node already exists, is already offerable from the panel, and stays off by default.

It also explains the two decisions already shipped rather than leaving them as unrelated facts: specify dispatches when a request names two or more code areas, plan dispatches per area, and implement dispatches a phase only when it owns enough files to be worth the startup (#719).

## Review checklist

- ✅ **Living specs** — folded into `commands-pipeline`, which now owns the dispatch rules for the whole pipeline
- — **SpecKit extension code** — no behaviour change; tasks already did not dispatch
- — **VS Code extension** — not touched
- — **Changelog** — nothing user-facing changed
- ✅ **Verify**
    - `pytest speckit-extension/tests` — 1408 passed, 8 skipped
    - `living_validate.py` — 59 specs, nothing to report

## Gaps / how to see it

- This corrects the premise the issue was written on: **specify already dispatches**, and has since `698ba039`, two days before the issue. Only tasks was ever an open question.
- Turning the gap review on by default is still unmeasured and stays out. Flipping it on unmeasured is the mistake this session has spent its time undoing.

Closes #716
