### PR TITLE
feat(speckit-ext): ask about drift on one branch, while it can still be answered

### DIFF
--- a/.claude/commands/ship-ticket.md
+++ b/.claude/commands/ship-ticket.md
@@ -57,6 +57,9 @@ Run `/code-review` on the branch diff vs `main` at **high** effort, apply findin
 
 **Two passes is the ceiling.** One review, one re-review, then ship. If the second pass still finds something real, fix it and open a follow-up issue for anything it raises beyond that rather than starting a third. An unbounded loop finds real things and costs more than they are worth: on PR #720 the third pass found a genuine dispatch bug, and the fourth found nothing while the branch sat unmerged. Convergence is a budget, not a proof.
 
+### 1b. Did the branch say what it changed? — main loop
+`python3 speckit-extension/scripts/drift.py --since main --working`. Anything it names is code this branch changed inside a capability, with nothing said about it. Fold it into that spec, or `--accept` the capability when the spec is genuinely still true. Neither is bookkeeping: the first is the loop closing, the second is a review someone actually did.
+
 ### 2. Open the PR — main loop
 Use `/create-pr` conventions (reads `.claude/pr-profile.md`): conventional-commit title `type(scope): summary`, body with `Closes #N`, summary, technical notes, how-to-verify.
 ```bash

--- a/.claude/review-checklist.md
+++ b/.claude/review-checklist.md
@@ -14,6 +14,8 @@ The review subagent in `/ship-ticket` and `/fix-tickets` reads this **before** r
 - **Comments.** Flag added comments — **including Python docstrings and test docstrings** — that restate the code, narrate a fix's history ("""The #432 regression itself…"""), carry a spec/PR/finding id (`// per #182`), or run past one line. Default is no comment. (#432)
 - **Diagnostic logs.** Flag `console.log`/bracket-tag debug lines left in; structural `logError`/catch-block logging stays.
 
+- **Unfolded living-spec changes.** Run `python3 speckit-extension/scripts/drift.py --since main --working` on the branch. Flag any capability it names: the branch changed code that capability claims and said nothing about it. Fold it, or `--accept` the spec when it is genuinely still true. Whole-repo drift is only ever read once it is a backlog, and by then it is on everything and means nothing. (#723)
+
 ## Capture / `.spec-context.json`
 
 - **Terminal status is `implemented`, never `completed`.** `completed` is the user's Mark-Completed action only; the capture script refuses to write it. Flag any code/doc that forces `completed` on autonomous finish. (#208, #244)

--- a/living-specs.yml
+++ b/living-specs.yml
@@ -144,6 +144,9 @@ capabilities:
   - name: capture-runtime-living-resolve
     match: ["speckit-extension/scripts/resolve-spec-paths.py", "speckit-extension/scripts/record-living-specs.py", "speckit-extension/scripts/register-capability.py", "speckit-extension/scripts/relocate-capability.py"]
     spec: speckit-extension/scripts/capture-runtime-living-resolve.spec.md
+  - name: capture-runtime-drift
+    match: ["speckit-extension/scripts/drift.py", "speckit-extension/scripts/doctor_drift.py"]
+    spec: speckit-extension/scripts/capture-runtime-drift.spec.md
   - name: capture-runtime-reports
     match: ["speckit-extension/scripts/drift.py", "speckit-extension/scripts/check-coverage.py", "speckit-extension/scripts/doctor.py", "speckit-extension/scripts/doctor_checks.py", "speckit-extension/scripts/doctor_bleed.py", "speckit-extension/scripts/doctor_chat.py", "speckit-extension/scripts/doctor_drift.py"]
     spec: speckit-extension/scripts/capture-runtime-reports.spec.md

--- a/speckit-extension/CHANGELOG.md
+++ b/speckit-extension/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/); this ext
 
 ### Changed
 
+- The drift report can be asked about one branch: `living-drift --since main` names only the capabilities your own work touched without saying anything about them. Measured across a whole project, drift is only ever read once it has piled up, and by then it is on nearly everything and tells you nothing. A capability whose spec you also wrote reports nothing, because that is the loop closing.
+
 - A living spec that is still correct can now say so. Drift is measured from the moment a spec was last written, so a spec nobody needed to change drifted further every week and there was no way to record that someone had read it and found it right. `living-drift --accept <capability>` writes down the version it was checked against. Nothing records that for you: reviewing is a claim you make.
 
 - Implementing a feature no longer hands every piece of work to its own agent. A small phase costs more to hand out than to build, so only the substantial ones are, and the run says which it did which way. On a feature with small phases this halves the cost and changes nothing else; on one with large phases the parallel work still saves you minutes.

--- a/speckit-extension/scripts/capture-runtime-drift.spec.md
+++ b/speckit-extension/scripts/capture-runtime-drift.spec.md
@@ -1,0 +1,51 @@
+# Run Reports — Drift
+
+## Purpose
+
+Drift is the code a capability claims that changed without anyone saying what it changed about the behaviour. This capability covers what counts as drift, what does not, and how the question can be asked early enough to answer rather than only in aggregate once it has become a backlog.
+
+## Requirements
+
+### The drift detector offers an opt-in working-tree mode
+
+The drift script SHALL accept a working-tree mode that widens each capability's changed set from committed history to the baseline→worktree diff plus untracked files, de-duplicated, with the tracked-vs-unspeced scan widened the same way. The default invocation issues exactly the pre-existing git commands and renders identical human output; the machine-readable result names which mode produced it. The never-fails exit contract and the checked/skipped counts semantics hold in both modes.
+
+#### Scenario: an uncommitted edit in a capability's area
+- **WHEN** drift runs without the flag and then with it
+- **THEN** the default run reads the capability as in sync and the working-tree run reports the file as drifted
+
+### A file a run already accounted for is not drift
+
+Drift is code that changed with nobody saying whether the spec still describes it, and a run that folded a delta into a capability, or recorded a reasoned skip for it, has said exactly that. The detector SHALL therefore drop from a capability's drifted set every file changed by such a run, read from the runs' own records rather than from anything the report keeps for itself. Reporting them anyway tells a developer to review work they finished on the run that changed the file, which is how a drift report becomes a list people scroll past. A file changed by hand, with no run behind it, is drift as before, and the accounting is per capability: a run that settled one capability vouches for nothing in another.
+
+#### Scenario: a completed run folded into this capability
+- **WHEN** drift runs afterwards
+- **THEN** the files that run changed are not reported, while a hand edit since is
+
+#### Scenario: a run recorded a reasoned skip
+- **WHEN** drift runs afterwards
+- **THEN** that run's files are not reported either, because a skip is the run saying the spec still holds
+
+### A living spec is not code that drifts, whoever wrote it
+
+A capability's own spec documents are already excluded from its drift. That is not enough where capabilities sit beside the code they describe: one capability's membership routinely claims the directory its siblings keep their specs in, so writing one spec reports every neighbour as having drifted code. Any registered capability's spec documents SHALL therefore be excluded from every capability's drift, not only from its own.
+
+#### Scenario: two colocated capabilities share a directory
+- **WHEN** one of their specs is written
+- **THEN** the other reports no drift from it
+
+### Drift can be asked about one branch, so it is answerable before it is a backlog
+
+Measured across the whole repository, drift is only ever read once it has become a backlog, and by then it is on nearly every capability and means nothing. The report SHALL therefore also measure from the merge base with a named ref, so it answers a question about the work in hand: which capabilities did this branch touch, and did it fold any of them. A capability whose spec was written on the same branch reports nothing, because that is the loop closing rather than drift. Work that was already on the base is not this branch's to answer for, and reporting it is how a branch-scoped check becomes noise like the whole-repo one.
+
+#### Scenario: a branch changes code a capability claims and writes no spec
+- **WHEN** drift is measured from the branch point
+- **THEN** that capability is named
+
+#### Scenario: the same branch also writes that spec
+- **WHEN** drift is measured from the branch point
+- **THEN** nothing is named, because the change was accounted for
+
+#### Scenario: an unfolded change was already on the base
+- **WHEN** drift is measured from the branch point
+- **THEN** nothing is named, because this branch did not make it

--- a/speckit-extension/scripts/capture-runtime-reports.spec.md
+++ b/speckit-extension/scripts/capture-runtime-reports.spec.md
@@ -40,35 +40,6 @@ Reporting tools exit successfully by default, and that default does not change. 
 - **WHEN** a strict verdict is requested and a problem-severity finding is present
 - **THEN** the command exits non-zero, while the default invocation still succeeds
 
-### The drift detector offers an opt-in working-tree mode
-
-The drift script SHALL accept a working-tree mode that widens each capability's changed set from committed history to the baseline→worktree diff plus untracked files, de-duplicated, with the tracked-vs-unspeced scan widened the same way. The default invocation issues exactly the pre-existing git commands and renders identical human output; the machine-readable result names which mode produced it. The never-fails exit contract and the checked/skipped counts semantics hold in both modes.
-
-#### Scenario: an uncommitted edit in a capability's area
-- **WHEN** drift runs without the flag and then with it
-- **THEN** the default run reads the capability as in sync and the working-tree run reports the file as drifted
-
-### A file a run already accounted for is not drift
-
-Drift is code that changed with nobody saying whether the spec still describes it, and a run that folded a delta into a capability, or recorded a reasoned skip for it, has said exactly that. The detector SHALL therefore drop from a capability's drifted set every file changed by such a run, read from the runs' own records rather than from anything the report keeps for itself. Reporting them anyway tells a developer to review work they finished on the run that changed the file, which is how a drift report becomes a list people scroll past. A file changed by hand, with no run behind it, is drift as before, and the accounting is per capability: a run that settled one capability vouches for nothing in another.
-
-#### Scenario: a completed run folded into this capability
-- **WHEN** drift runs afterwards
-- **THEN** the files that run changed are not reported, while a hand edit since is
-
-#### Scenario: a run recorded a reasoned skip
-- **WHEN** drift runs afterwards
-- **THEN** that run's files are not reported either, because a skip is the run saying the spec still holds
-
-
-### A living spec is not code that drifts, whoever wrote it
-
-A capability's own spec documents are already excluded from its drift. That is not enough where capabilities sit beside the code they describe: one capability's membership routinely claims the directory its siblings keep their specs in, so writing one spec reports every neighbour as having drifted code. Any registered capability's spec documents SHALL therefore be excluded from every capability's drift, not only from its own.
-
-#### Scenario: two colocated capabilities share a directory
-- **WHEN** one of their specs is written
-- **THEN** the other reports no drift from it
-
 ### The health check MUST consult the unrecorded-calls marker before concluding a spec has no trace evidence
 
 A run that cannot write into its spec directory can still complete captures while the trace line recording them fails to append. That run leaves a marker and no trace file. The check SHALL read the marker first, so the single failure mode that produces no trace at all is reportable rather than indistinguishable from a spec that has simply captured nothing yet.

--- a/speckit-extension/scripts/drift.py
+++ b/speckit-extension/scripts/drift.py
@@ -274,7 +274,8 @@ def _exempt(file: str, exempt_globs: list[str]) -> bool:
     )
 
 
-def compute_drift(root: str, living: dict, working: bool = False) -> dict:
+def compute_drift(root: str, living: dict, working: bool = False,
+                  since: str | None = None) -> dict:
     """The drift result object. Inert (empty) when living specs are disabled.
     `working` widens each changed set to the working tree (uncommitted +
     untracked); the default path issues exactly the same git commands as before.
@@ -286,7 +287,7 @@ def compute_drift(root: str, living: dict, working: bool = False) -> dict:
 
     _started = _time.monotonic()
     try:
-        result = _compute_drift(root, living, working)
+        result = _compute_drift(root, living, working, since)
     except Exception as exc:  # noqa: BLE001
         _trace_drift(root, living, working, None, exc,
                      int((_time.monotonic() - _started) * 1000))
@@ -351,7 +352,8 @@ def _record_drift_verdict(root: str, verdict: dict) -> None:
         pass
 
 
-def _compute_drift(root: str, living: dict, working: bool = False) -> dict:
+def _compute_drift(root: str, living: dict, working: bool = False,
+                   since: str | None = None) -> dict:
     if not living["enabled"]:
         return {"enabled": False, "working": working, "checked": 0,
                 "capabilities": [], "skipped": []}
@@ -386,6 +388,14 @@ def _compute_drift(root: str, living: dict, working: bool = False) -> dict:
             skipped.append({"name": cap["name"], "reason": SKIP_UNREADABLE})
             continue
         state, commit = _spec_commit(root, spec)
+        if since:
+            # Branch-scoped: measure from where this work started rather than from each
+            # spec's own last commit. Whole-repo drift only ever gets read once it is a
+            # backlog; this answers the question while the change is still in hand — which
+            # capabilities did I touch, and did I fold any of them.
+            merge_base = _git(root, ["merge-base", since, "HEAD"])[1].strip()
+            if merge_base:
+                state, commit = "ok", merge_base
         if state != "ok":
             unreadable = state == "unreadable" and has_commits
             reason = SKIP_UNREADABLE if unreadable else SKIP_UNCOMMITTED
@@ -402,6 +412,7 @@ def _compute_drift(root: str, living: dict, working: bool = False) -> dict:
         if working:
             changed += untracked
         drifted = []
+        folded_here = False
         seen: set[str] = set()
         for f in changed:
             fp = rsp._posix(f)
@@ -409,6 +420,7 @@ def _compute_drift(root: str, living: dict, working: bool = False) -> dict:
                 continue
             seen.add(fp)
             if _is_own_spec_doc(fp, spec_posix) or _is_any_spec_doc(fp, spec_dirs):
+                folded_here = folded_here or _is_own_spec_doc(fp, spec_posix)
                 continue
             if not rsp.matches(cap, fp):
                 continue
@@ -419,6 +431,9 @@ def _compute_drift(root: str, living: dict, working: bool = False) -> dict:
             severity = "tracked" if fp in tracked else "unspeced"
             drifted.append({"file": fp, "severity": severity})
         drifted.sort(key=lambda d: (d["severity"], d["file"]))
+        if since and folded_here:
+            # The spec was written on this branch, so its code changing is the fold, not drift.
+            drifted = []
         caps_out.append({
             "name": cap["name"],
             "spec": spec_posix,
@@ -565,6 +580,9 @@ def main(argv=None) -> int:
     ap.add_argument("--working", action="store_true",
                     help="also count working-tree changes (uncommitted edits, "
                          "deletions, and untracked files) as drift")
+    ap.add_argument("--since", metavar="REF",
+                    help="measure from the merge base with REF instead of each spec's own "
+                         "last commit, so the report is about this branch's work alone")
     ap.add_argument("--accept", metavar="CAPABILITY", action="append", default=[],
                     help="record that this capability's spec was read against the code and "
                          "found still true; repeatable. Commit the spec to move its baseline")
@@ -573,7 +591,7 @@ def main(argv=None) -> int:
     living = rsp.load_living(args.root)
     if args.accept:
         return accept(args.root, living, args.accept)
-    result = compute_drift(args.root, living, working=args.working)
+    result = compute_drift(args.root, living, working=args.working, since=args.since)
     if args.json:
         print(json.dumps(result, indent=2))
     else:

--- a/speckit-extension/tests/test_drift_since.py
+++ b/speckit-extension/tests/test_drift_since.py
@@ -1,0 +1,107 @@
+"""Drift scoped to one branch, so an unfolded change is caught while it is still in hand.
+
+Whole-repo drift is only ever read once it has become a backlog, and by then the flag is on
+everything and means nothing. Measuring from where this work started answers the question at
+the moment it can still be acted on: which capabilities did this branch touch, and did it
+fold any of them.
+
+A capability whose spec was written on this branch is folded, not drifted — that is the
+whole difference between "you changed code here" and "you changed code here and said
+nothing about it".
+"""
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS = ROOT / "speckit-extension" / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+_spec = importlib.util.spec_from_file_location("drift", SCRIPTS / "drift.py")
+drift = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(drift)
+
+SPEC = ("# Billing\n\n## Requirements\n\n### It charges once\n"
+        "<!-- touches: src/billing/** -->\n\nIt SHALL charge once.\n\n"
+        "#### Scenario: a charge\n- **WHEN** asked\n- **THEN** it charges once\n")
+
+
+def git(cwd, *args):
+    return subprocess.run(["git", *args], cwd=cwd, check=True,
+                          capture_output=True, text=True).stdout.strip()
+
+
+class DriftSinceABranchPoint(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp(prefix="drift-since-")
+        self.root = Path(self.tmp)
+        (self.root / "src" / "billing").mkdir(parents=True)
+        (self.root / "src" / "billing" / "charge.ts").write_text("export {};\n")
+        (self.root / "capabilities" / "billing").mkdir(parents=True)
+        self.spec_rel = "capabilities/billing/billing.spec.md"
+        (self.root / self.spec_rel).write_text(SPEC, encoding="utf-8")
+        (self.root / "living-specs.yml").write_text(
+            "enabled: true\ncapabilities:\n  - name: billing\n    match:\n"
+            "      - src/billing/**\n" f"    spec: {self.spec_rel}\n", encoding="utf-8")
+        git(self.tmp, "init", "-q")
+        git(self.tmp, "config", "user.email", "t@t")
+        git(self.tmp, "config", "user.name", "t")
+        git(self.tmp, "add", "-A")
+        git(self.tmp, "commit", "-qm", "baseline")
+        git(self.tmp, "branch", "-M", "main")
+        self.living = drift.rsp.load_living(str(self.root))
+
+    def tearDown(self):
+        import shutil
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def _flagged(self, since="main") -> list:
+        result = drift.compute_drift(str(self.root), self.living, since=since)
+        return [c["name"] for c in result["capabilities"] if c.get("drifted")]
+
+    def test_a_clean_branch_flags_nothing(self):
+        git(self.tmp, "checkout", "-qb", "work")
+        self.assertEqual(self._flagged(), [])
+
+    def test_code_changed_without_touching_the_spec_is_flagged(self):
+        git(self.tmp, "checkout", "-qb", "work")
+        (self.root / "src" / "billing" / "charge.ts").write_text("export const x = 1;\n")
+        git(self.tmp, "add", "-A")
+        git(self.tmp, "commit", "-qm", "change the code")
+        self.assertEqual(self._flagged(), ["billing"])
+
+    def test_folding_on_the_same_branch_clears_it(self):
+        git(self.tmp, "checkout", "-qb", "work")
+        (self.root / "src" / "billing" / "charge.ts").write_text("export const x = 1;\n")
+        (self.root / self.spec_rel).write_text(
+            SPEC.replace("It SHALL charge once.", "It SHALL charge exactly once."),
+            encoding="utf-8")
+        git(self.tmp, "add", "-A")
+        git(self.tmp, "commit", "-qm", "change the code and say so")
+        self.assertEqual(self._flagged(), [])
+
+    def test_work_already_on_the_base_is_not_this_branch_to_answer_for(self):
+        # The point of measuring from the merge base: someone else's unfolded change is
+        # their problem, and reporting it here is how a branch-scoped check becomes noise.
+        (self.root / "src" / "billing" / "charge.ts").write_text("export const y = 2;\n")
+        git(self.tmp, "add", "-A")
+        git(self.tmp, "commit", "-qm", "landed on main without folding")
+        git(self.tmp, "checkout", "-qb", "work")
+        self.assertEqual(self._flagged(), [])
+
+    def test_without_since_it_still_measures_from_the_specs_own_commit(self):
+        git(self.tmp, "checkout", "-qb", "work")
+        (self.root / "src" / "billing" / "charge.ts").write_text("export const x = 1;\n")
+        git(self.tmp, "add", "-A")
+        git(self.tmp, "commit", "-qm", "change the code")
+        result = drift.compute_drift(str(self.root), self.living)
+        self.assertEqual([c["name"] for c in result["capabilities"] if c.get("drifted")],
+                         ["billing"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Clearing the drift backlog does not stop it rebuilding. Whole-repo drift is only ever read once it has piled up, and by then it is on nearly every capability and tells you nothing — which is how thirty-one of fifty-six came to be flagged against a single baseline.

`living-drift --since main` measures from the merge base instead of each spec's own last commit, so the report answers a question about the work in hand rather than about the project's history: **which capabilities did this branch touch, and did it fold any of them.**

## Technical

- A capability whose spec was written on the same branch reports nothing. That is the loop closing, not drift, and treating it as drift would flag exactly the people doing the right thing.
- Work already on the base is not this branch's to answer for. Reporting someone else's unfolded change is how a branch-scoped check becomes noise like the whole-repo one.
- Without `--since`, behaviour is unchanged and pinned by a test.
- Wired into `.claude/review-checklist.md` and into `ship-ticket` before the PR is opened, which is the point where the answer is still cheap.

## Runbook

`try-living-specs.md` in the vault gained a Part 6 covering everything shipped since it was drafted and never manually walked: the three panel first-run states, `Set up living specs`, the adopt prompt, Move Living Spec, the three coverage states, the living-spec Overview and approve, the two membership findings, the "resolved nothing" concern, `--accept`, the `aligns` hop through plan and the implement worker, and the exempt-glob fix.

## Review checklist

- ✅ **SpecKit extension** — `drift.py` gains `--since`
- — **VS Code extension** — not touched
- ✅ **Changelog** — spec-kit extension, user-facing voice
- ✅ **Living specs** — the four drift requirements moved into their own capability; the reports spec had grown past the size the shape check allows and said so
- ✅ **Verify**
    - `pytest speckit-extension/tests` — 1425 passed, 8 skipped
    - `living_validate.py` — 60 specs, nothing to report
    - `drift.py --since main --working` — all 57 in sync, run against this branch
    - Behaviour proved both ways: change code a capability claims and it is named; also write that spec and it is not

## Gaps / how to see it

- It reports; it does not block. A gate that refuses a PR over drift would be wrong while a third of drift findings are legitimately "no change needed" — that judgement is still a person's.
- Try: on a branch, edit a file some capability claims, then run `python3 speckit-extension/scripts/drift.py --since main --working`. It names that capability. Edit its spec too, and it stops.

Closes #723
